### PR TITLE
Neutralize Win32 reserved device names in EPContext external-blob path handling

### DIFF
--- a/onnxruntime/core/framework/tensorprotoutils.cc
+++ b/onnxruntime/core/framework/tensorprotoutils.cc
@@ -601,9 +601,13 @@ Status SanitizeFilePath(const std::filesystem::path& path, std::filesystem::path
     absolute_path = path;
   } else {
     const std::filesystem::path cwd = std::filesystem::current_path(ec);
-    ORT_RETURN_IF(ec, "Failed to resolve the current working directory to sanitize path: '",
-                  path, "', error: ", ec.message());
+    ORT_RETURN_IF(ec, "Failed to resolve the current working directory to sanitize path: ",
+                  path, ", error: ", ec.message());
     absolute_path = cwd / path;
+    // A drive-relative path (e.g. "C:blob.bin") stays relative when its drive differs from the current directory's
+    // drive, and cannot be resolved without invoking the Win32 path parsing.
+    ORT_RETURN_IF(!absolute_path.is_absolute(),
+                  "The path is not fully qualified (e.g. a drive-relative path): ", path);
   }
   absolute_path = absolute_path.lexically_normal();
   absolute_path.make_preferred();

--- a/onnxruntime/core/framework/tensorprotoutils.cc
+++ b/onnxruntime/core/framework/tensorprotoutils.cc
@@ -7,6 +7,7 @@
 #include <algorithm>
 #include <limits>
 #include <string>
+#include <string_view>
 #include <filesystem>
 #if defined(__wasm__)
 #include <emscripten.h>
@@ -566,6 +567,63 @@ Status ValidateExternalDataPath(const std::filesystem::path& model_path,
                          "External data path escapes model directory. ",
                          "External data path: ", external_data_path, " resolved path: ",
                          external_data_canonical, " ", "allowed directory: ", real_model_dir);
+}
+
+Status SanitizeFilePath(const std::filesystem::path& path, std::filesystem::path& sanitized_path) {
+#ifdef _WIN32
+  if (path.empty()) {
+    sanitized_path = path;
+    return Status::OK();
+  }
+
+  // On Windows, opening a path whose final component is a reserved DOS device name (e.g. CON, PRN, AUX, NUL, COM1-9,
+  // LPT1-9) resolves to the device itself rather than a file on disk, because the path goes through normal Win32 path
+  // parsing.
+  //
+  // Prefixing a fully-qualified path with "\\?\" selects the extended-length path syntax, which disables Win32 path
+  // parsing, so reserved device names can no longer be opened as devices.
+  constexpr std::wstring_view kExtendedPrefix = L"\\\\?\\";          // the \\?\ prefix
+  constexpr std::wstring_view kUncPrefix = L"\\\\";                  // the \\ UNC prefix
+  constexpr std::wstring_view kExtendedUncPrefix = L"\\\\?\\UNC\\";  // the \\?\UNC\ prefix
+
+  // Already an extended-length path.
+  if (path.native().rfind(kExtendedPrefix, 0) == 0) {
+    sanitized_path = path;
+    return Status::OK();
+  }
+
+  // "\\?\" requires an absolute path with backslash separators and no relative components. Build the absolute path
+  // lexically rather than with std::filesystem::absolute(), which on Windows calls GetFullPathNameW and would itself
+  // resolve a reserved device name to its "\\.\<device>" form before we could neutralize it.
+  std::error_code ec;
+  std::filesystem::path absolute_path;
+  if (path.is_absolute()) {
+    absolute_path = path;
+  } else {
+    const std::filesystem::path cwd = std::filesystem::current_path(ec);
+    ORT_RETURN_IF(ec, "Failed to resolve the current working directory to sanitize path: '",
+                  path, "', error: ", ec.message());
+    absolute_path = cwd / path;
+  }
+  absolute_path = absolute_path.lexically_normal();
+  absolute_path.make_preferred();
+
+  const std::wstring native = absolute_path.native();
+
+  // UNC path ("\\server\share\..."): the extended-length form replaces the leading "\\" with "\\?\UNC\", e.g.
+  // \\server\share -> \\?\UNC\server\share. Prepending a bare "\\?\" here would produce a malformed path and break
+  // legitimate network shares, so handle it explicitly.
+  if (native.rfind(kUncPrefix, 0) == 0) {
+    sanitized_path = std::filesystem::path(std::wstring(kExtendedUncPrefix) + native.substr(kUncPrefix.size()));
+    return Status::OK();
+  }
+
+  sanitized_path = std::filesystem::path(std::wstring(kExtendedPrefix) + native);
+  return Status::OK();
+#else
+  sanitized_path = path;
+  return Status::OK();
+#endif
 }
 
 Status GetExternalDataInfo(const ONNX_NAMESPACE::TensorProto& tensor_proto,

--- a/onnxruntime/core/framework/tensorprotoutils.h
+++ b/onnxruntime/core/framework/tensorprotoutils.h
@@ -672,6 +672,19 @@ Status ValidateExternalDataPath(const std::filesystem::path& model_path,
 Status ValidateExternalDataPathFromDir(const std::filesystem::path& model_dir,
                                        const std::filesystem::path& external_data_path);
 
+/// <summary>
+/// On Windows, converts `path` to an absolute extended-length path ("\\?\") so Win32 path parsing is
+/// disabled and a reserved DOS device name (CON, NUL, COM1-9, ...) is treated as a literal file instead
+/// of being opened as a device. Use it on caller-controlled paths before opening. On non-Windows,
+/// or for an empty path, the path is copied through unchanged.
+///
+/// `sanitized_path` may alias `path` (e.g. SanitizeFilePath(p, p)).
+/// </summary>
+/// <param name="path">The file path to sanitize.</param>
+/// <param name="sanitized_path">Receives a path that is safe to open. May alias `path`.</param>
+/// <returns>The function will fail if `path` cannot be made absolute.</returns>
+Status SanitizeFilePath(const std::filesystem::path& path, std::filesystem::path& sanitized_path);
+
 #endif  // !defined(SHARED_PROVIDER)
 
 inline bool HasType(const ONNX_NAMESPACE::AttributeProto& at_proto) {

--- a/onnxruntime/core/providers/nv_tensorrt_rtx/onnx_ctx_model_helper.cc
+++ b/onnxruntime/core/providers/nv_tensorrt_rtx/onnx_ctx_model_helper.cc
@@ -260,6 +260,9 @@ Status TensorRTCacheModelHandler::GetEpContextFromGraph(const Node& node) {
     auto engine_cache_path = ctx_model_dir.append(cache_path);
     LOGS_DEFAULT(VERBOSE) << "[NvTensorRTRTX EP] GetEpContextFromGraph engine_cache_path: " + engine_cache_path.string();
 
+    // Sanitize the path before opening.
+    ORT_RETURN_IF_ERROR(utils::SanitizeFilePath(engine_cache_path, engine_cache_path));
+
     if (!std::filesystem::exists(engine_cache_path)) {
       return ORT_MAKE_STATUS(ONNXRUNTIME, EP_FAIL,
                              "Nv EP can't find engine cache: " + engine_cache_path.string() +

--- a/onnxruntime/core/providers/openvino/onnx_ctx_model_helper.cc
+++ b/onnxruntime/core/providers/openvino/onnx_ctx_model_helper.cc
@@ -117,6 +117,8 @@ std::unique_ptr<ModelBlobWrapper> EPCtxHandler::GetModelBlobStream(const std::fi
     }
     ORT_THROW_IF_ERROR(utils::ValidateExternalDataPath(blob_filepath, std::filesystem::path(ep_cache_context)));
     blob_filepath = blob_filepath.parent_path() / ep_cache_context;
+    // Sanitize the path before opening.
+    ORT_THROW_IF_ERROR(utils::SanitizeFilePath(blob_filepath, blob_filepath));
     ORT_ENFORCE(std::filesystem::exists(blob_filepath), "Blob file not found: ", blob_filepath.string());
     result.reset((std::istream*)new std::ifstream(blob_filepath, std::ios_base::binary | std::ios_base::in));
   }
@@ -256,7 +258,10 @@ std::shared_ptr<SharedContext> EPCtxHandler::Initialize(const std::vector<IExecu
       ORT_THROW_IF_ERROR(utils::ValidateExternalDataPath(validation_base_path, cache_context_path));
       const std::filesystem::path ep_context_path = validation_base_path.parent_path() / cache_context_path;
       if (!is_xml) {
-        shared_context = shared_context_manager_->GetOrCreateSharedContext(ep_context_path);
+        // Sanitize the path before opening.
+        std::filesystem::path sanitized_ep_context_path;
+        ORT_THROW_IF_ERROR(utils::SanitizeFilePath(ep_context_path, sanitized_ep_context_path));
+        shared_context = shared_context_manager_->GetOrCreateSharedContext(sanitized_ep_context_path);
         shared_context->Deserialize();
       }
     }

--- a/onnxruntime/core/providers/qnn/builder/onnx_ctx_model_helper.cc
+++ b/onnxruntime/core/providers/qnn/builder/onnx_ctx_model_helper.cc
@@ -118,6 +118,8 @@ Status GetEpContextFromMainNode(const onnxruntime::Node& main_context_node,
     return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_GRAPH, "The file path in ep_cache_context does not exist or is not accessible.");
   }
 
+  // Sanitize the path before opening.
+  ORT_RETURN_IF_ERROR(::onnxruntime::utils::SanitizeFilePath(context_binary_path, context_binary_path));
   std::string context_binary_path_str = context_binary_path.string();
 #ifdef QNN_FILE_MAPPED_WEIGHTS_AVAILABLE
   if (qnn_backend_manager->FileMappingIsEnabled()) {

--- a/onnxruntime/core/providers/shared_library/provider_api.h
+++ b/onnxruntime/core/providers/shared_library/provider_api.h
@@ -472,6 +472,10 @@ inline Status ValidateExternalDataPathFromDir(const std::filesystem::path& model
   return g_host->Utils__ValidateExternalDataPathFromDir(model_dir, external_data_path);
 }
 
+inline Status SanitizeFilePath(const std::filesystem::path& path, std::filesystem::path& sanitized_path) {
+  return g_host->Utils__SanitizeFilePath(path, sanitized_path);
+}
+
 }  // namespace utils
 
 namespace graph_utils {

--- a/onnxruntime/core/providers/shared_library/provider_interfaces.h
+++ b/onnxruntime/core/providers/shared_library/provider_interfaces.h
@@ -1008,7 +1008,6 @@ struct ProviderHost {
                                                  const std::filesystem::path& external_data_path) = 0;
   virtual Status Utils__ValidateExternalDataPathFromDir(const std::filesystem::path& model_dir,
                                                         const std::filesystem::path& external_data_path) = 0;
-  virtual Status Utils__SanitizeFilePath(const std::filesystem::path& path, std::filesystem::path& sanitized_path) = 0;
 
   // Model
   virtual std::unique_ptr<Model> Model__construct(ONNX_NAMESPACE::ModelProto&& model_proto, const PathString& model_path,
@@ -1423,6 +1422,8 @@ struct ProviderHost {
   virtual const Float8E8M0* Tensor__Data_Float8E8M0(const Tensor* p) = 0;
   virtual bool Tensor__IsDataType_Float8E8M0(const Tensor* p) noexcept = 0;
 #endif
+
+  virtual Status Utils__SanitizeFilePath(const std::filesystem::path& path, std::filesystem::path& sanitized_path) = 0;
 };
 
 #if defined(_MSC_VER) && !defined(__clang__)

--- a/onnxruntime/core/providers/shared_library/provider_interfaces.h
+++ b/onnxruntime/core/providers/shared_library/provider_interfaces.h
@@ -1008,6 +1008,7 @@ struct ProviderHost {
                                                  const std::filesystem::path& external_data_path) = 0;
   virtual Status Utils__ValidateExternalDataPathFromDir(const std::filesystem::path& model_dir,
                                                         const std::filesystem::path& external_data_path) = 0;
+  virtual Status Utils__SanitizeFilePath(const std::filesystem::path& path, std::filesystem::path& sanitized_path) = 0;
 
   // Model
   virtual std::unique_ptr<Model> Model__construct(ONNX_NAMESPACE::ModelProto&& model_proto, const PathString& model_path,

--- a/onnxruntime/core/providers/tensorrt/onnx_ctx_model_helper.cc
+++ b/onnxruntime/core/providers/tensorrt/onnx_ctx_model_helper.cc
@@ -233,6 +233,9 @@ Status TensorRTCacheModelHandler::GetEpContextFromGraph(const GraphViewer& graph
     auto engine_cache_path = ctx_model_dir.append(cache_path);
     LOGS_DEFAULT(VERBOSE) << "[TensorRT EP] GetEpContextFromGraph engine_cache_path: " + engine_cache_path.string();
 
+    // Sanitize the path before opening.
+    ORT_RETURN_IF_ERROR(utils::SanitizeFilePath(engine_cache_path, engine_cache_path));
+
     // If it's a weight-stripped engine cache, it needs to be refitted even though the refit flag is not enabled
     if (!weight_stripped_engine_refit_) {
       weight_stripped_engine_refit_ = IsWeightStrippedEngineCache(engine_cache_path);

--- a/onnxruntime/core/providers/tensorrt/onnx_ctx_model_helper.cc
+++ b/onnxruntime/core/providers/tensorrt/onnx_ctx_model_helper.cc
@@ -233,9 +233,6 @@ Status TensorRTCacheModelHandler::GetEpContextFromGraph(const GraphViewer& graph
     auto engine_cache_path = ctx_model_dir.append(cache_path);
     LOGS_DEFAULT(VERBOSE) << "[TensorRT EP] GetEpContextFromGraph engine_cache_path: " + engine_cache_path.string();
 
-    // Sanitize the path before opening.
-    ORT_RETURN_IF_ERROR(utils::SanitizeFilePath(engine_cache_path, engine_cache_path));
-
     // If it's a weight-stripped engine cache, it needs to be refitted even though the refit flag is not enabled
     if (!weight_stripped_engine_refit_) {
       weight_stripped_engine_refit_ = IsWeightStrippedEngineCache(engine_cache_path);
@@ -250,6 +247,9 @@ Status TensorRTCacheModelHandler::GetEpContextFromGraph(const GraphViewer& graph
         weight_stripped_engine_refit_ = false;
       }
     }
+
+    // Sanitize the path before opening.
+    ORT_RETURN_IF_ERROR(utils::SanitizeFilePath(engine_cache_path, engine_cache_path));
 
     if (!std::filesystem::exists(engine_cache_path)) {
       return ORT_MAKE_STATUS(ONNXRUNTIME, EP_FAIL,

--- a/onnxruntime/core/session/provider_bridge_ort.cc
+++ b/onnxruntime/core/session/provider_bridge_ort.cc
@@ -1305,6 +1305,10 @@ struct ProviderHostImpl : ProviderHost {
     return onnxruntime::utils::ValidateExternalDataPathFromDir(model_dir, external_data_path);
   }
 
+  Status Utils__SanitizeFilePath(const std::filesystem::path& path, std::filesystem::path& sanitized_path) override {
+    return onnxruntime::utils::SanitizeFilePath(path, sanitized_path);
+  }
+
   // Model (wrapped)
   std::unique_ptr<Model> Model__construct(ONNX_NAMESPACE::ModelProto&& model_proto, const PathString& model_path,
                                           const IOnnxRuntimeOpSchemaRegistryList* local_registries,

--- a/onnxruntime/test/framework/tensorutils_test.cc
+++ b/onnxruntime/test/framework/tensorutils_test.cc
@@ -726,6 +726,67 @@ TEST(TensorProtoUtilsTest, ConstantTensorProtoWithExternalData) {
   TestConstantNodeConversionWithExternalData<double>(TensorProto_DataType_DOUBLE);
 }
 
+#ifdef _WIN32
+TEST(TensorProtoUtilsTest, SanitizeFilePathAddsExtendedPrefix) {
+  // Empty path passes through unchanged.
+  {
+    std::filesystem::path out;
+    ASSERT_STATUS_OK(utils::SanitizeFilePath({}, out));
+    EXPECT_TRUE(out.empty());
+  }
+
+  // A drive-absolute path gets the "\\?\" prefix and is otherwise left intact. A reserved device
+  // name in the final component (NUL) is thereby treated as a literal file, not the device.
+  {
+    std::filesystem::path out;
+    ASSERT_STATUS_OK(utils::SanitizeFilePath(std::filesystem::path{L"C:\\dir\\NUL"}, out));
+    EXPECT_EQ(out.native(), std::wstring(L"\\\\?\\C:\\dir\\NUL"));
+  }
+
+  // A bare relative device name is made absolute against the current directory and prefixed,
+  // so it can no longer resolve to the device.
+  {
+    std::filesystem::path out;
+    ASSERT_STATUS_OK(utils::SanitizeFilePath(std::filesystem::path{L"NUL"}, out));
+    EXPECT_EQ(out.native().rfind(L"\\\\?\\", 0), 0u);
+    EXPECT_EQ(out.filename().native(), std::wstring(L"NUL"));
+  }
+
+  // A UNC path uses the "\\?\UNC\" form rather than a malformed "\\?\\\server\share".
+  {
+    std::filesystem::path out;
+    ASSERT_STATUS_OK(utils::SanitizeFilePath(std::filesystem::path{L"\\\\server\\share\\blob.bin"}, out));
+    EXPECT_EQ(out.native(), std::wstring(L"\\\\?\\UNC\\server\\share\\blob.bin"));
+  }
+
+  // Already-extended paths are returned unchanged, for both drive and UNC forms.
+  {
+    std::filesystem::path out;
+    const std::wstring already = L"\\\\?\\C:\\dir\\blob.bin";
+    ASSERT_STATUS_OK(utils::SanitizeFilePath(std::filesystem::path{already}, out));
+    EXPECT_EQ(out.native(), already);
+
+    std::filesystem::path out_unc;
+    const std::wstring already_unc = L"\\\\?\\UNC\\server\\share\\blob.bin";
+    ASSERT_STATUS_OK(utils::SanitizeFilePath(std::filesystem::path{already_unc}, out_unc));
+    EXPECT_EQ(out_unc.native(), already_unc);
+  }
+
+  // The output may alias the input.
+  {
+    std::filesystem::path p{L"C:\\dir\\blob.bin"};
+    ASSERT_STATUS_OK(utils::SanitizeFilePath(p, p));
+    EXPECT_EQ(p.native(), std::wstring(L"\\\\?\\C:\\dir\\blob.bin"));
+  }
+}
+#else
+TEST(TensorProtoUtilsTest, SanitizeFilePathIsPassthroughOnNonWindows) {
+  std::filesystem::path out;
+  ASSERT_STATUS_OK(utils::SanitizeFilePath(std::filesystem::path{"some/relative/NUL"}, out));
+  EXPECT_EQ(out, std::filesystem::path{"some/relative/NUL"});
+}
+#endif
+
 // Test fixture for creating temporary directories and files for path validation tests.
 class PathValidationTest : public ::testing::Test {
  protected:

--- a/onnxruntime/test/framework/tensorutils_test.cc
+++ b/onnxruntime/test/framework/tensorutils_test.cc
@@ -743,6 +743,18 @@ TEST(TensorProtoUtilsTest, SanitizeFilePathAddsExtendedPrefix) {
     EXPECT_EQ(out.native(), std::wstring(L"\\\\?\\C:\\dir\\NUL"));
   }
 
+  // Forward slashes are normalized to backslashes.
+  {
+    std::filesystem::path out;
+    ASSERT_STATUS_OK(utils::SanitizeFilePath(std::filesystem::path{L"C:/dir/blob.bin"}, out));
+    EXPECT_EQ(out.native(), std::wstring(L"\\\\?\\C:\\dir\\blob.bin"));
+  }
+  {
+    std::filesystem::path out;
+    ASSERT_STATUS_OK(utils::SanitizeFilePath(std::filesystem::path{L"C:\\dir/sub\\blob.bin"}, out));
+    EXPECT_EQ(out.native(), std::wstring(L"\\\\?\\C:\\dir\\sub\\blob.bin"));
+  }
+
   // A bare relative device name is made absolute against the current directory and prefixed,
   // so it can no longer resolve to the device.
   {
@@ -765,11 +777,12 @@ TEST(TensorProtoUtilsTest, SanitizeFilePathAddsExtendedPrefix) {
     const std::wstring already = L"\\\\?\\C:\\dir\\blob.bin";
     ASSERT_STATUS_OK(utils::SanitizeFilePath(std::filesystem::path{already}, out));
     EXPECT_EQ(out.native(), already);
-
-    std::filesystem::path out_unc;
-    const std::wstring already_unc = L"\\\\?\\UNC\\server\\share\\blob.bin";
-    ASSERT_STATUS_OK(utils::SanitizeFilePath(std::filesystem::path{already_unc}, out_unc));
-    EXPECT_EQ(out_unc.native(), already_unc);
+  }
+  {
+    std::filesystem::path out;
+    const std::wstring already = L"\\\\?\\UNC\\server\\share\\blob.bin";
+    ASSERT_STATUS_OK(utils::SanitizeFilePath(std::filesystem::path{already}, out));
+    EXPECT_EQ(out.native(), already);
   }
 
   // The output may alias the input.
@@ -777,6 +790,20 @@ TEST(TensorProtoUtilsTest, SanitizeFilePathAddsExtendedPrefix) {
     std::filesystem::path p{L"C:\\dir\\blob.bin"};
     ASSERT_STATUS_OK(utils::SanitizeFilePath(p, p));
     EXPECT_EQ(p.native(), std::wstring(L"\\\\?\\C:\\dir\\blob.bin"));
+  }
+
+  // A drive-relative path (drive letter with no root directory) cannot be fully qualified without
+  // Win32 path parsing, so it is rejected rather than turned into a malformed "\\?\<drive>:cache.bin".
+  {
+    // Use a drive letter different from the current directory's drive, otherwise cwd/path would
+    // resolve it to an absolute path (a same-drive "C:foo" becomes "<cwd>\foo"). A cross-drive
+    // drive-relative path stays relative, which is the case we want to exercise.
+    const std::wstring cwd_root = std::filesystem::current_path().root_name().native();
+    const wchar_t cur_drive = cwd_root.empty() ? L'C' : cwd_root[0];
+    const wchar_t other_drive = (cur_drive == L'Z' || cur_drive == L'z') ? L'Y' : L'Z';
+    const std::filesystem::path drive_relative = std::wstring(1, other_drive) + L":cache.bin";
+    std::filesystem::path out;
+    EXPECT_FALSE(utils::SanitizeFilePath(drive_relative, out).IsOK());
   }
 }
 #else


### PR DESCRIPTION
### Description
Reserved Win32 device names (`CON`, `NUL`, `COM1`–`COM9`, `LPT1`–`LPT9`, …) supplied via an EPContext node's `ep_cache_context` attribute could be opened as devices on Windows. The existing `ValidateExternalDataPath()` containment check does not catch this, because a bare device name is a relative path that does not escape the model directory, yet normal Win32 path parsing still resolves it to the device (potentially hanging on I/O, i.e. a DoS).

### Security improvements

This PR adds `utils::SanitizeFilePath()` and applies it before every EPContext external blob open across all affected EPs (TensorRT, NV TensorRT RTX, QNN, and OpenVINO).



