### PR TITLE
Support attention bias with windowed CPU GQA

### DIFF
--- a/onnxruntime/contrib_ops/cpu/bert/gqa_attention_base.h
+++ b/onnxruntime/contrib_ops/cpu/bert/gqa_attention_base.h
@@ -137,6 +137,7 @@ class GQAAttentionBase {
                         const T* V,                                 // V data with shape BxN_kvxSxH
                         const T* head_sink,                         // Head sink for smooth softmax, nullptr if not used
                         const Tensor* attention_bias,               // Attention bias to add to QxK'
+                        const int32_t* attention_bias_offsets,      // Per-batch absolute KV origin, or nullptr
                         const Tensor* past_key,                     // past K input tensor (if not using past state)
                         const Tensor* past_value,                   // past V input tensor (if not using past state)
                         Tensor* output,                             // output tensor
@@ -196,6 +197,7 @@ class GQAAttentionBase {
 
     if (gqa_mlas_supported) {
       ComputeAttentionProbs(static_cast<T*>(attention_probs), Q, k, head_sink, seqlens_k->Data<int32_t>(), attention_bias_data,
+                            attention_bias_offsets,
                             batch_size, sequence_length, kv_sequence_length, total_sequence_length, attention_bias_shape, seqlen_past_kv_cache,
                             seqlen_present_kv_cache, head_size, past_key_data, present_key_data, output_qk_buffer,
                             past_present_share_buffer, packed_qkv, is_prompt, tp, allocator);
@@ -209,6 +211,7 @@ class GQAAttentionBase {
                               is_prompt, tp, allocator);
     } else {
       ComputeAttentionProbs(static_cast<float*>(attention_probs), Q, k, head_sink, seqlens_k->Data<int32_t>(), attention_bias_data,
+                            attention_bias_offsets,
                             batch_size, sequence_length, kv_sequence_length, total_sequence_length, attention_bias_shape, seqlen_past_kv_cache,
                             seqlen_present_kv_cache, head_size, past_key_data, present_key_data, output_qk_buffer,
                             past_present_share_buffer, packed_qkv, is_prompt, tp, allocator);
@@ -229,16 +232,17 @@ class GQAAttentionBase {
   // quantized present K/V (uint8_t storage).
   template <typename T>
   Status ApplyAttentionQuantized(
-      const T* Q,                    // Q data [B, N, S, H] BNSH
-      const T* K,                    // K data [B, N_kv, L, H] or nullptr for packed_qkv
-      const T* V,                    // V data [B, N_kv, L, H] or nullptr for packed_qkv
-      const T* head_sink,            // smooth softmax sink per head, or nullptr
-      const Tensor* attention_bias,  // additive bias or nullptr
-      const Tensor* past_key,        // past K (uint8_t)
-      const Tensor* past_value,      // past V (uint8_t)
-      Tensor* output,                // output [B, S, N*H] T
-      Tensor* present_key,           // present K (uint8_t)
-      Tensor* present_value,         // present V (uint8_t)
+      const T* Q,                             // Q data [B, N, S, H] BNSH
+      const T* K,                             // K data [B, N_kv, L, H] or nullptr for packed_qkv
+      const T* V,                             // V data [B, N_kv, L, H] or nullptr for packed_qkv
+      const T* head_sink,                     // smooth softmax sink per head, or nullptr
+      const Tensor* attention_bias,           // additive bias or nullptr
+      const int32_t* attention_bias_offsets,  // per-batch absolute KV origin, or nullptr
+      const Tensor* past_key,                 // past K (uint8_t)
+      const Tensor* past_value,               // past V (uint8_t)
+      Tensor* output,                         // output [B, S, N*H] T
+      Tensor* present_key,                    // present K (uint8_t)
+      Tensor* present_value,                  // present V (uint8_t)
       Tensor* output_qk,
       const Tensor* seqlens_k,
       const float* k_scale,
@@ -440,6 +444,9 @@ class GQAAttentionBase {
             if (attention_bias_shape[1] != 1) {
               bias_offset += SafeInt<ptrdiff_t>(head_index) * bias_matrix_size;
             }
+            if (attention_bias_offsets != nullptr) {
+              bias_offset += attention_bias_offsets[batch_index];
+            }
             attn_bias = attention_bias_data + bias_offset;
           }
 
@@ -596,15 +603,16 @@ class GQAAttentionBase {
   // Uses online softmax with KV block tiling for reduced memory usage.
   template <typename T>
   Status ApplyAttentionQuantizedFlash(
-      const T* Q,                    // Q data [B, N, S, H] BNSH
-      const T* K,                    // K data [B, N_kv, L, H] or nullptr for packed_qkv
-      const T* V,                    // V data [B, N_kv, L, H] or nullptr for packed_qkv
-      const Tensor* attention_bias,  // additive bias [B|1, N|1, S, T] or nullptr
-      const Tensor* past_key,        // past K (uint8_t)
-      const Tensor* past_value,      // past V (uint8_t)
-      Tensor* output,                // output [B, S, N*H] T
-      Tensor* present_key,           // present K (uint8_t)
-      Tensor* present_value,         // present V (uint8_t)
+      const T* Q,                             // Q data [B, N, S, H] BNSH
+      const T* K,                             // K data [B, N_kv, L, H] or nullptr for packed_qkv
+      const T* V,                             // V data [B, N_kv, L, H] or nullptr for packed_qkv
+      const Tensor* attention_bias,           // additive bias [B|1, N|1, S, T] or nullptr
+      const int32_t* attention_bias_offsets,  // per-batch absolute KV origin, or nullptr
+      const Tensor* past_key,                 // past K (uint8_t)
+      const Tensor* past_value,               // past V (uint8_t)
+      Tensor* output,                         // output [B, S, N*H] T
+      Tensor* present_key,                    // present K (uint8_t)
+      Tensor* present_value,                  // present V (uint8_t)
       const Tensor* seqlens_k,
       const float* k_scale,
       const float* v_scale,
@@ -795,8 +803,14 @@ class GQAAttentionBase {
       min_total_seqlen = std::min(min_total_seqlen, total_sl);
     }
     const bool ragged_seqlens = (max_total_seqlen != min_total_seqlen);
+    bool ragged_bias_offsets = false;
+    if (attention_bias_data != nullptr && attention_bias_offsets != nullptr) {
+      for (int b = 1; b < batch_size; ++b) {
+        ragged_bias_offsets = ragged_bias_offsets || attention_bias_offsets[b] != attention_bias_offsets[0];
+      }
+    }
 
-    if (ragged_seqlens) {
+    if (ragged_seqlens || ragged_bias_offsets) {
       // Ragged seqlens: each batch item has its own total_seqlen (and therefore
       // past_seqlen). Must use per-batch invocation regardless of past_key/prompt state.
       common_past_seqlen = -1;  // sentinel: per-batch
@@ -885,10 +899,14 @@ class GQAAttentionBase {
       args.v_scale = v_scale;
       if constexpr (std::is_same_v<T, float>) {
         args.output = output->MutableData<float>();
-        args.attention_bias = attention_bias_data;
+        args.attention_bias = attention_bias_data == nullptr
+                                  ? nullptr
+                                  : attention_bias_data + (attention_bias_offsets == nullptr ? 0 : attention_bias_offsets[0]);
       } else {
         args.output_fp16 = output->MutableData<T>();
-        args.attention_bias_fp16 = attention_bias_data;
+        args.attention_bias_fp16 = attention_bias_data == nullptr
+                                       ? nullptr
+                                       : attention_bias_data + (attention_bias_offsets == nullptr ? 0 : attention_bias_offsets[0]);
       }
       args.attention_bias_seqlen_stride = attention_bias_seqlen_stride;
       args.attention_bias_broadcast_batch = attention_bias_broadcast_batch;
@@ -958,6 +976,9 @@ class GQAAttentionBase {
           const size_t bias_head_extent = attention_bias_broadcast_head ? 1 : static_cast<size_t>(num_heads_);
           batch_bias += static_cast<size_t>(SafeInt<size_t>(b) * bias_head_extent * sequence_length * attention_bias_seqlen_stride);
         }
+        if (batch_bias != nullptr && attention_bias_offsets != nullptr) {
+          batch_bias += attention_bias_offsets[b];
+        }
         if constexpr (std::is_same_v<T, float>) {
           args.attention_bias = batch_bias;
         } else {
@@ -980,15 +1001,16 @@ class GQAAttentionBase {
   // Concatenates new K/V into the FP32 present cache, then runs the tiled
   // online-softmax kernel MlasFlashAttentionGQA (QK^T + softmax + S*V fused).
   Status ApplyAttentionFlash(
-      const float* Q,                // Q data [B, N, S, H] BNSH
-      const float* K,                // K data [B, N_kv, L, H] or nullptr for packed_qkv
-      const float* V,                // V data [B, N_kv, L, H] or nullptr for packed_qkv
-      const Tensor* attention_bias,  // additive bias [B|1, N|1, S, T] or nullptr
-      const Tensor* past_key,        // past K (float)
-      const Tensor* past_value,      // past V (float)
-      Tensor* output,                // output [B, S, N*H] float
-      Tensor* present_key,           // present K (float)
-      Tensor* present_value,         // present V (float)
+      const float* Q,                         // Q data [B, N, S, H] BNSH
+      const float* K,                         // K data [B, N_kv, L, H] or nullptr for packed_qkv
+      const float* V,                         // V data [B, N_kv, L, H] or nullptr for packed_qkv
+      const Tensor* attention_bias,           // additive bias [B|1, N|1, S, T] or nullptr
+      const int32_t* attention_bias_offsets,  // per-batch absolute KV origin, or nullptr
+      const Tensor* past_key,                 // past K (float)
+      const Tensor* past_value,               // past V (float)
+      Tensor* output,                         // output [B, S, N*H] float
+      Tensor* present_key,                    // present K (float)
+      Tensor* present_value,                  // present V (float)
       const Tensor* seqlens_k,
       GroupQueryAttentionParameters& parameters,
       AllocatorPtr allocator,
@@ -1139,8 +1161,14 @@ class GQAAttentionBase {
       min_total_seqlen = std::min(min_total_seqlen, total_sl);
     }
     const bool ragged_seqlens = (max_total_seqlen != min_total_seqlen);
+    bool ragged_bias_offsets = false;
+    if (attention_bias_data != nullptr && attention_bias_offsets != nullptr) {
+      for (int b = 1; b < batch_size; ++b) {
+        ragged_bias_offsets = ragged_bias_offsets || attention_bias_offsets[b] != attention_bias_offsets[0];
+      }
+    }
 
-    if (ragged_seqlens) {
+    if (ragged_seqlens || ragged_bias_offsets) {
       common_past_seqlen = -1;  // sentinel: per-batch
     } else if (past_key == nullptr || is_prompt) {
       common_past_seqlen = 0;
@@ -1229,7 +1257,9 @@ class GQAAttentionBase {
       args.k_cache = present_key_data;
       args.v_cache = present_value_data;
       args.output = output->MutableData<float>();
-      args.attention_bias = attention_bias_data;
+      args.attention_bias = attention_bias_data == nullptr
+                                ? nullptr
+                                : attention_bias_data + (attention_bias_offsets == nullptr ? 0 : attention_bias_offsets[0]);
       args.attention_bias_seqlen_stride = attention_bias_seqlen_stride;
       args.attention_bias_broadcast_batch = attention_bias_broadcast_batch;
       args.attention_bias_broadcast_head = attention_bias_broadcast_head;
@@ -1283,6 +1313,9 @@ class GQAAttentionBase {
           const size_t bias_head_extent = attention_bias_broadcast_head ? 1 : static_cast<size_t>(num_heads_);
           batch_bias += static_cast<size_t>(b) * bias_head_extent * sequence_length * attention_bias_seqlen_stride;
         }
+        if (batch_bias != nullptr && attention_bias_offsets != nullptr) {
+          batch_bias += attention_bias_offsets[b];
+        }
         args.attention_bias = batch_bias;
         args.attention_bias_seqlen_stride = attention_bias_seqlen_stride;
         args.attention_bias_broadcast_batch = true;  // batch offset handled above
@@ -1309,6 +1342,7 @@ class GQAAttentionBase {
                              const T* head_sink,                                   // smooth softmax sink per head, or nullptr
                              const int32_t* seqlens_k,                             // total_sequence_length - 1 per batch
                              const T* attention_bias,                              // additive bias [B|1, N|1, S, T], or nullptr
+                             const int32_t* attention_bias_offsets,                // per-batch absolute KV origin, or nullptr
                              const size_t batch_size,                              // batch size
                              const size_t sequence_length,                         // Q sequence length (new tokens)
                              const size_t kv_sequence_length,                      // K/V input sequence length; 0 for shared KV
@@ -1407,6 +1441,9 @@ class GQAAttentionBase {
           }
           if (attention_bias_shape[1] != 1) {
             attention_bias_offset += SafeInt<ptrdiff_t>(head_index) * attention_matrix_size;
+          }
+          if (attention_bias_offsets != nullptr) {
+            attention_bias_offset += attention_bias_offsets[batch_index];
           }
 
           attention_bias_thread = attention_bias + attention_bias_offset;

--- a/onnxruntime/contrib_ops/cpu/bert/gqa_attention_base.h
+++ b/onnxruntime/contrib_ops/cpu/bert/gqa_attention_base.h
@@ -832,9 +832,11 @@ class GQAAttentionBase {
     thread_count = std::max(thread_count, 1);
 
     // Flash decoding: for decode (sequence_length==1), partition KV across threads
-    // to improve parallelism when batch*heads < thread_count.
+    // to improve parallelism when batch*heads < thread_count. The per-batch fallback
+    // uses the regular tiled kernel and therefore needs its larger scratch layout.
     const int kv_chunk_count = (max_total_seqlen + kv_block_size - 1) / kv_block_size;
     const bool use_flash_decoding = (sequence_length == 1 &&
+                                     common_past_seqlen >= 0 &&
                                      batch_size * num_heads_ < thread_count &&
                                      kv_chunk_count > 1);
 

--- a/onnxruntime/contrib_ops/cpu/bert/group_query_attention.cc
+++ b/onnxruntime/contrib_ops/cpu/bert/group_query_attention.cc
@@ -277,7 +277,8 @@ Status GroupQueryAttention<T>::Compute(OpKernelContext* context) const {
   ORT_RETURN_IF_ERROR(group_query_attention_helper::CheckCustomAttentionInputs(position_ids,
                                                                                attention_bias,
                                                                                head_sink,
-                                                                               parameters));
+                                                                               parameters,
+                                                                               /*support_windowed_attention_bias=*/true));
 
   // Populate quantization fields in parameters.
   parameters.k_quant_type = k_quant_type_;
@@ -507,9 +508,11 @@ Status GroupQueryAttention<T>::Compute(OpKernelContext* context) const {
   Tensor* attention_present_key = present_k;
   Tensor* attention_present_value = present_v;
   const Tensor* attention_seqlens_k = seqlens_k;
+  const int32_t* attention_bias_offsets = nullptr;
 
   std::vector<WindowedStep> windowed_steps;
   std::vector<int32_t> windowed_cache_seqlens;
+  std::vector<int32_t> windowed_attention_bias_offsets;
   std::optional<Tensor> windowed_seqlens_tensor;
   std::optional<Tensor> staged_key_tensor;
   std::optional<Tensor> staged_value_tensor;
@@ -529,6 +532,13 @@ Status GroupQueryAttention<T>::Compute(OpKernelContext* context) const {
     PlanWindowedKvCache(seqlens_k->Data<int32_t>(), batch_size, sequence_length, windowed_capacity,
                         local_window_size_, windowed_steps, windowed_cache_seqlens, windowed_use_staging,
                         windowed_staged_capacity);
+    if (attention_bias != nullptr) {
+      windowed_attention_bias_offsets.resize(batch_size);
+      for (int b = 0; b < batch_size; ++b) {
+        windowed_attention_bias_offsets[b] = seqlens_k->Data<int32_t>()[b] - windowed_cache_seqlens[b];
+      }
+      attention_bias_offsets = windowed_attention_bias_offsets.data();
+    }
 
     // Rows are moved verbatim, so the row size is taken from the cache tensor itself and covers
     // fp32/fp16 as well as the int8 and (nibble-packed) int4 quantized layouts.
@@ -623,7 +633,7 @@ Status GroupQueryAttention<T>::Compute(OpKernelContext* context) const {
       if (use_flash) {
         return ApplyAttentionQuantizedFlash(
             q_rotary, k_data_q, v_data_q,
-            attention_bias,
+            attention_bias, attention_bias_offsets,
             attention_past_key, attention_past_value,
             output, attention_present_key, attention_present_value, attention_seqlens_k,
             k_scale->Data<float>(), v_scale->Data<float>(),
@@ -632,7 +642,7 @@ Status GroupQueryAttention<T>::Compute(OpKernelContext* context) const {
 
       return ApplyAttentionQuantized(
           q_rotary, k_data_q, v_data_q, head_sink_data,
-          attention_bias, attention_past_key, attention_past_value,
+          attention_bias, attention_bias_offsets, attention_past_key, attention_past_value,
           output, attention_present_key, attention_present_value, output_qk, attention_seqlens_k,
           k_scale->Data<float>(), v_scale->Data<float>(),
           mlas_quant_type, parameters, allocator, context);
@@ -661,14 +671,15 @@ Status GroupQueryAttention<T>::Compute(OpKernelContext* context) const {
                              attention_present_key != nullptr && attention_present_value != nullptr;
       if (use_flash) {
         return ApplyAttentionFlash(q_rotary, k_data, v_data,
-                                   attention_bias, attention_past_key, attention_past_value,
+                                   attention_bias, attention_bias_offsets, attention_past_key, attention_past_value,
                                    output, attention_present_key, attention_present_value, attention_seqlens_k,
                                    parameters, allocator, context);
       }
     }
 
     return ApplyAttention(q_rotary, k_data, v_data,
-                          head_sink_data, attention_bias, attention_past_key, attention_past_value, output,
+                          head_sink_data, attention_bias, attention_bias_offsets,
+                          attention_past_key, attention_past_value, output,
                           attention_present_key, attention_present_value,
                           output_qk, attention_seqlens_k, parameters, allocator, context);
   };

--- a/onnxruntime/contrib_ops/cpu/bert/group_query_attention.cc
+++ b/onnxruntime/contrib_ops/cpu/bert/group_query_attention.cc
@@ -319,6 +319,11 @@ Status GroupQueryAttention<T>::Compute(OpKernelContext* context) const {
                                "seqlens_k[", b, "] = ", seqlens_k_data[b],
                                " is out of range [0, ", present_kv_seqlen, ")");
       }
+      if (windowed && attention_bias != nullptr && seqlens_k_data[b] >= attention_bias->Shape()[3]) {
+        return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
+                               "seqlens_k[", b, "] = ", seqlens_k_data[b],
+                               " exceeds the attention_bias sequence dimension ", attention_bias->Shape()[3], ".");
+      }
       if ((windowed || !parameters.is_first_prompt) &&
           static_cast<int64_t>(seqlens_k_data[b]) + 1 < sequence_length) {
         return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,

--- a/onnxruntime/contrib_ops/cpu/bert/group_query_attention_helper.h
+++ b/onnxruntime/contrib_ops/cpu/bert/group_query_attention_helper.h
@@ -452,7 +452,8 @@ template <typename T = Tensor>
 Status CheckCustomAttentionInputs(const T* position_ids,
                                   const T* attention_bias,
                                   const T* head_sink,
-                                  const GroupQueryAttentionParameters& parameters) {
+                                  const GroupQueryAttentionParameters& parameters,
+                                  bool support_windowed_attention_bias = false) {
   if (position_ids != nullptr) {
     const auto& pos_ids_shape = position_ids->Shape();
     if (pos_ids_shape[0] != parameters.batch_size) {
@@ -467,7 +468,7 @@ Status CheckCustomAttentionInputs(const T* position_ids,
   }
 
   if (attention_bias != nullptr) {
-    if (parameters.is_windowed_kv_cache) {
+    if (parameters.is_windowed_kv_cache && !support_windowed_attention_bias) {
       return ORT_MAKE_STATUS(ONNXRUNTIME, NOT_IMPLEMENTED,
                              "attention_bias with sliding_window_cache is not implemented in GroupQueryAttention.");
     }

--- a/onnxruntime/test/contrib_ops/group_query_attention_op_test.cc
+++ b/onnxruntime/test/contrib_ops/group_query_attention_op_test.cc
@@ -204,6 +204,61 @@ TEST(GroupQueryAttentionTest, CausalMaskDefaultsToEnabled_CPU) {
   RunGQACausalMaskTest<float>(GqaTargetEp::kCpu, std::nullopt, expected_output);
 }
 
+TEST(GroupQueryAttentionTest, WindowedCacheAttentionBiasWithPositionIds_CPU) {
+  constexpr int batch_size = 1;
+  constexpr int sequence_length = 1;
+  constexpr int num_heads = 1;
+  constexpr int kv_num_heads = 1;
+  constexpr int head_size = 16;
+  constexpr int cache_capacity = 2;
+  constexpr int total_sequence_length = 5;
+
+  OpTester tester("GroupQueryAttention", 1, onnxruntime::kMSDomain);
+  tester.AddAttribute<int64_t>("num_heads", num_heads);
+  tester.AddAttribute<int64_t>("kv_num_heads", kv_num_heads);
+  tester.AddAttribute<int64_t>("do_rotary", 1);
+  tester.AddAttribute<int64_t>("local_window_size", cache_capacity);
+  tester.AddAttribute<int64_t>("sliding_window_cache", 1);
+
+  tester.AddInput<float>("query", {batch_size, sequence_length, head_size}, std::vector<float>(head_size, 0.0f));
+  tester.AddInput<float>("key", {batch_size, sequence_length, head_size}, std::vector<float>(head_size, 0.0f));
+  tester.AddInput<float>("value", {batch_size, sequence_length, head_size}, std::vector<float>(head_size, 20.0f));
+  tester.AddInput<float>("past_key", {batch_size, kv_num_heads, cache_capacity, head_size},
+                         std::vector<float>(cache_capacity * head_size, 0.0f));
+
+  std::vector<float> past_value(cache_capacity * head_size, 5.0f);
+  std::fill(past_value.begin() + head_size, past_value.end(), 10.0f);
+  tester.AddInput<float>("past_value", {batch_size, kv_num_heads, cache_capacity, head_size}, past_value);
+  tester.AddInput<int32_t>("seqlens_k", {batch_size}, {total_sequence_length - 1});
+  tester.AddInput<int32_t>("total_sequence_length", {1}, {total_sequence_length}, /*is_initializer=*/true);
+
+  constexpr int rotary_dim = head_size / 2;
+  tester.AddInput<float>("cos_cache", {total_sequence_length, rotary_dim},
+                         std::vector<float>(total_sequence_length * rotary_dim, 1.0f));
+  tester.AddInput<float>("sin_cache", {total_sequence_length, rotary_dim},
+                         std::vector<float>(total_sequence_length * rotary_dim, 0.0f));
+  tester.AddInput<int64_t>("position_ids", {batch_size, sequence_length}, {total_sequence_length - 1});
+
+  // The two resident rows are absolute positions 3 and 4. Their bias weights are 1:3,
+  // so the expected value is 10 * 1/4 + 20 * 3/4 = 17.5 in every head dimension.
+  tester.AddInput<float>("attention_bias", {batch_size, num_heads, sequence_length, total_sequence_length},
+                         {-100.0f, -100.0f, -100.0f, 0.0f, std::log(3.0f)});
+  tester.AddOptionalInputEdge<float>();  // head_sink
+
+  tester.AddOutput<float>("output", {batch_size, sequence_length, head_size}, std::vector<float>(head_size, 17.5f));
+  tester.AddOutput<float>("present_key", {batch_size, kv_num_heads, cache_capacity, head_size},
+                          std::vector<float>(cache_capacity * head_size, 0.0f));
+  std::vector<float> expected_present_value(cache_capacity * head_size, 10.0f);
+  std::fill(expected_present_value.begin() + head_size, expected_present_value.end(), 20.0f);
+  tester.AddOutput<float>("present_value", {batch_size, kv_num_heads, cache_capacity, head_size},
+                          expected_present_value);
+  tester.SetOutputTolerance(0.001f);
+
+  std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
+  execution_providers.push_back(DefaultCpuExecutionProvider());
+  tester.Run(OpTester::ExpectResult::kExpectSuccess, "", {}, nullptr, &execution_providers);
+}
+
 TEST(GroupQueryAttentionTest, BidirectionalMask_CPU) {
   RunGQACausalMaskTest<float>(GqaTargetEp::kCpu, 0, std::vector<float>(16, 2.5f));
 }

--- a/onnxruntime/test/contrib_ops/group_query_attention_op_test.cc
+++ b/onnxruntime/test/contrib_ops/group_query_attention_op_test.cc
@@ -12,6 +12,7 @@
 #include <vector>
 
 #include "gtest/gtest.h"
+#include "core/platform/env.h"
 #include "test/common/tensor_op_test_utils.h"
 #include "test/providers/provider_test_utils.h"
 #include "test/util/include/default_providers.h"
@@ -253,6 +254,115 @@ TEST(GroupQueryAttentionTest, WindowedCacheAttentionBiasWithPositionIds_CPU) {
   tester.AddOutput<float>("present_value", {batch_size, kv_num_heads, cache_capacity, head_size},
                           expected_present_value);
   tester.SetOutputTolerance(0.001f);
+
+  std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
+  execution_providers.push_back(DefaultCpuExecutionProvider());
+  tester.Run(OpTester::ExpectResult::kExpectSuccess, "", {}, nullptr, &execution_providers);
+}
+
+TEST(GroupQueryAttentionTest, WindowedCacheAttentionBiasRejectsAbsoluteLengthBeyondBias_CPU) {
+  constexpr int batch_size = 1;
+  constexpr int sequence_length = 1;
+  constexpr int num_heads = 1;
+  constexpr int kv_num_heads = 1;
+  constexpr int head_size = 16;
+  constexpr int cache_capacity = 16;
+  constexpr int total_sequence_length = 10;
+
+  OpTester tester("GroupQueryAttention", 1, onnxruntime::kMSDomain);
+  tester.AddAttribute<int64_t>("num_heads", num_heads);
+  tester.AddAttribute<int64_t>("kv_num_heads", kv_num_heads);
+  tester.AddAttribute<int64_t>("local_window_size", 8);
+  tester.AddAttribute<int64_t>("sliding_window_cache", 1);
+
+  tester.AddInput<float>("query", {batch_size, sequence_length, head_size}, std::vector<float>(head_size, 0.0f));
+  tester.AddInput<float>("key", {batch_size, sequence_length, head_size}, std::vector<float>(head_size, 0.0f));
+  tester.AddInput<float>("value", {batch_size, sequence_length, head_size}, std::vector<float>(head_size, 0.0f));
+  tester.AddInput<float>("past_key", {batch_size, kv_num_heads, cache_capacity, head_size},
+                         std::vector<float>(cache_capacity * head_size, 0.0f));
+  tester.AddInput<float>("past_value", {batch_size, kv_num_heads, cache_capacity, head_size},
+                         std::vector<float>(cache_capacity * head_size, 0.0f));
+  tester.AddInput<int32_t>("seqlens_k", {batch_size}, {cache_capacity});
+  tester.AddInput<int32_t>("total_sequence_length", {1}, {total_sequence_length}, /*is_initializer=*/true);
+  tester.AddOptionalInputEdge<float>();    // cos_cache
+  tester.AddOptionalInputEdge<float>();    // sin_cache
+  tester.AddOptionalInputEdge<int64_t>();  // position_ids
+  tester.AddInput<float>("attention_bias", {batch_size, num_heads, sequence_length, total_sequence_length},
+                         std::vector<float>(total_sequence_length, 0.0f));
+  tester.AddOptionalInputEdge<float>();  // head_sink
+
+  tester.AddOutput<float>("output", {batch_size, sequence_length, head_size}, std::vector<float>(head_size, 0.0f));
+  tester.AddOutput<float>("present_key", {batch_size, kv_num_heads, cache_capacity, head_size},
+                          std::vector<float>(cache_capacity * head_size, 0.0f));
+  tester.AddOutput<float>("present_value", {batch_size, kv_num_heads, cache_capacity, head_size},
+                          std::vector<float>(cache_capacity * head_size, 0.0f));
+
+  std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
+  execution_providers.push_back(DefaultCpuExecutionProvider());
+  tester.Run(OpTester::ExpectResult::kExpectFailure,
+             "exceeds the attention_bias sequence dimension 10", {}, nullptr, &execution_providers);
+}
+
+TEST(GroupQueryAttentionTest, QuantizedWindowedCacheRaggedBiasOffsetsDecode_CPU) {
+  constexpr int batch_size = 2;
+  constexpr int sequence_length = 1;
+  constexpr int num_heads = 1;
+  constexpr int kv_num_heads = 1;
+  constexpr int head_size = 256;
+  constexpr int hidden_size = num_heads * head_size;
+
+  const int l2_cache_size = std::max(Env::Default().GetL2CacheSize(), 1);
+  const int kv_block_size = std::max(l2_cache_size / (static_cast<int>(sizeof(float)) * 4 *
+                                                      (head_size + head_size)),
+                                     1);
+  const int cache_capacity = 2 * kv_block_size;
+  const int total_sequence_length = cache_capacity + 2;
+  const size_t cache_elements = static_cast<size_t>(batch_size) * kv_num_heads * cache_capacity * head_size;
+
+  OpTester tester("GroupQueryAttention", 1, onnxruntime::kMSDomain);
+  tester.AddAttribute<int64_t>("num_heads", num_heads);
+  tester.AddAttribute<int64_t>("kv_num_heads", kv_num_heads);
+  tester.AddAttribute<std::string>("k_quant_type", "PER_TENSOR");
+  tester.AddAttribute<std::string>("v_quant_type", "PER_TENSOR");
+  tester.AddAttribute<int64_t>("kv_cache_bit_width", 8);
+  tester.AddAttribute<int64_t>("local_window_size", cache_capacity);
+  tester.AddAttribute<int64_t>("sliding_window_cache", 1);
+
+  tester.AddInput<float>("query", {batch_size, sequence_length, hidden_size},
+                         std::vector<float>(batch_size * hidden_size, 0.0f));
+  tester.AddInput<float>("key", {batch_size, sequence_length, head_size},
+                         std::vector<float>(batch_size * head_size, 0.0f));
+  tester.AddInput<float>("value", {batch_size, sequence_length, head_size},
+                         std::vector<float>(batch_size * head_size, 0.25f));
+  tester.AddInput<int8_t>("past_key", {batch_size, kv_num_heads, cache_capacity, head_size},
+                          std::vector<int8_t>(cache_elements, 0));
+  tester.AddInput<int8_t>("past_value", {batch_size, kv_num_heads, cache_capacity, head_size},
+                          std::vector<int8_t>(cache_elements, 1));
+  tester.AddInput<int32_t>("seqlens_k", {batch_size}, {cache_capacity, cache_capacity + 1});
+  tester.AddInput<int32_t>("total_sequence_length", {1}, {total_sequence_length}, /*is_initializer=*/true);
+  tester.AddOptionalInputEdge<float>();    // cos_cache
+  tester.AddOptionalInputEdge<float>();    // sin_cache
+  tester.AddOptionalInputEdge<int64_t>();  // position_ids
+  tester.AddInput<float>("attention_bias", {batch_size, num_heads, sequence_length, total_sequence_length},
+                         std::vector<float>(batch_size * total_sequence_length, 0.0f));
+  tester.AddOptionalInputEdge<float>();  // head_sink
+  tester.AddInput<float>("k_scale", {1}, {0.01f});
+  tester.AddInput<float>("v_scale", {1}, {0.01f});
+
+  tester.AddOutput<float>("output", {batch_size, sequence_length, hidden_size},
+                          std::vector<float>(batch_size * hidden_size, 0.0f));
+  tester.AddOutput<int8_t>("present_key", {batch_size, kv_num_heads, cache_capacity, head_size},
+                           std::vector<int8_t>(cache_elements, 0));
+  tester.AddOutput<int8_t>("present_value", {batch_size, kv_num_heads, cache_capacity, head_size},
+                           std::vector<int8_t>(cache_elements, 0));
+  tester.SetCustomOutputVerifier([](const std::vector<OrtValue>& fetches,
+                                    const std::string& /*provider*/) {
+    ASSERT_FALSE(fetches.empty());
+    const float* output = fetches[0].Get<Tensor>().Data<float>();
+    for (int i = 0; i < batch_size * hidden_size; ++i) {
+      EXPECT_TRUE(std::isfinite(output[i])) << "Non-finite output at index " << i;
+    }
+  });
 
   std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
   execution_providers.push_back(DefaultCpuExecutionProvider());

--- a/onnxruntime/test/python/transformers/test_gqa.py
+++ b/onnxruntime/test/python/transformers/test_gqa.py
@@ -4221,6 +4221,8 @@ def _windowed_run_steps(
     ort_type,
     torch_type,
     head_sink=None,
+    attention_bias_all=None,
+    position_ids_all=None,
     k_scale=None,
     v_scale=None,
     providers=None,
@@ -4287,6 +4289,14 @@ def _windowed_run_steps(
         if cos is not None:
             bind_tensor(io_binding, "cos_cache", cos, device, ort_type)
             bind_tensor(io_binding, "sin_cache", sin, device, ort_type)
+
+        if position_ids_all is not None:
+            position_ids = position_ids_all[:, past_length:total_length].contiguous()
+            bind_tensor(io_binding, "position_ids", position_ids, device, TensorProto.INT64)
+
+        if attention_bias_all is not None:
+            attention_bias = attention_bias_all[:, :, past_length:total_length, :total_length].contiguous()
+            bind_tensor(io_binding, "attention_bias", attention_bias, device, ort_type)
 
         if head_sink is not None:
             bind_tensor(io_binding, "head_sink", head_sink, device, ort_type)
@@ -4372,6 +4382,22 @@ class TestGQAWindowedKvCache(unittest.TestCase):
         if base_config.has_head_sink:
             head_sink = torch.rand(base_config.num_heads, dtype=torch_type, device=device)
 
+        attention_bias_all = None
+        if base_config.has_attention_bias:
+            bias_shape = (
+                1 if base_config.attention_bias_broadcast_dim_0 else base_config.batch_size,
+                base_config.num_heads if base_config.attention_bias_per_head else 1,
+                total_length,
+                total_length,
+            )
+            attention_bias_all = torch.randn(bias_shape, dtype=torch_type, device=device) * 0.5
+
+        position_ids_all = None
+        if base_config.has_position_ids:
+            position_ids_all = (torch.arange(total_length, dtype=torch.int64, device=device) * 7) % self.max_length
+            position_ids_all = position_ids_all.unsqueeze(0)
+            position_ids_all = position_ids_all.expand(base_config.batch_size, -1).contiguous()
+
         k_scale, v_scale = None, None
         if base_config.k_quant_type != "NONE":
             k_scale, v_scale = get_static_scale(base_config, device, torch_type, 0.2)
@@ -4389,6 +4415,8 @@ class TestGQAWindowedKvCache(unittest.TestCase):
             "ort_type": ort_type,
             "torch_type": torch_type,
             "head_sink": head_sink,
+            "attention_bias_all": attention_bias_all,
+            "position_ids_all": position_ids_all,
             "k_scale": k_scale,
             "v_scale": v_scale,
             "providers": self.providers,
@@ -4557,6 +4585,29 @@ class TestGQAWindowedKvCacheCpu(TestGQAWindowedKvCache):
         # The float32 CPU kernel keeps an unquantized float32 cache by default.
         overrides.setdefault("kv_cache_type", "float32")
         return super()._base_config(**overrides)
+
+    def test_attention_bias_with_position_ids(self):
+        self._check_parity(
+            self._base_config(
+                rotary=True,
+                has_position_ids=True,
+                has_attention_bias=True,
+                attention_bias_per_head=True,
+            ),
+            step_lengths=[64, *([1] * 400)],
+        )
+
+    def test_attention_bias_with_position_ids_non_flash(self):
+        with scoped_env_var("ORT_GQA_DISABLE_FLASH_ATTENTION", "1"):
+            self._check_parity(
+                self._base_config(
+                    rotary=True,
+                    has_position_ids=True,
+                    has_attention_bias=True,
+                    attention_bias_per_head=True,
+                ),
+                step_lengths=[self.window_size + self.slack, 1, 1],
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description

Enables the CPU GroupQueryAttention implementation to use `attention_bias` with `sliding_window_cache`. This is needed by speculative decoding with sliding-window attention, including calls that provide explicit `position_ids` for RoPE.

## Summary of Changes

### CPU GQA

| File | Change |
|------|--------|
| `onnxruntime/contrib_ops/cpu/bert/group_query_attention.cc` | Derives the absolute KV origin for each cache-relative batch and forwards it to attention implementations. |
| `onnxruntime/contrib_ops/cpu/bert/gqa_attention_base.h` | Applies the absolute bias-column offset in quantized, unquantized, flash, and non-flash paths, with per-batch fallback for differing origins. |
| `onnxruntime/contrib_ops/cpu/bert/group_query_attention_helper.h` | Allows windowed attention bias only for callers that explicitly support absolute bias offsets; CUDA and WebGPU behavior is unchanged. |

### Tests

- Adds a deterministic CPU regression covering post-eviction bias indexing with explicit `position_ids`.
- Extends windowed-cache parity coverage to combine attention bias, non-default explicit position IDs, repeated eviction, and forced non-flash dispatch.

## Testing

- `cmake --build build/ci_cpu/Release --target onnxruntime_provider_test -j 8`
- `build/ci_cpu/Release/onnxruntime_provider_test --gtest_filter=GroupQueryAttentionTest.WindowedCacheAttentionBiasWithPositionIds_CPU`
- `ORT_GQA_DISABLE_FLASH_ATTENTION=1 build/ci_cpu/Release/onnxruntime_provider_test --gtest_filter=GroupQueryAttentionTest.WindowedCacheAttentionBiasWithPositionIds_CPU`
- `clang-format --dry-run --Werror onnxruntime/contrib_ops/cpu/bert/group_query_attention_helper.h onnxruntime/contrib_ops/cpu/bert/gqa_attention_base.h onnxruntime/contrib_ops/cpu/bert/group_query_attention.cc onnxruntime/test/contrib_ops/group_query_attention_op_test.cc`
- `python3 -m py_compile onnxruntime/test/python/transformers/test_gqa.py`

## Motivation and Context

A windowed KV cache stores resident rows in cache-relative coordinates after eviction, while `attention_bias` remains indexed by absolute sequence position. The previous validation rejected the combination to avoid silently reading incorrect bias columns. This change carries the per-batch absolute cache origin into the CPU attention paths so resident column zero maps to the correct absolute bias column. Explicit `position_ids` remain consumed by RoPE before the cache-relative transition.

## Checklist

- [x] Tests added/updated
- [x] No breaking changes
- [ ] Documentation updated (not applicable; no public API change)
