### PR TITLE
[Build] Parameterize CUDA and TensorRT Python wheel inputs

### DIFF
--- a/.github/workflows/reusable_linux_build.yml
+++ b/.github/workflows/reusable_linux_build.yml
@@ -63,6 +63,11 @@ on:
         required: false
         type: boolean
         default: false
+      artifact_name_suffix:
+        description: 'Optional suffix for uploaded artifact names, including any leading separator'
+        required: false
+        type: string
+        default: ''
       job_identifier:
         description: 'A unique identifier for the job, used for hosted pool tracking'
         required: true
@@ -208,7 +213,7 @@ jobs:
         if: inputs.upload_build_output == true
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
-          name: build-output-${{ inputs.architecture }}-${{ inputs.build_config }}
+          name: build-output-${{ inputs.architecture }}-${{ inputs.build_config }}${{ inputs.artifact_name_suffix }}
           path: ${{ runner.temp }}/${{ inputs.build_config }}
           if-no-files-found: error
 
@@ -217,6 +222,6 @@ jobs:
         if: steps.update_step.outcome == 'failure' || steps.build_step.outcome == 'failure'
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
-          name: vcpkg-manifest-install-log-${{ inputs.architecture }}-${{ inputs.build_config }}
+          name: vcpkg-manifest-install-log-${{ inputs.architecture }}-${{ inputs.build_config }}${{ inputs.artifact_name_suffix }}
           path: ${{ runner.temp }}/${{ inputs.build_config }}/${{ inputs.build_config }}/vcpkg-manifest-install.log
           if-no-files-found: ignore

--- a/tools/ci_build/github/azure-pipelines/py-cuda-packaging-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/py-cuda-packaging-pipeline.yml
@@ -63,6 +63,8 @@ extends:
         parameters:
           cmake_build_type: ${{ parameters.cmake_build_type }}
           cuda_version: '12.8'
+          tensorrt_version: '10.14.1.48'
+          tensorrt_cuda_version: '12.9'
           cudnn_folder: ''
           cmake_windows_x64_cuda_archs: '61-real;75-real;86-real;89-real;120-real'
           cmake_linux_x64_cuda_archs: '60-real;70-real;75-real;80-real;86-real;89-real;90-real;120-real'

--- a/tools/ci_build/github/azure-pipelines/py-cuda-packaging-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/py-cuda-packaging-pipeline.yml
@@ -63,6 +63,7 @@ extends:
         parameters:
           cmake_build_type: ${{ parameters.cmake_build_type }}
           cuda_version: '12.8'
+          linux_aarch64_cuda_version: '12.8'
           tensorrt_version: '10.14.1.48'
           tensorrt_cuda_version: '12.9'
           tensorrt_major_version: '10'

--- a/tools/ci_build/github/azure-pipelines/py-cuda-packaging-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/py-cuda-packaging-pipeline.yml
@@ -65,6 +65,7 @@ extends:
           cuda_version: '12.8'
           tensorrt_version: '10.14.1.48'
           tensorrt_cuda_version: '12.9'
+          tensorrt_major_version: '10'
           cudnn_folder: ''
           cmake_windows_x64_cuda_archs: '61-real;75-real;86-real;89-real;120-real'
           cmake_linux_x64_cuda_archs: '60-real;70-real;75-real;80-real;86-real;89-real;90-real;120-real'

--- a/tools/ci_build/github/azure-pipelines/py-cuda13-packaging-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/py-cuda13-packaging-pipeline.yml
@@ -63,6 +63,8 @@ extends:
         parameters:
           cmake_build_type: ${{ parameters.cmake_build_type }}
           cuda_version: '13.0'
+          tensorrt_version: '10.14.1.48'
+          tensorrt_cuda_version: '13.0'
           cudnn_folder: '9.14.0.64_cuda13'
           cmake_windows_x64_cuda_archs: '75-real;80-real;86-real;89-real;120-real'
           cmake_linux_x64_cuda_archs: '75-real;80-real;86-real;89-real;90-real;120-real'

--- a/tools/ci_build/github/azure-pipelines/py-cuda13-packaging-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/py-cuda13-packaging-pipeline.yml
@@ -63,6 +63,7 @@ extends:
         parameters:
           cmake_build_type: ${{ parameters.cmake_build_type }}
           cuda_version: '13.0'
+          linux_aarch64_cuda_version: '13.0'
           tensorrt_version: '10.14.1.48'
           tensorrt_cuda_version: '13.0'
           tensorrt_major_version: '10'

--- a/tools/ci_build/github/azure-pipelines/py-cuda13-packaging-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/py-cuda13-packaging-pipeline.yml
@@ -65,6 +65,7 @@ extends:
           cuda_version: '13.0'
           tensorrt_version: '10.14.1.48'
           tensorrt_cuda_version: '13.0'
+          tensorrt_major_version: '10'
           cudnn_folder: '9.14.0.64_cuda13'
           cmake_windows_x64_cuda_archs: '75-real;80-real;86-real;89-real;120-real'
           cmake_linux_x64_cuda_archs: '75-real;80-real;86-real;89-real;90-real;120-real'

--- a/tools/ci_build/github/azure-pipelines/stages/py-gpu-packaging-stage.yml
+++ b/tools/ci_build/github/azure-pipelines/stages/py-gpu-packaging-stage.yml
@@ -18,8 +18,16 @@ parameters:
 
 - name: cuda_version
   type: string
-  displayName: 'CUDA version. Windows Only.'
+  displayName: 'CUDA version for Windows and Linux x86_64.'
   default: '12.8'
+  values:
+   - 12.8
+   - 13.0
+   - 13.3
+
+- name: linux_aarch64_cuda_version
+  type: string
+  displayName: 'CUDA version for Linux aarch64.'
   values:
    - 12.8
    - 13.0
@@ -97,8 +105,8 @@ parameters:
   default: []
 
 stages:
-    # Use separated cudnn folder for CUDA 13.0 on Windows.
-    - ${{ if eq(parameters.cuda_version, '13.0') }}:
+    # Use a separate cuDNN folder for CUDA 13 on Windows.
+    - ${{ if startsWith(parameters.cuda_version, '13.') }}:
       - ${{ each python_version in parameters.PythonVersions }}:
         - template: py-win-gpu-stage.yml
           parameters:
@@ -150,7 +158,7 @@ stages:
           machine_pool: 'onnxruntime-linux-ARM64-CPU-2019'
           extra_build_arg: ${{ parameters.build_py_parameters }}
           cmake_build_type: ${{ parameters.cmake_build_type }}
-          cuda_version: ${{ parameters.cuda_version }}
+          cuda_version: ${{ parameters.linux_aarch64_cuda_version }}
           cmake_cuda_archs: ${{ parameters.cmake_linux_aarch64_cuda_archs }}
           docker_base_image: ${{ parameters.docker_base_image_aarch64 }}
           python_version: ${{ config.python_version }}

--- a/tools/ci_build/github/azure-pipelines/stages/py-gpu-packaging-stage.yml
+++ b/tools/ci_build/github/azure-pipelines/stages/py-gpu-packaging-stage.yml
@@ -24,6 +24,14 @@ parameters:
    - 12.8
    - 13.0
 
+- name: tensorrt_version
+  type: string
+  displayName: 'TensorRT version for Windows and Linux x86_64.'
+
+- name: tensorrt_cuda_version
+  type: string
+  displayName: 'CUDA version used to build TensorRT for Windows and Linux x86_64.'
+
 - name: cudnn_folder
   type: string
   default: '9.14.0.64_cuda13'
@@ -92,6 +100,7 @@ stages:
             CudaVersion: ${{ parameters.cuda_version }}
             EP_BUILD_FLAGS: --enable_lto --use_cuda --cuda_home=$(Agent.TempDirectory)\v${{ parameters.cuda_version }} --cudnn_home=$(Agent.TempDirectory)\${{ parameters.cudnn_folder }} --cmake_extra_defines "CMAKE_CUDA_ARCHITECTURES=${{ parameters.cmake_windows_x64_cuda_archs }}"
             use_tensorrt: True
+            TensorRTFolder: ${{ format('TensorRT-{0}.Windows.win10.cuda-{1}', parameters.tensorrt_version, parameters.tensorrt_cuda_version) }}
 
     - ${{ if eq(parameters.cuda_version, '12.8') }}:
       - ${{ each python_version in parameters.PythonVersions }}:
@@ -102,6 +111,7 @@ stages:
             CudaVersion: ${{ parameters.cuda_version }}
             EP_BUILD_FLAGS: --enable_lto --use_cuda --cuda_home=$(Agent.TempDirectory)\v${{ parameters.cuda_version }} --cmake_extra_defines "CMAKE_CUDA_ARCHITECTURES=${{ parameters.cmake_windows_x64_cuda_archs }}"
             use_tensorrt: True
+            TensorRTFolder: ${{ format('TensorRT-{0}.Windows.win10.cuda-{1}', parameters.tensorrt_version, parameters.tensorrt_cuda_version) }}
 
     # Linux: one parallel stage per Python version
     - ${{ each config in parameters.LinuxPythonConfigurations }}:
@@ -113,6 +123,7 @@ stages:
           extra_build_arg: ${{ parameters.build_py_parameters }}
           cmake_build_type: ${{ parameters.cmake_build_type }}
           cuda_version: ${{ parameters.cuda_version }}
+          trt_version_override: ${{ format('{0}-1.cuda{1}', parameters.tensorrt_version, parameters.tensorrt_cuda_version) }}
           cmake_cuda_archs: ${{ parameters.cmake_linux_x64_cuda_archs }}
           docker_base_image: ${{ parameters.docker_base_image }}
           python_version: ${{ config.python_version }}

--- a/tools/ci_build/github/azure-pipelines/stages/py-gpu-packaging-stage.yml
+++ b/tools/ci_build/github/azure-pipelines/stages/py-gpu-packaging-stage.yml
@@ -32,6 +32,13 @@ parameters:
   type: string
   displayName: 'CUDA version used to build TensorRT for Windows and Linux x86_64.'
 
+- name: tensorrt_major_version
+  type: string
+  displayName: 'TensorRT RPM package major version for Linux x86_64.'
+  values:
+   - '10'
+   - '11'
+
 - name: cudnn_folder
   type: string
   default: '9.14.0.64_cuda13'
@@ -124,6 +131,7 @@ stages:
           cmake_build_type: ${{ parameters.cmake_build_type }}
           cuda_version: ${{ parameters.cuda_version }}
           trt_version_override: ${{ format('{0}-1.cuda{1}', parameters.tensorrt_version, parameters.tensorrt_cuda_version) }}
+          trt_major_version: ${{ parameters.tensorrt_major_version }}
           cmake_cuda_archs: ${{ parameters.cmake_linux_x64_cuda_archs }}
           docker_base_image: ${{ parameters.docker_base_image }}
           python_version: ${{ config.python_version }}

--- a/tools/ci_build/github/azure-pipelines/stages/py-linux-gpu-stage.yml
+++ b/tools/ci_build/github/azure-pipelines/stages/py-linux-gpu-stage.yml
@@ -27,6 +27,7 @@ parameters:
   values:
    - 12.8
    - 13.0
+   - 13.3
 
 - name: trt_version_override
   type: string

--- a/tools/ci_build/github/azure-pipelines/stages/py-linux-gpu-stage.yml
+++ b/tools/ci_build/github/azure-pipelines/stages/py-linux-gpu-stage.yml
@@ -32,6 +32,10 @@ parameters:
   type: string
   default: ''
 
+- name: trt_major_version
+  type: string
+  default: ''
+
 - name: cmake_cuda_archs
   type: string
   default: ''
@@ -90,6 +94,11 @@ stages:
         ${{ else }}:
           value: ''
       - template: ../templates/common-variables.yml
+      - name: trt_major_version_build_arg
+        ${{ if ne(parameters.trt_major_version, '') }}:
+          value: '--build-arg TRT_MAJOR_VERSION=${{ parameters.trt_major_version }}'
+        ${{ else }}:
+          value: ''
       - name: trt_version
         ${{ if ne(parameters.trt_version_override, '') }}:
           value: ${{ parameters.trt_version_override }}
@@ -119,7 +128,7 @@ stages:
         parameters:
           Dockerfile: tools/ci_build/github/linux/docker/inference/${{ parameters.arch }}/python/cuda/Dockerfile
           Context: tools/ci_build/github/linux/docker/inference/${{ parameters.arch }}/python/cuda
-          DockerBuildArgs: "--build-arg BASEIMAGE=${{ parameters.docker_base_image }} --build-arg TRT_VERSION=${{ variables.trt_version }} --build-arg TRT_DOWNLOAD_URL=${{ variables.trt_download_url }} --build-arg BUILD_UID=$( id -u )"
+          DockerBuildArgs: "--build-arg BASEIMAGE=${{ parameters.docker_base_image }} --build-arg TRT_VERSION=${{ variables.trt_version }} $(trt_major_version_build_arg) --build-arg TRT_DOWNLOAD_URL=${{ variables.trt_download_url }} --build-arg BUILD_UID=$( id -u )"
           Repository: onnxruntimecuda${{ replace(parameters.cuda_version, '.', '') }}xtrt86build${{ parameters.arch }}
 
 

--- a/tools/ci_build/github/azure-pipelines/stages/py-linux-gpu-stage.yml
+++ b/tools/ci_build/github/azure-pipelines/stages/py-linux-gpu-stage.yml
@@ -28,6 +28,10 @@ parameters:
    - 12.8
    - 13.0
 
+- name: trt_version_override
+  type: string
+  default: ''
+
 - name: cmake_cuda_archs
   type: string
   default: ''
@@ -87,11 +91,13 @@ stages:
           value: ''
       - template: ../templates/common-variables.yml
       - name: trt_version
-        ${{ if eq(parameters.arch, 'aarch64') }}:
+        ${{ if ne(parameters.trt_version_override, '') }}:
+          value: ${{ parameters.trt_version_override }}
+        ${{ if and(eq(parameters.trt_version_override, ''), eq(parameters.arch, 'aarch64')) }}:
           value: ${{ variables.aarch64_trt_version }}
-        ${{ if and(ne(parameters.arch, 'aarch64'), eq(parameters.cuda_version, '13.0')) }}:
+        ${{ if and(eq(parameters.trt_version_override, ''), ne(parameters.arch, 'aarch64'), eq(parameters.cuda_version, '13.0')) }}:
           value: ${{ variables.linux_trt_version_cuda13 }}
-        ${{ if and(ne(parameters.arch, 'aarch64'), eq(parameters.cuda_version, '12.8')) }}:
+        ${{ if and(eq(parameters.trt_version_override, ''), ne(parameters.arch, 'aarch64'), eq(parameters.cuda_version, '12.8')) }}:
           value: ${{ variables.linux_trt_version_cuda12 }}
       - name: trt_download_url
         ${{ if and(eq(parameters.arch, 'aarch64'), eq(parameters.cuda_version, '13.0')) }}:

--- a/tools/ci_build/github/azure-pipelines/stages/py-win-gpu-stage.yml
+++ b/tools/ci_build/github/azure-pipelines/stages/py-win-gpu-stage.yml
@@ -40,6 +40,10 @@ parameters:
   type: boolean
   default: false
 
+- name: TensorRTFolder
+  type: string
+  default: ''
+
 stages:
   - stage: Win_py_${{ parameters.EP_NAME }}_Wheels_${{ replace(parameters.PYTHON_VERSION,'.','_') }}_Build
     dependsOn: []
@@ -76,9 +80,11 @@ stages:
       - name: CUDA_MODULE_LOADING
         value: 'LAZY'
       - name: win_trt_folder
-        ${{ if eq(parameters.CudaVersion, '12.8') }}:
+        ${{ if ne(parameters.TensorRTFolder, '') }}:
+          value: ${{ parameters.TensorRTFolder }}
+        ${{ if and(eq(parameters.TensorRTFolder, ''), eq(parameters.CudaVersion, '12.8')) }}:
           value: ${{ variables.win_trt_folder_cuda12 }}
-        ${{ if eq(parameters.CudaVersion, '13.0') }}:
+        ${{ if and(eq(parameters.TensorRTFolder, ''), eq(parameters.CudaVersion, '13.0')) }}:
           value: ${{ variables.win_trt_folder_cuda13 }}
       - name: trt_build_flag
         ${{ if eq(parameters.use_tensorrt, true) }}:
@@ -106,6 +112,7 @@ stages:
           ${{ if or(contains(parameters.EP_BUILD_FLAGS, 'use_cuda'), eq(parameters.use_tensorrt, true)) }}:
             DownloadCUDA: true
           DownloadTRT: ${{ parameters.use_tensorrt }}
+          TensorRTFolder: ${{ parameters.TensorRTFolder }}
 
 
       - template: ../templates/set-nightly-build-option-variable-step.yml
@@ -213,6 +220,7 @@ stages:
             ${{ if or(contains(parameters.EP_BUILD_FLAGS, 'use_cuda'), eq(parameters.use_tensorrt, true)) }}:
               DownloadCUDA: true
             DownloadTRT: ${{ parameters.use_tensorrt }}
+            TensorRTFolder: ${{ parameters.TensorRTFolder }}
 
         - script: python -m pip install -r $(Build.SourcesDirectory)\tools\ci_build\github\windows\python\requirements.txt
           env:

--- a/tools/ci_build/github/azure-pipelines/stages/py-win-gpu-stage.yml
+++ b/tools/ci_build/github/azure-pipelines/stages/py-win-gpu-stage.yml
@@ -25,6 +25,7 @@ parameters:
   values:
     - 12.8
     - 13.0
+    - 13.3
 
 - name: cmake_build_type
   type: string

--- a/tools/ci_build/github/azure-pipelines/templates/jobs/download_win_gpu_library.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/jobs/download_win_gpu_library.yml
@@ -14,6 +14,9 @@ parameters:
   - name: CudnnFolder
     type: string
     default: '9.14.0.64_cuda13'
+  - name: TensorRTFolder
+    type: string
+    default: ''
 
 steps:
   - ${{ if eq(parameters.DownloadCUDA, true) }}:
@@ -67,12 +70,17 @@ steps:
         $cuda12_trt_version = '10.14.1.48'
         $cuda13_trt_version = '10.14.1.48'
 
-        $trtFolder = ""
-        if ("${{ parameters.CudaVersion }}" -eq "13.0") {
-          $trtFolder = "TensorRT-$cuda13_trt_version.Windows.win10.cuda-13.0"
+        $trtFolder = "${{ parameters.TensorRTFolder }}"
+        if ([string]::IsNullOrEmpty($trtFolder)) {
+          if ("${{ parameters.CudaVersion }}" -eq "13.0") {
+            $trtFolder = "TensorRT-$cuda13_trt_version.Windows.win10.cuda-13.0"
+          }
+          elseif ("${{ parameters.CudaVersion }}" -eq "12.8") {
+            $trtFolder = "TensorRT-$cuda12_trt_version.Windows.win10.cuda-12.9"
+          }
         }
-        elseif ("${{ parameters.CudaVersion }}" -eq "12.8") {
-          $trtFolder = "TensorRT-$cuda12_trt_version.Windows.win10.cuda-12.9"
+        if ([string]::IsNullOrEmpty($trtFolder)) {
+          throw "TensorRTFolder is required for CUDA ${{ parameters.CudaVersion }}"
         }
 
         Write-Host "Setting TrtFolderRuntime variable to: $trtFolder"

--- a/tools/ci_build/github/azure-pipelines/templates/jobs/download_win_gpu_library.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/jobs/download_win_gpu_library.yml
@@ -10,6 +10,7 @@ parameters:
     default: '12.8'
     values:
       - 13.0
+      - 13.3
       - 12.8
   - name: CudnnFolder
     type: string
@@ -30,7 +31,7 @@ steps:
           set AZCOPY_AUTO_LOGIN_TYPE=AZCLI
           azcopy.exe cp --recursive https://lotusscus.blob.core.windows.net/models/cuda_sdk/v${{ parameters.CudaVersion }} $(Agent.TempDirectory)
 
-    # Since CUDA 13.0, CUDA DLLs are  in bin\x64 folder instead of bin folder for Windows.
+    # Since CUDA 13, CUDA DLLs are in bin\x64 instead of bin on Windows.
     - powershell: |
         Write-Host "##vso[task.prependpath]$(Agent.TempDirectory)\v${{ parameters.CudaVersion }}\bin;$(Agent.TempDirectory)\v${{ parameters.CudaVersion }}\bin\x64;$(Agent.TempDirectory)\v${{ parameters.CudaVersion }}\extras\CUPTI\lib64"
       displayName: 'Append CUDA SDK Directory to PATH'
@@ -42,7 +43,7 @@ steps:
           dir $(Agent.TempDirectory)
       displayName: 'Print PATH after download CUDA SDK'
 
-    - ${{ if eq(parameters.CudaVersion, '13.0') }}:
+    - ${{ if startsWith(parameters.CudaVersion, '13.') }}:
       - task: AzureCLI@2
         displayName: 'Download CUDNN ${{ parameters.CudnnFolder }}'
         inputs:

--- a/tools/ci_build/github/linux/build_linux_python_package.sh
+++ b/tools/ci_build/github/linux/build_linux_python_package.sh
@@ -77,11 +77,11 @@ if [ "$BUILD_DEVICE" == "GPU" ]; then
     # The caller (-a) normally supplies these. Keep in sync with plugin-cuda-pipeline.yml
     # (cmake_linux_x64_cuda_archs / cmake_linux_aarch64_cuda_archs).
     if [ -z "${CUDA_ARCHS:-}" ]; then
-        if [ "$CUDA_VERSION" == "13.0" ] && [ "$ARCH" == "aarch64" ]; then
+        if [[ "$CUDA_VERSION" == 13.* ]] && [ "$ARCH" == "aarch64" ]; then
             CUDA_ARCHS="89-real;90-real;120-real;121-real"
         elif [ "$CUDA_VERSION" == "12.8" ]; then
             CUDA_ARCHS="60-real;70-real;75-real;80-real;86-real;89-real;90-real;120-real"
-        elif [ "$CUDA_VERSION" == "13.0" ]; then
+        elif [[ "$CUDA_VERSION" == 13.* ]]; then
             CUDA_ARCHS="75-real;80-real;86-real;89-real;90-real;120-real"
         else
             echo "Error: Unrecognized CUDA_VERSION: $CUDA_VERSION"

--- a/tools/ci_build/github/linux/docker/Dockerfile.manylinux2_28_cuda
+++ b/tools/ci_build/github/linux/docker/Dockerfile.manylinux2_28_cuda
@@ -6,22 +6,23 @@ ARG BASEIMAGE=nvidia/cuda:12.8.1-cudnn-devel-ubi8
 
 FROM $BASEIMAGE
 ARG TRT_VERSION=10.14.1.48-1.cuda12.9
+ARG TRT_MAJOR_VERSION=10
 
 #Install TensorRT only if TRT_VERSION is not empty
 RUN if [ -n "$TRT_VERSION" ]; then  \
     echo "TRT_VERSION is $TRT_VERSION" && \
     dnf -y install  \
-    libnvinfer10-${TRT_VERSION}  \
+    libnvinfer${TRT_MAJOR_VERSION}-${TRT_VERSION}  \
     libnvinfer-headers-devel-${TRT_VERSION}  \
     libnvinfer-devel-${TRT_VERSION}  \
-    libnvinfer-lean10-${TRT_VERSION}  \
-    libnvonnxparsers10-${TRT_VERSION}  \
+    libnvinfer-lean${TRT_MAJOR_VERSION}-${TRT_VERSION}  \
+    libnvonnxparsers${TRT_MAJOR_VERSION}-${TRT_VERSION}  \
     libnvonnxparsers-devel-${TRT_VERSION}  \
-    libnvinfer-dispatch10-${TRT_VERSION}  \
-    libnvinfer-plugin10-${TRT_VERSION}  \
-    libnvinfer-vc-plugin10-${TRT_VERSION}  \
+    libnvinfer-dispatch${TRT_MAJOR_VERSION}-${TRT_VERSION}  \
+    libnvinfer-plugin${TRT_MAJOR_VERSION}-${TRT_VERSION}  \
+    libnvinfer-vc-plugin${TRT_MAJOR_VERSION}-${TRT_VERSION}  \
     libnvinfer-bin-${TRT_VERSION}  \
-    libnvinfer-plugin10-${TRT_VERSION}  \
+    libnvinfer-plugin${TRT_MAJOR_VERSION}-${TRT_VERSION}  \
     libnvinfer-plugin-devel-${TRT_VERSION}  \
     libnvinfer-vc-plugin-devel-${TRT_VERSION}  \
     libnvinfer-lean-devel-${TRT_VERSION}  \

--- a/tools/ci_build/github/linux/docker/inference/x86_64/python/cuda/Dockerfile
+++ b/tools/ci_build/github/linux/docker/inference/x86_64/python/cuda/Dockerfile
@@ -6,22 +6,23 @@ ARG BASEIMAGE=nvidia/cuda:12.8.1-cudnn-devel-ubi8
 
 FROM $BASEIMAGE
 ARG TRT_VERSION=10.14.1.48-1.cuda12.9
+ARG TRT_MAJOR_VERSION=10
 
 #Install TensorRT only if TRT_VERSION is not empty
 RUN if [ -n "${TRT_VERSION}" ]; then  \
     echo "TRT_VERSION is $TRT_VERSION" && \
     dnf -y install  \
-    libnvinfer10-${TRT_VERSION}  \
+    libnvinfer${TRT_MAJOR_VERSION}-${TRT_VERSION}  \
     libnvinfer-headers-devel-${TRT_VERSION}  \
     libnvinfer-devel-${TRT_VERSION}  \
-    libnvinfer-lean10-${TRT_VERSION}  \
-    libnvonnxparsers10-${TRT_VERSION}  \
+    libnvinfer-lean${TRT_MAJOR_VERSION}-${TRT_VERSION}  \
+    libnvonnxparsers${TRT_MAJOR_VERSION}-${TRT_VERSION}  \
     libnvonnxparsers-devel-${TRT_VERSION}  \
-    libnvinfer-dispatch10-${TRT_VERSION}  \
-    libnvinfer-plugin10-${TRT_VERSION}  \
-    libnvinfer-vc-plugin10-${TRT_VERSION}  \
+    libnvinfer-dispatch${TRT_MAJOR_VERSION}-${TRT_VERSION}  \
+    libnvinfer-plugin${TRT_MAJOR_VERSION}-${TRT_VERSION}  \
+    libnvinfer-vc-plugin${TRT_MAJOR_VERSION}-${TRT_VERSION}  \
     libnvinfer-bin-${TRT_VERSION}  \
-    libnvinfer-plugin10-${TRT_VERSION}  \
+    libnvinfer-plugin${TRT_MAJOR_VERSION}-${TRT_VERSION}  \
     libnvinfer-plugin-devel-${TRT_VERSION}  \
     libnvinfer-vc-plugin-devel-${TRT_VERSION}  \
     libnvinfer-lean-devel-${TRT_VERSION}  \


### PR DESCRIPTION
### Description

- Pass one TensorRT release and CUDA build version to the Windows x64 and Linux x86_64 Python wheel stages.
- Select the Linux TensorRT RPM package major through `TRT_MAJOR_VERSION`.
- Accept CUDA 13.3 in the Windows x64 and Linux x86_64 Python packaging paths while keeping Linux aarch64 on its explicit CUDA version.
- Add an optional suffix to reusable Linux workflow artifact names.

The CUDA 12 and CUDA 13 packaging pipelines retain their current CUDA and TensorRT values in this PR.

### Stack

Follow-up: #32280.

Top-only follow-up diff: https://github.com/Tenshock/onnxruntime/compare/trt11-cuda13-python-wheel-plumbing...trt11-cuda13-python-wheels

Addresses #32278.

### Validation

- Parsed all modified YAML files with PyYAML.
- `actionlint .github/workflows/reusable_linux_build.yml`
- `shellcheck -e SC2001 tools/ci_build/github/linux/build_linux_python_package.sh`
- `git diff --check main...HEAD`
