### PR TITLE
[WebNN] Fix inverted fallback data type support check

### DIFF
--- a/js/web/lib/wasm/jsep/webnn/tensor-manager.ts
+++ b/js/web/lib/wasm/jsep/webnn/tensor-manager.ts
@@ -345,7 +345,7 @@ class TensorIdTracker {
     // Check if the context supports the data type. If not, try to use the fallback data type.
     if (!opLimits?.input.dataTypes.includes(dataType)) {
       fallbackDataType = webnnDataTypeToFallback.get(dataType);
-      if (!fallbackDataType || opLimits?.input.dataTypes.includes(fallbackDataType)) {
+      if (!fallbackDataType || !opLimits?.input.dataTypes.includes(fallbackDataType)) {
         throw new Error(`WebNN backend does not support data type: ${dataType}`);
       }
       LOG_DEBUG(


### PR DESCRIPTION
The guard threw whenever the fallback type WAS supported, so int64->int32 fallback never worked. Add the missing negation.