### PR TITLE
Add Python bindings for EPContext data callbacks

### DIFF
--- a/onnxruntime/__init__.py
+++ b/onnxruntime/__init__.py
@@ -77,6 +77,9 @@ from onnxruntime.capi import onnxruntime_validation
 if import_capi_exception:
     raise import_capi_exception
 
+with contextlib.suppress(ImportError):
+    from onnxruntime.capi._pybind_state import OrtEpContextData, OrtEpContextDataBuffer  # noqa: F401
+
 from onnxruntime.capi.onnxruntime_inference_collection import (
     AdapterFormat,  # noqa: F401
     InferenceSession,  # noqa: F401

--- a/onnxruntime/python/onnxruntime_inference_collection.py
+++ b/onnxruntime/python/onnxruntime_inference_collection.py
@@ -866,6 +866,21 @@ class ModelCompiler:
             output_model_path = os.fspath(output_model_path)
         self._model_compiler.compile_to_file(output_model_path)
 
+    def set_ep_context_data_write_func(self, write_func: Callable[[str, C.OrtEpContextData], None]) -> None:
+        """
+        Registers a callback that receives external EPContext data during compilation.
+
+        The ``OrtEpContextData`` view is valid only during the callback. Read large payloads in chunks with
+        ``data.read(offset, length)``. ORT may invoke the callback concurrently, so synchronize shared state.
+
+        :param write_func: Callback receiving the logical data name and a bounded data view.
+        """
+        self._model_compiler.set_ep_context_data_write_func(write_func)
+
+    def clear_ep_context_data_write_func(self) -> None:
+        """Clears a previously registered external EPContext data write callback."""
+        self._model_compiler.clear_ep_context_data_write_func()
+
     def compile_to_bytes(self) -> bytes:
         """
         Compiles to bytes representing the serialized compiled ONNX model.

--- a/onnxruntime/python/onnxruntime_pybind_model_compiler.cc
+++ b/onnxruntime/python/onnxruntime_pybind_model_compiler.cc
@@ -6,14 +6,174 @@
 
 #include <algorithm>
 #include <cassert>
+#include <cstring>
 #include <iterator>
+#include <limits>
 #include "core/common/common.h"
 #include "core/framework/error_code_helper.h"
+#include "core/framework/ortmemoryinfo.h"
 #include "core/graph/abi_graph_types.h"
 #include "core/session/utils.h"
 
 namespace onnxruntime {
 namespace python {
+
+namespace {
+
+OrtStatus* ToCallbackStatus(OrtErrorCode error_code, const char* prefix, const std::exception& ex) {
+  if (error_code == ORT_INVALID_ARGUMENT) {
+    return ToOrtStatus(ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT, prefix, ex.what()));
+  }
+
+  return ToOrtStatus(ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, prefix, ex.what()));
+}
+
+OrtStatus* ORT_API_CALL PyEpContextDataWriteFuncWrapper(void* state, const char* name,
+                                                        const void* buffer, size_t buffer_size) {
+  auto* py_func = static_cast<PyEpContextDataWriteFunc*>(state);
+
+  try {
+    pybind11::gil_scoped_acquire acquire;
+    try {
+      auto data = std::make_shared<PyEpContextData>(buffer, buffer_size);
+      auto invalidate_data = gsl::finally([&data]() { data->Invalidate(); });
+      (*py_func)(name, data);
+      return nullptr;
+    } catch (const std::exception& ex) {
+      return ToCallbackStatus(ORT_FAIL, "Python EPContext data write callback failed: ", ex);
+    }
+  } catch (const std::exception& ex) {
+    return ToCallbackStatus(ORT_FAIL, "Python EPContext data write callback failed: ", ex);
+  }
+}
+
+}  // namespace
+
+pybind11::bytes PyEpContextData::Read(size_t offset, std::optional<size_t> length) const {
+  ORT_ENFORCE(valid_, "EPContext data is valid only during the write callback.");
+  ORT_ENFORCE(offset <= size_, "EPContext data offset exceeds the payload size.");
+
+  const size_t read_size = length.value_or(size_ - offset);
+  ORT_ENFORCE(read_size <= size_ - offset, "EPContext data range exceeds the payload size.");
+  ORT_ENFORCE(read_size <= static_cast<size_t>(std::numeric_limits<Py_ssize_t>::max()),
+              "EPContext data range is too large for one Python bytes object. Read it in chunks.");
+  ORT_ENFORCE(read_size == 0 || data_ != nullptr,
+              "EPContext data has a null buffer for a non-empty range.");
+
+  const char* begin = read_size == 0 ? "" : static_cast<const char*>(data_) + offset;
+  return pybind11::bytes(begin, static_cast<Py_ssize_t>(read_size));
+}
+
+void PyEpContextData::Invalidate() noexcept {
+  valid_ = false;
+  data_ = nullptr;
+}
+
+PyEpContextDataBuffer::~PyEpContextDataBuffer() {
+  Invalidate();
+}
+
+PyEpContextDataBuffer::PyEpContextDataBuffer(OrtAllocator* allocator, size_t max_data_size)
+    : allocator_(allocator), max_data_size_(max_data_size) {
+  const OrtMemoryInfo* memory_info = allocator_ == nullptr ? nullptr : allocator_->Info(allocator_);
+  if (memory_info == nullptr || !memory_info->device.UsesCpuMemory()) {
+    throw std::invalid_argument(
+        "Python EPContext data callbacks require a CPU or HOST_ACCESSIBLE allocator.");
+  }
+}
+
+void PyEpContextDataBuffer::Invalidate() noexcept {
+  if (buffer_ != nullptr && allocator_ != nullptr) {
+    allocator_->Free(allocator_, buffer_);
+  }
+  buffer_ = nullptr;
+  allocator_ = nullptr;
+  valid_ = false;
+}
+
+void PyEpContextDataBuffer::ThrowIfInvalid() const {
+  ORT_ENFORCE(valid_, "EPContext data output is valid only during the read callback.");
+}
+
+void PyEpContextDataBuffer::Allocate(size_t size) {
+  ThrowIfInvalid();
+  if (allocated_) {
+    throw std::invalid_argument("EPContext data output has already been allocated.");
+  }
+  if (size > max_data_size_) {
+    throw std::invalid_argument("EPContext data exceeds the configured maximum size.");
+  }
+
+  void* buffer = size == 0 ? nullptr : allocator_->Alloc(allocator_, size);
+  if (size != 0 && buffer == nullptr) {
+    ORT_THROW("The ORT allocator failed to allocate the EPContext data output buffer.");
+  }
+
+  buffer_ = buffer;
+  size_ = size;
+  allocated_ = true;
+}
+
+void PyEpContextDataBuffer::Write(size_t offset, const pybind11::buffer& data) {
+  ThrowIfInvalid();
+  if (!allocated_) {
+    throw std::invalid_argument("allocate() must be called before write().");
+  }
+
+  Py_buffer view{};
+  if (PyObject_GetBuffer(data.ptr(), &view, PyBUF_CONTIG_RO) != 0) {
+    throw pybind11::error_already_set();
+  }
+  auto release_view = gsl::finally([&view]() { PyBuffer_Release(&view); });
+
+  if (view.len < 0) {
+    throw std::invalid_argument("Python buffer has a negative size.");
+  }
+  const size_t data_size = static_cast<size_t>(view.len);
+  if (offset > size_ || data_size > size_ - offset) {
+    throw std::invalid_argument("Python buffer does not fit in the allocated EPContext data output range.");
+  }
+  if (data_size != 0) {
+    std::memcpy(static_cast<char*>(buffer_) + offset, view.buf, data_size);
+  }
+}
+
+void PyEpContextDataBuffer::Detach(void*& buffer, size_t& size) {
+  ThrowIfInvalid();
+  if (!allocated_) {
+    throw std::invalid_argument("The EPContext data read callback must allocate its output buffer.");
+  }
+
+  buffer = buffer_;
+  size = size_;
+  buffer_ = nullptr;
+  allocator_ = nullptr;
+  valid_ = false;
+}
+
+OrtStatus* ORT_API_CALL PyEpContextDataReadFuncWrapper(void* state, const char* name, OrtAllocator* allocator,
+                                                       void** buffer, size_t* data_size) {
+  auto* registration = static_cast<PyEpContextDataReadRegistration*>(state);
+  *buffer = nullptr;
+  *data_size = 0;
+
+  try {
+    pybind11::gil_scoped_acquire acquire;
+    try {
+      auto output = std::make_shared<PyEpContextDataBuffer>(allocator, registration->max_data_size);
+      auto invalidate_output = gsl::finally([&output]() { output->Invalidate(); });
+      registration->read_func(name, output);
+      output->Detach(*buffer, *data_size);
+      return nullptr;
+    } catch (const std::invalid_argument& ex) {
+      return ToCallbackStatus(ORT_INVALID_ARGUMENT, "Python EPContext data read callback failed: ", ex);
+    } catch (const std::exception& ex) {
+      return ToCallbackStatus(ORT_FAIL, "Python EPContext data read callback failed: ", ex);
+    }
+  } catch (const std::exception& ex) {
+    return ToCallbackStatus(ORT_FAIL, "Python EPContext data read callback failed: ", ex);
+  }
+}
 
 /// <summary>
 /// This function is called by ORT to allow the user to handle where every initializer is stored
@@ -35,25 +195,23 @@ static OrtStatus* ORT_API_CALL PyGetInitializerLocationFuncWrapper(
     /*out*/ OrtExternalInitializerInfo** new_external_info) {
   PyGetInitializerLocationFunc* py_func = reinterpret_cast<PyGetInitializerLocationFunc*>(state);
   OrtStatus* status = nullptr;
-  std::shared_ptr<const OrtExternalInitializerInfo> py_new_external_info = nullptr;
+  *new_external_info = nullptr;
 
   // Call the Python function and convert any exceptions to a status.
   ORT_TRY {
-    py_new_external_info = (*py_func)(initializer_name, *initializer_value, external_info);
+    pybind11::gil_scoped_acquire acquire;
+    auto py_new_external_info = (*py_func)(initializer_name, *initializer_value, external_info);
+    if (py_new_external_info) {
+      // ORT expects to take ownership of the new external info, so make a copy because other Python code
+      // may be holding a reference to the `py_new_external_info`.
+      auto py_result_copy = std::make_unique<OrtExternalInitializerInfo>(*py_new_external_info.get());
+      *new_external_info = py_result_copy.release();
+    }
   }
   ORT_CATCH(const std::exception& e) {
     ORT_HANDLE_EXCEPTION([&]() {
       status = ToOrtStatus(ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, e.what()));
     });
-  }
-
-  if (py_new_external_info) {
-    // ORT expects to take ownership of the new external info, so make a copy because other Python code
-    // may be holding a reference to the `py_new_external_info`.
-    auto py_result_copy = std::make_unique<OrtExternalInitializerInfo>(*py_new_external_info.get());
-    *new_external_info = py_result_copy.release();
-  } else {
-    *new_external_info = nullptr;
   }
 
   return status;
@@ -69,8 +227,12 @@ onnxruntime::Status PyModelCompiler::Create(/*out*/ std::unique_ptr<PyModelCompi
                                             uint32_t flags,
                                             GraphOptimizationLevel graph_optimization_level,
                                             const PyGetInitializerLocationFunc& py_get_initializer_location_func) {
-  auto model_compiler = std::make_unique<PyModelCompiler>(env, sess_options, py_get_initializer_location_func,
-                                                          PrivateConstructorTag{});
+  auto sess_options_snapshot = CreatePySessionOptionsSnapshot(sess_options);
+  auto model_compiler = std::make_unique<PyModelCompiler>(
+      env, sess_options_snapshot.options,
+      std::move(sess_options_snapshot.py_ep_selection_registration),
+      std::move(sess_options_snapshot.py_ep_context_data_read_registration),
+      py_get_initializer_location_func, PrivateConstructorTag{});
   ModelCompilationOptions& compile_options = model_compiler->model_compile_options_;
 
   if (input_model_is_path) {
@@ -104,13 +266,36 @@ onnxruntime::Status PyModelCompiler::Create(/*out*/ std::unique_ptr<PyModelCompi
   return Status::OK();
 }
 
+onnxruntime::Status PyModelCompiler::BeginCompilation() {
+  std::lock_guard<std::mutex> lock{compilation_mutex_};
+  ORT_RETURN_IF(compilation_in_progress_, "Compilation is already in progress for this ModelCompiler.");
+  compilation_in_progress_ = true;
+  return Status::OK();
+}
+
+void PyModelCompiler::EndCompilation() noexcept {
+  std::lock_guard<std::mutex> lock{compilation_mutex_};
+  compilation_in_progress_ = false;
+}
+
 onnxruntime::Status PyModelCompiler::CompileToFile(const std::string& output_model_path) {
+  ORT_RETURN_IF_ERROR(BeginCompilation());
+  auto finish_compilation = gsl::finally([this]() { EndCompilation(); });
+
   ORT_RETURN_IF_ERROR(model_compile_options_.SetOutputModelPath(output_model_path));
-  ORT_RETURN_IF_ERROR(onnxruntime::CompileModel(env_, model_compile_options_));
+  Status status;
+  {
+    pybind11::gil_scoped_release release;
+    status = onnxruntime::CompileModel(env_, model_compile_options_);
+  }
+  ORT_RETURN_IF_ERROR(status);
   return Status::OK();
 }
 
 onnxruntime::Status PyModelCompiler::CompileToBytes(std::string& output_buffer) {
+  ORT_RETURN_IF_ERROR(BeginCompilation());
+  auto finish_compilation = gsl::finally([this]() { EndCompilation(); });
+
   if (!output_buffer.empty()) {
     // Opt to return an error if the output buffer is not empty instead of just calling output_buffer.clear()
     // because the C++ standard does not explicitly require that capacity is unchanged by a call to clear().
@@ -125,7 +310,12 @@ onnxruntime::Status PyModelCompiler::CompileToBytes(std::string& output_buffer) 
   void* buffer_data = nullptr;
   size_t buffer_size = 0;
   ORT_RETURN_IF_ERROR(model_compile_options_.SetOutputModelBuffer(allocator, &buffer_data, &buffer_size));
-  ORT_RETURN_IF_ERROR(onnxruntime::CompileModel(env_, model_compile_options_));
+  Status status;
+  {
+    pybind11::gil_scoped_release release;
+    status = onnxruntime::CompileModel(env_, model_compile_options_);
+  }
+  ORT_RETURN_IF_ERROR(status);
 
   // Copy into output buffer.
   output_buffer.reserve(buffer_size);
@@ -149,6 +339,7 @@ static OrtStatus* ORT_API_CALL PyOutStreamWriteFuncWrapper(void* stream_state, c
 
   // Call the Python write function and convert any exceptions to a status.
   ORT_TRY {
+    pybind11::gil_scoped_acquire acquire;
     pybind11::bytes py_bytes(reinterpret_cast<const char*>(buffer), buffer_num_bytes);
     (*py_write_func)(py_bytes);
   }
@@ -162,18 +353,55 @@ static OrtStatus* ORT_API_CALL PyOutStreamWriteFuncWrapper(void* stream_state, c
 }
 
 onnxruntime::Status PyModelCompiler::CompileToOutStream(PyOutStreamWriteFunc& write_func) {
+  ORT_RETURN_IF_ERROR(BeginCompilation());
+  auto finish_compilation = gsl::finally([this]() { EndCompilation(); });
+
   model_compile_options_.SetOutputModelWriteFunc(PyOutStreamWriteFuncWrapper,
                                                  reinterpret_cast<void*>(&write_func));
-  ORT_RETURN_IF_ERROR(onnxruntime::CompileModel(env_, model_compile_options_));
+  Status status;
+  {
+    pybind11::gil_scoped_release release;
+    status = onnxruntime::CompileModel(env_, model_compile_options_);
+  }
+  ORT_RETURN_IF_ERROR(status);
   return Status::OK();
 }
 
-PyModelCompiler::PyModelCompiler(onnxruntime::Environment& env, const PySessionOptions& sess_options,
+void PyModelCompiler::SetEpContextDataWriteFunc(PyEpContextDataWriteFunc write_func) {
+  ORT_ENFORCE(static_cast<bool>(write_func), "EPContext data write callback must not be None.");
+  PyEpContextDataWriteFunc old_write_func;
+  {
+    std::lock_guard<std::mutex> lock{compilation_mutex_};
+    ORT_ENFORCE(!compilation_in_progress_,
+                "Cannot change the EPContext data write callback while compilation is in progress.");
+    old_write_func = std::move(py_ep_context_data_write_func_);
+    py_ep_context_data_write_func_ = std::move(write_func);
+    model_compile_options_.SetEpContextDataWriteFunc(PyEpContextDataWriteFuncWrapper,
+                                                     &py_ep_context_data_write_func_);
+  }
+}
+
+void PyModelCompiler::ClearEpContextDataWriteFunc() {
+  PyEpContextDataWriteFunc old_write_func;
+  {
+    std::lock_guard<std::mutex> lock{compilation_mutex_};
+    ORT_ENFORCE(!compilation_in_progress_,
+                "Cannot change the EPContext data write callback while compilation is in progress.");
+    model_compile_options_.SetEpContextDataWriteFunc(nullptr, nullptr);
+    old_write_func = std::move(py_ep_context_data_write_func_);
+  }
+}
+
+PyModelCompiler::PyModelCompiler(onnxruntime::Environment& env, const OrtSessionOptions& sess_options,
+                                 std::shared_ptr<PyEpSelectionRegistration> py_ep_selection_registration,
+                                 std::shared_ptr<PyEpContextDataReadRegistration> py_ep_context_data_read_registration,
                                  const PyGetInitializerLocationFunc& py_get_initializer_location_func,
                                  PrivateConstructorTag)
     : env_(env),
-      model_compile_options_(env, sess_options),
-      py_get_initializer_location_func_(py_get_initializer_location_func) {
+      py_ep_selection_registration_(std::move(py_ep_selection_registration)),
+      py_ep_context_data_read_registration_(std::move(py_ep_context_data_read_registration)),
+      py_get_initializer_location_func_(py_get_initializer_location_func),
+      model_compile_options_(env, sess_options) {
 }
 }  // namespace python
 }  // namespace onnxruntime

--- a/onnxruntime/python/onnxruntime_pybind_model_compiler.h
+++ b/onnxruntime/python/onnxruntime_pybind_model_compiler.h
@@ -4,6 +4,8 @@
 #pragma once
 
 #include <memory>
+#include <mutex>
+#include <optional>
 #include <string>
 #include "core/common/status.h"
 #include "core/session/model_compilation_options.h"
@@ -13,6 +15,62 @@ namespace onnxruntime {
 class Environment;
 
 namespace python {
+#if !defined(ORT_MINIMAL_BUILD)
+class PyEpContextData {
+ public:
+  PyEpContextData(const void* data, size_t size) : data_(data), size_(size) {}
+
+  size_t Size() const noexcept { return size_; }
+  pybind11::bytes Read(size_t offset, std::optional<size_t> length) const;
+  void Invalidate() noexcept;
+
+ private:
+  const void* data_ = nullptr;
+  size_t size_ = 0;
+  bool valid_ = true;
+};
+
+class PyEpContextDataBuffer {
+ public:
+  PyEpContextDataBuffer(OrtAllocator* allocator, size_t max_data_size);
+  ~PyEpContextDataBuffer();
+
+  ORT_DISALLOW_COPY_ASSIGNMENT_AND_MOVE(PyEpContextDataBuffer);
+
+  size_t Size() const noexcept { return size_; }
+  size_t MaxSize() const noexcept { return max_data_size_; }
+  bool IsAllocated() const noexcept { return allocated_; }
+
+  void Allocate(size_t size);
+  void Write(size_t offset, const pybind11::buffer& data);
+  void Detach(void*& buffer, size_t& size);
+  void Invalidate() noexcept;
+
+ private:
+  void ThrowIfInvalid() const;
+
+  OrtAllocator* allocator_ = nullptr;
+  const size_t max_data_size_;
+  void* buffer_ = nullptr;
+  size_t size_ = 0;
+  bool allocated_ = false;
+  bool valid_ = true;
+};
+
+using PyEpContextDataWriteFunc =
+    std::function<void(const std::string&, const std::shared_ptr<PyEpContextData>&)>;
+using PyEpContextDataReadFunc =
+    std::function<void(const std::string&, const std::shared_ptr<PyEpContextDataBuffer>&)>;
+
+struct PyEpContextDataReadRegistration {
+  PyEpContextDataReadFunc read_func;
+  size_t max_data_size;
+};
+
+OrtStatus* ORT_API_CALL PyEpContextDataReadFuncWrapper(void* state, const char* name, OrtAllocator* allocator,
+                                                       void** buffer, size_t* data_size);
+#endif  // !defined(ORT_MINIMAL_BUILD)
+
 // Type of the function provided by Python code that is called by ORT to write out the compiled model.
 using PyOutStreamWriteFunc = std::function<void(const pybind11::bytes& buffer)>;
 
@@ -67,7 +125,9 @@ class PyModelCompiler {
 
   // Note: Creation should be done via Create(). This constructor is public so that it can be called from
   // std::make_shared().
-  PyModelCompiler(onnxruntime::Environment& env, const PySessionOptions& sess_options,
+  PyModelCompiler(onnxruntime::Environment& env, const OrtSessionOptions& sess_options,
+                  std::shared_ptr<PyEpSelectionRegistration> py_ep_selection_registration,
+                  std::shared_ptr<PyEpContextDataReadRegistration> py_ep_context_data_read_registration,
                   const PyGetInitializerLocationFunc& py_get_initializer_location_func,
                   PrivateConstructorTag);
 
@@ -95,11 +155,22 @@ class PyModelCompiler {
   /// <returns>A Status indicating error or success.</returns>
   onnxruntime::Status CompileToOutStream(PyOutStreamWriteFunc& write_func);
 
+  void SetEpContextDataWriteFunc(PyEpContextDataWriteFunc write_func);
+  void ClearEpContextDataWriteFunc();
+
  private:
+  onnxruntime::Status BeginCompilation();
+  void EndCompilation() noexcept;
+
   onnxruntime::Environment& env_;
-  onnxruntime::ModelCompilationOptions model_compile_options_;
+  std::shared_ptr<PyEpSelectionRegistration> py_ep_selection_registration_;
+  std::shared_ptr<PyEpContextDataReadRegistration> py_ep_context_data_read_registration_;
   std::string input_model_bytes_;
   PyGetInitializerLocationFunc py_get_initializer_location_func_;
+  PyEpContextDataWriteFunc py_ep_context_data_write_func_;
+  onnxruntime::ModelCompilationOptions model_compile_options_;
+  std::mutex compilation_mutex_;
+  bool compilation_in_progress_{false};
 #endif  // defined(ORT_MINIMAL_BUILD)
 };
 }  // namespace python

--- a/onnxruntime/python/onnxruntime_pybind_state.cc
+++ b/onnxruntime/python/onnxruntime_pybind_state.cc
@@ -78,6 +78,7 @@ const OrtDevice::DeviceType OrtDevice::GPU;
 
 #include <iterator>
 #include <algorithm>
+#include <limits>
 #include <string_view>
 #include <utility>
 
@@ -1611,7 +1612,7 @@ static void GenerateProviderOptionsMap(const std::vector<std::string>& providers
 }
 
 #if !defined(ORT_MINIMAL_BUILD) || defined(ORT_MINIMAL_BUILD_CUSTOM_OPS)
-static void RegisterCustomOpDomains(PyInferenceSession* sess, const PySessionOptions& so) {
+static void RegisterCustomOpDomains(PyInferenceSession* sess, const OrtSessionOptions& so) {
   if (!so.custom_op_domains_.empty()) {
     // Register all custom op domains that will be needed for the session
     std::vector<OrtCustomOpDomain*> custom_op_domains;
@@ -2065,20 +2066,29 @@ static OrtStatus* ORT_API_CALL PyEpSelectionPolicyWrapper(_In_ const OrtEpDevice
                                                           _In_ size_t max_selected,
                                                           _Out_ size_t* num_selected,
                                                           _In_ void* state) {
-  PyEpSelectionDelegate* actual_delegate = reinterpret_cast<PyEpSelectionDelegate*>(state);
-  std::vector<const OrtEpDevice*> py_ep_devices(ep_devices, ep_devices + num_devices);
-  std::map<std::string, std::string> py_model_metadata =
-      model_metadata ? model_metadata->Entries() : std::map<std::string, std::string>{};
-  std::map<std::string, std::string> py_runtime_metadata =
-      runtime_metadata ? runtime_metadata->Entries() : std::map<std::string, std::string>{};
-
   *num_selected = 0;
-  std::vector<const OrtEpDevice*> py_selected;
   OrtStatus* status = nullptr;
 
   // Call the Python delegate function and convert any exceptions to a status.
   ORT_TRY {
-    py_selected = (*actual_delegate)(py_ep_devices, py_model_metadata, py_runtime_metadata, max_selected);
+    auto* registration = static_cast<PyEpSelectionRegistration*>(state);
+    std::vector<const OrtEpDevice*> py_ep_devices(ep_devices, ep_devices + num_devices);
+    std::map<std::string, std::string> py_model_metadata =
+        model_metadata ? model_metadata->Entries() : std::map<std::string, std::string>{};
+    std::map<std::string, std::string> py_runtime_metadata =
+        runtime_metadata ? runtime_metadata->Entries() : std::map<std::string, std::string>{};
+
+    py::gil_scoped_acquire acquire;
+    auto py_selected = registration->delegate(py_ep_devices, py_model_metadata, py_runtime_metadata, max_selected);
+    if (py_selected.size() > max_selected) {
+      return ToOrtStatus(ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "selected too many EP devices (", py_selected.size(), "). ",
+                                         "The limit is ", max_selected, " EP devices."));
+    }
+
+    *num_selected = py_selected.size();
+    for (size_t i = 0; i < py_selected.size(); ++i) {
+      selected[i] = py_selected[i];
+    }
   }
   ORT_CATCH(const std::exception& e) {
     ORT_HANDLE_EXCEPTION([&]() {
@@ -2086,21 +2096,7 @@ static OrtStatus* ORT_API_CALL PyEpSelectionPolicyWrapper(_In_ const OrtEpDevice
     });
   }
 
-  if (status != nullptr) {
-    return status;
-  }
-
-  if (py_selected.size() > max_selected) {
-    return ToOrtStatus(ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "selected too many EP devices (", py_selected.size(), "). ",
-                                       "The limit is ", max_selected, " EP devices."));
-  }
-
-  *num_selected = py_selected.size();
-  for (size_t i = 0; i < py_selected.size(); ++i) {
-    selected[i] = py_selected[i];
-  }
-
-  return nullptr;
+  return status;
 }
 #endif  // !defined(ORT_MINIMAL_BUILD)
 
@@ -2397,6 +2393,26 @@ execution provider)pbdoc");
 
   py::class_<PySessionOptions>
       sess(m, "SessionOptions", R"pbdoc(Configuration information for a session.)pbdoc");
+#if !defined(ORT_MINIMAL_BUILD)
+  py::class_<PyEpContextData, std::shared_ptr<PyEpContextData>>(
+      m, "OrtEpContextData",
+      R"pbdoc(Non-owning view of named EPContext data, valid only during its write callback.)pbdoc")
+      .def_property_readonly("size", &PyEpContextData::Size)
+      .def("read", &PyEpContextData::Read,
+           py::arg("offset") = 0, py::arg("length") = std::nullopt,
+           R"pbdoc(Copy a bounded range into Python bytes. Use chunks for large payloads.)pbdoc");
+
+  py::class_<PyEpContextDataBuffer, std::shared_ptr<PyEpContextDataBuffer>>(
+      m, "OrtEpContextDataBuffer",
+      R"pbdoc(Allocator-backed output valid only during its EPContext data read callback.)pbdoc")
+      .def_property_readonly("size", &PyEpContextDataBuffer::Size)
+      .def_property_readonly("max_size", &PyEpContextDataBuffer::MaxSize)
+      .def_property_readonly("is_allocated", &PyEpContextDataBuffer::IsAllocated)
+      .def("allocate", &PyEpContextDataBuffer::Allocate, py::arg("size"),
+           R"pbdoc(Allocate the final ORT-owned output buffer.)pbdoc")
+      .def("write", [](PyEpContextDataBuffer& output, const py::buffer& data, size_t offset) { output.Write(offset, data); }, py::arg("data"), py::arg("offset") = 0, R"pbdoc(Copy a contiguous bytes-like chunk into the allocated output.)pbdoc");
+#endif  // !defined(ORT_MINIMAL_BUILD)
+
   sess
       .def(py::init())
       .def(
@@ -2433,12 +2449,16 @@ must refer to the same execution provider.)pbdoc")
           [](PySessionOptions* py_sess_options,
              OrtExecutionProviderDevicePolicy policy) {
 #if !defined(ORT_MINIMAL_BUILD)
-            py_sess_options->py_ep_selection_delegate = nullptr;
+            std::shared_ptr<PyEpSelectionRegistration> old_registration;
+            {
+              std::lock_guard<std::mutex> lock{py_sess_options->py_callback_mutex};
+              old_registration = std::move(py_sess_options->py_ep_selection_registration);
 
-            py_sess_options->value.ep_selection_policy.enable = true;
-            py_sess_options->value.ep_selection_policy.policy = policy;
-            py_sess_options->value.ep_selection_policy.delegate = nullptr;
-            py_sess_options->value.ep_selection_policy.state = nullptr;
+              py_sess_options->value.ep_selection_policy.enable = true;
+              py_sess_options->value.ep_selection_policy.policy = policy;
+              py_sess_options->value.ep_selection_policy.delegate = nullptr;
+              py_sess_options->value.ep_selection_policy.state = nullptr;
+            }
 #else
             ORT_UNUSED_PARAMETER(py_sess_options);
             ORT_UNUSED_PARAMETER(policy);
@@ -2453,13 +2473,19 @@ selection policy for automatic execution provider (EP) selection.)pbdoc")
           [](PySessionOptions* py_sess_options,
              PyEpSelectionDelegate delegate_fn) {
 #if !defined(ORT_MINIMAL_BUILD)
-            py_sess_options->py_ep_selection_delegate = delegate_fn;  // Store python callback in PySessionOptions
+            auto registration = std::make_shared<PyEpSelectionRegistration>(
+                PyEpSelectionRegistration{std::move(delegate_fn)});
+            std::shared_ptr<PyEpSelectionRegistration> old_registration;
+            {
+              std::lock_guard<std::mutex> lock{py_sess_options->py_callback_mutex};
+              old_registration = std::move(py_sess_options->py_ep_selection_registration);
 
-            py_sess_options->value.ep_selection_policy.enable = true;
-            py_sess_options->value.ep_selection_policy.policy = OrtExecutionProviderDevicePolicy_DEFAULT;
-            py_sess_options->value.ep_selection_policy.delegate = PyEpSelectionPolicyWrapper;
-            py_sess_options->value.ep_selection_policy.state =
-                reinterpret_cast<void*>(&py_sess_options->py_ep_selection_delegate);
+              py_sess_options->value.ep_selection_policy.enable = true;
+              py_sess_options->value.ep_selection_policy.policy = OrtExecutionProviderDevicePolicy_DEFAULT;
+              py_sess_options->value.ep_selection_policy.delegate = PyEpSelectionPolicyWrapper;
+              py_sess_options->value.ep_selection_policy.state = registration.get();
+              py_sess_options->py_ep_selection_registration = std::move(registration);
+            }
 #else
             ORT_UNUSED_PARAMETER(py_sess_options);
             ORT_UNUSED_PARAMETER(delegate_fn);
@@ -2683,6 +2709,48 @@ Applies to session load, initialization, etc. Default is 0.)pbdoc")
               throw std::runtime_error(status.ErrorMessage());
           },
           R"pbdoc(Set a single session configuration entry as a pair of strings.)pbdoc")
+#if !defined(ORT_MINIMAL_BUILD)
+      .def(
+          "set_ep_context_data_read_func",
+          [](PySessionOptions* options, PyEpContextDataReadFunc read_func, size_t max_data_size) {
+            ORT_ENFORCE(static_cast<bool>(read_func), "EPContext data read callback must not be None.");
+            ORT_ENFORCE(max_data_size != 0 && max_data_size != std::numeric_limits<size_t>::max(),
+                        "EPContext data max_data_size must be finite and greater than zero.");
+
+            auto registration = std::make_shared<PyEpContextDataReadRegistration>(
+                PyEpContextDataReadRegistration{std::move(read_func), max_data_size});
+            std::shared_ptr<PyEpContextDataReadRegistration> old_registration;
+            {
+              std::lock_guard<std::mutex> lock{options->py_callback_mutex};
+              old_registration = std::move(options->py_ep_context_data_read_registration);
+              options->value.ep_context_data_read_func = PyEpContextDataReadFuncWrapper;
+              options->value.ep_context_data_read_state = registration.get();
+              options->value.ep_context_data_read_max_size = max_data_size;
+              options->py_ep_context_data_read_registration = std::move(registration);
+            }
+          },
+          py::arg("read_func"), py::arg("max_data_size"),
+          R"pbdoc(Register a bounded callback that supplies external EPContext data during session loading.
+
+The callback receives the data name and an OrtEpContextDataBuffer. It must call allocate(size) exactly once,
+where size is at most max_data_size, then populate that buffer with one or more write(data, offset) calls.
+The output object and its allocator are valid only until the callback returns.
+
+ORT may invoke the callback concurrently. Synchronize any shared Python state.)pbdoc")
+      .def(
+          "clear_ep_context_data_read_func",
+          [](PySessionOptions* options) {
+            std::shared_ptr<PyEpContextDataReadRegistration> old_registration;
+            {
+              std::lock_guard<std::mutex> lock{options->py_callback_mutex};
+              options->value.ep_context_data_read_func = nullptr;
+              options->value.ep_context_data_read_state = nullptr;
+              options->value.ep_context_data_read_max_size = std::numeric_limits<size_t>::max();
+              old_registration = std::move(options->py_ep_context_data_read_registration);
+            }
+          },
+          R"pbdoc(Clear the external EPContext data read callback.)pbdoc")
+#endif  // !defined(ORT_MINIMAL_BUILD)
       .def(
           "get_session_config_entry",
           [](const PySessionOptions* options, const char* config_key) -> std::string {
@@ -2895,12 +2963,13 @@ including arg name, arg type (contains both type and shape).)pbdoc")
       .def(py::init([](const PySessionOptions& so, const std::string arg, bool is_arg_file_name,
                        bool load_config_from_model = false) {
         std::unique_ptr<PyInferenceSession> sess;
+        auto so_snapshot = CreatePySessionOptionsSnapshot(so);
 
-        if (CheckIfUsingGlobalThreadPool() && so.value.use_per_session_threads) {
+        if (CheckIfUsingGlobalThreadPool() && so_snapshot.options.value.use_per_session_threads) {
           ORT_THROW("use_per_session_threads must be false when using a global thread pool");
         }
 
-        if (CheckIfUsingGlobalThreadPool() && (so.value.intra_op_param.thread_pool_size != 0 || so.value.inter_op_param.thread_pool_size != 0)) {
+        if (CheckIfUsingGlobalThreadPool() && (so_snapshot.options.value.intra_op_param.thread_pool_size != 0 || so_snapshot.options.value.inter_op_param.thread_pool_size != 0)) {
           LOGS_DEFAULT(WARNING) << "session options intra_op_param.thread_pool_size and inter_op_param.thread_pool_size are ignored when using a global thread pool";
         }
 
@@ -2908,23 +2977,39 @@ including arg name, arg type (contains both type and shape).)pbdoc")
         // in a minimal build we only support load via Load(...) and not at session creation time
         if (load_config_from_model) {
 #if !defined(ORT_MINIMAL_BUILD)
-          sess = std::make_unique<PyInferenceSession>(*GetOrtEnv(), so, arg, is_arg_file_name);
+          {
+            py::gil_scoped_release release;
+            sess = std::make_unique<PyInferenceSession>(*GetOrtEnv(), so_snapshot.options,
+                                                        so_snapshot.py_ep_selection_registration,
+                                                        so_snapshot.py_ep_context_data_read_registration,
+                                                        arg, is_arg_file_name);
+          }
 
-          RegisterCustomOpDomains(sess.get(), so);
+          RegisterCustomOpDomains(sess.get(), so_snapshot.options);
 
-          OrtPybindThrowIfError(sess->GetSessionHandle()->Load());
+          {
+            py::gil_scoped_release release;
+            OrtPybindThrowIfError(sess->GetSessionHandle()->Load());
+          }
 #else
           ORT_THROW("Loading configuration from an ONNX model is not supported in this build.");
 #endif
         } else {
-          sess = std::make_unique<PyInferenceSession>(*GetOrtEnv(), so);
+          {
+            py::gil_scoped_release release;
+            sess = std::make_unique<PyInferenceSession>(*GetOrtEnv(), so_snapshot.options,
+                                                        so_snapshot.py_ep_selection_registration,
+                                                        so_snapshot.py_ep_context_data_read_registration);
+          }
 #if !defined(ORT_MINIMAL_BUILD) || defined(ORT_MINIMAL_BUILD_CUSTOM_OPS)
-          RegisterCustomOpDomains(sess.get(), so);
+          RegisterCustomOpDomains(sess.get(), so_snapshot.options);
 #endif
 
           if (is_arg_file_name) {
+            py::gil_scoped_release release;
             OrtPybindThrowIfError(sess->GetSessionHandle()->Load(arg));
           } else {
+            py::gil_scoped_release release;
             OrtPybindThrowIfError(sess->GetSessionHandle()->Load(arg.data(), narrow<int>(arg.size())));
           }
         }
@@ -2937,6 +3022,9 @@ including arg name, arg type (contains both type and shape).)pbdoc")
                                const std::vector<std::string>& provider_types = {},
                                const ProviderOptionsVector& provider_options = {},
                                const std::unordered_set<std::string>& disabled_optimizer_names = {}) {
+            OrtPybindThrowIfError(sess->BeginInitialization());
+            auto finish_initialization = gsl::finally([sess]() { sess->EndInitialization(); });
+            py::gil_scoped_release release;
             // If the user did not explicitly specify providers when creating InferenceSession and the SessionOptions
             // has provider information (i.e., either explicit EPs or an EP selection policy), then use the information
             // in the session options to initialize the session.
@@ -3143,6 +3231,16 @@ including arg name, arg type (contains both type and shape).)pbdoc")
       .def_property_readonly("session_options", [](const PyInferenceSession* sess) -> PySessionOptions* {
             auto session_options = std::make_unique<PySessionOptions>();
             session_options->value = sess->GetSessionHandle()->GetSessionOptions();
+            session_options->py_ep_selection_registration = sess->GetEpSelectionRegistration();
+        session_options->py_ep_context_data_read_registration = sess->GetEpContextDataReadRegistration();
+            if (session_options->py_ep_selection_registration) {
+              session_options->value.ep_selection_policy.state =
+                  session_options->py_ep_selection_registration.get();
+            }
+            if (session_options->py_ep_context_data_read_registration) {
+              session_options->value.ep_context_data_read_state =
+                  session_options->py_ep_context_data_read_registration.get();
+            }
             return session_options.release(); }, py::return_value_policy::take_ownership)
       .def_property_readonly("inputs_meta", [](const PyInferenceSession* sess) -> const std::vector<const onnxruntime::NodeArg*>& {
             auto res = sess->GetSessionHandle()->GetModelInputs();
@@ -3407,7 +3505,25 @@ including arg name, arg type (contains both type and shape).)pbdoc")
             ORT_THROW("Compile API is not supported in this build.");
 #endif
           },
-          R"pbdoc(Compile an ONNX model into an output stream using the provided write functor.)pbdoc");
+          R"pbdoc(Compile an ONNX model into an output stream using the provided write functor.)pbdoc")
+#if !defined(ORT_MINIMAL_BUILD)
+      .def(
+          "set_ep_context_data_write_func",
+          [](PyModelCompiler* model_compiler, PyEpContextDataWriteFunc write_func) {
+            model_compiler->SetEpContextDataWriteFunc(std::move(write_func));
+          },
+          py::arg("write_func"),
+          R"pbdoc(Register a callback that receives external EPContext data during compilation.
+
+        ORT may invoke the callback concurrently. Synchronize any shared Python state.)pbdoc")
+      .def(
+          "clear_ep_context_data_write_func",
+          [](PyModelCompiler* model_compiler) {
+            model_compiler->ClearEpContextDataWriteFunc();
+          },
+          R"pbdoc(Clear the external EPContext data write callback.)pbdoc")
+#endif  // !defined(ORT_MINIMAL_BUILD)
+      ;
 }
 
 bool InitArray() {

--- a/onnxruntime/python/onnxruntime_pybind_state_common.h
+++ b/onnxruntime/python/onnxruntime_pybind_state_common.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <mutex>
 #include <unordered_map>
 
 #include "core/common/logging/logging.h"
@@ -222,32 +223,71 @@ extern OrtDevice::DeviceId cuda_device_id;
 // TODO remove deprecated global config
 extern size_t gpu_mem_limit;
 
+struct PyEpContextDataReadRegistration;
+struct PyEpSelectionRegistration;
+
 #if !defined(ORT_MINIMAL_BUILD)
 using PyEpSelectionDelegate =
     std::function<std::vector<const OrtEpDevice*>(const std::vector<const OrtEpDevice*>& ep_devices,
                                                   const std::map<std::string, std::string>& model_metadata,
                                                   const std::map<std::string, std::string>& runtime_metadata,
                                                   size_t max_selections)>;
+
+struct PyEpSelectionRegistration {
+  PyEpSelectionDelegate delegate;
+};
 #endif
 
 // Thin wrapper over internal C OrtSessionOptions to store additional state.
 struct PySessionOptions : public OrtSessionOptions {
-#if !defined(ORT_MINIMAL_BUILD)
-  // Callback function from Python application that allows the user to specify custom EP selection logic.
-  PyEpSelectionDelegate py_ep_selection_delegate;
-#endif  // !defined(ORT_MINIMAL_BUILD)
+  mutable std::mutex py_callback_mutex;
+  std::shared_ptr<PyEpSelectionRegistration> py_ep_selection_registration;
+  std::shared_ptr<PyEpContextDataReadRegistration> py_ep_context_data_read_registration;
 };
+
+struct PySessionOptionsSnapshot {
+  OrtSessionOptions options;
+  std::shared_ptr<PyEpSelectionRegistration> py_ep_selection_registration;
+  std::shared_ptr<PyEpContextDataReadRegistration> py_ep_context_data_read_registration;
+};
+
+inline PySessionOptionsSnapshot CreatePySessionOptionsSnapshot(const PySessionOptions& session_options) {
+  std::lock_guard<std::mutex> lock{session_options.py_callback_mutex};
+  PySessionOptionsSnapshot snapshot{
+      static_cast<const OrtSessionOptions&>(session_options),
+      session_options.py_ep_selection_registration,
+      session_options.py_ep_context_data_read_registration};
+
+  if (snapshot.py_ep_selection_registration) {
+    snapshot.options.value.ep_selection_policy.state = snapshot.py_ep_selection_registration.get();
+  }
+
+  if (snapshot.py_ep_context_data_read_registration) {
+    snapshot.options.value.ep_context_data_read_state = snapshot.py_ep_context_data_read_registration.get();
+  }
+
+  return snapshot;
+}
 
 // Thin wrapper over internal C++ InferenceSession to accommodate custom op library management for the Python user
 struct PyInferenceSession {
-  PyInferenceSession(OrtEnv& env, const PySessionOptions& so)
-      : session_options_(so) {
+  PyInferenceSession(OrtEnv& env, const OrtSessionOptions& so,
+                     std::shared_ptr<PyEpSelectionRegistration> py_ep_selection_registration,
+                     std::shared_ptr<PyEpContextDataReadRegistration> py_ep_context_data_read_registration)
+      : py_ep_selection_registration_(std::move(py_ep_selection_registration)),
+        py_ep_context_data_read_registration_(std::move(py_ep_context_data_read_registration)),
+        session_options_(so) {
     sess_ = std::make_unique<InferenceSession>(so.value, env.GetEnvironment());
   }
 
 #if !defined(ORT_MINIMAL_BUILD)
-  PyInferenceSession(OrtEnv& env, const PySessionOptions& so, const std::string& arg, bool is_arg_file_name)
-      : session_options_(so) {
+  PyInferenceSession(OrtEnv& env, const OrtSessionOptions& so,
+                     std::shared_ptr<PyEpSelectionRegistration> py_ep_selection_registration,
+                     std::shared_ptr<PyEpContextDataReadRegistration> py_ep_context_data_read_registration,
+                     const std::string& arg, bool is_arg_file_name)
+      : py_ep_selection_registration_(std::move(py_ep_selection_registration)),
+        py_ep_context_data_read_registration_(std::move(py_ep_context_data_read_registration)),
+        session_options_(so) {
     if (is_arg_file_name) {
       // Given arg is the file path. Invoke the corresponding ctor().
       sess_ = std::make_unique<InferenceSession>(so.value, env.GetEnvironment(), arg);
@@ -279,6 +319,26 @@ struct PyInferenceSession {
 
   InferenceSession* GetSessionHandle() const { return sess_.get(); }
 
+  const std::shared_ptr<PyEpSelectionRegistration>& GetEpSelectionRegistration() const {
+    return py_ep_selection_registration_;
+  }
+
+  const std::shared_ptr<PyEpContextDataReadRegistration>& GetEpContextDataReadRegistration() const {
+    return py_ep_context_data_read_registration_;
+  }
+
+  Status BeginInitialization() {
+    std::lock_guard<std::mutex> lock{initialization_mutex_};
+    ORT_RETURN_IF(initialization_in_progress_, "Session initialization is already in progress.");
+    initialization_in_progress_ = true;
+    return Status::OK();
+  }
+
+  void EndInitialization() noexcept {
+    std::lock_guard<std::mutex> lock{initialization_mutex_};
+    initialization_in_progress_ = false;
+  }
+
   virtual ~PyInferenceSession() = default;
 
  protected:
@@ -287,8 +347,12 @@ struct PyInferenceSession {
   }
 
  private:
-  std::unique_ptr<InferenceSession> sess_;
+  std::shared_ptr<PyEpSelectionRegistration> py_ep_selection_registration_;
+  std::shared_ptr<PyEpContextDataReadRegistration> py_ep_context_data_read_registration_;
   OrtSessionOptions session_options_;
+  std::mutex initialization_mutex_;
+  bool initialization_in_progress_{false};
+  std::unique_ptr<InferenceSession> sess_;
 };
 
 inline const PySessionOptions& GetDefaultCPUSessionOptions() {

--- a/onnxruntime/test/python/onnxruntime_test_python_compile_api.py
+++ b/onnxruntime/test/python/onnxruntime_test_python_compile_api.py
@@ -2,10 +2,14 @@
 # Licensed under the MIT License.
 from __future__ import annotations
 
+import gc
 import os
 import platform
+import subprocess
 import sys
+import threading
 import unittest
+import weakref
 from collections.abc import Sequence
 
 import onnx
@@ -13,7 +17,8 @@ from autoep_helper import AutoEpTestCase
 from helper import get_name, get_shared_library_filename_for_platform
 
 import onnxruntime as onnxrt
-from onnxruntime.capi.onnxruntime_pybind11_state import Fail, ModelRequiresCompilation
+from onnxruntime.capi.onnxruntime_inference_collection import ModelCompiler
+from onnxruntime.capi.onnxruntime_pybind11_state import Fail, InvalidArgument, ModelRequiresCompilation
 
 # handle change from python 3.8 and on where loading a dll from the current directory needs to be explicitly allowed.
 if platform.system() == "Windows" and sys.version_info.major >= 3 and sys.version_info.minor >= 8:  # noqa: YTT204
@@ -23,6 +28,80 @@ available_providers = list(onnxrt.get_available_providers())
 
 
 class TestCompileApi(AutoEpTestCase):
+    def test_callback_finalizers_can_reenter_configuration(self):
+        child_code = r"""
+import sys
+
+import onnxruntime as ort
+
+events = []
+
+
+class ReadCallback:
+    def __init__(self, options):
+        self.options = options
+
+    def __call__(self, _name, _output):
+        pass
+
+    def __del__(self):
+        self.options.clear_ep_context_data_read_func()
+        events.append("read")
+
+
+class SelectionCallback:
+    def __init__(self, options):
+        self.options = options
+
+    def __call__(self, _devices, _model_metadata, _runtime_metadata, _max_selections):
+        return []
+
+    def __del__(self):
+        self.options.set_provider_selection_policy(ort.OrtExecutionProviderDevicePolicy.PREFER_GPU)
+        events.append("selection")
+
+
+class WriteCallback:
+    def __init__(self, compiler):
+        self.compiler = compiler
+
+    def __call__(self, _name, _data):
+        pass
+
+    def __del__(self):
+        self.compiler.clear_ep_context_data_write_func()
+        events.append("write")
+
+
+read_options = ort.SessionOptions()
+read_callback = ReadCallback(read_options)
+read_options.set_ep_context_data_read_func(read_callback, 1)
+del read_callback
+read_options.clear_ep_context_data_read_func()
+
+selection_options = ort.SessionOptions()
+selection_callback = SelectionCallback(selection_options)
+selection_options.set_provider_selection_policy_delegate(selection_callback)
+del selection_callback
+selection_options.set_provider_selection_policy(ort.OrtExecutionProviderDevicePolicy.PREFER_GPU)
+
+compiler = ort.ModelCompiler(ort.SessionOptions(), sys.argv[1], embed_compiled_data_into_model=True)
+write_callback = WriteCallback(compiler)
+compiler.set_ep_context_data_write_func(write_callback)
+del write_callback
+compiler.clear_ep_context_data_write_func()
+
+assert events == ["read", "selection", "write"], events
+"""
+        result = subprocess.run(
+            [sys.executable, "-c", child_code, get_name("mul_1.onnx")],
+            capture_output=True,
+            text=True,
+            timeout=15,
+            check=False,
+        )
+        self.assertEqual(result.returncode, 0, msg=f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}")
+
     def test_compile_with_files_prefer_npu_policy(self):
         """
         Tests compiling a model (to/from files) using an EP selection policy (PREFER_NPU).
@@ -99,6 +178,220 @@ class TestCompileApi(AutoEpTestCase):
 
         self.unregister_execution_provider_library(ep_name)
 
+    def test_external_ep_context_data_callbacks(self):
+        ep_lib_path = get_shared_library_filename_for_platform("example_plugin_ep")
+        try:
+            ep_lib_path = get_name(ep_lib_path)
+        except FileNotFoundError:
+            self.skipTest(f"Skipping test because EP library '{ep_lib_path}' cannot be found")
+
+        ep_name = "python_ep_context"
+        self.register_execution_provider_library(ep_name, os.path.realpath(ep_lib_path))
+        try:
+            ep_device = next((device for device in onnxrt.get_ep_devices() if device.ep_name == ep_name), None)
+            self.assertIsNotNone(ep_device)
+            assert ep_device is not None
+
+            input_model_path = get_name("mul_1.onnx")
+            write_count = 0
+            read_count = 0
+            context_name = ""
+            context_payload = b""
+            retained_write_data = None
+            retained_read_output = None
+            retained_failed_write_data = None
+            retained_failed_read_output = None
+
+            write_failure_options = onnxrt.SessionOptions()
+            write_failure_options.add_provider_for_devices([ep_device], {})
+            write_failure_compiler: ModelCompiler = onnxrt.ModelCompiler(
+                write_failure_options, input_model_path, embed_compiled_data_into_model=False
+            )
+
+            def fail_write(_name: str, data: onnxrt.OrtEpContextData):
+                nonlocal retained_failed_write_data
+                retained_failed_write_data = data
+                raise ValueError("synthetic Python EPContext write failure")
+
+            write_failure_compiler.set_ep_context_data_write_func(fail_write)
+            with self.assertRaises(Fail) as context:
+                write_failure_compiler.compile_to_bytes()
+            self.assertIn("synthetic Python EPContext write failure", str(context.exception))
+            assert retained_failed_write_data is not None
+            with self.assertRaises(RuntimeError):
+                retained_failed_write_data.read()
+
+            compile_options = onnxrt.SessionOptions()
+            compile_options.add_provider_for_devices([ep_device], {})
+            compiler: ModelCompiler = onnxrt.ModelCompiler(
+                compile_options, input_model_path, embed_compiled_data_into_model=False
+            )
+            compiler_ref = weakref.ref(compiler)
+
+            def write_context(name: str, data: onnxrt.OrtEpContextData):
+                nonlocal write_count, context_name, context_payload, retained_write_data
+                write_count += 1
+                context_name = name
+                retained_write_data = data
+                model_compiler = compiler_ref()
+                self.assertIsNotNone(model_compiler)
+                assert model_compiler is not None
+                with self.assertRaises(RuntimeError) as context:
+                    model_compiler.clear_ep_context_data_write_func()
+                self.assertIn("while compilation is in progress", str(context.exception))
+                midpoint = data.size // 2
+                context_payload = data.read(0, midpoint) + data.read(midpoint)
+
+            compiler.set_ep_context_data_write_func(write_context)
+            compiled_model = compiler.compile_to_bytes()
+
+            self.assertEqual(write_count, 1)
+            self.assertTrue(context_name)
+            self.assertTrue(context_payload)
+            assert retained_write_data is not None
+            self.assertFalse(os.path.exists(context_name))
+            with self.assertRaises(RuntimeError):
+                retained_write_data.read()
+
+            missing_output_options = onnxrt.SessionOptions()
+            missing_output_options.set_ep_context_data_read_func(lambda _name, _output: None, len(context_payload))
+            missing_output_options.add_provider_for_devices([ep_device], {})
+            with self.assertRaises(InvalidArgument) as context:
+                onnxrt.InferenceSession(compiled_model, sess_options=missing_output_options)
+            self.assertIn("must allocate its output buffer", str(context.exception))
+            self.assertFalse(os.path.exists(context_name))
+
+            oversized_options = onnxrt.SessionOptions()
+            oversized_options.set_ep_context_data_read_func(
+                lambda _name, output: output.allocate(len(context_payload) + 1), len(context_payload)
+            )
+            oversized_options.add_provider_for_devices([ep_device], {})
+            with self.assertRaises(Fail) as context:
+                onnxrt.InferenceSession(compiled_model, sess_options=oversized_options)
+            self.assertIn("configured maximum size", str(context.exception))
+            self.assertFalse(os.path.exists(context_name))
+
+            failure_options = onnxrt.SessionOptions()
+
+            def fail_read(_name: str, output: onnxrt.OrtEpContextDataBuffer):
+                nonlocal retained_failed_read_output
+                retained_failed_read_output = output
+                output.allocate(len(context_payload))
+                raise ValueError("synthetic Python EPContext read failure")
+
+            failure_options.set_ep_context_data_read_func(fail_read, len(context_payload))
+            failure_options.add_provider_for_devices([ep_device], {})
+            with self.assertRaises(Fail) as context:
+                onnxrt.InferenceSession(compiled_model, sess_options=failure_options)
+            self.assertIn("synthetic Python EPContext read failure", str(context.exception))
+            self.assertFalse(os.path.exists(context_name))
+            assert retained_failed_read_output is not None
+            with self.assertRaises(RuntimeError):
+                retained_failed_read_output.write(b"x")
+
+            load_options = onnxrt.SessionOptions()
+
+            def read_context(name: str, output: onnxrt.OrtEpContextDataBuffer):
+                nonlocal read_count, retained_read_output
+                read_count += 1
+                self.assertEqual(name, context_name)
+                retained_read_output = output
+                output.allocate(len(context_payload))
+                midpoint = len(context_payload) // 2
+                output.write(context_payload[:midpoint])
+                output.write(context_payload[midpoint:], midpoint)
+
+            load_options.set_ep_context_data_read_func(read_context, len(context_payload))
+            load_options.add_provider_for_devices([ep_device], {})
+            session = onnxrt.InferenceSession(compiled_model, sess_options=load_options)
+            self.assertIsNotNone(session)
+            self.assertEqual(read_count, 1)
+            assert retained_read_output is not None
+            with self.assertRaises(RuntimeError):
+                retained_read_output.write(b"x")
+
+            propagated_load_options = session.get_session_options()
+            propagated_load_options.add_provider_for_devices([ep_device], {})
+            load_options.clear_ep_context_data_read_func()
+            del load_options, session
+            gc.collect()
+
+            propagated_session = onnxrt.InferenceSession(compiled_model, sess_options=propagated_load_options)
+            self.assertIsNotNone(propagated_session)
+            self.assertEqual(read_count, 2)
+
+            compile_read_count = 0
+            source_compile_options = onnxrt.SessionOptions()
+
+            def read_context_for_compile(name: str, output: onnxrt.OrtEpContextDataBuffer):
+                nonlocal compile_read_count
+                compile_read_count += 1
+                self.assertEqual(name, context_name)
+                output.allocate(len(context_payload))
+                output.write(context_payload)
+
+            read_context_for_compile_ref = weakref.ref(read_context_for_compile)
+            source_compile_options.set_ep_context_data_read_func(read_context_for_compile, len(context_payload))
+            source_compile_options.add_provider_for_devices([ep_device], {})
+            retained_compiler: ModelCompiler = onnxrt.ModelCompiler(
+                source_compile_options, input_model_path, embed_compiled_data_into_model=True
+            )
+            source_compile_options.clear_ep_context_data_read_func()
+            del source_compile_options, read_context_for_compile
+            gc.collect()
+
+            self.assertIsNotNone(read_context_for_compile_ref())
+            self.assertTrue(retained_compiler.compile_to_bytes())
+            self.assertEqual(compile_read_count, 0)
+            self.assertFalse(os.path.exists(context_name))
+
+            del retained_compiler
+            gc.collect()
+            self.assertIsNone(read_context_for_compile_ref())
+
+            concurrent_options = onnxrt.SessionOptions()
+            concurrent_options.add_provider_for_devices([ep_device], {})
+            concurrent_compiler: ModelCompiler = onnxrt.ModelCompiler(
+                concurrent_options, input_model_path, embed_compiled_data_into_model=False
+            )
+            callback_started = threading.Event()
+            release_callback = threading.Event()
+            compile_errors: list[BaseException] = []
+            concurrent_compiler_ref = weakref.ref(concurrent_compiler)
+
+            def blocking_write(_name: str, _data: onnxrt.OrtEpContextData):
+                callback_started.set()
+                self.assertTrue(release_callback.wait(timeout=10))
+
+            def compile_in_thread():
+                try:
+                    model_compiler = concurrent_compiler_ref()
+                    if model_compiler is None:
+                        raise RuntimeError("ModelCompiler was released before compilation started")
+                    model_compiler.compile_to_bytes()
+                except BaseException as exception:
+                    compile_errors.append(exception)
+
+            concurrent_compiler.set_ep_context_data_write_func(blocking_write)
+            compile_thread = threading.Thread(target=compile_in_thread)
+            compile_thread.start()
+            try:
+                self.assertTrue(callback_started.wait(timeout=10))
+                with self.assertRaises(Fail) as context:
+                    concurrent_compiler.compile_to_bytes()
+                self.assertIn("Compilation is already in progress", str(context.exception))
+            finally:
+                release_callback.set()
+                compile_thread.join(timeout=10)
+
+            self.assertFalse(compile_thread.is_alive())
+            self.assertEqual(compile_errors, [])
+
+            del propagated_session, concurrent_compiler, compiler, write_failure_compiler
+            gc.collect()
+        finally:
+            self.unregister_execution_provider_library(ep_name)
+
     def test_compile_with_ep_selection_delegate(self):
         """
         Tests compiling a model (to/from files) using an EP selection delegate callback.
@@ -129,6 +422,7 @@ class TestCompileApi(AutoEpTestCase):
 
         session_options = onnxrt.SessionOptions()
         session_options.set_provider_selection_policy_delegate(my_delegate)
+        delegate_ref = weakref.ref(my_delegate)
 
         model_compiler = onnxrt.ModelCompiler(
             session_options,
@@ -136,8 +430,16 @@ class TestCompileApi(AutoEpTestCase):
             embed_compiled_data_into_model=True,
             external_initializers_file_path=None,
         )
+        del session_options, my_delegate
+        gc.collect()
+        self.assertIsNotNone(delegate_ref())
+
         model_compiler.compile_to_file(output_model_path)
         self.assertTrue(os.path.exists(output_model_path))
+
+        del model_compiler
+        gc.collect()
+        self.assertIsNone(delegate_ref())
 
     def test_compile_with_input_and_output_files(self):
         """


### PR DESCRIPTION
## Summary
- expose the stable named EPContext data read/write callbacks through Python
- add bounded, allocator-backed callback data objects with callback-scoped lifetimes
- preserve Python callback ownership across session/compiler snapshots and handle GIL, reentrancy, and free-threaded concurrency safely

## Testing
- incremental Windows RelWithDebInfo build: `onnxruntime_pybind11_state`, `example_plugin_ep`
- `onnxruntime_test_python_compile_api.py`: 14 passed, 2 skipped (hardware-dependent)
- scoped lintrunner, `git diff --check`, and editor diagnostics

Depends on #32265.