### PR TITLE
Accept ',' as separator for optimization.disable_specified_optimizers

### DIFF
--- a/include/onnxruntime/core/session/onnxruntime_session_options_config_keys.h
+++ b/include/onnxruntime/core/session/onnxruntime_session_options_config_keys.h
@@ -115,7 +115,8 @@ static const char* const kOrtSessionOptionsMemoryOptimizerApplyConfig = "optimiz
 static const char* const kOrtSessionOptionsMemoryOptimizerProbeConfig = "optimization.enable_memory_probe_recompute_config";
 #endif
 
-// This setting if set should contain a comma separated list of optimizers names that should be disabled.
+// This setting if set should contain a comma- or semicolon-separated list of optimizers names that should
+// be disabled.
 // Optimizers may take time to execute and affect model loading time. If you feel that a specific optimizer
 // does not provider runtime benefits, but affects your model loading time you may disable it using this config
 // entry. This option is not enabled in ORT_MINIMAL_BUILD build.

--- a/onnxruntime/core/session/inference_session.cc
+++ b/onnxruntime/core/session/inference_session.cc
@@ -4,6 +4,7 @@
 #include "core/graph/onnx_protobuf.h"
 #include "core/session/inference_session.h"
 
+#include <algorithm>
 #include <memory>
 #include <sstream>
 #include <list>
@@ -500,6 +501,9 @@ void InferenceSession::ConstructorCommon(const SessionOptions& session_options,
     auto disabled_string = session_options_.config_options.GetConfigOrDefault(
         kOrtSessionOptionsDisableSpecifiedOptimizers, "");
     if (!disabled_string.empty()) {
+      // The setting is documented as a comma separated list, but ';' was historically the only accepted
+      // separator. Treat ',' as a separator too so both forms work.
+      std::replace(disabled_string.begin(), disabled_string.end(), ',', ';');
       const auto disabled_list = utils::SplitString(disabled_string, ";");
       InlinedHashSet<std::string> disabled_rules_and_transformers;
       disabled_rules_and_transformers.reserve(disabled_list.size());

--- a/onnxruntime/test/optimizer/graph_transform_test.cc
+++ b/onnxruntime/test/optimizer/graph_transform_test.cc
@@ -9998,6 +9998,37 @@ TEST_F(GraphTransformationTests, FilterEnabledOptimizersViaSessionOptions) {
   ASSERT_TRUE(op_to_count["Add"] == 1);
 }
 
+TEST_F(GraphTransformationTests, FilterEnabledOptimizersViaSessionOptionsCommaSeparated) {
+  constexpr const ORTCHAR_T* model_uri = MODEL_FOLDER "fusion/constant_folding_with_scalar_shape_to_initializer.onnx";
+
+  SessionOptions so;
+  so.session_logid = "GraphTransformationTests.FilterEnabledOptimizersViaSessionOptionsCommaSeparated";
+  // The setting is documented as a comma separated list; verify ',' works as a separator.
+  // MatMulAddFusion is a registered transformer, so the entry is not a single unknown name:
+  // ConstantFolding must still be recognized and disabled.
+  ASSERT_STATUS_OK(so.config_options.AddConfigEntry(kOrtSessionOptionsDisableSpecifiedOptimizers,
+                                                    "MatMulAddFusion,ConstantFolding"));
+
+  InferenceSessionWrapper session_object{so, GetEnvironment()};
+
+  ASSERT_STATUS_OK(session_object.Load(model_uri));
+
+  const auto& graph = session_object.GetGraph();
+
+  // check the ops that should go away if the constant folding transformer runs
+  std::map<std::string, int> op_to_count = CountOpsInGraph(graph);
+  ASSERT_TRUE(op_to_count["Shape"] == 1);
+  ASSERT_TRUE(op_to_count["ConstantOfShape"] == 1);
+  ASSERT_TRUE(op_to_count["Add"] == 1);
+
+  ASSERT_STATUS_OK(session_object.Initialize());  // Initialize runs the transformers
+
+  op_to_count = CountOpsInGraph(graph);
+  ASSERT_TRUE(op_to_count["Shape"] == 1);
+  ASSERT_TRUE(op_to_count["ConstantOfShape"] == 1);
+  ASSERT_TRUE(op_to_count["Add"] == 1);
+}
+
 TEST_F(GraphTransformationTests, PropagateCastOpsTests) {
   using Strategy = GraphTransformerConfiguration::PropagateCastOpsConfiguration::Strategy;
   struct PropagateCastOpsTestSpecs {


### PR DESCRIPTION
The config key is documented as a comma separated list, but the parser split only on ';', so a comma-separated value silently disabled nothing. Normalize ',' to ';' before splitting so both forms work, update the header comment, and add a regression test.

Fixes #32211

### Description
<!-- Describe your changes. -->



### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


