### PR TITLE
[MLAS] Integrate new optimised SME2 SGEMM and GEMV using common MatMul API

### DIFF
--- a/cmake/deps.txt
+++ b/cmake/deps.txt
@@ -61,7 +61,7 @@ directx_headers;https://github.com/microsoft/DirectX-Headers/archive/refs/tags/v
 cudnn_frontend;https://github.com/NVIDIA/cudnn-frontend/archive/refs/tags/v1.27.0.zip;1e4c9a464d3437e388ab0163f3be068dba783c08
 dawn;https://github.com/google/dawn/archive/refs/tags/v20260818.211311.zip;10e42c94f70fc222ecbafebbd1cfbb5482593d59
 dawn_agility_sdk;https://www.nuget.org/api/v2/package/Microsoft.Direct3D.D3D12/1.721.0-preview;fbeb58268d47626027ab670928817cbb955755db
-kleidiai;https://github.com/ARM-software/kleidiai/archive/refs/tags/v1.20.0.tar.gz;6895e72b3d5cf1173358164cb3d64c9d7d33cc84
+kleidiai;https://github.com/ARM-software/kleidiai/archive/refs/tags/v1.30.0.tar.gz;36aebdd5bd28c40b1943eb93498ae42e703510e5
 # kleidiai-qmx is pinned to a specific commit as there are no tagged releases. When an appropriate tagged release becomes available,
 # this entry will be updated to use refs/tags/<version> instead of the raw commit hash.
 kleidiai-qmx;https://github.com/qualcomm/kleidiai/archive/2f10c9a8d32f81ffeeb6d4885a29cc35d2b0da87.zip;5e855730a2d69057a569f43dd7532db3b2d2a05c

--- a/onnxruntime/core/mlas/lib/kleidiai/kai_ukernel_interface.cpp
+++ b/onnxruntime/core/mlas/lib/kleidiai/kai_ukernel_interface.cpp
@@ -40,16 +40,18 @@
 
 // SME2 kernels
 //   GEMM/QGEMM/SBGEMM
-#include "kai/ukernels/matmul/matmul_clamp_f32_f32p_f32p/kai_matmul_clamp_f32_f32p2vlx1_f32p2vlx1biasf32_sme2_mopa.h"
 #include "kai/ukernels/matmul/matmul_clamp_f32_qai8dxp_qsi8cxp/kai_matmul_clamp_f32_qai8dxp1vlx4_qsi8cxp4vlx4_1vlx4vl_sme2_mopa.h"
 #include "kai/ukernels/matmul/matmul_clamp_fp32_bf16p_bf16p/kai_matmul_clamp_f32_bf16p2vlx2_bf16p2vlx2_2vlx2vl_sme2_mopa.h"
 
-//   GEMV
-#include "kai/ukernels/matmul/matmul_clamp_f32_f32_f32p/kai_matmul_clamp_f32_f32_f32p16vlx1b_1x16vl_sme2_mla.h"
-#include "kai/ukernels/matmul/matmul_clamp_f32_f32_f32p/kai_matmul_clamp_f32_f32_f32p2vlx1b_1x16vl_sme2_mla.h"
 //   IMATMUL
 #include "kai/ukernels/matmul/imatmul_clamp_f32_f32p_f32p/kai_imatmul_clamp_f32_f32p2vlx1_f32p2vlx1b_2vlx2vl_sme2_mopa.h"
 #include "kai/ukernels/matmul/imatmul_clamp_f16_f16p_f16p/kai_imatmul_clamp_f16_f16p2vlx2_f16p2vlx2_2vlx2vl_sme2_mopa.h"
+
+// FP32 legacy packers. The legacy SME/QMX kernels use these directly; their
+// next-generation counterparts are provided by the common packer API.
+#include "kai/ukernels/matmul/pack/kai_lhs_pack_f32p2vlx1_f32_sme.h"
+#include "kai/ukernels/matmul/pack/kai_rhs_pack_kxn_f32p2vlx1biasf32_f32_f32_sme.h"
+#include "kai/ukernels/matmul/pack/kai_rhs_pack_nxk_f32p2vlx1biasf32_f32_f32_sme.h"
 
 // FP16 HGEMM kernels
 #include "kai/ukernels/matmul/matmul_clamp_f16_f16_f16p/kai_matmul_clamp_f16_f16_f16p2vlx2b_1x8vl_sme_mla.h"
@@ -63,6 +65,225 @@
 //   IMATMUL
 #include "kai/ukernels/matmul/imatmul_clamp_f32_f32p_f32p/kai_imatmul_clamp_f32_f32p2vlx1_f32p2vlx1b_2vlx2vl_qmx_mopa.h"
 #endif // ENABLE_QMX_KERNELS
+
+namespace {
+
+const kai_matmul_uker_config kMatmulConfig{};
+const kai_matmul_pack_lhs_uker_config kLhsPackConfig{};
+const kai_matmul_pack_rhs_uker_config kRhsPackConfig{};
+
+}  // namespace
+
+KaiF32SgemmUkernel::KaiF32SgemmUkernel(kai_matmul_clamp_f32_f32p_f32p_ukernel ukernel)
+    : KaiMatmulUkernel(ukernel) {}
+
+KaiF32SgemmUkernel::KaiF32SgemmUkernel(kai_matmul_uker_api ukernel,
+                                       kai_matmul_pack_lhs_uker_api lhs_packer,
+                                       kai_matmul_pack_rhs_uker_api rhs_kxn_packer,
+                                       kai_matmul_pack_rhs_uker_api rhs_nxk_packer)
+    : KaiMatmulUkernel(ukernel),
+      lhs_packer_(lhs_packer),
+      rhs_kxn_packer_(rhs_kxn_packer),
+      rhs_nxk_packer_(rhs_nxk_packer) {}
+
+size_t KaiF32SgemmUkernel::get_m_step() const {
+    if (!UsesUkernelApi()) {
+        return LegacyUkernelInterface().get_m_step();
+    }
+
+    return UkernelApi().get_step(&kMatmulConfig).m;
+}
+
+size_t KaiF32SgemmUkernel::get_n_step() const {
+    if (!UsesUkernelApi()) {
+        return LegacyUkernelInterface().get_n_step();
+    }
+
+    return UkernelApi().get_step(&kMatmulConfig).n;
+}
+
+size_t KaiF32SgemmUkernel::get_lhs_packed_offset(size_t m_idx, size_t k) const {
+    if (!UsesUkernelApi()) {
+        return LegacyUkernelInterface().get_lhs_packed_offset(m_idx, k);
+    }
+
+    const kai_matmul_uker_lhs_dim_args shape{0, k};
+    const auto stride = UkernelApi().get_lhs_stride(&kMatmulConfig, &shape);
+    const kai_matmul_uker_lhs_dim_args index{m_idx, 0};
+    return UkernelApi().get_lhs_offset(&kMatmulConfig, &index, &stride);
+}
+
+size_t KaiF32SgemmUkernel::get_rhs_packed_offset(size_t n_idx, size_t k) const {
+    if (!UsesUkernelApi()) {
+        return LegacyUkernelInterface().get_rhs_packed_offset(n_idx, k);
+    }
+
+    const kai_matmul_uker_rhs_dim_args shape{0, k};
+    const auto stride = UkernelApi().get_rhs_stride(&kMatmulConfig, &shape);
+    const kai_matmul_uker_rhs_dim_args index{n_idx, 0};
+    return UkernelApi().get_rhs_offset(&kMatmulConfig, &index, &stride);
+}
+
+void KaiF32SgemmUkernel::run_matmul(size_t m, size_t n, size_t k,
+                                    const void* lhs_packed, const void* rhs_packed, void* dst,
+                                    size_t dst_stride_row, size_t dst_stride_col,
+                                    float clamp_min, float clamp_max) const {
+    if (!UsesUkernelApi()) {
+        LegacyUkernelInterface().run_matmul(m, n, k, lhs_packed, rhs_packed, dst,
+                                            dst_stride_row, dst_stride_col, clamp_min, clamp_max);
+        return;
+    }
+
+    const kai_matmul_uker_lhs_dim_args lhs_shape{m, k};
+    const kai_matmul_uker_rhs_dim_args rhs_shape{n, k};
+    kai_matmul_uker_args args{};
+    args.flags = KAI_MATMUL_UKER_FLAGS_ARGS_CLAMP;
+    args.shape = {m, n, k};
+    args.operand.lhs.ptr = lhs_packed;
+    args.operand.lhs.stride = UkernelApi().get_lhs_stride(&kMatmulConfig, &lhs_shape);
+    args.operand.rhs.ptr = rhs_packed;
+    args.operand.rhs.stride = UkernelApi().get_rhs_stride(&kMatmulConfig, &rhs_shape);
+    args.operand.dst.ptr = dst;
+    args.operand.dst.stride.m = dst_stride_row;
+    args.activation.clamp.min_ptr = &clamp_min;
+    args.activation.clamp.max_ptr = &clamp_max;
+    UkernelApi().run(&kMatmulConfig, &args);
+    MLAS_UNREFERENCED_PARAMETER(dst_stride_col);
+}
+
+size_t KaiF32SgemmUkernel::GetLhsPackedSize(size_t m, size_t k) const {
+    if (!UsesUkernelApi()) {
+        const auto& ukernel = LegacyUkernelInterface();
+        return kai_get_lhs_packed_size_lhs_pack_f32p2vlx1_f32_sme(
+            m, k, ukernel.get_mr(), ukernel.get_kr(), ukernel.get_sr());
+    }
+
+    const kai_matmul_pack_lhs_uker_lhs_packed_dim_args shape{m, k};
+    const auto stride = lhs_packer_.get_lhs_packed_stride(&kLhsPackConfig, &shape);
+    return lhs_packer_.get_lhs_packed_size(&kLhsPackConfig, &shape, &stride);
+}
+
+const char* KaiF32SgemmUkernel::GetLhsPackerName() const {
+    return UsesUkernelApi()
+               ? "kai_matmul_pack_lhs_mxk_x32p4vsx1_x32_sme"
+               : "kai_run_lhs_pack_f32p2vlx1_f32_sme";
+}
+
+void KaiF32SgemmUkernel::PackLhs(size_t m, size_t k, const float* lhs,
+                                 size_t lhs_stride, void* lhs_packed) const {
+    if (!UsesUkernelApi()) {
+        const auto& ukernel = LegacyUkernelInterface();
+        kai_run_lhs_pack_f32p2vlx1_f32_sme(m, k, ukernel.get_mr(), ukernel.get_kr(), ukernel.get_sr(),
+                                            0, lhs, lhs_stride * sizeof(float), lhs_packed);
+        return;
+    }
+
+    const kai_matmul_pack_lhs_uker_lhs_packed_dim_args packed_shape{m, k};
+    kai_matmul_pack_lhs_uker_args args{};
+    args.shape = {m, k};
+    args.operand.lhs.ptr = lhs;
+    args.operand.lhs.stride.m = lhs_stride * sizeof(float);
+    args.operand.lhs_packed.ptr = lhs_packed;
+    args.operand.lhs_packed.stride =
+        lhs_packer_.get_lhs_packed_stride(&kLhsPackConfig, &packed_shape);
+    lhs_packer_.run(&kLhsPackConfig, &args);
+}
+
+const kai_matmul_pack_rhs_uker_api& KaiF32SgemmUkernel::RhsPacker(KaiF32RhsLayout layout) const {
+    return layout == KaiF32RhsLayout::KxN ? rhs_kxn_packer_ : rhs_nxk_packer_;
+}
+
+size_t KaiF32SgemmUkernel::GetRhsPackedSize(KaiF32RhsLayout layout, size_t n, size_t k) const {
+    if (!UsesUkernelApi()) {
+        return layout == KaiF32RhsLayout::KxN
+                   ? kai_get_rhs_packed_size_rhs_pack_kxn_f32p2vlx1biasf32_f32_f32_sme(n, k)
+                   : kai_get_rhs_packed_size_rhs_pack_nxk_f32p2vlx1biasf32_f32_f32_sme(n, k);
+    }
+
+    const auto& packer = RhsPacker(layout);
+    const kai_matmul_pack_rhs_uker_rhs_packed_dim_args shape{n, k};
+    const auto stride = packer.get_rhs_packed_stride(&kRhsPackConfig, &shape);
+    return packer.get_rhs_packed_size(&kRhsPackConfig, &shape, &stride);
+}
+
+const char* KaiF32SgemmUkernel::GetRhsPackerName(KaiF32RhsLayout layout) const {
+    if (UsesUkernelApi()) {
+        return layout == KaiF32RhsLayout::KxN
+                   ? "kai_matmul_pack_rhs_kxn_x32p4vsx1bx32_x32_x32_sme"
+                   : "kai_matmul_pack_rhs_nxk_x32p4vsx1bx32_x32_x32_sme";
+    }
+
+    return layout == KaiF32RhsLayout::KxN
+               ? "kai_run_rhs_pack_kxn_f32p2vlx1biasf32_f32_f32_sme"
+               : "kai_run_rhs_pack_nxk_f32p2vlx1biasf32_f32_f32_sme";
+}
+
+void KaiF32SgemmUkernel::PackRhs(KaiF32RhsLayout layout, size_t n, size_t k,
+                                 const float* rhs, size_t rhs_stride,
+                                 const float* bias, void* rhs_packed) const {
+    if (!UsesUkernelApi()) {
+        const auto& ukernel = LegacyUkernelInterface();
+        if (layout == KaiF32RhsLayout::KxN) {
+            kai_run_rhs_pack_kxn_f32p2vlx1biasf32_f32_f32_sme(
+                1, n, k, ukernel.get_nr(), ukernel.get_kr(), ukernel.get_sr(), rhs_stride * sizeof(float),
+                rhs, bias, nullptr, rhs_packed, 0, nullptr);
+        } else {
+            kai_run_rhs_pack_nxk_f32p2vlx1biasf32_f32_f32_sme(
+                1, n, k, ukernel.get_nr(), ukernel.get_kr(), ukernel.get_sr(), rhs_stride * sizeof(float),
+                rhs, bias, nullptr, rhs_packed, 0, nullptr);
+        }
+        return;
+    }
+
+    const auto& packer = RhsPacker(layout);
+    const kai_matmul_pack_rhs_uker_rhs_packed_dim_args packed_shape{n, k};
+    kai_matmul_pack_rhs_uker_args args{};
+    args.shape = {n, k};
+    args.operand.rhs.ptr = rhs;
+    args.operand.rhs.stride = layout == KaiF32RhsLayout::KxN
+                                  ? kai_matmul_pack_rhs_uker_rhs_stride_args{sizeof(float),
+                                                                            rhs_stride * sizeof(float)}
+                                  : kai_matmul_pack_rhs_uker_rhs_stride_args{rhs_stride * sizeof(float),
+                                                                            sizeof(float)};
+    args.operand.rhs_packed.ptr = rhs_packed;
+    args.operand.rhs_packed.stride =
+        packer.get_rhs_packed_stride(&kRhsPackConfig, &packed_shape);
+    args.operand.bias_n.ptr = bias;
+    packer.run(&kRhsPackConfig, &args);
+}
+
+KaiF32SgemvUkernel::KaiF32SgemvUkernel(kai_matmul_clamp_f32_f32_f32p_ukernel ukernel)
+    : KaiMatmulUkernel(ukernel) {}
+
+KaiF32SgemvUkernel::KaiF32SgemvUkernel(kai_matmul_uker_api ukernel)
+    : KaiMatmulUkernel(ukernel) {}
+
+void KaiF32SgemvUkernel::run_matmul(size_t m, size_t n, size_t k,
+                                    const void* lhs, size_t lhs_stride,
+                                    const void* rhs_packed, void* dst,
+                                    size_t dst_stride_row, size_t dst_stride_col,
+                                    float clamp_min, float clamp_max) const {
+    if (!UsesUkernelApi()) {
+        LegacyUkernelInterface().run_matmul(m, n, k, lhs, lhs_stride, rhs_packed, dst,
+                                            dst_stride_row, dst_stride_col, clamp_min, clamp_max);
+        return;
+    }
+
+    const kai_matmul_uker_rhs_dim_args rhs_shape{n, k};
+    kai_matmul_uker_args args{};
+    args.flags = KAI_MATMUL_UKER_FLAGS_ARGS_CLAMP;
+    args.shape = {m, n, k};
+    args.operand.lhs.ptr = lhs;
+    args.operand.lhs.stride.m = lhs_stride;
+    args.operand.rhs.ptr = rhs_packed;
+    args.operand.rhs.stride = UkernelApi().get_rhs_stride(&kMatmulConfig, &rhs_shape);
+    args.operand.dst.ptr = dst;
+    args.operand.dst.stride.m = dst_stride_row;
+    args.activation.clamp.min_ptr = &clamp_min;
+    args.activation.clamp.max_ptr = &clamp_max;
+    UkernelApi().run(&kMatmulConfig, &args);
+    MLAS_UNREFERENCED_PARAMETER(dst_stride_col);
+}
 
 // -------------------------------------------------------------------------------------------------
 // KleidiAI ukernel wrapper macros
@@ -109,6 +330,26 @@
          kai_get_dst_offset_##STEM,                                                                      \
          kai_get_dst_size_##STEM,                                                                        \
          kai_run_##STEM}                                                                                 \
+    }
+
+#define KAI_WRAP_F32_SGEMM_LEGACY(STEM)                                                                  \
+    {                                                                                                    \
+        "kai_run_" #STEM,                                                                                \
+        KaiF32SgemmUkernel {                                                                             \
+            kai_matmul_clamp_f32_f32p_f32p_ukernel {                                                    \
+                kai_get_m_step_##STEM,                                                                   \
+                kai_get_n_step_##STEM,                                                                   \
+                kai_get_mr_##STEM,                                                                       \
+                kai_get_nr_##STEM,                                                                       \
+                kai_get_kr_##STEM,                                                                       \
+                kai_get_sr_##STEM,                                                                       \
+                kai_get_lhs_packed_offset_##STEM,                                                        \
+                kai_get_rhs_packed_offset_##STEM,                                                        \
+                kai_get_dst_offset_##STEM,                                                               \
+                kai_get_dst_size_##STEM,                                                                 \
+                kai_run_##STEM                                                                           \
+            }                                                                                            \
+        }                                                                                                \
     }
 
 #define KAI_WRAP_Q4_UKERNEL_RUN_MATMUL_11(STEM, RHS_LAYOUT)                                              \
@@ -287,7 +528,7 @@ const KaiQnbitAsymGemmKernel kai_matmul_clamp_f32_qsi8d32p1x4_qai4c32p4vlx4_1x4v
                                       KaiQ4RhsPackLayout::AsymmetricNxKInterleavedNrx4);
 
 const KaiF32SgemmKernel sgemm_gemm_sme =
-    KAI_WRAP_UKERNEL_RUN_MATMUL_11(matmul_clamp_f32_f32p2vlx1_f32p2vlx1b_2vlx2vl_sme_mopa);
+    KAI_WRAP_F32_SGEMM_LEGACY(matmul_clamp_f32_f32p2vlx1_f32p2vlx1b_2vlx2vl_sme_mopa);
 
 // IMATMUL kernels used by KleidiAI convolution. These are packed-imatmul (7-slot) interfaces.
 const KaiF32IMatmulKernel imatmul_conv_sme =
@@ -311,7 +552,15 @@ const KaiF32IMatmulKernel imatmul_conv_qmx =
 #endif // ENABLE_QMX_KERNELS
 
 const KaiF32SgemmKernel sgemm_gemm_sme2 =
-    KAI_WRAP_UKERNEL_RUN_MATMUL_11(matmul_clamp_f32_f32p2vlx1_f32p2vlx1biasf32_sme2_mopa);
+    {
+        "kai_matmul_clamp_f32_f32p4vsx1_f32p4vsx1bf32_8vsx8vs_sme2_mopa",
+        KaiF32SgemmUkernel{
+            kai_matmul_clamp_f32_f32p4vsx1_f32p4vsx1bf32_8vsx8vs_sme2_mopa(),
+            kai_matmul_pack_lhs_mxk_x32p4vsx1_x32_sme(),
+            kai_matmul_pack_rhs_kxn_x32p4vsx1bx32_x32_x32_sme(),
+            kai_matmul_pack_rhs_nxk_x32p4vsx1bx32_x32_x32_sme(),
+        },
+    };
 
 const KaiDynamicQGemmKernel qgemm_gemm_sme =
     KAI_WRAP_UKERNEL_RUN_MATMUL_11(matmul_clamp_f32_qai8dxp1vlx4_qsi8cxp4vlx4_1vlx4vl_sme_mopa);
@@ -332,7 +581,7 @@ const KaiDynamicQGemmKernel qgemm_gemm_qmx =
     KAI_WRAP_UKERNEL_RUN_MATMUL_11(matmul_clamp_f32_qai8dxp1vlx4_qsi8cxp4vlx4_1vlx4vl_qmx_mopa);
 
 const KaiF32SgemmKernel sgemm_gemm_qmx =
-    KAI_WRAP_UKERNEL_RUN_MATMUL_11(matmul_clamp_f32_f32p2vlx1_f32p2vlx1biasf32_qmx_mopa);
+    KAI_WRAP_F32_SGEMM_LEGACY(matmul_clamp_f32_f32p2vlx1_f32p2vlx1biasf32_qmx_mopa);
 #endif // ENABLE_QMX_KERNELS
 
 // Gemv kernels do not conform to the same ukernel interface layout
@@ -340,31 +589,26 @@ const KaiF32SgemmKernel sgemm_gemm_qmx =
 const KaiF32SgemvKernel sgemm_gemv_sme =
     {
         "kai_run_matmul_clamp_f32_f32_f32p2vlx1b_1x8vl_sme_mla",
-        {kai_get_m_step_matmul_clamp_f32_f32_f32p2vlx1b_1x8vl_sme_mla,
-        kai_get_n_step_matmul_clamp_f32_f32_f32p2vlx1b_1x8vl_sme_mla,
-        kai_get_nr_matmul_clamp_f32_f32_f32p2vlx1b_1x8vl_sme_mla,
-        kai_get_kr_matmul_clamp_f32_f32_f32p2vlx1b_1x8vl_sme_mla,
-        kai_get_sr_matmul_clamp_f32_f32_f32p2vlx1b_1x8vl_sme_mla,
-        kai_get_lhs_offset_matmul_clamp_f32_f32_f32p2vlx1b_1x8vl_sme_mla,
-        kai_get_rhs_packed_offset_matmul_clamp_f32_f32_f32p2vlx1b_1x8vl_sme_mla,
-        kai_get_dst_offset_matmul_clamp_f32_f32_f32p2vlx1b_1x8vl_sme_mla,
-        kai_get_dst_size_matmul_clamp_f32_f32_f32p2vlx1b_1x8vl_sme_mla,
-        kai_run_matmul_clamp_f32_f32_f32p2vlx1b_1x8vl_sme_mla}
+        KaiF32SgemvUkernel{
+            kai_matmul_clamp_f32_f32_f32p_ukernel{
+                kai_get_m_step_matmul_clamp_f32_f32_f32p2vlx1b_1x8vl_sme_mla,
+                kai_get_n_step_matmul_clamp_f32_f32_f32p2vlx1b_1x8vl_sme_mla,
+                kai_get_nr_matmul_clamp_f32_f32_f32p2vlx1b_1x8vl_sme_mla,
+                kai_get_kr_matmul_clamp_f32_f32_f32p2vlx1b_1x8vl_sme_mla,
+                kai_get_sr_matmul_clamp_f32_f32_f32p2vlx1b_1x8vl_sme_mla,
+                kai_get_lhs_offset_matmul_clamp_f32_f32_f32p2vlx1b_1x8vl_sme_mla,
+                kai_get_rhs_packed_offset_matmul_clamp_f32_f32_f32p2vlx1b_1x8vl_sme_mla,
+                kai_get_dst_offset_matmul_clamp_f32_f32_f32p2vlx1b_1x8vl_sme_mla,
+                kai_get_dst_size_matmul_clamp_f32_f32_f32p2vlx1b_1x8vl_sme_mla,
+                kai_run_matmul_clamp_f32_f32_f32p2vlx1b_1x8vl_sme_mla,
+            },
+        },
     };
 
 const KaiF32SgemvKernel sgemm_gemv_sme2 =
     {
-        "kai_run_matmul_clamp_f32_f32_f32p2vlx1b_1x16vl_sme2_mla",
-        {kai_get_m_step_matmul_clamp_f32_f32_f32p2vlx1b_1x16vl_sme2_mla,
-        kai_get_n_step_matmul_clamp_f32_f32_f32p2vlx1b_1x16vl_sme2_mla,
-        kai_get_nr_matmul_clamp_f32_f32_f32p2vlx1b_1x16vl_sme2_mla,
-        kai_get_kr_matmul_clamp_f32_f32_f32p2vlx1b_1x16vl_sme2_mla,
-        kai_get_sr_matmul_clamp_f32_f32_f32p2vlx1b_1x16vl_sme2_mla,
-        kai_get_lhs_offset_matmul_clamp_f32_f32_f32p2vlx1b_1x16vl_sme2_mla,
-        kai_get_rhs_packed_offset_matmul_clamp_f32_f32_f32p2vlx1b_1x16vl_sme2_mla,
-        kai_get_dst_offset_matmul_clamp_f32_f32_f32p2vlx1b_1x16vl_sme2_mla,
-        kai_get_dst_size_matmul_clamp_f32_f32_f32p2vlx1b_1x16vl_sme2_mla,
-        kai_run_matmul_clamp_f32_f32_f32p2vlx1b_1x16vl_sme2_mla}
+        "kai_matmul_clamp_f32_f32_f32p4vsx1bf32_1x32vs_sme2_mla",
+        KaiF32SgemvUkernel{kai_matmul_clamp_f32_f32_f32p4vsx1bf32_1x32vs_sme2_mla()},
     };
 
 

--- a/onnxruntime/core/mlas/lib/kleidiai/kai_ukernel_interface.h
+++ b/onnxruntime/core/mlas/lib/kleidiai/kai_ukernel_interface.h
@@ -6,6 +6,10 @@
 
 #pragma once
 
+#include "kai/ukernels/matmul/kai_matmul.h"
+#include "kai/ukernels/matmul/kai_matmul_pack_lhs.h"
+#include "kai/ukernels/matmul/kai_matmul_pack_rhs.h"
+
 #include "kai/ukernels/matmul/matmul_clamp_f32_qai8dxp_qsi4c32p/kai_matmul_clamp_f32_qai8dxp_qsi4c32p_interface.h"
 
 #include "kai/ukernels/matmul/matmul_clamp_f32_qsi8d32p_qai4c32p/kai_matmul_clamp_f32_qsi8d32p_qai4c32p_interface.h"
@@ -32,6 +36,74 @@ struct KaiMatmulKernel {
     UkernelFn ukernel;
 };
 
+// Holds either a family-specific legacy interface or the common matmul ukernel API.
+// Type-specific adapters derive from this and expose the operations required by their caller.
+template <typename LegacyUkernel>
+class KaiMatmulUkernel {
+  protected:
+    explicit KaiMatmulUkernel(LegacyUkernel ukernel) : legacy_ukernel_(ukernel) {}
+    explicit KaiMatmulUkernel(kai_matmul_uker_api ukernel)
+        : ukernel_api_(ukernel), uses_ukernel_api_(true) {}
+
+    bool UsesUkernelApi() const { return uses_ukernel_api_; }
+    const LegacyUkernel& LegacyUkernelInterface() const { return legacy_ukernel_; }
+    const kai_matmul_uker_api& UkernelApi() const { return ukernel_api_; }
+
+  private:
+    LegacyUkernel legacy_ukernel_{};
+    kai_matmul_uker_api ukernel_api_{};
+    bool uses_ukernel_api_{false};
+};
+
+enum class KaiF32RhsLayout {
+    KxN,
+    NxK,
+};
+
+class KaiF32SgemmUkernel final : public KaiMatmulUkernel<kai_matmul_clamp_f32_f32p_f32p_ukernel> {
+  public:
+    explicit KaiF32SgemmUkernel(kai_matmul_clamp_f32_f32p_f32p_ukernel ukernel);
+    KaiF32SgemmUkernel(kai_matmul_uker_api ukernel,
+                       kai_matmul_pack_lhs_uker_api lhs_packer,
+                       kai_matmul_pack_rhs_uker_api rhs_kxn_packer,
+                       kai_matmul_pack_rhs_uker_api rhs_nxk_packer);
+
+    size_t get_m_step() const;
+    size_t get_n_step() const;
+    size_t get_lhs_packed_offset(size_t m_idx, size_t k) const;
+    size_t get_rhs_packed_offset(size_t n_idx, size_t k) const;
+    void run_matmul(size_t m, size_t n, size_t k,
+                    const void* lhs_packed, const void* rhs_packed, void* dst,
+                    size_t dst_stride_row, size_t dst_stride_col,
+                    float clamp_min, float clamp_max) const;
+
+    size_t GetLhsPackedSize(size_t m, size_t k) const;
+    const char* GetLhsPackerName() const;
+    void PackLhs(size_t m, size_t k, const float* lhs, size_t lhs_stride, void* lhs_packed) const;
+    size_t GetRhsPackedSize(KaiF32RhsLayout layout, size_t n, size_t k) const;
+    const char* GetRhsPackerName(KaiF32RhsLayout layout) const;
+    void PackRhs(KaiF32RhsLayout layout, size_t n, size_t k,
+                 const float* rhs, size_t rhs_stride, const float* bias, void* rhs_packed) const;
+
+  private:
+    const kai_matmul_pack_rhs_uker_api& RhsPacker(KaiF32RhsLayout layout) const;
+
+    kai_matmul_pack_lhs_uker_api lhs_packer_{};
+    kai_matmul_pack_rhs_uker_api rhs_kxn_packer_{};
+    kai_matmul_pack_rhs_uker_api rhs_nxk_packer_{};
+};
+
+class KaiF32SgemvUkernel final : public KaiMatmulUkernel<kai_matmul_clamp_f32_f32_f32p_ukernel> {
+  public:
+    explicit KaiF32SgemvUkernel(kai_matmul_clamp_f32_f32_f32p_ukernel ukernel);
+    explicit KaiF32SgemvUkernel(kai_matmul_uker_api ukernel);
+
+    void run_matmul(size_t m, size_t n, size_t k,
+                    const void* lhs, size_t lhs_stride, const void* rhs_packed, void* dst,
+                    size_t dst_stride_row, size_t dst_stride_col,
+                    float clamp_min, float clamp_max) const;
+};
+
 enum class KaiQ4RhsPackLayout {
     SymmetricNxK,
     SymmetricNxKInterleavedNrx4,
@@ -47,10 +119,10 @@ struct KaiQ4MatmulKernel {
 };
 
 // Wrapper for FP32 GEMM kernels where both LHS and RHS are pre-packed (common SGEMM path).
-using KaiF32SgemmKernel = KaiMatmulKernel<kai_matmul_clamp_f32_f32p_f32p_ukernel>;
+using KaiF32SgemmKernel = KaiMatmulKernel<KaiF32SgemmUkernel>;
 
 // Wrapper for FP32 kernels used for GEMV-style workloads (typically a single-row/skinny-M use case).
-using KaiF32SgemvKernel = KaiMatmulKernel<kai_matmul_clamp_f32_f32_f32p_ukernel>;
+using KaiF32SgemvKernel = KaiMatmulKernel<KaiF32SgemvUkernel>;
 
 // Wrapper for Qnbit GEMM kernels producing FP32 output.
 using KaiQnbitGemmKernel = KaiQ4MatmulKernel<kai_matmul_clamp_f32_qai8dxp_qsi4c32p_ukernel>;

--- a/onnxruntime/core/mlas/lib/kleidiai/sgemm_kleidiai.cpp
+++ b/onnxruntime/core/mlas/lib/kleidiai/sgemm_kleidiai.cpp
@@ -16,10 +16,6 @@
 
 #include "kai_ukernel_interface.h"
 
-#include "kai/ukernels/matmul/pack/kai_lhs_pack_f32p2vlx1_f32_sme.h"
-#include "kai/ukernels/matmul/pack/kai_rhs_pack_kxn_f32p2vlx1biasf32_f32_f32_sme.h"
-#include "kai/ukernels/matmul/pack/kai_rhs_pack_nxk_f32p2vlx1biasf32_f32_f32_sme.h"
-
 // Thread-local reusable buffers to reduce allocation overhead across tiles.
 struct KaiTlsBuffers {
     std::vector<float> output_tile;
@@ -286,6 +282,9 @@ ArmKleidiAI::MlasGemvBatch(
             // Temporary buffer for output row
             g_kai_tls.output_tile.resize(rhs_shape);
 
+            KLEIDIAI_KERNEL_LOG(sgemm_gemv.name
+                                << " M=1 N=" << rhs_shape << " K=" << K);
+
             // Run specialized 1xN-by-K kernel
             sgemm_gemv.ukernel.run_matmul(
                 1,                                          // Value of 1 for M == 1 and this value represents N when N == 1 case
@@ -348,10 +347,10 @@ Return Value:
     size_t bytes = 0;
     switch (TransB) {
         case CblasNoTrans:
-            bytes = kai_get_rhs_packed_size_rhs_pack_kxn_f32p2vlx1biasf32_f32_f32_sme(N, K);
+            bytes = sgemm_gemm.ukernel.GetRhsPackedSize(KaiF32RhsLayout::KxN, N, K);
             break;
         case CblasTrans:
-            bytes = kai_get_rhs_packed_size_rhs_pack_nxk_f32p2vlx1biasf32_f32_f32_sme(N, K);
+            bytes = sgemm_gemm.ukernel.GetRhsPackedSize(KaiF32RhsLayout::NxK, N, K);
             break;
         default:
             KLEIDIAI_DEBUG_LOG("MlasGemmPackBSize TransB is neither CblasNoTrans nor CblasTrans, returning 0.");
@@ -409,24 +408,23 @@ Return Value:
     }
 
     if (TransA == CblasNoTrans) {
-
-        const size_t nr = sgemm_gemm.ukernel.get_nr();
-        const size_t kr = sgemm_gemm.ukernel.get_kr();
-        const size_t sr = sgemm_gemm.ukernel.get_sr();
-
         // Ensure size and zero the used span.
         g_kai_tls.bias_zero.resize(N, 0.0f);
 
         switch (TransB) {
             case CblasNoTrans:
-            KLEIDIAI_KERNEL_LOG("kai_run_rhs_pack_kxn_f32p2vlx1biasf32_f32_f32_sme Groups=1"
-                                    << " N="<< N << " K=" << K << " nr=" << nr << " kr=" << kr << " sr=" << sr << " rhs_stride_row=" << ldb * sizeof(float));
-                kai_run_rhs_pack_kxn_f32p2vlx1biasf32_f32_f32_sme(1, N, K, nr, kr, sr, ldb * sizeof(float), B, g_kai_tls.bias_zero.data(), nullptr, PackedB, 0, nullptr);
+                KLEIDIAI_KERNEL_LOG(sgemm_gemm.ukernel.GetRhsPackerName(KaiF32RhsLayout::KxN)
+                                    << " N=" << N << " K=" << K
+                                    << " rhs_stride_row=" << ldb * sizeof(float));
+                sgemm_gemm.ukernel.PackRhs(KaiF32RhsLayout::KxN, N, K, B, ldb,
+                                           g_kai_tls.bias_zero.data(), PackedB);
                 break;
             case CblasTrans:
-            KLEIDIAI_KERNEL_LOG("kai_run_rhs_pack_nxk_f32p2vlx1biasf32_f32_f32_sme Groups=1"
-                                    << " N="<< N << " K=" << K << " nr=" << nr << " kr=" << kr << " sr=" << sr << " rhs_stride_row=" << ldb * sizeof(float));
-                kai_run_rhs_pack_nxk_f32p2vlx1biasf32_f32_f32_sme(1, N, K, nr, kr, sr, ldb * sizeof(float), B, g_kai_tls.bias_zero.data(), nullptr, PackedB, 0, nullptr);
+                KLEIDIAI_KERNEL_LOG(sgemm_gemm.ukernel.GetRhsPackerName(KaiF32RhsLayout::NxK)
+                                    << " N=" << N << " K=" << K
+                                    << " rhs_stride_row=" << ldb * sizeof(float));
+                sgemm_gemm.ukernel.PackRhs(KaiF32RhsLayout::NxK, N, K, B, ldb,
+                                           g_kai_tls.bias_zero.data(), PackedB);
                 break;
             default:
             KLEIDIAI_DEBUG_LOG("MlasGemmPackB TransB is neither CblasNoTrans nor CblasTrans, falling back to MLAS.");
@@ -532,14 +530,10 @@ Return Value:
         return false;
     }
 
-    const size_t mr = sgemm_gemm.ukernel.get_mr();
-    const size_t kr = sgemm_gemm.ukernel.get_kr();
-    const size_t sr = sgemm_gemm.ukernel.get_sr();
-
     size_t LhsPackedStride = 0;
     std::byte* LhsPackedData = nullptr;
 
-    LhsPackedStride = kai_get_lhs_packed_size_lhs_pack_f32p2vlx1_f32_sme(M, K, mr, kr, sr);
+    LhsPackedStride = sgemm_gemm.ukernel.GetLhsPackedSize(M, K);
 
     size_t lhs_resize = 0;
     if(MlasMultiplyOverflowsSizeT(LhsPackedStride, BatchSize, &lhs_resize))
@@ -560,9 +554,9 @@ Return Value:
         // We have already decided the matmul variant we are using, before having values for M,N,K
         MlasTrySimpleParallel(ThreadPool, BatchSize, [&](ptrdiff_t batch_idx) {
             std::byte* LhsPackedPtr = &(LhsPackedData[LhsPackedStride * batch_idx]);
-            KLEIDIAI_KERNEL_LOG("kai_run_lhs_pack_f32p2vlx1_f32_sme"
-                                    << " M=" << M << " K=" << K << " mr=" << mr << " kr=" << kr << " sr=" << sr);
-            kai_run_lhs_pack_f32p2vlx1_f32_sme(M, K, mr, kr, sr, 0, Data[batch_idx].A, Data[batch_idx].lda * sizeof(float), LhsPackedPtr);
+            KLEIDIAI_KERNEL_LOG(sgemm_gemm.ukernel.GetLhsPackerName()
+                                << " M=" << M << " K=" << K);
+            sgemm_gemm.ukernel.PackLhs(M, K, Data[batch_idx].A, Data[batch_idx].lda, LhsPackedPtr);
         });
     } else {
         // Multithread pack lhs and rhs
@@ -581,7 +575,9 @@ Return Value:
             if (batch_idx & 0x1) {
                 batch_idx >>= 1;
                 std::byte* LhsPackedPtr = &(LhsPackedData[LhsPackedStride * batch_idx]);
-                kai_run_lhs_pack_f32p2vlx1_f32_sme(M, K, mr, kr, sr, 0, Data[batch_idx].A, Data[batch_idx].lda * sizeof(float), LhsPackedPtr);
+                KLEIDIAI_KERNEL_LOG(sgemm_gemm.ukernel.GetLhsPackerName()
+                                    << " M=" << M << " K=" << K);
+                sgemm_gemm.ukernel.PackLhs(M, K, Data[batch_idx].A, Data[batch_idx].lda, LhsPackedPtr);
             } else {
                 batch_idx >>= 1;
                 std::byte* RhsPackedPtr = &(RhsPackedData[RhsPackedStride * batch_idx]);


### PR DESCRIPTION
### Description

- Bump KleidiAI version to v1.30.0.
- Add FP32 SGEMM/GEMV adapters for KleidiAI’s generic matmul and packing APIs.
- Migrate SME2 FP32 SGEMM and GEMV to the newer optimized kernels and packing format.
- Preserve the existing fixed SME kernel paths.
- Support both KxN and NxK RHS packing through the common interface.

### Motivation and Context

KleidiAI v1.30 exposes its newer optimized SME2 FP32 kernels through generic matmul and packing APIs. The existing integration was tied to fixed kernel signatures. This PR sets the groundwork for integrating more KleidiAI kernels that use the new common API while retaining compatibility with the existing SME implementations.