### PR TITLE
Add Java EPContext data callbacks

### DIFF
--- a/java/src/main/java/ai/onnxruntime/OrtModelCompilationOptions.java
+++ b/java/src/main/java/ai/onnxruntime/OrtModelCompilationOptions.java
@@ -14,10 +14,14 @@ public final class OrtModelCompilationOptions implements AutoCloseable {
   /**
    * Receives external EPContext data during model compilation.
    *
-   * <p>Each payload is copied into a new Java array that the application owns and may retain.
-   * ONNX Runtime may invoke this callback concurrently from multiple threads, so implementations
-   * must synchronize access to shared state. Throwing an exception fails compilation without
-   * falling back to filesystem output.
+   * <p>Each payload is copied into a new Java array that the application owns and may retain. ONNX
+   * Runtime may invoke this callback concurrently from multiple threads, so implementations must
+   * synchronize access to shared state. Throwing an exception fails compilation without falling
+   * back to filesystem output.
+   *
+   * <p>Methods that mutate or close the originating {@link OrtModelCompilationOptions} throw {@link
+   * IllegalStateException} while compilation is in progress. This also applies when they are called
+   * reentrantly from this callback.
    */
   @FunctionalInterface
   public interface EpContextDataWriteCallback {
@@ -68,14 +72,14 @@ public final class OrtModelCompilationOptions implements AutoCloseable {
   private final SessionOptions.EpContextDataReadCallbackRegistration
       epContextDataReadCallbackRegistration;
   private long epContextDataWriteCallbackHandle;
+  private boolean compilationInProgress;
 
   // Used to ensure the byte buffer doesn't get GC'd before the model is compiled.
   private ByteBuffer buffer;
 
   OrtModelCompilationOptions(
       long nativeHandle,
-      SessionOptions.EpContextDataReadCallbackRegistration
-          epContextDataReadCallbackRegistration) {
+      SessionOptions.EpContextDataReadCallbackRegistration epContextDataReadCallbackRegistration) {
     this.nativeHandle = nativeHandle;
     this.epContextDataReadCallbackRegistration = epContextDataReadCallbackRegistration;
   }
@@ -94,24 +98,24 @@ public final class OrtModelCompilationOptions implements AutoCloseable {
    */
   public static OrtModelCompilationOptions createFromSessionOptions(
       OrtEnvironment env, OrtSession.SessionOptions sessionOptions) throws OrtException {
-    synchronized (sessionOptions) {
-      SessionOptions.EpContextDataReadCallbackRegistration registration =
-          sessionOptions.retainEpContextDataReadCallbackRegistration();
-      boolean created = false;
+    try (SessionOptions.NativeSessionOptionsSnapshot snapshot = sessionOptions.createSnapshot()) {
+      long handle =
+          createFromSessionOptions(
+              OnnxRuntime.ortApiHandle,
+              OnnxRuntime.ortCompileApiHandle,
+              env.getNativeHandle(),
+              snapshot.getNativeHandle());
+      boolean wrapped = false;
       try {
-        long handle =
-            createFromSessionOptions(
-                OnnxRuntime.ortApiHandle,
-                OnnxRuntime.ortCompileApiHandle,
-                env.getNativeHandle(),
-                sessionOptions.getNativeHandle());
         OrtModelCompilationOptions options =
-            new OrtModelCompilationOptions(handle, registration);
-        created = true;
+            new OrtModelCompilationOptions(
+                handle, snapshot.getEpContextDataReadCallbackRegistration());
+        snapshot.transferEpContextDataReadCallbackRegistration();
+        wrapped = true;
         return options;
       } finally {
-        if (!created && registration != null) {
-          registration.release();
+        if (!wrapped) {
+          close(OnnxRuntime.ortCompileApiHandle, handle);
         }
       }
     }
@@ -126,9 +130,18 @@ public final class OrtModelCompilationOptions implements AutoCloseable {
     }
   }
 
+  private void checkMutable() {
+    checkClosed();
+    if (compilationInProgress) {
+      throw new IllegalStateException(
+          "Cannot modify OrtModelCompilationOptions while model compilation is in progress.");
+    }
+  }
+
   @Override
   public synchronized void close() {
     if (!closed) {
+      checkMutable();
       close(OnnxRuntime.ortCompileApiHandle, nativeHandle);
       closed = true;
       if (epContextDataWriteCallbackHandle != 0) {
@@ -152,8 +165,8 @@ public final class OrtModelCompilationOptions implements AutoCloseable {
    * @param inputModelPath The path to the model on disk.
    * @throws OrtException If the set failed.
    */
-  public void setInputModelPath(String inputModelPath) throws OrtException {
-    checkClosed();
+  public synchronized void setInputModelPath(String inputModelPath) throws OrtException {
+    checkMutable();
     setInputModelPath(
         OnnxRuntime.ortApiHandle, OnnxRuntime.ortCompileApiHandle, nativeHandle, inputModelPath);
   }
@@ -170,8 +183,9 @@ public final class OrtModelCompilationOptions implements AutoCloseable {
    * @param inputModelBuffer The buffer.
    * @throws OrtException If the buffer could not be set.
    */
-  public void setInputModelFromBuffer(ByteBuffer inputModelBuffer) throws OrtException {
-    checkClosed();
+  public synchronized void setInputModelFromBuffer(ByteBuffer inputModelBuffer)
+      throws OrtException {
+    checkMutable();
     if (!inputModelBuffer.isDirect()) {
       // if it's not a direct buffer, copy it.
       buffer = ByteBuffer.allocateDirect(inputModelBuffer.remaining());
@@ -202,8 +216,8 @@ public final class OrtModelCompilationOptions implements AutoCloseable {
    * @param outputModelPath The output model path.
    * @throws OrtException If the path could not be set.
    */
-  public void setOutputModelPath(String outputModelPath) throws OrtException {
-    checkClosed();
+  public synchronized void setOutputModelPath(String outputModelPath) throws OrtException {
+    checkMutable();
     setOutputModelPath(
         OnnxRuntime.ortApiHandle, OnnxRuntime.ortCompileApiHandle, nativeHandle, outputModelPath);
   }
@@ -221,9 +235,9 @@ public final class OrtModelCompilationOptions implements AutoCloseable {
    * @param sizeThreshold Initializers larger than this threshold are stored in the file.
    * @throws OrtException If the path could not be set.
    */
-  public void setOutputExternalInitializersPath(
+  public synchronized void setOutputExternalInitializersPath(
       String outputExternalInitializersPath, long sizeThreshold) throws OrtException {
-    checkClosed();
+    checkMutable();
     // check positive
     setOutputExternalInitializersPath(
         OnnxRuntime.ortApiHandle,
@@ -251,8 +265,8 @@ public final class OrtModelCompilationOptions implements AutoCloseable {
    *     ep_cache_context attribute.
    * @throws OrtException If the set operation failed.
    */
-  public void setEpContextEmbedMode(boolean embedEpContext) throws OrtException {
-    checkClosed();
+  public synchronized void setEpContextEmbedMode(boolean embedEpContext) throws OrtException {
+    checkMutable();
     setEpContextEmbedMode(
         OnnxRuntime.ortApiHandle, OnnxRuntime.ortCompileApiHandle, nativeHandle, embedEpContext);
   }
@@ -269,14 +283,11 @@ public final class OrtModelCompilationOptions implements AutoCloseable {
    */
   public synchronized void setEpContextDataWriteCallback(EpContextDataWriteCallback callback)
       throws OrtException {
-    checkClosed();
+    checkMutable();
     Objects.requireNonNull(callback, "callback must not be null");
     long callbackHandle =
         setEpContextDataWriteCallback(
-            OnnxRuntime.ortApiHandle,
-            OnnxRuntime.ortCompileApiHandle,
-            nativeHandle,
-            callback);
+            OnnxRuntime.ortApiHandle, OnnxRuntime.ortCompileApiHandle, nativeHandle, callback);
     long previousHandle = epContextDataWriteCallbackHandle;
     epContextDataWriteCallbackHandle = callbackHandle;
     if (previousHandle != 0) {
@@ -290,7 +301,7 @@ public final class OrtModelCompilationOptions implements AutoCloseable {
    * @throws OrtException If native registration fails.
    */
   public synchronized void clearEpContextDataWriteCallback() throws OrtException {
-    checkClosed();
+    checkMutable();
     clearEpContextDataWriteCallback(
         OnnxRuntime.ortApiHandle, OnnxRuntime.ortCompileApiHandle, nativeHandle);
     if (epContextDataWriteCallbackHandle != 0) {
@@ -305,8 +316,9 @@ public final class OrtModelCompilationOptions implements AutoCloseable {
    * @param flags The compilation flags.
    * @throws OrtException If the set operation failed.
    */
-  public void setCompilationFlags(EnumSet<OrtCompileApiFlags> flags) throws OrtException {
-    checkClosed();
+  public synchronized void setCompilationFlags(EnumSet<OrtCompileApiFlags> flags)
+      throws OrtException {
+    checkMutable();
     setCompilationFlags(
         OnnxRuntime.ortApiHandle,
         OnnxRuntime.ortCompileApiHandle,
@@ -319,16 +331,31 @@ public final class OrtModelCompilationOptions implements AutoCloseable {
    * OrtModelCompilationOptions.
    *
    * @throws OrtException If the compilation failed.
+   * @throws IllegalStateException If these options are closed or another compilation is in
+   *     progress.
    */
-  public synchronized void compileModel() throws OrtException {
-    checkClosed();
-    // Safe as the environment must exist to create one of these objects.
-    OrtEnvironment env = OrtEnvironment.getEnvironment();
-    compileModel(
-        OnnxRuntime.ortApiHandle,
-        OnnxRuntime.ortCompileApiHandle,
-        env.getNativeHandle(),
-        nativeHandle);
+  public void compileModel() throws OrtException {
+    synchronized (this) {
+      checkClosed();
+      if (compilationInProgress) {
+        throw new IllegalStateException("Model compilation is already in progress.");
+      }
+      compilationInProgress = true;
+    }
+
+    try {
+      // Safe as the environment must exist to create one of these objects.
+      OrtEnvironment env = OrtEnvironment.getEnvironment();
+      compileModel(
+          OnnxRuntime.ortApiHandle,
+          OnnxRuntime.ortCompileApiHandle,
+          env.getNativeHandle(),
+          nativeHandle);
+    } finally {
+      synchronized (this) {
+        compilationInProgress = false;
+      }
+    }
   }
 
   private static native long createFromSessionOptions(
@@ -366,10 +393,7 @@ public final class OrtModelCompilationOptions implements AutoCloseable {
       throws OrtException;
 
   private static native long setEpContextDataWriteCallback(
-      long apiHandle,
-      long compileApiHandle,
-      long nativeHandle,
-      EpContextDataWriteCallback callback)
+      long apiHandle, long compileApiHandle, long nativeHandle, EpContextDataWriteCallback callback)
       throws OrtException;
 
   private static native void clearEpContextDataWriteCallback(

--- a/java/src/main/java/ai/onnxruntime/OrtModelCompilationOptions.java
+++ b/java/src/main/java/ai/onnxruntime/OrtModelCompilationOptions.java
@@ -4,11 +4,33 @@
  */
 package ai.onnxruntime;
 
+import ai.onnxruntime.OrtSession.SessionOptions;
 import java.nio.ByteBuffer;
 import java.util.EnumSet;
+import java.util.Objects;
 
 /** Configuration options for compiling ONNX models. */
 public final class OrtModelCompilationOptions implements AutoCloseable {
+  /**
+   * Receives external EPContext data during model compilation.
+   *
+   * <p>Each payload is copied into a new Java array that the application owns and may retain.
+   * ONNX Runtime may invoke this callback concurrently from multiple threads, so implementations
+   * must synchronize access to shared state. Throwing an exception fails compilation without
+   * falling back to filesystem output.
+   */
+  @FunctionalInterface
+  public interface EpContextDataWriteCallback {
+    /**
+     * Writes one complete named EPContext payload.
+     *
+     * @param name The logical UTF-8 data identifier stored in the EPContext node.
+     * @param data The payload, owned by the application.
+     * @throws Exception If the payload cannot be written.
+     */
+    void write(String name, byte[] data) throws Exception;
+  }
+
   /** Flags representing options when compiling a model. */
   public enum OrtCompileApiFlags implements OrtFlags {
     /** Default. Do not enable any additional compilation options. */
@@ -43,11 +65,19 @@ public final class OrtModelCompilationOptions implements AutoCloseable {
   private final long nativeHandle;
   private boolean closed = false;
 
+  private final SessionOptions.EpContextDataReadCallbackRegistration
+      epContextDataReadCallbackRegistration;
+  private long epContextDataWriteCallbackHandle;
+
   // Used to ensure the byte buffer doesn't get GC'd before the model is compiled.
   private ByteBuffer buffer;
 
-  OrtModelCompilationOptions(long nativeHandle) {
+  OrtModelCompilationOptions(
+      long nativeHandle,
+      SessionOptions.EpContextDataReadCallbackRegistration
+          epContextDataReadCallbackRegistration) {
     this.nativeHandle = nativeHandle;
+    this.epContextDataReadCallbackRegistration = epContextDataReadCallbackRegistration;
   }
 
   /**
@@ -64,13 +94,27 @@ public final class OrtModelCompilationOptions implements AutoCloseable {
    */
   public static OrtModelCompilationOptions createFromSessionOptions(
       OrtEnvironment env, OrtSession.SessionOptions sessionOptions) throws OrtException {
-    long handle =
-        createFromSessionOptions(
-            OnnxRuntime.ortApiHandle,
-            OnnxRuntime.ortCompileApiHandle,
-            env.getNativeHandle(),
-            sessionOptions.getNativeHandle());
-    return new OrtModelCompilationOptions(handle);
+    synchronized (sessionOptions) {
+      SessionOptions.EpContextDataReadCallbackRegistration registration =
+          sessionOptions.retainEpContextDataReadCallbackRegistration();
+      boolean created = false;
+      try {
+        long handle =
+            createFromSessionOptions(
+                OnnxRuntime.ortApiHandle,
+                OnnxRuntime.ortCompileApiHandle,
+                env.getNativeHandle(),
+                sessionOptions.getNativeHandle());
+        OrtModelCompilationOptions options =
+            new OrtModelCompilationOptions(handle, registration);
+        created = true;
+        return options;
+      } finally {
+        if (!created && registration != null) {
+          registration.release();
+        }
+      }
+    }
   }
 
   /**
@@ -83,10 +127,17 @@ public final class OrtModelCompilationOptions implements AutoCloseable {
   }
 
   @Override
-  public void close() {
+  public synchronized void close() {
     if (!closed) {
       close(OnnxRuntime.ortCompileApiHandle, nativeHandle);
       closed = true;
+      if (epContextDataWriteCallbackHandle != 0) {
+        releaseEpContextDataCallback(epContextDataWriteCallbackHandle);
+        epContextDataWriteCallbackHandle = 0;
+      }
+      if (epContextDataReadCallbackRegistration != null) {
+        epContextDataReadCallbackRegistration.release();
+      }
     } else {
       throw new IllegalStateException("Trying to close a closed OrtModelCompilationOptions.");
     }
@@ -207,6 +258,48 @@ public final class OrtModelCompilationOptions implements AutoCloseable {
   }
 
   /**
+   * Registers a callback that receives external EPContext data when embed mode is disabled.
+   *
+   * <p>The callback and its captured state are retained until they are replaced, cleared, or these
+   * options are closed.
+   *
+   * @param callback The callback that receives named data.
+   * @throws OrtException If native registration fails.
+   * @throws NullPointerException If {@code callback} is null.
+   */
+  public synchronized void setEpContextDataWriteCallback(EpContextDataWriteCallback callback)
+      throws OrtException {
+    checkClosed();
+    Objects.requireNonNull(callback, "callback must not be null");
+    long callbackHandle =
+        setEpContextDataWriteCallback(
+            OnnxRuntime.ortApiHandle,
+            OnnxRuntime.ortCompileApiHandle,
+            nativeHandle,
+            callback);
+    long previousHandle = epContextDataWriteCallbackHandle;
+    epContextDataWriteCallbackHandle = callbackHandle;
+    if (previousHandle != 0) {
+      releaseEpContextDataCallback(previousHandle);
+    }
+  }
+
+  /**
+   * Clears the EPContext data write callback.
+   *
+   * @throws OrtException If native registration fails.
+   */
+  public synchronized void clearEpContextDataWriteCallback() throws OrtException {
+    checkClosed();
+    clearEpContextDataWriteCallback(
+        OnnxRuntime.ortApiHandle, OnnxRuntime.ortCompileApiHandle, nativeHandle);
+    if (epContextDataWriteCallbackHandle != 0) {
+      releaseEpContextDataCallback(epContextDataWriteCallbackHandle);
+      epContextDataWriteCallbackHandle = 0;
+    }
+  }
+
+  /**
    * Sets the specified compilation flags.
    *
    * @param flags The compilation flags.
@@ -227,7 +320,7 @@ public final class OrtModelCompilationOptions implements AutoCloseable {
    *
    * @throws OrtException If the compilation failed.
    */
-  public void compileModel() throws OrtException {
+  public synchronized void compileModel() throws OrtException {
     checkClosed();
     // Safe as the environment must exist to create one of these objects.
     OrtEnvironment env = OrtEnvironment.getEnvironment();
@@ -271,6 +364,18 @@ public final class OrtModelCompilationOptions implements AutoCloseable {
   private static native void setEpContextEmbedMode(
       long apiHandle, long compileApiHandle, long nativeHandle, boolean embedEpContext)
       throws OrtException;
+
+  private static native long setEpContextDataWriteCallback(
+      long apiHandle,
+      long compileApiHandle,
+      long nativeHandle,
+      EpContextDataWriteCallback callback)
+      throws OrtException;
+
+  private static native void clearEpContextDataWriteCallback(
+      long apiHandle, long compileApiHandle, long nativeHandle) throws OrtException;
+
+  private static native void releaseEpContextDataCallback(long callbackHandle);
 
   private static native void setCompilationFlags(
       long apiHandle, long compileApiHandle, long nativeHandle, int flags) throws OrtException;

--- a/java/src/main/java/ai/onnxruntime/OrtSession.java
+++ b/java/src/main/java/ai/onnxruntime/OrtSession.java
@@ -65,7 +65,7 @@ public class OrtSession implements AutoCloseable {
 
   @FunctionalInterface
   private interface NativeSessionCreator {
-    long create() throws OrtException;
+    long create(long optionsHandle) throws OrtException;
   }
 
   private static final class SessionCreationResult {
@@ -94,12 +94,9 @@ public class OrtSession implements AutoCloseable {
     this(
         createSession(
             options,
-            () ->
+            optionsHandle ->
                 createSession(
-                    OnnxRuntime.ortApiHandle,
-                    env.getNativeHandle(),
-                    modelPath,
-                    options.getNativeHandle())),
+                    OnnxRuntime.ortApiHandle, env.getNativeHandle(), modelPath, optionsHandle)),
         allocator);
   }
 
@@ -117,12 +114,9 @@ public class OrtSession implements AutoCloseable {
     this(
         createSession(
             options,
-            () ->
+            optionsHandle ->
                 createSession(
-                    OnnxRuntime.ortApiHandle,
-                    env.getNativeHandle(),
-                    modelArray,
-                    options.getNativeHandle())),
+                    OnnxRuntime.ortApiHandle, env.getNativeHandle(), modelArray, optionsHandle)),
         allocator);
   }
 
@@ -143,30 +137,32 @@ public class OrtSession implements AutoCloseable {
     this(
         createSession(
             options,
-            () ->
+            optionsHandle ->
                 createSession(
                     OnnxRuntime.ortApiHandle,
                     env.getNativeHandle(),
                     modelBuffer,
                     modelBuffer.position(),
                     modelBuffer.remaining(),
-                    options.getNativeHandle())),
+                    optionsHandle)),
         allocator);
   }
 
   private static SessionCreationResult createSession(
       SessionOptions options, NativeSessionCreator creator) throws OrtException {
-    synchronized (options) {
-      SessionOptions.EpContextDataReadCallbackRegistration registration =
-          options.retainEpContextDataReadCallbackRegistration();
-      boolean created = false;
+    try (SessionOptions.NativeSessionOptionsSnapshot snapshot = options.createSnapshot()) {
+      long nativeHandle = creator.create(snapshot.getNativeHandle());
+      boolean wrapped = false;
       try {
-        SessionCreationResult result = new SessionCreationResult(creator.create(), registration);
-        created = true;
+        SessionCreationResult result =
+            new SessionCreationResult(
+                nativeHandle, snapshot.getEpContextDataReadCallbackRegistration());
+        snapshot.transferEpContextDataReadCallbackRegistration();
+        wrapped = true;
         return result;
       } finally {
-        if (!created && registration != null) {
-          registration.release();
+        if (!wrapped) {
+          closeSession(OnnxRuntime.ortApiHandle, nativeHandle);
         }
       }
     }
@@ -672,7 +668,7 @@ public class OrtSession implements AutoCloseable {
   private native String endProfiling(long apiHandle, long nativeHandle, long allocatorHandle)
       throws OrtException;
 
-  private native void closeSession(long apiHandle, long nativeHandle);
+  private static native void closeSession(long apiHandle, long nativeHandle);
 
   /**
    * Builds the {@link OnnxModelMetadata} for this session.
@@ -712,6 +708,10 @@ public class OrtSession implements AutoCloseable {
      *
      * <p>ONNX Runtime may invoke this callback concurrently from multiple threads. Implementations
      * must synchronize access to shared state.
+     *
+     * <p>Session creation uses a snapshot of the source {@link SessionOptions}. Replacing or
+     * clearing the callback on those options from inside this callback does not affect the
+     * in-progress creation. Closing the source options while creation is in progress is rejected.
      */
     @FunctionalInterface
     public interface EpContextDataReadCallback {
@@ -747,6 +747,51 @@ public class OrtSession implements AutoCloseable {
         referenceCount--;
         if (referenceCount == 0) {
           releaseEpContextDataCallback(nativeHandle);
+        }
+      }
+
+      synchronized int getReferenceCount() {
+        return referenceCount;
+      }
+    }
+
+    static final class NativeSessionOptionsSnapshot implements AutoCloseable {
+      private final SessionOptions owner;
+      private final long nativeHandle;
+      private final EpContextDataReadCallbackRegistration callbackRegistration;
+      private boolean callbackRegistrationTransferred;
+      private boolean closed;
+
+      private NativeSessionOptionsSnapshot(
+          SessionOptions owner,
+          long nativeHandle,
+          EpContextDataReadCallbackRegistration callbackRegistration) {
+        this.owner = owner;
+        this.nativeHandle = nativeHandle;
+        this.callbackRegistration = callbackRegistration;
+      }
+
+      long getNativeHandle() {
+        return nativeHandle;
+      }
+
+      EpContextDataReadCallbackRegistration getEpContextDataReadCallbackRegistration() {
+        return callbackRegistration;
+      }
+
+      void transferEpContextDataReadCallbackRegistration() {
+        callbackRegistrationTransferred = true;
+      }
+
+      @Override
+      public void close() {
+        if (!closed) {
+          owner.closeOptions(OnnxRuntime.ortApiHandle, nativeHandle);
+          if (!callbackRegistrationTransferred && callbackRegistration != null) {
+            callbackRegistration.release();
+          }
+          owner.releaseSnapshot();
+          closed = true;
         }
       }
     }
@@ -838,6 +883,7 @@ public class OrtSession implements AutoCloseable {
     private final Map<String, String> configEntries;
 
     private EpContextDataReadCallbackRegistration epContextDataReadCallbackRegistration;
+    private int activeSnapshots;
 
     private boolean closed = false;
 
@@ -848,10 +894,18 @@ public class OrtSession implements AutoCloseable {
       configEntries = new LinkedHashMap<String, String>();
     }
 
-    /** Closes the session options, releasing any memory acquired. */
+    /**
+     * Closes the session options, releasing any memory acquired.
+     *
+     * @throws IllegalStateException If a native operation is currently using an options snapshot.
+     */
     @Override
     public synchronized void close() {
       if (!closed) {
+        if (activeSnapshots != 0) {
+          throw new IllegalStateException(
+              "Cannot close SessionOptions while a native operation is using a snapshot.");
+        }
         if (!customLibraryHandles.isEmpty()) {
           long[] longArray = new long[customLibraryHandles.size()];
           for (int i = 0; i < customLibraryHandles.size(); i++) {
@@ -935,12 +989,40 @@ public class OrtSession implements AutoCloseable {
       }
     }
 
-    synchronized EpContextDataReadCallbackRegistration
-        retainEpContextDataReadCallbackRegistration() {
+    synchronized NativeSessionOptionsSnapshot createSnapshot() throws OrtException {
       checkClosed();
-      if (epContextDataReadCallbackRegistration != null) {
-        epContextDataReadCallbackRegistration.retain();
+      long snapshotHandle = cloneOptions(OnnxRuntime.ortApiHandle, nativeHandle);
+      boolean retained = false;
+      boolean created = false;
+      try {
+        if (epContextDataReadCallbackRegistration != null) {
+          epContextDataReadCallbackRegistration.retain();
+          retained = true;
+        }
+        NativeSessionOptionsSnapshot snapshot =
+            new NativeSessionOptionsSnapshot(
+                this, snapshotHandle, epContextDataReadCallbackRegistration);
+        activeSnapshots++;
+        created = true;
+        return snapshot;
+      } finally {
+        if (!created) {
+          closeOptions(OnnxRuntime.ortApiHandle, snapshotHandle);
+          if (retained) {
+            epContextDataReadCallbackRegistration.release();
+          }
+        }
       }
+    }
+
+    private synchronized void releaseSnapshot() {
+      if (activeSnapshots == 0) {
+        throw new IllegalStateException("SessionOptions snapshot is already released.");
+      }
+      activeSnapshots--;
+    }
+
+    synchronized EpContextDataReadCallbackRegistration getEpContextDataReadCallbackRegistration() {
       return epContextDataReadCallbackRegistration;
     }
 
@@ -1569,6 +1651,8 @@ public class OrtSession implements AutoCloseable {
 
     private native long createOptions(long apiHandle);
 
+    private native long cloneOptions(long apiHandle, long handle) throws OrtException;
+
     private native void setLoggerId(long apiHandle, long nativeHandle, String loggerId)
         throws OrtException;
 
@@ -1600,10 +1684,7 @@ public class OrtSession implements AutoCloseable {
     private native void closeOptions(long apiHandle, long nativeHandle);
 
     private static native long setEpContextDataReadCallback(
-        long apiHandle,
-        long nativeHandle,
-        EpContextDataReadCallback callback,
-        long maxDataSize)
+        long apiHandle, long nativeHandle, EpContextDataReadCallback callback, long maxDataSize)
         throws OrtException;
 
     private static native void clearEpContextDataReadCallback(long apiHandle, long nativeHandle)

--- a/java/src/main/java/ai/onnxruntime/OrtSession.java
+++ b/java/src/main/java/ai/onnxruntime/OrtSession.java
@@ -92,7 +92,7 @@ public class OrtSession implements AutoCloseable {
   OrtSession(OrtEnvironment env, String modelPath, OrtAllocator allocator, SessionOptions options)
       throws OrtException {
     this(
-        createSession(
+        createSessionWithOptionsSnapshot(
             options,
             optionsHandle ->
                 createSession(
@@ -112,7 +112,7 @@ public class OrtSession implements AutoCloseable {
   OrtSession(OrtEnvironment env, byte[] modelArray, OrtAllocator allocator, SessionOptions options)
       throws OrtException {
     this(
-        createSession(
+        createSessionWithOptionsSnapshot(
             options,
             optionsHandle ->
                 createSession(
@@ -135,7 +135,7 @@ public class OrtSession implements AutoCloseable {
       OrtEnvironment env, ByteBuffer modelBuffer, OrtAllocator allocator, SessionOptions options)
       throws OrtException {
     this(
-        createSession(
+        createSessionWithOptionsSnapshot(
             options,
             optionsHandle ->
                 createSession(
@@ -148,7 +148,9 @@ public class OrtSession implements AutoCloseable {
         allocator);
   }
 
-  private static SessionCreationResult createSession(
+  // Native session creation may synchronously invoke EPContext callbacks. Snapshot options and
+  // callback ownership under synchronization, then invoke native creation outside the source lock.
+  private static SessionCreationResult createSessionWithOptionsSnapshot(
       SessionOptions options, NativeSessionCreator creator) throws OrtException {
     try (SessionOptions.NativeSessionOptionsSnapshot snapshot = options.createSnapshot()) {
       long nativeHandle = creator.create(snapshot.getNativeHandle());

--- a/java/src/main/java/ai/onnxruntime/OrtSession.java
+++ b/java/src/main/java/ai/onnxruntime/OrtSession.java
@@ -58,7 +58,27 @@ public class OrtSession implements AutoCloseable {
 
   private OnnxModelMetadata metadata;
 
+  private final SessionOptions.EpContextDataReadCallbackRegistration
+      epContextDataReadCallbackRegistration;
+
   private boolean closed = false;
+
+  @FunctionalInterface
+  private interface NativeSessionCreator {
+    long create() throws OrtException;
+  }
+
+  private static final class SessionCreationResult {
+    private final long nativeHandle;
+    private final SessionOptions.EpContextDataReadCallbackRegistration callbackRegistration;
+
+    private SessionCreationResult(
+        long nativeHandle,
+        SessionOptions.EpContextDataReadCallbackRegistration callbackRegistration) {
+      this.nativeHandle = nativeHandle;
+      this.callbackRegistration = callbackRegistration;
+    }
+  }
 
   /**
    * Create a session loading the model from disk.
@@ -73,7 +93,13 @@ public class OrtSession implements AutoCloseable {
       throws OrtException {
     this(
         createSession(
-            OnnxRuntime.ortApiHandle, env.getNativeHandle(), modelPath, options.getNativeHandle()),
+            options,
+            () ->
+                createSession(
+                    OnnxRuntime.ortApiHandle,
+                    env.getNativeHandle(),
+                    modelPath,
+                    options.getNativeHandle())),
         allocator);
   }
 
@@ -90,7 +116,13 @@ public class OrtSession implements AutoCloseable {
       throws OrtException {
     this(
         createSession(
-            OnnxRuntime.ortApiHandle, env.getNativeHandle(), modelArray, options.getNativeHandle()),
+            options,
+            () ->
+                createSession(
+                    OnnxRuntime.ortApiHandle,
+                    env.getNativeHandle(),
+                    modelArray,
+                    options.getNativeHandle())),
         allocator);
   }
 
@@ -110,13 +142,34 @@ public class OrtSession implements AutoCloseable {
       throws OrtException {
     this(
         createSession(
-            OnnxRuntime.ortApiHandle,
-            env.getNativeHandle(),
-            modelBuffer,
-            modelBuffer.position(),
-            modelBuffer.remaining(),
-            options.getNativeHandle()),
+            options,
+            () ->
+                createSession(
+                    OnnxRuntime.ortApiHandle,
+                    env.getNativeHandle(),
+                    modelBuffer,
+                    modelBuffer.position(),
+                    modelBuffer.remaining(),
+                    options.getNativeHandle())),
         allocator);
+  }
+
+  private static SessionCreationResult createSession(
+      SessionOptions options, NativeSessionCreator creator) throws OrtException {
+    synchronized (options) {
+      SessionOptions.EpContextDataReadCallbackRegistration registration =
+          options.retainEpContextDataReadCallbackRegistration();
+      boolean created = false;
+      try {
+        SessionCreationResult result = new SessionCreationResult(creator.create(), registration);
+        created = true;
+        return result;
+      } finally {
+        if (!created && registration != null) {
+          registration.release();
+        }
+      }
+    }
   }
 
   /**
@@ -126,18 +179,31 @@ public class OrtSession implements AutoCloseable {
    * @param allocator The allocator to use.
    * @throws OrtException If the model's inputs, outputs or metadata could not be read.
    */
-  private OrtSession(long nativeHandle, OrtAllocator allocator) throws OrtException {
-    this.nativeHandle = nativeHandle;
+  private OrtSession(SessionCreationResult result, OrtAllocator allocator) throws OrtException {
+    this.nativeHandle = result.nativeHandle;
     this.allocator = allocator;
-    numInputs = getNumInputs(OnnxRuntime.ortApiHandle, nativeHandle);
-    inputNames =
-        new LinkedHashSet<>(
-            Arrays.asList(getInputNames(OnnxRuntime.ortApiHandle, nativeHandle, allocator.handle)));
-    numOutputs = getNumOutputs(OnnxRuntime.ortApiHandle, nativeHandle);
-    outputNames =
-        new LinkedHashSet<>(
-            Arrays.asList(
-                getOutputNames(OnnxRuntime.ortApiHandle, nativeHandle, allocator.handle)));
+    this.epContextDataReadCallbackRegistration = result.callbackRegistration;
+    boolean initialized = false;
+    try {
+      numInputs = getNumInputs(OnnxRuntime.ortApiHandle, nativeHandle);
+      inputNames =
+          new LinkedHashSet<>(
+              Arrays.asList(
+                  getInputNames(OnnxRuntime.ortApiHandle, nativeHandle, allocator.handle)));
+      numOutputs = getNumOutputs(OnnxRuntime.ortApiHandle, nativeHandle);
+      outputNames =
+          new LinkedHashSet<>(
+              Arrays.asList(
+                  getOutputNames(OnnxRuntime.ortApiHandle, nativeHandle, allocator.handle)));
+      initialized = true;
+    } finally {
+      if (!initialized) {
+        closeSession(OnnxRuntime.ortApiHandle, nativeHandle);
+        if (epContextDataReadCallbackRegistration != null) {
+          epContextDataReadCallbackRegistration.release();
+        }
+      }
+    }
   }
 
   /**
@@ -512,6 +578,9 @@ public class OrtSession implements AutoCloseable {
     if (!closed) {
       closeSession(OnnxRuntime.ortApiHandle, nativeHandle);
       closed = true;
+      if (epContextDataReadCallbackRegistration != null) {
+        epContextDataReadCallbackRegistration.release();
+      }
     } else {
       throw new IllegalStateException("Trying to close an already closed OrtSession.");
     }
@@ -603,7 +672,7 @@ public class OrtSession implements AutoCloseable {
   private native String endProfiling(long apiHandle, long nativeHandle, long allocatorHandle)
       throws OrtException;
 
-  private native void closeSession(long apiHandle, long nativeHandle) throws OrtException;
+  private native void closeSession(long apiHandle, long nativeHandle);
 
   /**
    * Builds the {@link OnnxModelMetadata} for this session.
@@ -633,6 +702,54 @@ public class OrtSession implements AutoCloseable {
    * otherwise it could release resources that are in use.
    */
   public static class SessionOptions implements AutoCloseable {
+
+    /**
+     * Supplies external EPContext data during session initialization.
+     *
+     * <p>The returned array is copied into memory owned by ONNX Runtime and may be reused by the
+     * application after this method returns. Returning {@code null} or throwing an exception fails
+     * the ONNX Runtime operation without falling back to filesystem access.
+     *
+     * <p>ONNX Runtime may invoke this callback concurrently from multiple threads. Implementations
+     * must synchronize access to shared state.
+     */
+    @FunctionalInterface
+    public interface EpContextDataReadCallback {
+      /**
+       * Reads one complete named EPContext payload.
+       *
+       * @param name The logical UTF-8 data identifier stored in the EPContext node.
+       * @return The payload. A zero-length array represents an empty payload.
+       * @throws Exception If the payload cannot be read.
+       */
+      byte[] read(String name) throws Exception;
+    }
+
+    static final class EpContextDataReadCallbackRegistration {
+      private final long nativeHandle;
+      private int referenceCount = 1;
+
+      private EpContextDataReadCallbackRegistration(long nativeHandle) {
+        this.nativeHandle = nativeHandle;
+      }
+
+      synchronized void retain() {
+        if (referenceCount == 0) {
+          throw new IllegalStateException("EPContext data read callback is already released.");
+        }
+        referenceCount++;
+      }
+
+      synchronized void release() {
+        if (referenceCount == 0) {
+          throw new IllegalStateException("EPContext data read callback is already released.");
+        }
+        referenceCount--;
+        if (referenceCount == 0) {
+          releaseEpContextDataCallback(nativeHandle);
+        }
+      }
+    }
 
     /**
      * The optimisation level to use. Needs to be kept in sync with the GraphOptimizationLevel enum
@@ -720,6 +837,8 @@ public class OrtSession implements AutoCloseable {
 
     private final Map<String, String> configEntries;
 
+    private EpContextDataReadCallbackRegistration epContextDataReadCallbackRegistration;
+
     private boolean closed = false;
 
     /** Create an empty session options. */
@@ -731,7 +850,7 @@ public class OrtSession implements AutoCloseable {
 
     /** Closes the session options, releasing any memory acquired. */
     @Override
-    public void close() {
+    public synchronized void close() {
       if (!closed) {
         if (!customLibraryHandles.isEmpty()) {
           long[] longArray = new long[customLibraryHandles.size()];
@@ -742,6 +861,10 @@ public class OrtSession implements AutoCloseable {
         }
         closeOptions(OnnxRuntime.ortApiHandle, nativeHandle);
         closed = true;
+        if (epContextDataReadCallbackRegistration != null) {
+          epContextDataReadCallbackRegistration.release();
+          epContextDataReadCallbackRegistration = null;
+        }
       } else {
         throw new IllegalStateException("Trying to close a closed SessionOptions.");
       }
@@ -761,6 +884,64 @@ public class OrtSession implements AutoCloseable {
      */
     long getNativeHandle() {
       return nativeHandle;
+    }
+
+    /**
+     * Registers a callback that supplies external EPContext data during session initialization.
+     *
+     * <p>The callback and its captured state are retained until these options and every session or
+     * model compilation options created from them are closed. Replacing or clearing the callback
+     * does not affect existing sessions or compilation options.
+     *
+     * @param callback The callback that supplies named data.
+     * @param maxDataSize A finite maximum payload size in bytes. Must be greater than zero. A
+     *     callback result larger than this limit fails the ONNX Runtime operation.
+     * @throws OrtException If native registration fails.
+     * @throws IllegalArgumentException If {@code maxDataSize} is not positive.
+     * @throws NullPointerException If {@code callback} is null.
+     */
+    public synchronized void setEpContextDataReadCallback(
+        EpContextDataReadCallback callback, long maxDataSize) throws OrtException {
+      checkClosed();
+      Objects.requireNonNull(callback, "callback must not be null");
+      if (maxDataSize <= 0) {
+        throw new IllegalArgumentException("maxDataSize must be greater than zero");
+      }
+
+      long callbackHandle =
+          setEpContextDataReadCallback(
+              OnnxRuntime.ortApiHandle, nativeHandle, callback, maxDataSize);
+      EpContextDataReadCallbackRegistration previous = epContextDataReadCallbackRegistration;
+      epContextDataReadCallbackRegistration =
+          new EpContextDataReadCallbackRegistration(callbackHandle);
+      if (previous != null) {
+        previous.release();
+      }
+    }
+
+    /**
+     * Clears the EPContext data read callback.
+     *
+     * <p>Existing sessions and model compilation options retain their callback snapshot.
+     *
+     * @throws OrtException If native registration fails.
+     */
+    public synchronized void clearEpContextDataReadCallback() throws OrtException {
+      checkClosed();
+      clearEpContextDataReadCallback(OnnxRuntime.ortApiHandle, nativeHandle);
+      if (epContextDataReadCallbackRegistration != null) {
+        epContextDataReadCallbackRegistration.release();
+        epContextDataReadCallbackRegistration = null;
+      }
+    }
+
+    synchronized EpContextDataReadCallbackRegistration
+        retainEpContextDataReadCallbackRegistration() {
+      checkClosed();
+      if (epContextDataReadCallbackRegistration != null) {
+        epContextDataReadCallbackRegistration.retain();
+      }
+      return epContextDataReadCallbackRegistration;
     }
 
     /**
@@ -1417,6 +1598,18 @@ public class OrtSession implements AutoCloseable {
     private native void closeCustomLibraries(long[] nativeHandle);
 
     private native void closeOptions(long apiHandle, long nativeHandle);
+
+    private static native long setEpContextDataReadCallback(
+        long apiHandle,
+        long nativeHandle,
+        EpContextDataReadCallback callback,
+        long maxDataSize)
+        throws OrtException;
+
+    private static native void clearEpContextDataReadCallback(long apiHandle, long nativeHandle)
+        throws OrtException;
+
+    private static native void releaseEpContextDataCallback(long callbackHandle);
 
     private native void setDeterministicCompute(
         long apiHandle, long nativeHandle, boolean isDeterministic) throws OrtException;

--- a/java/src/main/native/OrtJniUtil.c
+++ b/java/src/main/native/OrtJniUtil.c
@@ -3,8 +3,18 @@
  * Licensed under the MIT License.
  */
 #include <jni.h>
+#include <limits.h>
 #include <stdio.h>
+#include <string.h>
 #include "OrtJniUtil.h"
+
+struct EpContextDataCallbackState {
+    JavaVM* jvm;
+    jobject callback;
+    jmethodID method;
+    const OrtApi* api;
+    size_t maxDataSize;
+};
 
 jint JNI_OnLoad(JavaVM *vm, void *reserved) {
     // To silence unused-parameter error.
@@ -14,6 +24,252 @@ jint JNI_OnLoad(JavaVM *vm, void *reserved) {
     // Requesting 1.6 to support Android. Will need to be bumped to a later version to call interface default methods
     // from native code, or to access other new Java features.
     return JNI_VERSION_1_6;
+}
+
+static OrtStatus* createCallbackStatus(
+    const EpContextDataCallbackState* state, OrtErrorCode code, const char* message) {
+    return state->api->CreateStatus(code, message);
+}
+
+static OrtStatus* createJavaExceptionStatus(
+    const EpContextDataCallbackState* state, JNIEnv* jniEnv, const char* prefix) {
+    jthrowable throwable = (*jniEnv)->ExceptionOccurred(jniEnv);
+    (*jniEnv)->ExceptionClear(jniEnv);
+
+    const char* detail = NULL;
+    jstring detailString = NULL;
+    jclass throwableClass = NULL;
+    if (throwable != NULL) {
+        throwableClass = (*jniEnv)->GetObjectClass(jniEnv, throwable);
+        if (throwableClass != NULL) {
+            jmethodID toString = (*jniEnv)->GetMethodID(
+                jniEnv, throwableClass, "toString", "()Ljava/lang/String;");
+            if (toString != NULL) {
+                detailString = (jstring)(*jniEnv)->CallObjectMethod(jniEnv, throwable, toString);
+                if (!(*jniEnv)->ExceptionCheck(jniEnv) && detailString != NULL) {
+                    detail = (*jniEnv)->GetStringUTFChars(jniEnv, detailString, NULL);
+                }
+            }
+        }
+    }
+
+    if ((*jniEnv)->ExceptionCheck(jniEnv)) {
+        (*jniEnv)->ExceptionClear(jniEnv);
+    }
+
+    OrtStatus* status = NULL;
+    if (detail != NULL) {
+        size_t prefixLength = strlen(prefix);
+        size_t detailLength = strlen(detail);
+        char* message = (char*)malloc(prefixLength + detailLength + 3);
+        if (message != NULL) {
+            snprintf(message, prefixLength + detailLength + 3, "%s: %s", prefix, detail);
+            status = createCallbackStatus(state, ORT_FAIL, message);
+            free(message);
+        }
+        (*jniEnv)->ReleaseStringUTFChars(jniEnv, detailString, detail);
+    }
+
+    if (detailString != NULL) {
+        (*jniEnv)->DeleteLocalRef(jniEnv, detailString);
+    }
+    if (throwableClass != NULL) {
+        (*jniEnv)->DeleteLocalRef(jniEnv, throwableClass);
+    }
+    if (throwable != NULL) {
+        (*jniEnv)->DeleteLocalRef(jniEnv, throwable);
+    }
+
+    return status != NULL ? status : createCallbackStatus(state, ORT_FAIL, prefix);
+}
+
+static OrtStatus* getCallbackEnv(
+    EpContextDataCallbackState* state, JNIEnv** jniEnv, bool* attached) {
+    *attached = false;
+    jint result = (*state->jvm)->GetEnv(state->jvm, (void**)jniEnv, JNI_VERSION_1_6);
+    if (result == JNI_OK) {
+        return NULL;
+    }
+    if (result != JNI_EDETACHED) {
+        return createCallbackStatus(state, ORT_FAIL, "Failed to access the JVM for an EPContext callback");
+    }
+
+    result = (*state->jvm)->AttachCurrentThread(state->jvm, (void**)jniEnv, NULL);
+    if (result != JNI_OK) {
+        return createCallbackStatus(state, ORT_FAIL, "Failed to attach an EPContext callback thread to the JVM");
+    }
+    *attached = true;
+    return NULL;
+}
+
+static void detachCallbackThread(EpContextDataCallbackState* state, bool attached) {
+    if (attached) {
+        (*state->jvm)->DetachCurrentThread(state->jvm);
+    }
+}
+
+EpContextDataCallbackState* createEpContextDataCallbackState(
+    JNIEnv* jniEnv, const OrtApi* api, jobject callback, const char* methodName,
+    const char* methodSignature, size_t maxDataSize) {
+    EpContextDataCallbackState* state =
+        (EpContextDataCallbackState*)calloc(1, sizeof(EpContextDataCallbackState));
+    if (state == NULL) {
+        throwOrtException(jniEnv, ORT_FAIL, "Not enough memory for the EPContext callback state");
+        return NULL;
+    }
+
+    state->api = api;
+    state->maxDataSize = maxDataSize;
+    if ((*jniEnv)->GetJavaVM(jniEnv, &state->jvm) != JNI_OK) {
+        free(state);
+        throwOrtException(jniEnv, ORT_FAIL, "Failed to access the JVM for the EPContext callback");
+        return NULL;
+    }
+
+    state->callback = (*jniEnv)->NewGlobalRef(jniEnv, callback);
+    if (state->callback == NULL) {
+        free(state);
+        return NULL;
+    }
+
+    jclass callbackClass = (*jniEnv)->GetObjectClass(jniEnv, callback);
+    if (callbackClass == NULL) {
+        (*jniEnv)->DeleteGlobalRef(jniEnv, state->callback);
+        free(state);
+        return NULL;
+    }
+
+    state->method = (*jniEnv)->GetMethodID(jniEnv, callbackClass, methodName, methodSignature);
+    (*jniEnv)->DeleteLocalRef(jniEnv, callbackClass);
+    if (state->method == NULL) {
+        (*jniEnv)->DeleteGlobalRef(jniEnv, state->callback);
+        free(state);
+        return NULL;
+    }
+
+    return state;
+}
+
+void releaseEpContextDataCallbackState(JNIEnv* jniEnv, EpContextDataCallbackState* state) {
+    if (state != NULL) {
+        (*jniEnv)->DeleteGlobalRef(jniEnv, state->callback);
+        free(state);
+    }
+}
+
+OrtStatus* ORT_API_CALL javaEpContextDataReadCallback(
+    void* callbackState, const char* name, OrtAllocator* allocator, void** buffer, size_t* dataSize) {
+    EpContextDataCallbackState* state = (EpContextDataCallbackState*)callbackState;
+    JNIEnv* jniEnv = NULL;
+    bool attached = false;
+    OrtStatus* status = getCallbackEnv(state, &jniEnv, &attached);
+    if (status != NULL) {
+        return status;
+    }
+
+    *buffer = NULL;
+    *dataSize = 0;
+    jstring javaName = (*jniEnv)->NewStringUTF(jniEnv, name);
+    if (javaName == NULL) {
+        status = createJavaExceptionStatus(state, jniEnv, "Failed to create the EPContext data name");
+        detachCallbackThread(state, attached);
+        return status;
+    }
+
+    jbyteArray javaData =
+        (jbyteArray)(*jniEnv)->CallObjectMethod(jniEnv, state->callback, state->method, javaName);
+    if ((*jniEnv)->ExceptionCheck(jniEnv)) {
+        status = createJavaExceptionStatus(state, jniEnv, "EPContext data read callback failed");
+    } else if (javaData == NULL) {
+        status = createCallbackStatus(
+            state, ORT_FAIL, "EPContext data read callback returned null");
+    } else {
+        jsize length = (*jniEnv)->GetArrayLength(jniEnv, javaData);
+        size_t outputSize = (size_t)length;
+        if (outputSize > state->maxDataSize) {
+            status = createCallbackStatus(
+                state, ORT_INVALID_ARGUMENT,
+                "EPContext data read callback result exceeds the configured maximum size");
+        } else if (outputSize != 0) {
+            void* output = allocator->Alloc(allocator, outputSize);
+            if (output == NULL) {
+                status = createCallbackStatus(
+                    state, ORT_FAIL, "Failed to allocate the EPContext data read result");
+            } else {
+                (*jniEnv)->GetByteArrayRegion(
+                    jniEnv, javaData, 0, length, (jbyte*)output);
+                if ((*jniEnv)->ExceptionCheck(jniEnv)) {
+                    allocator->Free(allocator, output);
+                    status = createJavaExceptionStatus(
+                        state, jniEnv, "Failed to copy the EPContext data read result");
+                } else {
+                    *buffer = output;
+                    *dataSize = outputSize;
+                }
+            }
+        }
+    }
+
+    if (javaData != NULL) {
+        (*jniEnv)->DeleteLocalRef(jniEnv, javaData);
+    }
+    (*jniEnv)->DeleteLocalRef(jniEnv, javaName);
+    detachCallbackThread(state, attached);
+    return status;
+}
+
+OrtStatus* ORT_API_CALL javaEpContextDataWriteCallback(
+    void* callbackState, const char* name, const void* buffer, size_t bufferSize) {
+    EpContextDataCallbackState* state = (EpContextDataCallbackState*)callbackState;
+    if (bufferSize > INT_MAX) {
+        return createCallbackStatus(
+            state, ORT_INVALID_ARGUMENT,
+            "EPContext data is too large for a Java byte array");
+    }
+    if (bufferSize != 0 && buffer == NULL) {
+        return createCallbackStatus(
+            state, ORT_INVALID_ARGUMENT,
+            "EPContext data has a null buffer for a non-empty payload");
+    }
+
+    JNIEnv* jniEnv = NULL;
+    bool attached = false;
+    OrtStatus* status = getCallbackEnv(state, &jniEnv, &attached);
+    if (status != NULL) {
+        return status;
+    }
+
+    jstring javaName = (*jniEnv)->NewStringUTF(jniEnv, name);
+    jbyteArray javaData = (*jniEnv)->NewByteArray(jniEnv, (jsize)bufferSize);
+    if (javaName == NULL || javaData == NULL) {
+        status = createJavaExceptionStatus(
+            state, jniEnv, "Failed to allocate Java EPContext callback arguments");
+    } else {
+        if (bufferSize != 0) {
+            (*jniEnv)->SetByteArrayRegion(
+                jniEnv, javaData, 0, (jsize)bufferSize, (const jbyte*)buffer);
+        }
+        if ((*jniEnv)->ExceptionCheck(jniEnv)) {
+            status = createJavaExceptionStatus(
+                state, jniEnv, "Failed to copy EPContext data into Java");
+        } else {
+            (*jniEnv)->CallVoidMethod(
+                jniEnv, state->callback, state->method, javaName, javaData);
+            if ((*jniEnv)->ExceptionCheck(jniEnv)) {
+                status = createJavaExceptionStatus(
+                    state, jniEnv, "EPContext data write callback failed");
+            }
+        }
+    }
+
+    if (javaData != NULL) {
+        (*jniEnv)->DeleteLocalRef(jniEnv, javaData);
+    }
+    if (javaName != NULL) {
+        (*jniEnv)->DeleteLocalRef(jniEnv, javaName);
+    }
+    detachCallbackThread(state, attached);
+    return status;
 }
 
 /**

--- a/java/src/main/native/OrtJniUtil.c
+++ b/java/src/main/native/OrtJniUtil.c
@@ -4,6 +4,7 @@
  */
 #include <jni.h>
 #include <limits.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <string.h>
 #include "OrtJniUtil.h"
@@ -108,6 +109,130 @@ static void detachCallbackThread(EpContextDataCallbackState* state, bool attache
     }
 }
 
+static bool decodeUtf8CodePoint(const unsigned char** cursor, uint32_t* codePoint) {
+  const unsigned char* input = *cursor;
+  const unsigned char first = input[0];
+  if (first <= 0x7f) {
+    *codePoint = first;
+    *cursor = input + 1;
+    return true;
+  }
+
+  const unsigned char second = input[1];
+  if (first >= 0xc2 && first <= 0xdf) {
+    if (second < 0x80 || second > 0xbf) {
+      return false;
+    }
+    *codePoint = ((uint32_t)(first & 0x1f) << 6) | (uint32_t)(second & 0x3f);
+    *cursor = input + 2;
+    return true;
+  }
+
+  if (first >= 0xe0 && first <= 0xef) {
+    if (second < 0x80 || second > 0xbf ||
+        (first == 0xe0 && second < 0xa0) ||
+        (first == 0xed && second > 0x9f)) {
+      return false;
+    }
+    const unsigned char third = input[2];
+    if (third < 0x80 || third > 0xbf) {
+      return false;
+    }
+    *codePoint = ((uint32_t)(first & 0x0f) << 12) |
+                 ((uint32_t)(second & 0x3f) << 6) |
+                 (uint32_t)(third & 0x3f);
+    *cursor = input + 3;
+    return true;
+  }
+
+  if (first >= 0xf0 && first <= 0xf4) {
+    if (second < 0x80 || second > 0xbf ||
+        (first == 0xf0 && second < 0x90) ||
+        (first == 0xf4 && second > 0x8f)) {
+      return false;
+    }
+    const unsigned char third = input[2];
+    if (third < 0x80 || third > 0xbf) {
+      return false;
+    }
+    const unsigned char fourth = input[3];
+    if (fourth < 0x80 || fourth > 0xbf) {
+      return false;
+    }
+    *codePoint = ((uint32_t)(first & 0x07) << 18) |
+                 ((uint32_t)(second & 0x3f) << 12) |
+                 ((uint32_t)(third & 0x3f) << 6) |
+                 (uint32_t)(fourth & 0x3f);
+    *cursor = input + 4;
+    return true;
+  }
+
+  return false;
+}
+
+static jstring createJavaStringFromUtf8(
+    const EpContextDataCallbackState* state, JNIEnv* jniEnv, const char* input,
+    OrtStatus** status) {
+  *status = NULL;
+  if (input == NULL) {
+    *status = createCallbackStatus(state, ORT_INVALID_ARGUMENT, "EPContext data name is null");
+    return NULL;
+  }
+
+  const unsigned char* cursor = (const unsigned char*)input;
+  size_t utf16Length = 0;
+  while (*cursor != '\0') {
+    uint32_t codePoint;
+    if (!decodeUtf8CodePoint(&cursor, &codePoint)) {
+      *status = createCallbackStatus(
+          state, ORT_INVALID_ARGUMENT, "EPContext data name is not valid UTF-8");
+      return NULL;
+    }
+
+    const size_t codeUnits = codePoint <= 0xffff ? 1 : 2;
+    if (utf16Length > (size_t)INT_MAX - codeUnits) {
+      *status = createCallbackStatus(
+          state, ORT_INVALID_ARGUMENT, "EPContext data name is too large for a Java string");
+      return NULL;
+    }
+    utf16Length += codeUnits;
+  }
+
+  jchar emptyString = 0;
+  jchar* utf16 = utf16Length == 0
+                     ? &emptyString
+                     : (jchar*)malloc(utf16Length * sizeof(jchar));
+  if (utf16 == NULL) {
+    *status = createCallbackStatus(
+        state, ORT_FAIL, "Failed to allocate the EPContext data name");
+    return NULL;
+  }
+
+  cursor = (const unsigned char*)input;
+  size_t outputIndex = 0;
+  while (*cursor != '\0') {
+    uint32_t codePoint;
+    (void)decodeUtf8CodePoint(&cursor, &codePoint);
+    if (codePoint <= 0xffff) {
+      utf16[outputIndex++] = (jchar)codePoint;
+    } else {
+      codePoint -= 0x10000;
+      utf16[outputIndex++] = (jchar)(0xd800 | (codePoint >> 10));
+      utf16[outputIndex++] = (jchar)(0xdc00 | (codePoint & 0x3ff));
+    }
+  }
+
+  jstring result = (*jniEnv)->NewString(jniEnv, utf16, (jsize)utf16Length);
+  if (utf16Length != 0) {
+    free(utf16);
+  }
+  if (result == NULL) {
+    *status = createJavaExceptionStatus(
+        state, jniEnv, "Failed to create the EPContext data name");
+  }
+  return result;
+}
+
 EpContextDataCallbackState* createEpContextDataCallbackState(
     JNIEnv* jniEnv, const OrtApi* api, jobject callback, const char* methodName,
     const char* methodSignature, size_t maxDataSize) {
@@ -169,11 +294,10 @@ OrtStatus* ORT_API_CALL javaEpContextDataReadCallback(
 
     *buffer = NULL;
     *dataSize = 0;
-    jstring javaName = (*jniEnv)->NewStringUTF(jniEnv, name);
+    jstring javaName = createJavaStringFromUtf8(state, jniEnv, name, &status);
     if (javaName == NULL) {
-        status = createJavaExceptionStatus(state, jniEnv, "Failed to create the EPContext data name");
-        detachCallbackThread(state, attached);
-        return status;
+      detachCallbackThread(state, attached);
+      return status;
     }
 
     jbyteArray javaData =
@@ -239,27 +363,30 @@ OrtStatus* ORT_API_CALL javaEpContextDataWriteCallback(
         return status;
     }
 
-    jstring javaName = (*jniEnv)->NewStringUTF(jniEnv, name);
-    jbyteArray javaData = (*jniEnv)->NewByteArray(jniEnv, (jsize)bufferSize);
-    if (javaName == NULL || javaData == NULL) {
+    jstring javaName = createJavaStringFromUtf8(state, jniEnv, name, &status);
+    jbyteArray javaData = NULL;
+    if (javaName != NULL) {
+      javaData = (*jniEnv)->NewByteArray(jniEnv, (jsize)bufferSize);
+    }
+    if (status == NULL && javaData == NULL) {
+      status = createJavaExceptionStatus(
+          state, jniEnv, "Failed to allocate Java EPContext callback arguments");
+    } else if (status == NULL) {
+      if (bufferSize != 0) {
+        (*jniEnv)->SetByteArrayRegion(
+            jniEnv, javaData, 0, (jsize)bufferSize, (const jbyte*)buffer);
+      }
+      if ((*jniEnv)->ExceptionCheck(jniEnv)) {
         status = createJavaExceptionStatus(
-            state, jniEnv, "Failed to allocate Java EPContext callback arguments");
-    } else {
-        if (bufferSize != 0) {
-            (*jniEnv)->SetByteArrayRegion(
-                jniEnv, javaData, 0, (jsize)bufferSize, (const jbyte*)buffer);
-        }
+            state, jniEnv, "Failed to copy EPContext data into Java");
+      } else {
+        (*jniEnv)->CallVoidMethod(
+            jniEnv, state->callback, state->method, javaName, javaData);
         if ((*jniEnv)->ExceptionCheck(jniEnv)) {
-            status = createJavaExceptionStatus(
-                state, jniEnv, "Failed to copy EPContext data into Java");
-        } else {
-            (*jniEnv)->CallVoidMethod(
-                jniEnv, state->callback, state->method, javaName, javaData);
-            if ((*jniEnv)->ExceptionCheck(jniEnv)) {
-                status = createJavaExceptionStatus(
-                    state, jniEnv, "EPContext data write callback failed");
-            }
+          status = createJavaExceptionStatus(
+              state, jniEnv, "EPContext data write callback failed");
         }
+      }
     }
 
     if (javaData != NULL) {

--- a/java/src/main/native/OrtJniUtil.c
+++ b/java/src/main/native/OrtJniUtil.c
@@ -170,7 +170,9 @@ static bool decodeUtf8CodePoint(const unsigned char** cursor, uint32_t* codePoin
   return false;
 }
 
-static jstring createJavaStringFromUtf8(
+// ORT callback names use standard UTF-8, while NewStringUTF expects JNI modified UTF-8.
+// Decode strictly to UTF-16 for NewString so supplementary characters are handled correctly.
+static jstring createJavaStringFromStandardUtf8(
     const EpContextDataCallbackState* state, JNIEnv* jniEnv, const char* input,
     OrtStatus** status) {
   *status = NULL;
@@ -294,7 +296,7 @@ OrtStatus* ORT_API_CALL javaEpContextDataReadCallback(
 
     *buffer = NULL;
     *dataSize = 0;
-    jstring javaName = createJavaStringFromUtf8(state, jniEnv, name, &status);
+    jstring javaName = createJavaStringFromStandardUtf8(state, jniEnv, name, &status);
     if (javaName == NULL) {
       detachCallbackThread(state, attached);
       return status;
@@ -363,7 +365,7 @@ OrtStatus* ORT_API_CALL javaEpContextDataWriteCallback(
         return status;
     }
 
-    jstring javaName = createJavaStringFromUtf8(state, jniEnv, name, &status);
+    jstring javaName = createJavaStringFromStandardUtf8(state, jniEnv, name, &status);
     jbyteArray javaData = NULL;
     if (javaName != NULL) {
       javaData = (*jniEnv)->NewByteArray(jniEnv, (jsize)bufferSize);

--- a/java/src/main/native/OrtJniUtil.h
+++ b/java/src/main/native/OrtJniUtil.h
@@ -22,6 +22,8 @@ typedef struct {
   ONNXTensorElementDataType onnxTypeEnum;
 } JavaTensorTypeShape;
 
+typedef struct EpContextDataCallbackState EpContextDataCallbackState;
+
 jint JNI_OnLoad(JavaVM *vm, void *reserved);
 
 OrtLoggingLevel convertLoggingLevel(jint level);
@@ -89,6 +91,18 @@ jint throwOrtException(JNIEnv *env, int messageId, const char *message);
 jint convertErrorCode(OrtErrorCode code);
 
 OrtErrorCode checkOrtStatus(JNIEnv * env, const OrtApi * api, OrtStatus * status);
+
+EpContextDataCallbackState* createEpContextDataCallbackState(
+    JNIEnv* jniEnv, const OrtApi* api, jobject callback, const char* methodName,
+    const char* methodSignature, size_t maxDataSize);
+
+void releaseEpContextDataCallbackState(JNIEnv* jniEnv, EpContextDataCallbackState* state);
+
+OrtStatus* ORT_API_CALL javaEpContextDataReadCallback(
+    void* state, const char* name, OrtAllocator* allocator, void** buffer, size_t* dataSize);
+
+OrtStatus* ORT_API_CALL javaEpContextDataWriteCallback(
+    void* state, const char* name, const void* buffer, size_t bufferSize);
 
 jsize safecast_size_t_to_jsize(size_t v);
 

--- a/java/src/main/native/ai_onnxruntime_OrtModelCompilationOptions.c
+++ b/java/src/main/native/ai_onnxruntime_OrtModelCompilationOptions.c
@@ -165,6 +165,63 @@ JNIEXPORT void JNICALL Java_ai_onnxruntime_OrtModelCompilationOptions_setEpConte
 
 /*
  * Class:     ai_onnxruntime_OrtModelCompilationOptions
+ * Method:    setEpContextDataWriteCallback
+ * Signature: (JJJLai/onnxruntime/OrtModelCompilationOptions/EpContextDataWriteCallback;)J
+ */
+JNIEXPORT jlong JNICALL Java_ai_onnxruntime_OrtModelCompilationOptions_setEpContextDataWriteCallback
+    (JNIEnv* jniEnv, jclass jclazz, jlong apiHandle, jlong compileApiHandle,
+     jlong nativeHandle, jobject callback) {
+  (void)jclazz;
+  const OrtApi* api = (const OrtApi*)apiHandle;
+  const OrtCompileApi* compileApi = (const OrtCompileApi*)compileApiHandle;
+  EpContextDataCallbackState* callbackState = createEpContextDataCallbackState(
+      jniEnv, api, callback, "write", "(Ljava/lang/String;[B)V", 0);
+  if (callbackState == NULL) {
+    return 0;
+  }
+
+  OrtStatus* status = compileApi->ModelCompilationOptions_SetEpContextDataWriteFunc(
+      (OrtModelCompilationOptions*)nativeHandle, javaEpContextDataWriteCallback, callbackState);
+  if (status != NULL) {
+    releaseEpContextDataCallbackState(jniEnv, callbackState);
+    checkOrtStatus(jniEnv, api, status);
+    return 0;
+  }
+
+  return (jlong)callbackState;
+}
+
+/*
+ * Class:     ai_onnxruntime_OrtModelCompilationOptions
+ * Method:    clearEpContextDataWriteCallback
+ * Signature: (JJJ)V
+ */
+JNIEXPORT void JNICALL Java_ai_onnxruntime_OrtModelCompilationOptions_clearEpContextDataWriteCallback
+    (JNIEnv* jniEnv, jclass jclazz, jlong apiHandle, jlong compileApiHandle,
+     jlong nativeHandle) {
+  (void)jclazz;
+  const OrtApi* api = (const OrtApi*)apiHandle;
+  const OrtCompileApi* compileApi = (const OrtCompileApi*)compileApiHandle;
+  checkOrtStatus(
+      jniEnv, api,
+      compileApi->ModelCompilationOptions_SetEpContextDataWriteFunc(
+          (OrtModelCompilationOptions*)nativeHandle, NULL, NULL));
+}
+
+/*
+ * Class:     ai_onnxruntime_OrtModelCompilationOptions
+ * Method:    releaseEpContextDataCallback
+ * Signature: (J)V
+ */
+JNIEXPORT void JNICALL Java_ai_onnxruntime_OrtModelCompilationOptions_releaseEpContextDataCallback
+    (JNIEnv* jniEnv, jclass jclazz, jlong callbackHandle) {
+  (void)jclazz;
+  releaseEpContextDataCallbackState(
+      jniEnv, (EpContextDataCallbackState*)callbackHandle);
+}
+
+/*
+ * Class:     ai_onnxruntime_OrtModelCompilationOptions
  * Method:    setCompilationFlags
  * Signature: (JJJI)V
  */

--- a/java/src/main/native/ai_onnxruntime_OrtSession_SessionOptions.c
+++ b/java/src/main/native/ai_onnxruntime_OrtSession_SessionOptions.c
@@ -143,6 +143,75 @@ JNIEXPORT void JNICALL Java_ai_onnxruntime_OrtSession_00024SessionOptions_closeO
 
 /*
  * Class:     ai_onnxruntime_OrtSession_SessionOptions
+ * Method:    setEpContextDataReadCallback
+ * Signature: (JJLai/onnxruntime/OrtSession/SessionOptions/EpContextDataReadCallback;J)J
+ */
+JNIEXPORT jlong JNICALL Java_ai_onnxruntime_OrtSession_00024SessionOptions_setEpContextDataReadCallback
+    (JNIEnv* jniEnv, jclass jclazz, jlong apiHandle, jlong optionsHandle,
+     jobject callback, jlong maxDataSize) {
+  (void)jclazz;
+  const OrtApi* api = (const OrtApi*)apiHandle;
+  if (maxDataSize <= 0 ||
+      (sizeof(size_t) < sizeof(uint64_t) && (uint64_t)maxDataSize > SIZE_MAX)) {
+    throwOrtException(jniEnv, ORT_INVALID_ARGUMENT, "maxDataSize must be finite and greater than zero");
+    return 0;
+  }
+
+  EpContextDataCallbackState* callbackState = createEpContextDataCallbackState(
+      jniEnv, api, callback, "read", "(Ljava/lang/String;)[B", (size_t)maxDataSize);
+  if (callbackState == NULL) {
+    return 0;
+  }
+
+  OrtEpContextDataReadOptions* readOptions = NULL;
+  OrtStatus* status = api->CreateEpContextDataReadOptions(&readOptions);
+  if (status == NULL) {
+    status = api->EpContextDataReadOptionsSetMaxDataSize(readOptions, (size_t)maxDataSize);
+  }
+  if (status == NULL) {
+    status = api->SessionOptionsSetEpContextDataReadFunc(
+        (OrtSessionOptions*)optionsHandle, javaEpContextDataReadCallback, callbackState, readOptions);
+  }
+  api->ReleaseEpContextDataReadOptions(readOptions);
+
+  if (status != NULL) {
+    releaseEpContextDataCallbackState(jniEnv, callbackState);
+    checkOrtStatus(jniEnv, api, status);
+    return 0;
+  }
+
+  return (jlong)callbackState;
+}
+
+/*
+ * Class:     ai_onnxruntime_OrtSession_SessionOptions
+ * Method:    clearEpContextDataReadCallback
+ * Signature: (JJ)V
+ */
+JNIEXPORT void JNICALL Java_ai_onnxruntime_OrtSession_00024SessionOptions_clearEpContextDataReadCallback
+    (JNIEnv* jniEnv, jclass jclazz, jlong apiHandle, jlong optionsHandle) {
+  (void)jclazz;
+  const OrtApi* api = (const OrtApi*)apiHandle;
+  checkOrtStatus(
+      jniEnv, api,
+      api->SessionOptionsSetEpContextDataReadFunc(
+          (OrtSessionOptions*)optionsHandle, NULL, NULL, NULL));
+}
+
+/*
+ * Class:     ai_onnxruntime_OrtSession_SessionOptions
+ * Method:    releaseEpContextDataCallback
+ * Signature: (J)V
+ */
+JNIEXPORT void JNICALL Java_ai_onnxruntime_OrtSession_00024SessionOptions_releaseEpContextDataCallback
+    (JNIEnv* jniEnv, jclass jclazz, jlong callbackHandle) {
+  (void)jclazz;
+  releaseEpContextDataCallbackState(
+      jniEnv, (EpContextDataCallbackState*)callbackHandle);
+}
+
+/*
+ * Class:     ai_onnxruntime_OrtSession_SessionOptions
  * Method:    setLoggerId
  * Signature: (JJLjava/lang/String;)V
  */

--- a/java/src/main/native/ai_onnxruntime_OrtSession_SessionOptions.c
+++ b/java/src/main/native/ai_onnxruntime_OrtSession_SessionOptions.c
@@ -131,6 +131,21 @@ JNIEXPORT jlong JNICALL Java_ai_onnxruntime_OrtSession_00024SessionOptions_creat
 
 /*
  * Class:     ai_onnxruntime_OrtSession_SessionOptions
+ * Method:    cloneOptions
+ * Signature: (JJ)J
+ */
+JNIEXPORT jlong JNICALL Java_ai_onnxruntime_OrtSession_00024SessionOptions_cloneOptions(JNIEnv* jniEnv, jobject jobj, jlong apiHandle, jlong handle) {
+  (void)jobj;
+  const OrtApi* api = (const OrtApi*)apiHandle;
+  OrtSessionOptions* clonedOptions = NULL;
+  checkOrtStatus(
+      jniEnv, api,
+      api->CloneSessionOptions((const OrtSessionOptions*)handle, &clonedOptions));
+  return (jlong)clonedOptions;
+}
+
+/*
+ * Class:     ai_onnxruntime_OrtSession_SessionOptions
  * Method:    closeOptions
  * Signature: (JJ)V
  */

--- a/java/src/test/java/ai/onnxruntime/CompileApiTest.java
+++ b/java/src/test/java/ai/onnxruntime/CompileApiTest.java
@@ -189,6 +189,7 @@ public class CompileApiTest {
       Assertions.assertEquals(0, clearedWriteCount.get());
       Assertions.assertTrue(Files.exists(clearedWriteModelPath.resolveSibling(contextName.get())));
 
+      // Supplementary characters distinguish standard UTF-8 from JNI modified UTF-8.
       String supplementaryContextPrefix = "context-\uD83D\uDE80-";
       int namePaddingLength =
           contextName.get().getBytes(StandardCharsets.UTF_8).length

--- a/java/src/test/java/ai/onnxruntime/CompileApiTest.java
+++ b/java/src/test/java/ai/onnxruntime/CompileApiTest.java
@@ -7,11 +7,17 @@ package ai.onnxruntime;
 import ai.onnxruntime.OrtSession.SessionOptions;
 import java.io.File;
 import java.io.IOException;
+import java.lang.ref.WeakReference;
 import java.nio.ByteBuffer;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Collections;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 
 /** Test for the compilation API. */
 public class CompileApiTest {
@@ -49,5 +55,244 @@ public class CompileApiTest {
 
       f.delete();
     }
+  }
+
+  @Test
+  public void epContextDataCallbackValidation() throws OrtException {
+    try (SessionOptions sessionOptions = new SessionOptions()) {
+      Assertions.assertThrows(
+          NullPointerException.class,
+          () -> sessionOptions.setEpContextDataReadCallback(null, 1024));
+      Assertions.assertThrows(
+          IllegalArgumentException.class,
+          () -> sessionOptions.setEpContextDataReadCallback(name -> new byte[0], 0));
+      Assertions.assertThrows(
+          IllegalArgumentException.class,
+          () -> sessionOptions.setEpContextDataReadCallback(name -> new byte[0], -1));
+
+      sessionOptions.setEpContextDataReadCallback(name -> new byte[0], 1024);
+      sessionOptions.setEpContextDataReadCallback(name -> new byte[] {1}, 1024);
+      sessionOptions.clearEpContextDataReadCallback();
+
+      try (OrtModelCompilationOptions compileOptions =
+          OrtModelCompilationOptions.createFromSessionOptions(env, sessionOptions)) {
+        Assertions.assertThrows(
+            NullPointerException.class,
+            () -> compileOptions.setEpContextDataWriteCallback(null));
+        compileOptions.setEpContextDataWriteCallback((name, data) -> {});
+        compileOptions.setEpContextDataWriteCallback((name, data) -> {});
+        compileOptions.clearEpContextDataWriteCallback();
+      }
+    }
+  }
+
+  @Test
+  @EnabledOnOs(OS.WINDOWS)
+  public void externalEpContextDataUsesCallbacks() throws Exception {
+    String libraryPath = TestHelpers.getResourcePath("/example_plugin_ep.dll").toString();
+    Assertions.assertTrue(
+        new File(libraryPath).exists(), "Expected library " + libraryPath + " does not exist.");
+
+    String registrationName = "java_ep_context_callbacks";
+    env.registerExecutionProviderLibrary(registrationName, libraryPath);
+
+    Path compiledModelPath = Files.createTempFile("java_ep_context", ".onnx");
+    Path failedModelPath = Files.createTempFile("java_ep_context_failed", ".onnx");
+    Path clearedWriteModelPath = Files.createTempFile("java_ep_context_cleared", ".onnx");
+    Files.deleteIfExists(compiledModelPath);
+    Files.deleteIfExists(failedModelPath);
+    Files.deleteIfExists(clearedWriteModelPath);
+
+    AtomicReference<String> contextName = new AtomicReference<>();
+    AtomicReference<byte[]> contextData = new AtomicReference<>();
+    AtomicInteger replacedWriteCount = new AtomicInteger();
+    AtomicInteger writeCount = new AtomicInteger();
+
+    try {
+      OrtEpDevice device =
+          env.getEpDevices().stream()
+              .filter(candidate -> candidate.getEpName().equals(registrationName))
+              .findFirst()
+              .orElseThrow(() -> new AssertionError("Registered EP device was not found"));
+      byte[] inputModel = Files.readAllBytes(TestHelpers.getResourcePath("/mul_1.onnx"));
+
+      try (SessionOptions sessionOptions = createPluginSessionOptions(device);
+          OrtModelCompilationOptions compileOptions =
+              OrtModelCompilationOptions.createFromSessionOptions(env, sessionOptions)) {
+        configureCompilation(compileOptions, inputModel, failedModelPath);
+        compileOptions.setEpContextDataWriteCallback(
+            (name, data) -> {
+              throw new IOException("synthetic Java EPContext write failure");
+            });
+
+        OrtException exception =
+            Assertions.assertThrows(OrtException.class, compileOptions::compileModel);
+        Assertions.assertTrue(
+            exception.getMessage().contains("synthetic Java EPContext write failure"));
+      }
+
+      try (SessionOptions sessionOptions = createPluginSessionOptions(device);
+          OrtModelCompilationOptions compileOptions =
+              OrtModelCompilationOptions.createFromSessionOptions(env, sessionOptions)) {
+        configureCompilation(compileOptions, inputModel, compiledModelPath);
+        compileOptions.setEpContextDataWriteCallback(
+            (name, data) -> replacedWriteCount.incrementAndGet());
+        compileOptions.setEpContextDataWriteCallback(
+            (name, data) -> {
+              writeCount.incrementAndGet();
+              contextName.set(name);
+              contextData.set(data);
+            });
+        compileOptions.compileModel();
+      }
+
+      Assertions.assertEquals(0, replacedWriteCount.get());
+      Assertions.assertEquals(1, writeCount.get());
+      Assertions.assertNotNull(contextName.get());
+      Assertions.assertFalse(contextName.get().isEmpty());
+      Assertions.assertNotNull(contextData.get());
+      Assertions.assertTrue(contextData.get().length > 0);
+      Assertions.assertTrue(Files.exists(compiledModelPath));
+      Assertions.assertFalse(Files.exists(compiledModelPath.resolveSibling(contextName.get())));
+
+      AtomicInteger clearedWriteCount = new AtomicInteger();
+      try (SessionOptions sessionOptions = createPluginSessionOptions(device);
+          OrtModelCompilationOptions compileOptions =
+              OrtModelCompilationOptions.createFromSessionOptions(env, sessionOptions)) {
+        configureCompilation(compileOptions, inputModel, clearedWriteModelPath);
+        compileOptions.setEpContextDataWriteCallback(
+            (name, data) -> clearedWriteCount.incrementAndGet());
+        compileOptions.clearEpContextDataWriteCallback();
+        compileOptions.compileModel();
+      }
+      Assertions.assertEquals(0, clearedWriteCount.get());
+      Assertions.assertTrue(
+          Files.exists(clearedWriteModelPath.resolveSibling(contextName.get())));
+
+      byte[] compiledModel = Files.readAllBytes(compiledModelPath);
+
+      try (SessionOptions sessionOptions = createPluginSessionOptions(device)) {
+        sessionOptions.setEpContextDataReadCallback(
+            name -> {
+              throw new IOException("synthetic Java EPContext read failure");
+            },
+            contextData.get().length);
+        OrtException exception =
+            Assertions.assertThrows(
+                OrtException.class, () -> env.createSession(compiledModel, sessionOptions));
+        Assertions.assertTrue(
+            exception.getMessage().contains("synthetic Java EPContext read failure"));
+      }
+
+      try (SessionOptions sessionOptions = createPluginSessionOptions(device)) {
+        sessionOptions.setEpContextDataReadCallback(name -> contextData.get(), 1);
+        OrtException exception =
+            Assertions.assertThrows(
+                OrtException.class, () -> env.createSession(compiledModel, sessionOptions));
+        Assertions.assertTrue(exception.getMessage().contains("configured maximum size"));
+      }
+
+      AtomicInteger emptyReadCount = new AtomicInteger();
+      try (SessionOptions sessionOptions = createPluginSessionOptions(device);
+          OrtSession session =
+              createSessionWithReadCallback(
+                  compiledModel,
+                  sessionOptions,
+                  name -> {
+                    emptyReadCount.incrementAndGet();
+                    return new byte[0];
+                  },
+                  contextData.get().length)) {
+        Assertions.assertNotNull(session);
+      }
+      Assertions.assertEquals(1, emptyReadCount.get());
+
+      AtomicInteger firstReadCount = new AtomicInteger();
+      AtomicInteger secondReadCount = new AtomicInteger();
+      SessionOptions replacementOptions = createPluginSessionOptions(device);
+      replacementOptions.setEpContextDataReadCallback(
+          name -> {
+            firstReadCount.incrementAndGet();
+            return contextData.get();
+          },
+          contextData.get().length);
+      replacementOptions.setEpContextDataReadCallback(
+          name -> {
+            secondReadCount.incrementAndGet();
+            Assertions.assertEquals(contextName.get(), name);
+            return contextData.get();
+          },
+          contextData.get().length);
+      try (OrtSession session = env.createSession(compiledModel, replacementOptions)) {
+        replacementOptions.clearEpContextDataReadCallback();
+        replacementOptions.close();
+        Assertions.assertNotNull(session);
+      }
+      Assertions.assertEquals(0, firstReadCount.get());
+      Assertions.assertEquals(1, secondReadCount.get());
+
+      AtomicInteger clearedReadCount = new AtomicInteger();
+      try (SessionOptions sessionOptions = createPluginSessionOptions(device)) {
+        sessionOptions.setEpContextDataReadCallback(
+            name -> {
+              clearedReadCount.incrementAndGet();
+              return contextData.get();
+            },
+            contextData.get().length);
+        sessionOptions.clearEpContextDataReadCallback();
+        Assertions.assertThrows(
+            OrtException.class, () -> env.createSession(compiledModel, sessionOptions));
+      }
+      Assertions.assertEquals(0, clearedReadCount.get());
+
+      SessionOptions sourceOptions = createPluginSessionOptions(device);
+      SessionOptions.EpContextDataReadCallback retainedCallback = name -> contextData.get();
+      WeakReference<SessionOptions.EpContextDataReadCallback> retainedCallbackReference =
+          new WeakReference<>(retainedCallback);
+      sourceOptions.setEpContextDataReadCallback(retainedCallback, contextData.get().length);
+      try (OrtModelCompilationOptions compileOptions =
+          OrtModelCompilationOptions.createFromSessionOptions(env, sourceOptions)) {
+        retainedCallback = null;
+        sourceOptions.clearEpContextDataReadCallback();
+        sourceOptions.close();
+        System.gc();
+        Assertions.assertNotNull(retainedCallbackReference.get());
+      }
+    } finally {
+      Files.deleteIfExists(compiledModelPath);
+      Files.deleteIfExists(failedModelPath);
+      Files.deleteIfExists(clearedWriteModelPath);
+      if (contextName.get() != null) {
+        Files.deleteIfExists(compiledModelPath.resolveSibling(contextName.get()));
+        Files.deleteIfExists(failedModelPath.resolveSibling(contextName.get()));
+        Files.deleteIfExists(clearedWriteModelPath.resolveSibling(contextName.get()));
+      }
+      env.unregisterExecutionProviderLibrary(registrationName);
+    }
+  }
+
+  private SessionOptions createPluginSessionOptions(OrtEpDevice device) throws OrtException {
+    SessionOptions sessionOptions = new SessionOptions();
+    sessionOptions.addExecutionProvider(
+        Collections.singletonList(device), Collections.emptyMap());
+    return sessionOptions;
+  }
+
+  private void configureCompilation(
+      OrtModelCompilationOptions compileOptions, byte[] inputModel, Path outputModel)
+      throws OrtException {
+    compileOptions.setInputModelFromBuffer(ByteBuffer.wrap(inputModel));
+    compileOptions.setOutputModelPath(outputModel.toString());
+    compileOptions.setEpContextEmbedMode(false);
+  }
+
+  private OrtSession createSessionWithReadCallback(
+      byte[] model,
+      SessionOptions sessionOptions,
+      SessionOptions.EpContextDataReadCallback callback,
+      long maxDataSize)
+      throws OrtException {
+    sessionOptions.setEpContextDataReadCallback(callback, maxDataSize);
+    return env.createSession(model, sessionOptions);
   }
 }

--- a/java/src/test/java/ai/onnxruntime/CompileApiTest.java
+++ b/java/src/test/java/ai/onnxruntime/CompileApiTest.java
@@ -7,10 +7,11 @@ package ai.onnxruntime;
 import ai.onnxruntime.OrtSession.SessionOptions;
 import java.io.File;
 import java.io.IOException;
-import java.lang.ref.WeakReference;
 import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
@@ -77,8 +78,7 @@ public class CompileApiTest {
       try (OrtModelCompilationOptions compileOptions =
           OrtModelCompilationOptions.createFromSessionOptions(env, sessionOptions)) {
         Assertions.assertThrows(
-            NullPointerException.class,
-            () -> compileOptions.setEpContextDataWriteCallback(null));
+            NullPointerException.class, () -> compileOptions.setEpContextDataWriteCallback(null));
         compileOptions.setEpContextDataWriteCallback((name, data) -> {});
         compileOptions.setEpContextDataWriteCallback((name, data) -> {});
         compileOptions.clearEpContextDataWriteCallback();
@@ -139,6 +139,27 @@ public class CompileApiTest {
             (name, data) -> replacedWriteCount.incrementAndGet());
         compileOptions.setEpContextDataWriteCallback(
             (name, data) -> {
+              AtomicReference<Throwable> workerResult = new AtomicReference<>();
+              Thread worker =
+                  new Thread(
+                      () -> {
+                        try {
+                          compileOptions.clearEpContextDataWriteCallback();
+                        } catch (Throwable throwable) {
+                          workerResult.set(throwable);
+                        }
+                      });
+              worker.setDaemon(true);
+              worker.start();
+              worker.join(5000);
+              Assertions.assertFalse(
+                  worker.isAlive(), "Write callback reentry must not block on compilation");
+              Assertions.assertInstanceOf(IllegalStateException.class, workerResult.get());
+              Assertions.assertThrows(IllegalStateException.class, compileOptions::close);
+              Assertions.assertThrows(
+                  IllegalStateException.class,
+                  () ->
+                      compileOptions.setEpContextDataWriteCallback((unusedName, unusedData) -> {}));
               writeCount.incrementAndGet();
               contextName.set(name);
               contextData.set(data);
@@ -166,10 +187,19 @@ public class CompileApiTest {
         compileOptions.compileModel();
       }
       Assertions.assertEquals(0, clearedWriteCount.get());
-      Assertions.assertTrue(
-          Files.exists(clearedWriteModelPath.resolveSibling(contextName.get())));
+      Assertions.assertTrue(Files.exists(clearedWriteModelPath.resolveSibling(contextName.get())));
 
-      byte[] compiledModel = Files.readAllBytes(compiledModelPath);
+      String supplementaryContextPrefix = "context-\uD83D\uDE80-";
+      int namePaddingLength =
+          contextName.get().getBytes(StandardCharsets.UTF_8).length
+              - supplementaryContextPrefix.getBytes(StandardCharsets.UTF_8).length;
+      Assertions.assertTrue(namePaddingLength >= 0);
+      char[] namePadding = new char[namePaddingLength];
+      Arrays.fill(namePadding, 'x');
+      String supplementaryContextName = supplementaryContextPrefix + new String(namePadding);
+      byte[] compiledModel =
+          replaceUtf8(
+              Files.readAllBytes(compiledModelPath), contextName.get(), supplementaryContextName);
 
       try (SessionOptions sessionOptions = createPluginSessionOptions(device)) {
         sessionOptions.setEpContextDataReadCallback(
@@ -181,7 +211,8 @@ public class CompileApiTest {
             Assertions.assertThrows(
                 OrtException.class, () -> env.createSession(compiledModel, sessionOptions));
         Assertions.assertTrue(
-            exception.getMessage().contains("synthetic Java EPContext read failure"));
+            exception.getMessage().contains("synthetic Java EPContext read failure"),
+            exception.getMessage());
       }
 
       try (SessionOptions sessionOptions = createPluginSessionOptions(device)) {
@@ -209,6 +240,7 @@ public class CompileApiTest {
 
       AtomicInteger firstReadCount = new AtomicInteger();
       AtomicInteger secondReadCount = new AtomicInteger();
+      AtomicInteger reentrantReplacementReadCount = new AtomicInteger();
       SessionOptions replacementOptions = createPluginSessionOptions(device);
       replacementOptions.setEpContextDataReadCallback(
           name -> {
@@ -219,17 +251,41 @@ public class CompileApiTest {
       replacementOptions.setEpContextDataReadCallback(
           name -> {
             secondReadCount.incrementAndGet();
-            Assertions.assertEquals(contextName.get(), name);
+            Assertions.assertEquals(supplementaryContextName, name);
+            Assertions.assertThrows(IllegalStateException.class, replacementOptions::close);
+            replacementOptions.setEpContextDataReadCallback(
+                unusedName -> {
+                  reentrantReplacementReadCount.incrementAndGet();
+                  return contextData.get();
+                },
+                contextData.get().length);
+
+            AtomicReference<Throwable> workerResult = new AtomicReference<>();
+            Thread worker =
+                new Thread(
+                    () -> {
+                      try {
+                        replacementOptions.clearEpContextDataReadCallback();
+                      } catch (Throwable throwable) {
+                        workerResult.set(throwable);
+                      }
+                    });
+            worker.setDaemon(true);
+            worker.start();
+            worker.join(5000);
+            Assertions.assertFalse(
+                worker.isAlive(), "Read callback reentry must not block on session creation");
+            Assertions.assertNull(workerResult.get());
             return contextData.get();
           },
           contextData.get().length);
       try (OrtSession session = env.createSession(compiledModel, replacementOptions)) {
-        replacementOptions.clearEpContextDataReadCallback();
         replacementOptions.close();
         Assertions.assertNotNull(session);
       }
       Assertions.assertEquals(0, firstReadCount.get());
       Assertions.assertEquals(1, secondReadCount.get());
+      Assertions.assertEquals(0, reentrantReplacementReadCount.get());
 
       AtomicInteger clearedReadCount = new AtomicInteger();
       try (SessionOptions sessionOptions = createPluginSessionOptions(device)) {
@@ -246,18 +302,22 @@ public class CompileApiTest {
       Assertions.assertEquals(0, clearedReadCount.get());
 
       SessionOptions sourceOptions = createPluginSessionOptions(device);
-      SessionOptions.EpContextDataReadCallback retainedCallback = name -> contextData.get();
-      WeakReference<SessionOptions.EpContextDataReadCallback> retainedCallbackReference =
-          new WeakReference<>(retainedCallback);
-      sourceOptions.setEpContextDataReadCallback(retainedCallback, contextData.get().length);
-      try (OrtModelCompilationOptions compileOptions =
-          OrtModelCompilationOptions.createFromSessionOptions(env, sourceOptions)) {
-        retainedCallback = null;
+      sourceOptions.setEpContextDataReadCallback(
+          name -> contextData.get(), contextData.get().length);
+      SessionOptions.EpContextDataReadCallbackRegistration registration =
+          sourceOptions.getEpContextDataReadCallbackRegistration();
+      Assertions.assertEquals(1, registration.getReferenceCount());
+      OrtModelCompilationOptions retainedCompileOptions =
+          OrtModelCompilationOptions.createFromSessionOptions(env, sourceOptions);
+      try {
+        Assertions.assertEquals(2, registration.getReferenceCount());
         sourceOptions.clearEpContextDataReadCallback();
+        Assertions.assertEquals(1, registration.getReferenceCount());
         sourceOptions.close();
-        System.gc();
-        Assertions.assertNotNull(retainedCallbackReference.get());
+      } finally {
+        retainedCompileOptions.close();
       }
+      Assertions.assertEquals(0, registration.getReferenceCount());
     } finally {
       Files.deleteIfExists(compiledModelPath);
       Files.deleteIfExists(failedModelPath);
@@ -273,9 +333,34 @@ public class CompileApiTest {
 
   private SessionOptions createPluginSessionOptions(OrtEpDevice device) throws OrtException {
     SessionOptions sessionOptions = new SessionOptions();
-    sessionOptions.addExecutionProvider(
-        Collections.singletonList(device), Collections.emptyMap());
+    sessionOptions.addExecutionProvider(Collections.singletonList(device), Collections.emptyMap());
     return sessionOptions;
+  }
+
+  private static byte[] replaceUtf8(byte[] input, String oldValue, String newValue) {
+    byte[] oldBytes = oldValue.getBytes(StandardCharsets.UTF_8);
+    byte[] newBytes = newValue.getBytes(StandardCharsets.UTF_8);
+    Assertions.assertEquals(oldBytes.length, newBytes.length);
+
+    int match = -1;
+    for (int i = 0; i <= input.length - oldBytes.length; i++) {
+      boolean matches = true;
+      for (int j = 0; j < oldBytes.length; j++) {
+        if (input[i + j] != oldBytes[j]) {
+          matches = false;
+          break;
+        }
+      }
+      if (matches) {
+        Assertions.assertEquals(-1, match, "Expected the old value to occur exactly once");
+        match = i;
+      }
+    }
+    Assertions.assertNotEquals(-1, match, "Expected the old value in the compiled model");
+
+    byte[] output = Arrays.copyOf(input, input.length);
+    System.arraycopy(newBytes, 0, output, match, newBytes.length);
+    return output;
   }
 
   private void configureCompilation(


### PR DESCRIPTION
## Summary
- add public Java read/write callback APIs using owned `byte[]` payloads and a required finite read-size limit
- bridge callbacks through JNI with OrtStatus exception propagation, safe JVM thread attachment, and ORT-allocator ownership
- retain callback global references deterministically across session and model-compilation option snapshots, replacement, clearing, and close
- add focused validation and Windows example-plugin integration coverage for invocation, empty payloads, exceptions, size enforcement, replacement, clearing, and copied-option lifetime

## Validation
- built `onnxruntime4j_jni`, `example_plugin_ep`, and `custom_op_library` (RelWithDebInfo)
- `CompileApiTest`: 3/3 passed
- Java Javadocs generated successfully
- changed JNI files pass lintrunner/clang-format