### PR TITLE
Add JavaScript EPContext data callbacks

### DIFF
--- a/js/common/lib/inference-session.ts
+++ b/js/common/lib/inference-session.ts
@@ -48,6 +48,29 @@ export declare namespace InferenceSession {
    */
   export interface SessionOptions extends OnnxModelOptions {
     /**
+     * Configure loading external data referenced by EPContext nodes.
+     *
+     * The callback is invoked synchronously with the external data name and must return a `Uint8Array`. The returned
+     * bytes are copied before the callback returns, so the application retains ownership of the array. Empty arrays are
+     * supported. Callback invocations may originate from multiple ONNX Runtime threads; the native JavaScript bindings
+     * serialize calls before invoking JavaScript.
+     *
+     * `maxDataSize` is a required, finite, positive safe integer. Session creation fails if the callback throws, returns
+     * another type, or returns more bytes than this limit. ONNX Runtime does not fall back to loading the data from disk
+     * after a callback failure.
+     *
+     * This setting is available only in the Node.js and React Native bindings. ONNX Runtime Web rejects it because a
+     * JavaScript callback cannot currently be registered safely through the WebAssembly ABI.
+     *
+     * JavaScript does not currently expose model compilation, so the corresponding EPContext data write callback is not
+     * available.
+     */
+    epContextDataRead?: {
+      callback: (name: string) => Uint8Array;
+      maxDataSize: number;
+    };
+
+    /**
      * An array of execution provider options.
      *
      * An execution provider option can be a string indicating the name of the execution provider,

--- a/js/common/test/type-tests/inference-session/ep-context-data-read.ts
+++ b/js/common/test/type-tests/inference-session/ep-context-data-read.ts
@@ -1,0 +1,30 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import * as ort from 'onnxruntime-common';
+
+const validOptions: ort.InferenceSession.SessionOptions = {
+  epContextDataRead: {
+    callback: (name) => new TextEncoder().encode(name),
+    maxDataSize: 1024,
+  },
+};
+void validOptions;
+
+const invalidCallback: ort.InferenceSession.SessionOptions = {
+  epContextDataRead: {
+    // {type-tests}|fail|1|2740
+    callback: async () => new Uint8Array(),
+    maxDataSize: 1024,
+  },
+};
+void invalidCallback;
+
+const invalidReturnType: ort.InferenceSession.SessionOptions = {
+  epContextDataRead: {
+    // {type-tests}|fail|1|2740
+    callback: () => new ArrayBuffer(0),
+    maxDataSize: 1024,
+  },
+};
+void invalidReturnType;

--- a/js/node/CMakeLists.txt
+++ b/js/node/CMakeLists.txt
@@ -60,7 +60,14 @@ if(USE_QNN)
 endif()
 
 # source files
-file(GLOB ORT_NODEJS_BINDING_SOURCE_FILES ${CMAKE_SOURCE_DIR}/src/*.cc)
+#
+# CONFIGURE_DEPENDS makes CMake re-run the glob when a source file is added or removed, so that new
+# files (e.g. src/ep_context_data_read_helper.cc) are picked up by incremental builds as well.
+if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.12)
+  file(GLOB ORT_NODEJS_BINDING_SOURCE_FILES CONFIGURE_DEPENDS ${CMAKE_SOURCE_DIR}/src/*.cc)
+else()
+  file(GLOB ORT_NODEJS_BINDING_SOURCE_FILES ${CMAKE_SOURCE_DIR}/src/*.cc)
+endif()
 
 add_library(onnxruntime_binding SHARED ${ORT_NODEJS_BINDING_SOURCE_FILES} ${CMAKE_JS_SRC})
 file(MAKE_DIRECTORY ${dist_folder})

--- a/js/node/lib/backend.ts
+++ b/js/node/lib/backend.ts
@@ -94,8 +94,8 @@ class OnnxruntimeSessionHandler implements InferenceSessionHandler {
   ): Promise<OnnxruntimeSessionHandler> {
     initOrt();
 
-    // The native binding creates the session asynchronously and snapshots model/external data before
-    // yielding so JavaScript can safely release, mutate, or transfer its original buffers.
+    // A callback-enabled session is created asynchronously so the event loop can service synchronous
+    // EPContext reads. The native binding retains the synchronous zero-copy path otherwise.
     const inferenceSession = new binding.InferenceSession();
     if (typeof pathOrBuffer === 'string') {
       await inferenceSession.loadModel(pathOrBuffer, options);

--- a/js/node/lib/backend.ts
+++ b/js/node/lib/backend.ts
@@ -34,20 +34,8 @@ const dataTypeStrings = [
 class OnnxruntimeSessionHandler implements InferenceSessionHandler {
   #inferenceSession: Binding.InferenceSession;
 
-  constructor(pathOrBuffer: string | Uint8Array, options: InferenceSession.SessionOptions) {
-    initOrt();
-
-    this.#inferenceSession = new binding.InferenceSession();
-    if (typeof pathOrBuffer === 'string') {
-      this.#inferenceSession.loadModel(pathOrBuffer, options);
-    } else {
-      this.#inferenceSession.loadModel(
-        pathOrBuffer.buffer as ArrayBuffer,
-        pathOrBuffer.byteOffset,
-        pathOrBuffer.byteLength,
-        options,
-      );
-    }
+  private constructor(inferenceSession: Binding.InferenceSession) {
+    this.#inferenceSession = inferenceSession;
 
     // prepare input/output names and metadata
     this.inputNames = [];
@@ -100,6 +88,29 @@ class OnnxruntimeSessionHandler implements InferenceSessionHandler {
     [this.outputNames, this.outputMetadata] = fillNamesAndMetadata(this.#inferenceSession.outputMetadata);
   }
 
+  static async create(
+    pathOrBuffer: string | Uint8Array,
+    options: InferenceSession.SessionOptions,
+  ): Promise<OnnxruntimeSessionHandler> {
+    initOrt();
+
+    // The native binding creates the session asynchronously and snapshots model/external data before
+    // yielding so JavaScript can safely release, mutate, or transfer its original buffers.
+    const inferenceSession = new binding.InferenceSession();
+    if (typeof pathOrBuffer === 'string') {
+      await inferenceSession.loadModel(pathOrBuffer, options);
+    } else {
+      await inferenceSession.loadModel(
+        pathOrBuffer.buffer as ArrayBuffer,
+        pathOrBuffer.byteOffset,
+        pathOrBuffer.byteLength,
+        options,
+      );
+    }
+
+    return new OnnxruntimeSessionHandler(inferenceSession);
+  }
+
   async dispose(): Promise<void> {
     this.#inferenceSession.dispose();
   }
@@ -146,16 +157,7 @@ class OnnxruntimeBackend implements Backend {
     pathOrBuffer: string | Uint8Array,
     options?: InferenceSession.SessionOptions,
   ): Promise<InferenceSessionHandler> {
-    return new Promise((resolve, reject) => {
-      setImmediate(() => {
-        try {
-          resolve(new OnnxruntimeSessionHandler(pathOrBuffer, options || {}));
-        } catch (e) {
-          // reject if any error is thrown
-          reject(e);
-        }
-      });
-    });
+    return OnnxruntimeSessionHandler.create(pathOrBuffer, options || {});
   }
 }
 

--- a/js/node/lib/binding.ts
+++ b/js/node/lib/binding.ts
@@ -20,8 +20,8 @@ type RunOptions = InferenceSession.RunOptions;
 /**
  * Binding exports a simple inference session object wrap.
  *
- * `loadModel()` is asynchronous: the native session is constructed on a worker thread so that the
- * JavaScript event loop stays available while ONNX Runtime initializes the session.
+ * `loadModel()` returns a Promise. A session that registers a synchronous JavaScript callback is
+ * constructed on a worker thread so that the event loop remains available to service that callback.
  */
 export declare namespace Binding {
   export interface ValueMetadata {

--- a/js/node/lib/binding.ts
+++ b/js/node/lib/binding.ts
@@ -18,7 +18,10 @@ type ReturnType = {
 type RunOptions = InferenceSession.RunOptions;
 
 /**
- * Binding exports a simple synchronized inference session object wrap.
+ * Binding exports a simple inference session object wrap.
+ *
+ * `loadModel()` is asynchronous: the native session is constructed on a worker thread so that the
+ * JavaScript event loop stays available while ONNX Runtime initializes the session.
  */
 export declare namespace Binding {
   export interface ValueMetadata {
@@ -29,8 +32,8 @@ export declare namespace Binding {
     type: number;
   }
   export interface InferenceSession {
-    loadModel(modelPath: string, options: SessionOptions): void;
-    loadModel(buffer: ArrayBuffer, byteOffset: number, byteLength: number, options: SessionOptions): void;
+    loadModel(modelPath: string, options: SessionOptions): Promise<void>;
+    loadModel(buffer: ArrayBuffer, byteOffset: number, byteLength: number, options: SessionOptions): Promise<void>;
 
     readonly inputMetadata: ValueMetadata[];
     readonly outputMetadata: ValueMetadata[];

--- a/js/node/src/ep_context_data_read_helper.cc
+++ b/js/node/src/ep_context_data_read_helper.cc
@@ -1,0 +1,378 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "onnxruntime_cxx_api.h"
+#include <napi.h>
+
+#include <cmath>
+#include <condition_variable>
+#include <cstdint>
+#include <cstring>
+#include <limits>
+#include <string>
+#include <utility>
+
+#include "common.h"
+#include "ep_context_data_read_helper.h"
+
+namespace {
+
+// Number.MAX_SAFE_INTEGER. A larger value cannot round-trip through a JavaScript number.
+constexpr double kMaxSafeInteger = 9007199254740991.0;
+
+// RAII owner for a buffer allocated through the OrtAllocator that ONNX Runtime supplies to the read
+// callback. The bytes are only detached (handed over to ONNX Runtime) once the whole callback succeeded.
+struct AllocatorBuffer {
+  OrtAllocator* allocator = nullptr;
+  void* data = nullptr;
+  size_t size = 0;
+
+  AllocatorBuffer() = default;
+  AllocatorBuffer(const AllocatorBuffer&) = delete;
+  AllocatorBuffer& operator=(const AllocatorBuffer&) = delete;
+  ~AllocatorBuffer() { Reset(); }
+
+  void Reset() noexcept {
+    if (data != nullptr && allocator != nullptr) {
+      allocator->Free(allocator, data);
+    }
+    data = nullptr;
+    size = 0;
+  }
+
+  void* Detach() noexcept {
+    void* detached = data;
+    data = nullptr;
+    return detached;
+  }
+};
+
+OrtStatus* MakeOrtStatus(OrtErrorCode code, const std::string& message) noexcept {
+  return Ort::GetApi().CreateStatus(code, message.c_str());
+}
+
+}  // namespace
+
+// One read request. The requesting ONNX Runtime thread blocks on `Wait()` until the JavaScript thread
+// has produced a result or reported a failure.
+struct EpContextDataReadState::CallItem {
+  // inputs
+  const char* name = nullptr;
+  OrtAllocator* allocator = nullptr;
+  size_t max_data_size = 0;
+
+  // outputs
+  AllocatorBuffer buffer;
+  bool succeeded = false;
+  OrtErrorCode error_code = ORT_FAIL;
+  std::string error_message;
+
+  std::mutex mutex;
+  std::condition_variable cv;
+  bool completed = false;
+
+  void Succeed() noexcept { succeeded = true; }
+
+  void Fail(OrtErrorCode code, std::string message) noexcept {
+    buffer.Reset();
+    succeeded = false;
+    error_code = code;
+    error_message = std::move(message);
+  }
+
+  void Complete() noexcept {
+    {
+      std::lock_guard<std::mutex> lock{mutex};
+      completed = true;
+    }
+    cv.notify_all();
+  }
+
+  void Wait() noexcept {
+    std::unique_lock<std::mutex> lock{mutex};
+    cv.wait(lock, [this] { return completed; });
+  }
+};
+
+EpContextDataReadState::EpContextDataReadState(size_t maxDataSize)
+    : max_data_size_{maxDataSize}, owner_thread_id_{std::this_thread::get_id()} {}
+
+EpContextDataReadState::~EpContextDataReadState() {
+  // The thread-safe function finalizer already dropped `callback_ref_` on the JavaScript thread, so no
+  // N-API reference is touched here. This destructor may run long after environment teardown.
+  Release();
+}
+
+std::shared_ptr<EpContextDataReadState> EpContextDataReadState::Create(Napi::Env env, Napi::Function callback,
+                                                                       size_t maxDataSize) {
+  std::shared_ptr<EpContextDataReadState> state{new EpContextDataReadState{maxDataSize}};
+
+  state->callback_ref_ = Napi::Persistent(callback);
+  // The reference is always dropped explicitly (finalizer or the failure path below). Suppressing the
+  // destructor guarantees that the last shared_ptr release never calls into N-API.
+  state->callback_ref_.SuppressDestruct();
+
+  Napi::String resourceName = Napi::String::New(env, "onnxruntime.epContextDataRead");
+
+  // The finalizer data keeps the state alive until N-API is done with the thread-safe function, so the
+  // finalizer can never observe a destroyed object, including during environment teardown.
+  auto* finalizeData = new std::shared_ptr<EpContextDataReadState>{state};
+
+  napi_threadsafe_function tsfn = nullptr;
+  napi_status status = napi_create_threadsafe_function(
+      env, callback, /* async_resource */ nullptr, resourceName,
+      /* max_queue_size */ 0, /* initial_thread_count */ 1, finalizeData,
+      &EpContextDataReadState::FinalizeThreadSafeFunction, state.get(), &EpContextDataReadState::CallJs, &tsfn);
+  if (status != napi_ok) {
+    delete finalizeData;
+    state->callback_ref_.Reset();
+    ORT_NAPI_THROW_ERROR(env, "Failed to register 'sessionOptions.epContextDataRead.callback'.");
+  }
+
+  state->tsfn_.store(tsfn, std::memory_order_release);
+  state->js_available_.store(true, std::memory_order_release);
+
+  // The callback must not keep the Node.js event loop alive on its own: the pending asynchronous session
+  // construction already holds the event loop open for as long as callbacks can be delivered.
+  napi_unref_threadsafe_function(env, tsfn);
+
+  return state;
+}
+
+void EpContextDataReadState::Release() noexcept {
+  if (tsfn_released_.exchange(true, std::memory_order_acq_rel)) {
+    return;
+  }
+  js_available_.store(false, std::memory_order_release);
+
+  napi_threadsafe_function tsfn = tsfn_.exchange(nullptr, std::memory_order_acq_rel);
+  if (tsfn != nullptr) {
+    napi_release_threadsafe_function(tsfn, napi_tsfn_release);
+  }
+}
+
+void EpContextDataReadState::OnThreadSafeFunctionFinalize() noexcept {
+  // Runs on the JavaScript thread while the environment is still usable, including during teardown.
+  js_available_.store(false, std::memory_order_release);
+  tsfn_released_.store(true, std::memory_order_release);
+  tsfn_.store(nullptr, std::memory_order_release);
+  callback_ref_.Reset();
+}
+
+void EpContextDataReadState::FinalizeThreadSafeFunction(napi_env /* env */, void* finalizeData, void* /* hint */) {
+  auto* holder = static_cast<std::shared_ptr<EpContextDataReadState>*>(finalizeData);
+  if (holder == nullptr) {
+    return;
+  }
+  (*holder)->OnThreadSafeFunctionFinalize();
+  delete holder;
+}
+
+void EpContextDataReadState::RunCallback(napi_env rawEnv, napi_value jsCallback, CallItem& item) noexcept {
+  try {
+    Napi::Env env{rawEnv};
+    Napi::HandleScope scope{env};
+
+    Napi::Function callback{env, jsCallback};
+    Napi::Value result = callback.Call({Napi::String::New(env, item.name)});
+
+    // A Node.js Buffer is a Uint8Array, so it is accepted by this check. Any other type is not.
+    if (!result.IsTypedArray() || result.As<Napi::TypedArray>().TypedArrayType() != napi_uint8_array) {
+      item.Fail(ORT_INVALID_ARGUMENT,
+                MakeString("'sessionOptions.epContextDataRead.callback' must return a Uint8Array, but it returned "
+                           "another type for '",
+                           item.name, "'."));
+      return;
+    }
+
+    auto typedArray = result.As<Napi::TypedArray>();
+    const size_t byteLength = typedArray.ByteLength();
+    if (byteLength > item.max_data_size) {
+      item.Fail(ORT_INVALID_ARGUMENT,
+                MakeString("'sessionOptions.epContextDataRead.callback' returned ", byteLength, " bytes for '",
+                           item.name, "', which exceeds 'sessionOptions.epContextDataRead.maxDataSize' (",
+                           item.max_data_size, ")."));
+      return;
+    }
+
+    // An empty payload is reported as {nullptr, 0}; nothing is allocated for it.
+    if (byteLength == 0) {
+      item.Succeed();
+      return;
+    }
+
+    void* allocated = item.allocator->Alloc(item.allocator, byteLength);
+    if (allocated == nullptr) {
+      item.Fail(ORT_FAIL, MakeString("Failed to allocate ", byteLength, " bytes for the EPContext data of '",
+                                     item.name, "'."));
+      return;
+    }
+    item.buffer.allocator = item.allocator;
+    item.buffer.data = allocated;
+    item.buffer.size = byteLength;
+
+    const auto* source =
+        reinterpret_cast<const uint8_t*>(typedArray.ArrayBuffer().Data()) + typedArray.ByteOffset();
+    std::memcpy(allocated, source, byteLength);
+    item.Succeed();
+  } catch (Napi::Error const& e) {
+    item.Fail(ORT_FAIL, MakeString("'sessionOptions.epContextDataRead.callback' failed for '", item.name,
+                                   "': ", e.Message()));
+  } catch (std::exception const& e) {
+    item.Fail(ORT_FAIL, MakeString("'sessionOptions.epContextDataRead.callback' failed for '", item.name,
+                                   "': ", e.what()));
+  } catch (...) {
+    item.Fail(ORT_FAIL, MakeString("'sessionOptions.epContextDataRead.callback' failed for '", item.name,
+                                   "' with an unknown error."));
+  }
+}
+
+void EpContextDataReadState::CallJs(napi_env env, napi_value jsCallback, void* /* context */, void* data) {
+  auto* payload = static_cast<std::shared_ptr<CallItem>*>(data);
+  if (payload == nullptr) {
+    return;
+  }
+  std::shared_ptr<CallItem> item = *payload;
+  delete payload;
+
+  if (env == nullptr || jsCallback == nullptr) {
+    // N-API drains the queue with null arguments when the environment can no longer run JavaScript.
+    item->Fail(ORT_FAIL,
+               "The JavaScript environment was torn down before 'sessionOptions.epContextDataRead.callback' ran.");
+  } else {
+    RunCallback(env, jsCallback, *item);
+  }
+  item->Complete();
+}
+
+void EpContextDataReadState::InvokeOnOwnerThread(CallItem& item) noexcept {
+  try {
+    Napi::Env env = callback_ref_.Env();
+    Napi::HandleScope scope{env};
+    RunCallback(env, callback_ref_.Value(), item);
+  } catch (...) {
+    item.Fail(ORT_FAIL, "Failed to enter the JavaScript scope for 'sessionOptions.epContextDataRead.callback'.");
+  }
+}
+
+OrtStatus* EpContextDataReadState::Invoke(const char* name, OrtAllocator* allocator, void** buffer,
+                                          size_t* data_size) noexcept {
+  // The outputs are initialized before anything else runs, so ONNX Runtime never observes stale values.
+  if (buffer != nullptr) {
+    *buffer = nullptr;
+  }
+  if (data_size != nullptr) {
+    *data_size = 0;
+  }
+  if (buffer == nullptr || data_size == nullptr || name == nullptr || allocator == nullptr) {
+    return MakeOrtStatus(ORT_INVALID_ARGUMENT,
+                         "Invalid argument passed to the 'sessionOptions.epContextDataRead' callback.");
+  }
+
+  // ONNX Runtime does not serialize calls from different EP instances or worker threads, but the
+  // JavaScript callback is user code that expects one call at a time.
+  std::lock_guard<std::mutex> callLock{call_mutex_};
+
+  if (!js_available_.load(std::memory_order_acquire)) {
+    return MakeOrtStatus(ORT_FAIL, "'sessionOptions.epContextDataRead.callback' is no longer available.");
+  }
+
+  auto item = std::make_shared<CallItem>();
+  item->name = name;
+  item->allocator = allocator;
+  item->max_data_size = max_data_size_;
+
+  if (std::this_thread::get_id() == owner_thread_id_) {
+    // ONNX Runtime can only reach this point on the JavaScript thread while that thread is inside a
+    // native call made on its behalf, which is a context where N-API permits calling into JavaScript.
+    // A thread-safe function call would deadlock here because the queued item could never be drained.
+    InvokeOnOwnerThread(*item);
+  } else {
+    napi_threadsafe_function tsfn = tsfn_.load(std::memory_order_acquire);
+    if (tsfn == nullptr || napi_acquire_threadsafe_function(tsfn) != napi_ok) {
+      return MakeOrtStatus(ORT_FAIL, "'sessionOptions.epContextDataRead.callback' is no longer available.");
+    }
+
+    auto* payload = new std::shared_ptr<CallItem>{item};
+    napi_status status = napi_call_threadsafe_function(tsfn, payload, napi_tsfn_blocking);
+    if (status != napi_ok) {
+      delete payload;
+      napi_release_threadsafe_function(tsfn, napi_tsfn_release);
+      return MakeOrtStatus(ORT_FAIL,
+                           "Failed to dispatch 'sessionOptions.epContextDataRead.callback' to the JavaScript thread.");
+    }
+
+    item->Wait();
+    napi_release_threadsafe_function(tsfn, napi_tsfn_release);
+  }
+
+  if (!item->succeeded) {
+    return MakeOrtStatus(item->error_code, item->error_message);
+  }
+
+  *data_size = item->buffer.size;
+  *buffer = item->buffer.Detach();
+  return nullptr;
+}
+
+OrtStatus* ORT_API_CALL EpContextDataReadState::ReadNamedBuffer(void* state, const char* name,
+                                                                OrtAllocator* allocator, void** buffer,
+                                                                size_t* data_size) noexcept {
+  if (buffer != nullptr) {
+    *buffer = nullptr;
+  }
+  if (data_size != nullptr) {
+    *data_size = 0;
+  }
+  if (state == nullptr) {
+    return MakeOrtStatus(ORT_INVALID_ARGUMENT, "'sessionOptions.epContextDataRead' state is missing.");
+  }
+  return static_cast<EpContextDataReadState*>(state)->Invoke(name, allocator, buffer, data_size);
+}
+
+void ParseEpContextDataReadOptions(const Napi::Object options, Ort::SessionOptions& sessionOptions,
+                                   std::shared_ptr<EpContextDataReadState>& state) {
+  Napi::Env env = options.Env();
+
+  if (!options.Has("epContextDataRead")) {
+    return;
+  }
+  auto value = options.Get("epContextDataRead");
+  if (value.IsNull() || value.IsUndefined()) {
+    return;
+  }
+
+  ORT_NAPI_THROW_TYPEERROR_IF(!value.IsObject(), env,
+                              "Invalid argument: sessionOptions.epContextDataRead must be an object.");
+  auto config = value.As<Napi::Object>();
+
+  auto callbackValue = config.Get("callback");
+  ORT_NAPI_THROW_TYPEERROR_IF(!callbackValue.IsFunction(), env,
+                              "Invalid argument: sessionOptions.epContextDataRead.callback must be a function.");
+
+  auto maxDataSizeValue = config.Get("maxDataSize");
+  ORT_NAPI_THROW_TYPEERROR_IF(!maxDataSizeValue.IsNumber(), env,
+                              "Invalid argument: sessionOptions.epContextDataRead.maxDataSize must be a number.");
+  const double maxDataSize = maxDataSizeValue.As<Napi::Number>().DoubleValue();
+  ORT_NAPI_THROW_RANGEERROR_IF(!std::isfinite(maxDataSize) || std::floor(maxDataSize) != maxDataSize ||
+                                   maxDataSize < 1 || maxDataSize > kMaxSafeInteger ||
+                                   maxDataSize >= static_cast<double>(std::numeric_limits<size_t>::max()),
+                               env, "'epContextDataRead.maxDataSize' is invalid: ", maxDataSize);
+  const size_t maxDataSizeBytes = static_cast<size_t>(maxDataSize);
+
+  // Transactional setup: retain the new state first, register it next, and publish it only after the
+  // native setter succeeded.
+  auto newState = EpContextDataReadState::Create(env, callbackValue.As<Napi::Function>(), maxDataSizeBytes);
+  try {
+    sessionOptions.SetEpContextDataReadFunc(&EpContextDataReadState::ReadNamedBuffer, newState.get(),
+                                            maxDataSizeBytes);
+  } catch (...) {
+    newState->Release();
+    throw;
+  }
+
+  if (state) {
+    state->Release();
+  }
+  state = std::move(newState);
+}

--- a/js/node/src/ep_context_data_read_helper.h
+++ b/js/node/src/ep_context_data_read_helper.h
@@ -1,0 +1,103 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include <napi.h>
+
+#include <atomic>
+#include <cstddef>
+#include <memory>
+#include <mutex>
+#include <thread>
+
+#include "onnxruntime_cxx_api.h"
+
+/**
+ * EpContextDataReadState owns the JavaScript callback registered through
+ * `InferenceSession.SessionOptions.epContextDataRead` and adapts it to OrtReadNamedBufferFunc.
+ *
+ * Threading model:
+ * - The state is created on the JavaScript thread that parses the session options, and it keeps a
+ *   thread-safe function that is used to reach that thread again.
+ * - ONNX Runtime may invoke the read callback from any of its worker threads and does not serialize
+ *   calls, so every invocation is serialized here before JavaScript runs.
+ * - No exception ever crosses the C ABI: every failure is converted to an OrtStatus.
+ *
+ * Lifetime model:
+ * - The state is reference counted. The InferenceSession wrapper holds a strong reference for as long
+ *   as its native session exists, and the asynchronous session construction takes its own strong
+ *   snapshot, so the state always outlives any ONNX Runtime code that can call it.
+ * - `Release()` gives up the thread-safe function. It must be called on the JavaScript thread, and only
+ *   once the native session that could invoke the callback has been released.
+ * - After environment teardown the N-API references are dropped by the thread-safe function finalizer,
+ *   and later calls fail with a status instead of touching N-API.
+ */
+class EpContextDataReadState final {
+ public:
+  /**
+   * Create the state on the JavaScript thread.
+   * @throw Napi::Error if the thread-safe function cannot be created.
+   */
+  static std::shared_ptr<EpContextDataReadState> Create(Napi::Env env, Napi::Function callback, size_t maxDataSize);
+
+  ~EpContextDataReadState();
+
+  EpContextDataReadState(const EpContextDataReadState&) = delete;
+  EpContextDataReadState& operator=(const EpContextDataReadState&) = delete;
+  EpContextDataReadState(EpContextDataReadState&&) = delete;
+  EpContextDataReadState& operator=(EpContextDataReadState&&) = delete;
+
+  /**
+   * OrtReadNamedBufferFunc implementation. `state` must be an EpContextDataReadState*.
+   */
+  static OrtStatus* ORT_API_CALL ReadNamedBuffer(void* state, const char* name, OrtAllocator* allocator,
+                                                 void** buffer, size_t* data_size) noexcept;
+
+  /**
+   * Give up the thread-safe function. Idempotent, and safe to call during environment teardown.
+   * Must be called on the JavaScript thread that created the state, and only after the native session
+   * that could trigger callbacks has been released.
+   */
+  void Release() noexcept;
+
+  size_t MaxDataSize() const noexcept { return max_data_size_; }
+
+ private:
+  struct CallItem;
+
+  explicit EpContextDataReadState(size_t maxDataSize);
+
+  OrtStatus* Invoke(const char* name, OrtAllocator* allocator, void** buffer, size_t* data_size) noexcept;
+  void InvokeOnOwnerThread(CallItem& item) noexcept;
+  void OnThreadSafeFunctionFinalize() noexcept;
+
+  static void RunCallback(napi_env env, napi_value jsCallback, CallItem& item) noexcept;
+  static void CallJs(napi_env env, napi_value jsCallback, void* context, void* data);
+  static void FinalizeThreadSafeFunction(napi_env env, void* finalizeData, void* hint);
+
+  const size_t max_data_size_;
+  const std::thread::id owner_thread_id_;
+
+  // Only touched on the JavaScript thread.
+  Napi::FunctionReference callback_ref_;
+
+  std::atomic<napi_threadsafe_function> tsfn_{nullptr};
+  std::atomic<bool> tsfn_released_{false};
+  std::atomic<bool> js_available_{false};
+
+  // Serializes callback invocations coming from different ONNX Runtime threads.
+  std::mutex call_mutex_;
+};
+
+/**
+ * Parse `sessionOptions.epContextDataRead` and register the callback on the native session options.
+ *
+ * The setup is transactional: the new state is created and retained first, the native setter is invoked
+ * next, and `state` is only replaced after the setter succeeded. A previously published state is
+ * released when it is replaced.
+ *
+ * @throw Napi::TypeError / Napi::RangeError for invalid configuration.
+ */
+void ParseEpContextDataReadOptions(const Napi::Object options, Ort::SessionOptions& sessionOptions,
+                                   std::shared_ptr<EpContextDataReadState>& state);

--- a/js/node/src/inference_session_wrap.cc
+++ b/js/node/src/inference_session_wrap.cc
@@ -16,6 +16,53 @@
 #include <utility>
 #include <vector>
 
+namespace {
+
+struct ModelBufferView {
+  const uint8_t* data = nullptr;
+  size_t size = 0;
+};
+
+ModelBufferView GetModelBufferView(Napi::ArrayBuffer buffer, int64_t byteOffset, int64_t byteLength) {
+  const size_t bufferLength = buffer.ByteLength();
+  if (byteOffset < 0 || byteLength < 0 || static_cast<uint64_t>(byteOffset) > bufferLength ||
+      static_cast<uint64_t>(byteLength) > bufferLength - static_cast<size_t>(byteOffset)) {
+    throw Napi::RangeError::New(buffer.Env(), "Model buffer offset or length is out of range.");
+  }
+
+  const size_t length = static_cast<size_t>(byteLength);
+  const auto* data =
+      length == 0 ? nullptr
+                  : static_cast<const uint8_t*>(buffer.Data()) + static_cast<size_t>(byteOffset);
+  return {data, length};
+}
+
+void ReadSessionMetadata(Ort::Session& session, std::vector<std::string>& inputNames,
+                         std::vector<Ort::TypeInfo>& inputTypes, std::vector<std::string>& outputNames,
+                         std::vector<Ort::TypeInfo>& outputTypes) {
+  Ort::AllocatorWithDefaultOptions allocator;
+
+  size_t count = session.GetInputCount();
+  inputNames.reserve(count);
+  inputTypes.reserve(count);
+  for (size_t i = 0; i < count; i++) {
+    auto inputName = session.GetInputNameAllocated(i, allocator);
+    inputNames.emplace_back(inputName.get());
+    inputTypes.push_back(session.GetInputTypeInfo(i));
+  }
+
+  count = session.GetOutputCount();
+  outputNames.reserve(count);
+  outputTypes.reserve(count);
+  for (size_t i = 0; i < count; i++) {
+    auto outputName = session.GetOutputNameAllocated(i, allocator);
+    outputNames.emplace_back(outputName.get());
+    outputTypes.push_back(session.GetOutputTypeInfo(i));
+  }
+}
+
+}  // namespace
+
 /**
  * LoadModelWorker constructs the native Ort::Session on a libuv worker thread.
  *
@@ -23,8 +70,8 @@
  * requirement for `sessionOptions.epContextDataRead`: ONNX Runtime calls that callback while the session
  * is being created and the call has to be marshalled back to the JavaScript thread.
  *
- * The worker owns everything the native constructor needs, including references to the JavaScript values
- * that back the model path/buffer and the session options, so that they stay alive until it completes.
+ * The worker owns everything the native constructor needs, including copied model/external-data buffers
+ * and the callback state, so that they remain valid until construction completes.
  */
 class LoadModelWorker : public Napi::AsyncWorker {
  public:
@@ -57,16 +104,10 @@ class LoadModelWorker : public Napi::AsyncWorker {
   // Copy the model before yielding to JavaScript. A persistent reference does not pin an ArrayBuffer's
   // backing store, which can be detached or transferred while the worker is running.
   void SetModelBuffer(Napi::ArrayBuffer buffer, int64_t byteOffset, int64_t byteLength) {
-    const size_t bufferLength = buffer.ByteLength();
-    if (byteOffset < 0 || byteLength < 0 || static_cast<uint64_t>(byteOffset) > bufferLength ||
-        static_cast<uint64_t>(byteLength) > bufferLength - static_cast<size_t>(byteOffset)) {
-      throw Napi::RangeError::New(buffer.Env(), "Model buffer offset or length is out of range.");
-    }
-
-    modelDataLength_ = static_cast<size_t>(byteLength);
+    const auto view = GetModelBufferView(buffer, byteOffset, byteLength);
+    modelDataLength_ = view.size;
     if (modelDataLength_ != 0) {
-      const auto* data = static_cast<const uint8_t*>(buffer.Data()) + static_cast<size_t>(byteOffset);
-      modelDataStorage_.assign(data, data + modelDataLength_);
+      modelDataStorage_.assign(view.data, view.data + modelDataLength_);
       modelData_ = modelDataStorage_.data();
     }
     useModelBuffer_ = true;
@@ -89,26 +130,7 @@ class LoadModelWorker : public Napi::AsyncWorker {
         session_ = std::make_unique<Ort::Session>(ortObjects->env, modelPath_.c_str(), sessionOptions_);
       }
 
-      // cache input/output names and types
-      Ort::AllocatorWithDefaultOptions allocator;
-
-      size_t count = session_->GetInputCount();
-      inputNames_.reserve(count);
-      inputTypes_.reserve(count);
-      for (size_t i = 0; i < count; i++) {
-        auto inputName = session_->GetInputNameAllocated(i, allocator);
-        inputNames_.emplace_back(inputName.get());
-        inputTypes_.push_back(session_->GetInputTypeInfo(i));
-      }
-
-      count = session_->GetOutputCount();
-      outputNames_.reserve(count);
-      outputTypes_.reserve(count);
-      for (size_t i = 0; i < count; i++) {
-        auto outputName = session_->GetOutputNameAllocated(i, allocator);
-        outputNames_.emplace_back(outputName.get());
-        outputTypes_.push_back(session_->GetOutputTypeInfo(i));
-      }
+      ReadSessionMetadata(*session_, inputNames_, inputTypes_, outputNames_, outputTypes_);
     } catch (std::exception const& e) {
       ReleaseNativeSession();
       SetError(e.what());
@@ -304,6 +326,57 @@ void InferenceSessionWrap::ReleaseEpContextDataReadState() noexcept {
   }
 }
 
+Napi::Value InferenceSessionWrap::LoadModelSynchronously(const Napi::CallbackInfo& info, bool isModelPath,
+                                                         const Napi::Object& options,
+                                                         Ort::SessionOptions&& sessionOptions) {
+  Napi::Env env = info.Env();
+  auto deferred = Napi::Promise::Deferred::New(env);
+  this->loading_ = true;
+
+  try {
+    auto* ortObjects = OrtSingletonData::GetOrtObjects();
+    ORT_NAPI_THROW_ERROR_IF(ortObjects == nullptr, env, "ONNX Runtime is not initialized.");
+
+    std::unique_ptr<Ort::Session> session;
+    if (isModelPath) {
+      auto value = info[0].As<Napi::String>();
+#ifdef _WIN32
+      auto modelPath = value.Utf16Value();
+      std::wstring wideModelPath{modelPath.begin(), modelPath.end()};
+      session = std::make_unique<Ort::Session>(ortObjects->env, wideModelPath.c_str(), sessionOptions);
+#else
+      auto modelPath = value.Utf8Value();
+      session = std::make_unique<Ort::Session>(ortObjects->env, modelPath.c_str(), sessionOptions);
+#endif
+    } else {
+      const auto view = GetModelBufferView(info[0].As<Napi::ArrayBuffer>(),
+                                           info[1].As<Napi::Number>().Int64Value(),
+                                           info[2].As<Napi::Number>().Int64Value());
+      session = std::make_unique<Ort::Session>(ortObjects->env, view.data, view.size, sessionOptions);
+    }
+
+    std::vector<std::string> inputNames;
+    std::vector<Ort::TypeInfo> inputTypes;
+    std::vector<std::string> outputNames;
+    std::vector<Ort::TypeInfo> outputTypes;
+    ReadSessionMetadata(*session, inputNames, inputTypes, outputNames, outputTypes);
+    AdoptLoadedSession(std::move(session), std::move(inputNames), std::move(inputTypes),
+                       std::move(outputNames), std::move(outputTypes), options);
+    deferred.Resolve(env.Undefined());
+  } catch (Napi::Error const& e) {
+    ResetAfterFailedLoad();
+    deferred.Reject(e.Value());
+  } catch (std::exception const& e) {
+    ResetAfterFailedLoad();
+    deferred.Reject(Napi::Error::New(env, e.what()).Value());
+  } catch (...) {
+    ResetAfterFailedLoad();
+    deferred.Reject(Napi::Error::New(env, "Failed to create the inference session.").Value());
+  }
+
+  return deferred.Promise();
+}
+
 Napi::Value InferenceSessionWrap::LoadModel(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
   Napi::EscapableHandleScope scope(env);
@@ -327,9 +400,15 @@ Napi::Value InferenceSessionWrap::LoadModel(const Napi::CallbackInfo& info) {
   std::unique_ptr<LoadModelWorker> worker;
   try {
     Ort::SessionOptions sessionOptions;
-    std::vector<std::vector<char>> externalDataBuffers;
-    ParseSessionOptions(options, sessionOptions, externalDataBuffers);
     ParseEpContextDataReadOptions(options, sessionOptions, this->epContextDataReadState_);
+
+    if (!this->epContextDataReadState_) {
+      ParseSessionOptions(options, sessionOptions);
+      return scope.Escape(LoadModelSynchronously(info, isModelPath, options, std::move(sessionOptions)));
+    }
+
+    std::vector<std::vector<char>> externalDataBuffers;
+    ParseSessionOptions(options, sessionOptions, &externalDataBuffers);
 
     worker = std::make_unique<LoadModelWorker>(env, *this, info.This().As<Napi::Object>(), options,
                                                std::move(sessionOptions), this->epContextDataReadState_,

--- a/js/node/src/inference_session_wrap.cc
+++ b/js/node/src/inference_session_wrap.cc
@@ -4,13 +4,187 @@
 #include "onnxruntime_cxx_api.h"
 
 #include "common.h"
+#include "ep_context_data_read_helper.h"
 #include "inference_session_wrap.h"
 #include "ort_instance_data.h"
 #include "ort_singleton_data.h"
 #include "run_options_helper.h"
 #include "session_options_helper.h"
 #include "tensor_helper.h"
+#include <memory>
 #include <string>
+#include <utility>
+#include <vector>
+
+/**
+ * LoadModelWorker constructs the native Ort::Session on a libuv worker thread.
+ *
+ * Constructing the session on a worker thread keeps the JavaScript event loop available, which is a
+ * requirement for `sessionOptions.epContextDataRead`: ONNX Runtime calls that callback while the session
+ * is being created and the call has to be marshalled back to the JavaScript thread.
+ *
+ * The worker owns everything the native constructor needs, including references to the JavaScript values
+ * that back the model path/buffer and the session options, so that they stay alive until it completes.
+ */
+class LoadModelWorker : public Napi::AsyncWorker {
+ public:
+  LoadModelWorker(Napi::Env env, InferenceSessionWrap& wrap, const Napi::Object self, const Napi::Object options,
+                  Ort::SessionOptions&& sessionOptions,
+                  std::shared_ptr<EpContextDataReadState> epContextDataReadState,
+                  std::vector<std::vector<char>>&& externalDataBuffers)
+      : Napi::AsyncWorker{env, "onnxruntime.InferenceSession.loadModel"},
+        wrap_{wrap},
+        selfRef_{Napi::Persistent(self)},
+        optionsRef_{Napi::Persistent(options)},
+        externalDataBuffers_{std::move(externalDataBuffers)},
+        sessionOptions_{std::move(sessionOptions)},
+        epContextDataReadState_{std::move(epContextDataReadState)},
+        deferred_{Napi::Promise::Deferred::New(env)} {
+    // The ORT singleton must not be destroyed by an environment cleanup hook while the worker thread
+    // is still using it.
+    OrtSingletonData::RetainOrtObjects();
+  }
+
+  ~LoadModelWorker() override {
+    // Give up the ORT objects before the reference that keeps the ORT singleton alive.
+    ReleaseNativeSession();
+    OrtSingletonData::ReleaseOrtObjects();
+  }
+
+  // Keep the model path alive for the duration of the native call.
+  void SetModelPath(std::basic_string<ORTCHAR_T> modelPath) { modelPath_ = std::move(modelPath); }
+
+  // Copy the model before yielding to JavaScript. A persistent reference does not pin an ArrayBuffer's
+  // backing store, which can be detached or transferred while the worker is running.
+  void SetModelBuffer(Napi::ArrayBuffer buffer, int64_t byteOffset, int64_t byteLength) {
+    const size_t bufferLength = buffer.ByteLength();
+    if (byteOffset < 0 || byteLength < 0 || static_cast<uint64_t>(byteOffset) > bufferLength ||
+        static_cast<uint64_t>(byteLength) > bufferLength - static_cast<size_t>(byteOffset)) {
+      throw Napi::RangeError::New(buffer.Env(), "Model buffer offset or length is out of range.");
+    }
+
+    modelDataLength_ = static_cast<size_t>(byteLength);
+    if (modelDataLength_ != 0) {
+      const auto* data = static_cast<const uint8_t*>(buffer.Data()) + static_cast<size_t>(byteOffset);
+      modelDataStorage_.assign(data, data + modelDataLength_);
+      modelData_ = modelDataStorage_.data();
+    }
+    useModelBuffer_ = true;
+  }
+
+  Napi::Promise Promise() const { return deferred_.Promise(); }
+
+ protected:
+  void Execute() override {
+    try {
+      auto* ortObjects = OrtSingletonData::GetOrtObjects();
+      if (ortObjects == nullptr) {
+        SetError("ONNX Runtime is not initialized.");
+        return;
+      }
+
+      if (useModelBuffer_) {
+        session_ = std::make_unique<Ort::Session>(ortObjects->env, modelData_, modelDataLength_, sessionOptions_);
+      } else {
+        session_ = std::make_unique<Ort::Session>(ortObjects->env, modelPath_.c_str(), sessionOptions_);
+      }
+
+      // cache input/output names and types
+      Ort::AllocatorWithDefaultOptions allocator;
+
+      size_t count = session_->GetInputCount();
+      inputNames_.reserve(count);
+      inputTypes_.reserve(count);
+      for (size_t i = 0; i < count; i++) {
+        auto inputName = session_->GetInputNameAllocated(i, allocator);
+        inputNames_.emplace_back(inputName.get());
+        inputTypes_.push_back(session_->GetInputTypeInfo(i));
+      }
+
+      count = session_->GetOutputCount();
+      outputNames_.reserve(count);
+      outputTypes_.reserve(count);
+      for (size_t i = 0; i < count; i++) {
+        auto outputName = session_->GetOutputNameAllocated(i, allocator);
+        outputNames_.emplace_back(outputName.get());
+        outputTypes_.push_back(session_->GetOutputTypeInfo(i));
+      }
+    } catch (std::exception const& e) {
+      ReleaseNativeSession();
+      SetError(e.what());
+    } catch (...) {
+      ReleaseNativeSession();
+      SetError("Failed to create the inference session.");
+    }
+  }
+
+  void OnOK() override {
+    Napi::Env env = Env();
+    Napi::HandleScope scope{env};
+
+    try {
+      wrap_.AdoptLoadedSession(std::move(session_), std::move(inputNames_), std::move(inputTypes_),
+                               std::move(outputNames_), std::move(outputTypes_), optionsRef_.Value());
+    } catch (Napi::Error const& e) {
+      ReleaseNativeSession();
+      wrap_.ResetAfterFailedLoad();
+      deferred_.Reject(e.Value());
+      return;
+    } catch (std::exception const& e) {
+      ReleaseNativeSession();
+      wrap_.ResetAfterFailedLoad();
+      deferred_.Reject(Napi::Error::New(env, e.what()).Value());
+      return;
+    }
+
+    deferred_.Resolve(env.Undefined());
+  }
+
+  void OnError(const Napi::Error& e) override {
+    Napi::Env env = Env();
+    Napi::HandleScope scope{env};
+
+    // The native session is released before the callback state that it can call into.
+    ReleaseNativeSession();
+    wrap_.ResetAfterFailedLoad();
+    deferred_.Reject(e.Value());
+  }
+
+ private:
+  void ReleaseNativeSession() noexcept {
+    inputTypes_.clear();
+    outputTypes_.clear();
+    session_.reset(nullptr);
+  }
+
+  InferenceSessionWrap& wrap_;
+
+  // Keeps the wrapper object and options object alive until the worker completes.
+  Napi::ObjectReference selfRef_;
+  Napi::ObjectReference optionsRef_;
+
+  // Owns every external initializer backing store referenced by sessionOptions_.
+  std::vector<std::vector<char>> externalDataBuffers_;
+  Ort::SessionOptions sessionOptions_;
+
+  // Strong snapshot of the callback state: it must outlive the native session under construction.
+  // Declared before `session_` so that the session is destroyed first.
+  std::shared_ptr<EpContextDataReadState> epContextDataReadState_;
+
+  std::basic_string<ORTCHAR_T> modelPath_;
+  bool useModelBuffer_ = false;
+  void* modelData_ = nullptr;
+  size_t modelDataLength_ = 0;
+  std::vector<uint8_t> modelDataStorage_;
+
+  std::unique_ptr<Ort::Session> session_;
+  std::vector<std::string> inputNames_;
+  std::vector<Ort::TypeInfo> inputTypes_;
+  std::vector<std::string> outputNames_;
+  std::vector<Ort::TypeInfo> outputTypes_;
+
+  Napi::Promise::Deferred deferred_;
+};
 
 Napi::Object InferenceSessionWrap::Init(Napi::Env env, Napi::Object exports) {
   // create ONNX runtime env
@@ -55,7 +229,11 @@ Napi::Value InferenceSessionWrap::InitOrtOnce(const Napi::CallbackInfo& info) {
 }
 
 InferenceSessionWrap::InferenceSessionWrap(const Napi::CallbackInfo& info)
-    : Napi::ObjectWrap<InferenceSessionWrap>(info), initialized_(false), disposed_(false), session_(nullptr) {}
+    : Napi::ObjectWrap<InferenceSessionWrap>(info),
+      initialized_(false),
+      loading_(false),
+      disposed_(false),
+      session_(nullptr) {}
 
 InferenceSessionWrap::~InferenceSessionWrap() {
   // If the ORT singleton has already been destroyed (e.g. during process shutdown when the
@@ -70,81 +248,127 @@ InferenceSessionWrap::~InferenceSessionWrap() {
     }
     (void)ioBinding_.release();
     (void)session_.release();
+  } else {
+    ioBinding_.reset(nullptr);
+    session_.reset(nullptr);
+  }
+
+  // The native session is gone, so the callback state can no longer be reached from ONNX Runtime.
+  ReleaseEpContextDataReadState();
+}
+
+void InferenceSessionWrap::AdoptLoadedSession(std::unique_ptr<Ort::Session> session,
+                                              std::vector<std::string> inputNames,
+                                              std::vector<Ort::TypeInfo> inputTypes,
+                                              std::vector<std::string> outputNames,
+                                              std::vector<Ort::TypeInfo> outputTypes, const Napi::Object options) {
+  this->session_ = std::move(session);
+  this->inputNames_ = std::move(inputNames);
+  this->inputTypes_ = std::move(inputTypes);
+  this->outputNames_ = std::move(outputNames);
+  this->outputTypes_ = std::move(outputTypes);
+
+  // cache preferred output locations
+  ParsePreferredOutputLocations(options, outputNames_, preferredOutputLocations_);
+  if (preferredOutputLocations_.size() > 0) {
+    ioBinding_ = std::make_unique<Ort::IoBinding>(*session_);
+  }
+
+  this->loading_ = false;
+  this->initialized_ = true;
+}
+
+void InferenceSessionWrap::ResetAfterFailedLoad() noexcept {
+  this->loading_ = false;
+  this->initialized_ = false;
+
+  this->inputNames_.clear();
+  this->outputNames_.clear();
+  this->preferredOutputLocations_.clear();
+
+  if (OrtSingletonData::GetOrtObjects()) {
+    this->inputTypes_.clear();
+    this->outputTypes_.clear();
+    this->ioBinding_.reset(nullptr);
+    this->session_.reset(nullptr);
+  }
+
+  // Deterministic teardown: the callback state is released only after the native session is gone.
+  ReleaseEpContextDataReadState();
+}
+
+void InferenceSessionWrap::ReleaseEpContextDataReadState() noexcept {
+  if (this->epContextDataReadState_) {
+    this->epContextDataReadState_->Release();
+    this->epContextDataReadState_.reset();
   }
 }
 
 Napi::Value InferenceSessionWrap::LoadModel(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env);
+  Napi::EscapableHandleScope scope(env);
 
   ORT_NAPI_THROW_ERROR_IF(this->initialized_, env, "Model already loaded. Cannot load model multiple times.");
+  ORT_NAPI_THROW_ERROR_IF(this->loading_, env, "Model is being loaded. Cannot load model multiple times.");
   ORT_NAPI_THROW_ERROR_IF(this->disposed_, env, "Session already disposed.");
 
   size_t argsLength = info.Length();
   ORT_NAPI_THROW_TYPEERROR_IF(argsLength == 0, env, "Expect argument: model file path or buffer.");
 
+  const bool isModelPath = argsLength == 2 && info[0].IsString() && info[1].IsObject();
+  const bool isModelBuffer = argsLength == 4 && info[0].IsArrayBuffer() && info[1].IsNumber() &&
+                             info[2].IsNumber() && info[3].IsObject();
+  ORT_NAPI_THROW_TYPEERROR_IF(
+      !isModelPath && !isModelBuffer, env,
+      "Invalid argument: args has to be either (modelPath, options) or (buffer, byteOffset, byteLength, options).");
+
+  auto options = info[argsLength - 1].As<Napi::Object>();
+
+  std::unique_ptr<LoadModelWorker> worker;
   try {
     Ort::SessionOptions sessionOptions;
+    std::vector<std::vector<char>> externalDataBuffers;
+    ParseSessionOptions(options, sessionOptions, externalDataBuffers);
+    ParseEpContextDataReadOptions(options, sessionOptions, this->epContextDataReadState_);
 
-    if (argsLength == 2 && info[0].IsString() && info[1].IsObject()) {
-      Napi::String value = info[0].As<Napi::String>();
+    worker = std::make_unique<LoadModelWorker>(env, *this, info.This().As<Napi::Object>(), options,
+                                               std::move(sessionOptions), this->epContextDataReadState_,
+                                               std::move(externalDataBuffers));
 
-      ParseSessionOptions(info[1].As<Napi::Object>(), sessionOptions);
-      this->session_.reset(new Ort::Session(OrtSingletonData::GetOrtObjects()->env,
+    if (isModelPath) {
+      auto value = info[0].As<Napi::String>();
 #ifdef _WIN32
-                                            reinterpret_cast<const wchar_t*>(value.Utf16Value().c_str()),
+      auto modelPath = value.Utf16Value();
+      worker->SetModelPath(std::wstring{modelPath.begin(), modelPath.end()});
 #else
-                                            value.Utf8Value().c_str(),
+      worker->SetModelPath(value.Utf8Value());
 #endif
-                                            sessionOptions));
-
-    } else if (argsLength == 4 && info[0].IsArrayBuffer() && info[1].IsNumber() && info[2].IsNumber() &&
-               info[3].IsObject()) {
-      void* buffer = info[0].As<Napi::ArrayBuffer>().Data();
-      int64_t bytesOffset = info[1].As<Napi::Number>().Int64Value();
-      int64_t bytesLength = info[2].As<Napi::Number>().Int64Value();
-
-      ParseSessionOptions(info[3].As<Napi::Object>(), sessionOptions);
-      this->session_.reset(new Ort::Session(OrtSingletonData::GetOrtObjects()->env,
-                                            reinterpret_cast<char*>(buffer) + bytesOffset, bytesLength,
-                                            sessionOptions));
     } else {
-      ORT_NAPI_THROW_TYPEERROR(
-          env,
-          "Invalid argument: args has to be either (modelPath, options) or (buffer, byteOffset, byteLength, options).");
-    }
-
-    // cache input/output names and types
-    Ort::AllocatorWithDefaultOptions allocator;
-
-    size_t count = session_->GetInputCount();
-    inputNames_.reserve(count);
-    for (size_t i = 0; i < count; i++) {
-      auto input_name = session_->GetInputNameAllocated(i, allocator);
-      inputNames_.emplace_back(input_name.get());
-      inputTypes_.push_back(session_->GetInputTypeInfo(i));
-    }
-
-    count = session_->GetOutputCount();
-    outputNames_.reserve(count);
-    for (size_t i = 0; i < count; i++) {
-      auto output_name = session_->GetOutputNameAllocated(i, allocator);
-      outputNames_.emplace_back(output_name.get());
-      outputTypes_.push_back(session_->GetOutputTypeInfo(i));
-    }
-
-    // cache preferred output locations
-    ParsePreferredOutputLocations(info[argsLength - 1].As<Napi::Object>(), outputNames_, preferredOutputLocations_);
-    if (preferredOutputLocations_.size() > 0) {
-      ioBinding_ = std::make_unique<Ort::IoBinding>(*session_);
+      worker->SetModelBuffer(info[0].As<Napi::ArrayBuffer>(), info[1].As<Napi::Number>().Int64Value(),
+                             info[2].As<Napi::Number>().Int64Value());
     }
   } catch (Napi::Error const& e) {
+    worker.reset(nullptr);
+    ReleaseEpContextDataReadState();
     throw e;
   } catch (std::exception const& e) {
+    worker.reset(nullptr);
+    ReleaseEpContextDataReadState();
     ORT_NAPI_THROW_ERROR(env, e.what());
   }
-  this->initialized_ = true;
-  return env.Undefined();
+
+  this->loading_ = true;
+  auto promise = worker->Promise();
+  // Napi::AsyncWorker deletes itself once it completed.
+  try {
+    worker->Queue();
+    worker.release();
+  } catch (...) {
+    this->loading_ = false;
+    ReleaseEpContextDataReadState();
+    throw;
+  }
+  return scope.Escape(promise);
 }
 
 Napi::Value InferenceSessionWrap::GetMetadata(const Napi::CallbackInfo& info) {
@@ -282,6 +506,9 @@ Napi::Value InferenceSessionWrap::Dispose(const Napi::CallbackInfo& info) {
 
   this->ioBinding_.reset(nullptr);
   this->session_.reset(nullptr);
+
+  // Deterministic teardown: the native session is released before the state it can call into.
+  this->ReleaseEpContextDataReadState();
 
   this->disposed_ = true;
   return env.Undefined();

--- a/js/node/src/inference_session_wrap.h
+++ b/js/node/src/inference_session_wrap.h
@@ -44,17 +44,20 @@ class InferenceSessionWrap : public Napi::ObjectWrap<InferenceSessionWrap> {
   static Napi::Value ListSupportedBackends(const Napi::CallbackInfo& info);
 
   /**
-   * [async] create the session.
+   * Create the session and return a Promise.
    *
-   * The native session is constructed on a worker thread so that the JavaScript event loop stays
-   * available. This is required because ONNX Runtime may call back into JavaScript (see
-   * `sessionOptions.epContextDataRead`) while the session is being created.
+   * Sessions with `sessionOptions.epContextDataRead` are constructed on a worker thread so that the
+   * JavaScript event loop stays available for the callback. Other sessions retain the synchronous,
+   * zero-copy native construction path and return an already-settled Promise.
    *
    * @param arg0 either a string (file path) or an ArrayBuffer
    * @returns a Promise that resolves when the session is created
    * @throw error if the arguments are invalid or the session options cannot be parsed
    */
   Napi::Value LoadModel(const Napi::CallbackInfo& info);
+
+  Napi::Value LoadModelSynchronously(const Napi::CallbackInfo& info, bool isModelPath,
+                                     const Napi::Object& options, Ort::SessionOptions&& sessionOptions);
 
   // following functions have to be called after model is loaded.
 

--- a/js/node/src/inference_session_wrap.h
+++ b/js/node/src/inference_session_wrap.h
@@ -7,6 +7,13 @@
 
 #include <memory>
 #include <napi.h>
+#include <string>
+#include <vector>
+
+#include "ep_context_data_read_helper.h"
+
+// LoadModelWorker performs the native session construction off the JavaScript thread.
+class LoadModelWorker;
 
 // class InferenceSessionWrap is a N-API object wrapper for native InferenceSession.
 class InferenceSessionWrap : public Napi::ObjectWrap<InferenceSessionWrap> {
@@ -17,6 +24,8 @@ class InferenceSessionWrap : public Napi::ObjectWrap<InferenceSessionWrap> {
   ~InferenceSessionWrap();
 
  private:
+  friend class ::LoadModelWorker;
+
   /**
    * [sync] initialize ONNX Runtime once.
    *
@@ -35,10 +44,15 @@ class InferenceSessionWrap : public Napi::ObjectWrap<InferenceSessionWrap> {
   static Napi::Value ListSupportedBackends(const Napi::CallbackInfo& info);
 
   /**
-   * [sync] create the session.
-   * @param arg0 either a string (file path) or a Uint8Array
-   * @returns nothing
-   * @throw error if status code != 0
+   * [async] create the session.
+   *
+   * The native session is constructed on a worker thread so that the JavaScript event loop stays
+   * available. This is required because ONNX Runtime may call back into JavaScript (see
+   * `sessionOptions.epContextDataRead`) while the session is being created.
+   *
+   * @param arg0 either a string (file path) or an ArrayBuffer
+   * @returns a Promise that resolves when the session is created
+   * @throw error if the arguments are invalid or the session options cannot be parsed
    */
   Napi::Value LoadModel(const Napi::CallbackInfo& info);
 
@@ -77,10 +91,27 @@ class InferenceSessionWrap : public Napi::ObjectWrap<InferenceSessionWrap> {
    */
   Napi::Value EndProfiling(const Napi::CallbackInfo& info);
 
+  // Take over the objects created by LoadModelWorker. Runs on the JavaScript thread.
+  // @throw Napi::Error if the preferred output locations are invalid.
+  void AdoptLoadedSession(std::unique_ptr<Ort::Session> session, std::vector<std::string> inputNames,
+                          std::vector<Ort::TypeInfo> inputTypes, std::vector<std::string> outputNames,
+                          std::vector<Ort::TypeInfo> outputTypes, const Napi::Object options);
+
+  // Reset the session state after a failed load. Runs on the JavaScript thread.
+  void ResetAfterFailedLoad() noexcept;
+
+  // Give up the EPContext data read callback state. Must run after the native session was released.
+  void ReleaseEpContextDataReadState() noexcept;
+
   // private members
+
+  // The EPContext data read callback state is declared first so that it is destroyed last: the native
+  // session must always be released before the state that it can call into.
+  std::shared_ptr<EpContextDataReadState> epContextDataReadState_;
 
   // session objects
   bool initialized_;
+  bool loading_;
   bool disposed_;
   std::unique_ptr<Ort::Session> session_;
 

--- a/js/node/src/ort_singleton_data.cc
+++ b/js/node/src/ort_singleton_data.cc
@@ -47,3 +47,13 @@ void OrtSingletonData::CleanupHook(void* arg) {
 OrtSingletonData::OrtObjects* OrtSingletonData::GetOrtObjects() {
   return ort_objects.load(std::memory_order_acquire);
 }
+
+void OrtSingletonData::RetainOrtObjects() {
+  std::lock_guard<std::mutex> lock(ort_singleton_mutex);
+  ref_count++;
+}
+
+void OrtSingletonData::ReleaseOrtObjects() {
+  std::lock_guard<std::mutex> lock(ort_singleton_mutex);
+  ref_count--;
+}

--- a/js/node/src/ort_singleton_data.h
+++ b/js/node/src/ort_singleton_data.h
@@ -52,6 +52,13 @@ struct OrtSingletonData {
   // Get the ORT singleton objects. Returns nullptr if the singleton has been destroyed.
   static OrtObjects* GetOrtObjects();
 
+  // Keep the singleton alive while native work that uses it is in flight (e.g. asynchronous session
+  // construction, which may run while an environment cleanup hook fires). Every RetainOrtObjects()
+  // call must be paired with exactly one ReleaseOrtObjects() call. While a reference is held the
+  // singleton is never destroyed; it safely leaks instead, as described above.
+  static void RetainOrtObjects();
+  static void ReleaseOrtObjects();
+
  private:
   static void CleanupHook(void* arg);
 };

--- a/js/node/src/session_options_helper.cc
+++ b/js/node/src/session_options_helper.cc
@@ -200,7 +200,7 @@ void IterateExtraOptions(const std::string& prefix, const Napi::Object& obj, Ort
 }
 
 void ParseSessionOptions(const Napi::Object options, Ort::SessionOptions& sessionOptions,
-                         std::vector<std::vector<char>>& externalDataBuffers) {
+                         std::vector<std::vector<char>>* externalDataBuffers) {
   // Execution provider
   if (options.Has("executionProviders")) {
     auto epsValue = options.Get("executionProviders");
@@ -382,7 +382,7 @@ void ParseSessionOptions(const Napi::Object options, Ort::SessionOptions& sessio
                                     "Invalid argument: sessionOptions.externalData value must have an 'data' property of type buffer or typed array in Node.js binding.");
 
         auto data = obj.Get("data");
-        const char* source;
+        char* source;
         size_t size;
         if (data.IsBuffer()) {
           source = data.As<Napi::Buffer<char>>().Data();
@@ -392,11 +392,15 @@ void ParseSessionOptions(const Napi::Object options, Ort::SessionOptions& sessio
           source = reinterpret_cast<char*>(typedArray.ArrayBuffer().Data()) + typedArray.ByteOffset();
           size = typedArray.ByteLength();
         }
-        externalDataBuffers.emplace_back();
-        if (size != 0) {
-          externalDataBuffers.back().assign(source, source + size);
+        if (externalDataBuffers != nullptr) {
+          externalDataBuffers->emplace_back();
+          if (size != 0) {
+            externalDataBuffers->back().assign(source, source + size);
+          }
+          buffs.push_back(externalDataBuffers->back().data());
+        } else {
+          buffs.push_back(source);
         }
-        buffs.push_back(externalDataBuffers.back().data());
         sizes.push_back(size);
       }
       sessionOptions.AddExternalInitializersFromFilesInMemory(paths, buffs, sizes);

--- a/js/node/src/session_options_helper.cc
+++ b/js/node/src/session_options_helper.cc
@@ -199,7 +199,8 @@ void IterateExtraOptions(const std::string& prefix, const Napi::Object& obj, Ort
   }
 }
 
-void ParseSessionOptions(const Napi::Object options, Ort::SessionOptions& sessionOptions) {
+void ParseSessionOptions(const Napi::Object options, Ort::SessionOptions& sessionOptions,
+                         std::vector<std::vector<char>>& externalDataBuffers) {
   // Execution provider
   if (options.Has("executionProviders")) {
     auto epsValue = options.Get("executionProviders");
@@ -374,20 +375,29 @@ void ParseSessionOptions(const Napi::Object options, Ort::SessionOptions& sessio
         paths.push_back(path);
 #endif
         ORT_NAPI_THROW_TYPEERROR_IF(!obj.Has("data") ||
-                                        !obj.Get("data").IsBuffer() ||
-                                        !(obj.Get("data").IsTypedArray() && obj.Get("data").As<Napi::TypedArray>().TypedArrayType() == napi_uint8_array),
+                                        (!obj.Get("data").IsBuffer() &&
+                                         !(obj.Get("data").IsTypedArray() &&
+                                           obj.Get("data").As<Napi::TypedArray>().TypedArrayType() == napi_uint8_array)),
                                     options.Env(),
                                     "Invalid argument: sessionOptions.externalData value must have an 'data' property of type buffer or typed array in Node.js binding.");
 
         auto data = obj.Get("data");
+        const char* source;
+        size_t size;
         if (data.IsBuffer()) {
-          buffs.push_back(data.As<Napi::Buffer<char>>().Data());
-          sizes.push_back(data.As<Napi::Buffer<char>>().Length());
+          source = data.As<Napi::Buffer<char>>().Data();
+          size = data.As<Napi::Buffer<char>>().Length();
         } else {
           auto typedArray = data.As<Napi::TypedArray>();
-          buffs.push_back(reinterpret_cast<char*>(typedArray.ArrayBuffer().Data()) + typedArray.ByteOffset());
-          sizes.push_back(typedArray.ByteLength());
+          source = reinterpret_cast<char*>(typedArray.ArrayBuffer().Data()) + typedArray.ByteOffset();
+          size = typedArray.ByteLength();
         }
+        externalDataBuffers.emplace_back();
+        if (size != 0) {
+          externalDataBuffers.back().assign(source, source + size);
+        }
+        buffs.push_back(externalDataBuffers.back().data());
+        sizes.push_back(size);
       }
       sessionOptions.AddExternalInitializersFromFilesInMemory(paths, buffs, sizes);
     }

--- a/js/node/src/session_options_helper.h
+++ b/js/node/src/session_options_helper.h
@@ -5,12 +5,15 @@
 
 #include <napi.h>
 
+#include <vector>
+
 namespace Ort {
 struct SessionOptions;
 }
 
 // parse a Javascript session options object and fill the native SessionOptions object.
-void ParseSessionOptions(const Napi::Object options, Ort::SessionOptions& sessionOptions);
+void ParseSessionOptions(const Napi::Object options, Ort::SessionOptions& sessionOptions,
+                         std::vector<std::vector<char>>& externalDataBuffers);
 
 // parse a Javascript session options object and prepare the preferred output locations.
 void ParsePreferredOutputLocations(const Napi::Object options, const std::vector<std::string>& outputNames, std::vector<int>& preferredOutputLocations);

--- a/js/node/src/session_options_helper.h
+++ b/js/node/src/session_options_helper.h
@@ -13,7 +13,7 @@ struct SessionOptions;
 
 // parse a Javascript session options object and fill the native SessionOptions object.
 void ParseSessionOptions(const Napi::Object options, Ort::SessionOptions& sessionOptions,
-                         std::vector<std::vector<char>>& externalDataBuffers);
+                         std::vector<std::vector<char>>* externalDataBuffers = nullptr);
 
 // parse a Javascript session options object and prepare the preferred output locations.
 void ParsePreferredOutputLocations(const Napi::Object options, const std::vector<std::string>& outputNames, std::vector<int>& preferredOutputLocations);

--- a/js/node/test/standalone/ep-context-data-read-main.ts
+++ b/js/node/test/standalone/ep-context-data-read-main.ts
@@ -1,0 +1,58 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import * as path from 'path';
+const ort = require(path.join(__dirname, '../../'));
+import * as process from 'process';
+
+// a minimal MatMul model, same as the one used by ./main.ts
+const modelData =
+  'CAMSDGJhY2tlbmQtdGVzdDpiChEKAWEKAWISAWMiBk1hdE11bBIOdGVzdF9tYXRtdWxfMmRaEwoBYRIOCgwIARIICgIIAwoCCARaEwoBYhIOCgwIARIICgIIBAoCCANiEwoBYxIOCgwIARIICgIIAwoCCANCAhAJ';
+
+const shouldFailFirst = process.argv.includes('--fail-first');
+const shouldRelease = process.argv.includes('--release');
+
+// This script intentionally never calls process.exit(): it verifies that a configured
+// `epContextDataRead` callback does not keep the Node.js event loop alive.
+async function main() {
+  try {
+    const epContextDataRead = {
+      callback: (name: string) => {
+        throw new Error(`unexpected EPContext data request for '${name}'`);
+      },
+      maxDataSize: 1024 * 1024,
+    };
+
+    if (shouldFailFirst) {
+      try {
+        await ort.InferenceSession.create('/this/is/an/invalid/path.onnx', { epContextDataRead });
+        console.error('ERROR: expected the session creation to fail');
+        process.exit(1);
+      } catch {
+        console.log('SUCCESS: Session creation failed as expected');
+      }
+    }
+
+    const modelBuffer = Buffer.from(modelData, 'base64');
+    const session = await ort.InferenceSession.create(modelBuffer, { epContextDataRead });
+
+    const dataA = Float32Array.from([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]);
+    const dataB = Float32Array.from([10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120]);
+    const tensorA = new ort.Tensor('float32', dataA, [3, 4]);
+    const tensorB = new ort.Tensor('float32', dataB, [4, 3]);
+
+    const results = await session.run({ a: tensorA, b: tensorB });
+    console.log('SUCCESS: Inference completed');
+    console.log(`Result: ${results.c.data}`);
+
+    if (shouldRelease) {
+      await session.release();
+      console.log('Session released');
+    }
+  } catch (e) {
+    console.error(`ERROR: ${e}`);
+    process.exit(1);
+  }
+}
+
+void main();

--- a/js/node/test/test-main.ts
+++ b/js/node/test/test-main.ts
@@ -14,6 +14,7 @@ warmup();
 
 // unittests
 require('./unittests/lib/index');
+require('./unittests/lib/ep-context-data-read');
 require('./unittests/lib/inference-session');
 require('./unittests/lib/model-metadata');
 require('./unittests/lib/tensor');

--- a/js/node/test/unittests/lib/ep-context-data-read.ts
+++ b/js/node/test/unittests/lib/ep-context-data-read.ts
@@ -127,6 +127,35 @@ describe('UnitTests - InferenceSession.SessionOptions.epContextDataRead', () => 
 
   // #region asynchronous session construction
 
+  it('uses the synchronous fast path for a model path without a callback', async () => {
+    const session = new binding.InferenceSession();
+    const promise = session.loadModel(SMALL_MODEL_PATH, {});
+
+    // The no-callback path finishes native construction before loadModel returns, while preserving
+    // the Promise API for callers.
+    assert.deepStrictEqual(
+      session.inputMetadata.map(({ name }) => name),
+      ['input'],
+    );
+    await promise;
+    session.dispose();
+  });
+
+  it('uses the synchronous fast path for a model buffer without an effective callback', async () => {
+    const modelData = new Uint8Array(fs.readFileSync(SMALL_MODEL_PATH));
+    const session = new binding.InferenceSession();
+    const promise = session.loadModel(modelData.buffer, modelData.byteOffset, modelData.byteLength, {
+      epContextDataRead: null,
+    } as unknown as InferenceSession.SessionOptions);
+
+    assert.deepStrictEqual(
+      session.inputMetadata.map(({ name }) => name),
+      ['input'],
+    );
+    await promise;
+    session.dispose();
+  });
+
   it('the event loop stays available while the session is being created', async function () {
     // eslint-disable-next-line no-invalid-this
     this.timeout(60000);
@@ -204,6 +233,7 @@ describe('UnitTests - InferenceSession.SessionOptions.epContextDataRead', () => 
     const modelData = new Uint8Array(fs.readFileSync(MODEL_PATH));
     const session = new binding.InferenceSession();
     const promise = session.loadModel(modelData.buffer, modelData.byteOffset, modelData.byteLength, validOptions());
+    assert.throws(() => session.inputMetadata, /not initialized/i);
     structuredClone(modelData.buffer, { transfer: [modelData.buffer] });
     assert.strictEqual(modelData.byteLength, 0);
 

--- a/js/node/test/unittests/lib/ep-context-data-read.ts
+++ b/js/node/test/unittests/lib/ep-context-data-read.ts
@@ -1,0 +1,318 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import assert from 'assert';
+import { spawn } from 'child_process';
+import * as fs from 'fs';
+import { InferenceSession, Tensor } from 'onnxruntime-common';
+import * as path from 'path';
+
+import { binding } from '../../../lib/binding';
+import { assertTensorEqual } from '../../test-utils';
+
+const SQUEEZENET_INPUT0_DATA = require(path.join(__dirname, '../../testdata/squeezenet.input0.json'));
+const SQUEEZENET_OUTPUT0_DATA = require(path.join(__dirname, '../../testdata/squeezenet.output0.json'));
+
+const MODEL_PATH = path.join(__dirname, '../../testdata/squeezenet.onnx');
+const SMALL_MODEL_PATH = path.join(__dirname, '../../testdata/test_types_float.onnx');
+
+const validOptions = (): InferenceSession.SessionOptions => ({
+  epContextDataRead: { callback: () => new Uint8Array(0), maxDataSize: 1024 * 1024 },
+});
+
+describe('UnitTests - InferenceSession.SessionOptions.epContextDataRead', () => {
+  const createAny: any = InferenceSession.create;
+
+  const assertTypeError = async (epContextDataRead: unknown) => {
+    await assert.rejects(
+      async () => {
+        await createAny(SMALL_MODEL_PATH, { epContextDataRead });
+      },
+      { name: 'TypeError', message: /epContextDataRead/ },
+    );
+  };
+
+  const assertRangeError = async (maxDataSize: unknown) => {
+    await assert.rejects(
+      async () => {
+        await createAny(SMALL_MODEL_PATH, { epContextDataRead: { callback: () => new Uint8Array(0), maxDataSize } });
+      },
+      { name: 'RangeError', message: /epContextDataRead\.maxDataSize/ },
+    );
+  };
+
+  // #region setup validation
+
+  it('BAD CALL - epContextDataRead is not an object', async () => {
+    await assertTypeError('yes please');
+  });
+  it('BAD CALL - epContextDataRead is a number', async () => {
+    await assertTypeError(42);
+  });
+  it('BAD CALL - callback is missing', async () => {
+    await assertTypeError({ maxDataSize: 1024 });
+  });
+  it('BAD CALL - callback is not a function', async () => {
+    await assertTypeError({ callback: 'not a function', maxDataSize: 1024 });
+  });
+  it('BAD CALL - callback is null', async () => {
+    await assertTypeError({ callback: null, maxDataSize: 1024 });
+  });
+  it('BAD CALL - maxDataSize is missing', async () => {
+    await assertTypeError({ callback: () => new Uint8Array(0) });
+  });
+  it('BAD CALL - maxDataSize is not a number', async () => {
+    await assertTypeError({ callback: () => new Uint8Array(0), maxDataSize: '1024' });
+  });
+  it('BAD CALL - maxDataSize is NaN', async () => {
+    await assertRangeError(NaN);
+  });
+  it('BAD CALL - maxDataSize is Infinity', async () => {
+    await assertRangeError(Infinity);
+  });
+  it('BAD CALL - maxDataSize is not an integer', async () => {
+    await assertRangeError(1024.5);
+  });
+  it('BAD CALL - maxDataSize is zero', async () => {
+    await assertRangeError(0);
+  });
+  it('BAD CALL - maxDataSize is negative', async () => {
+    await assertRangeError(-1);
+  });
+  it('BAD CALL - maxDataSize is above Number.MAX_SAFE_INTEGER', async () => {
+    await assertRangeError(Number.MAX_SAFE_INTEGER + 1);
+  });
+
+  it('epContextDataRead is optional', async () => {
+    const session = await InferenceSession.create(SMALL_MODEL_PATH, {});
+    await session.release();
+  });
+  it('epContextDataRead accepts undefined', async () => {
+    const session = await createAny(SMALL_MODEL_PATH, { epContextDataRead: undefined });
+    await session.release();
+  });
+  it('epContextDataRead accepts null', async () => {
+    const session = await createAny(SMALL_MODEL_PATH, { epContextDataRead: null });
+    await session.release();
+  });
+  it('epContextDataRead accepts a valid configuration', async () => {
+    const session = await InferenceSession.create(SMALL_MODEL_PATH, validOptions());
+    await session.release();
+  });
+  it('epContextDataRead accepts maxDataSize === 1', async () => {
+    const session = await InferenceSession.create(SMALL_MODEL_PATH, {
+      epContextDataRead: { callback: () => new Uint8Array(0), maxDataSize: 1 },
+    });
+    await session.release();
+  });
+
+  it('the callback is not invoked for a model without EPContext data', async function () {
+    // eslint-disable-next-line no-invalid-this
+    this.timeout(60000);
+
+    let callCount = 0;
+    const session = await InferenceSession.create(MODEL_PATH, {
+      epContextDataRead: {
+        callback: (name: string) => {
+          callCount++;
+          throw new Error(`unexpected callback for '${name}'`);
+        },
+        maxDataSize: 1024 * 1024,
+      },
+    });
+    await session.release();
+    assert.strictEqual(callCount, 0);
+  });
+  // #endregion
+
+  // #region asynchronous session construction
+
+  it('the event loop stays available while the session is being created', async function () {
+    // eslint-disable-next-line no-invalid-this
+    this.timeout(60000);
+
+    let ticks = 0;
+    let settled = false;
+    const spin = () => {
+      if (settled) {
+        return;
+      }
+      ticks++;
+      setImmediate(spin);
+    };
+    setImmediate(spin);
+
+    const session = await InferenceSession.create(MODEL_PATH, validOptions());
+    const ticksDuringCreate = ticks;
+    settled = true;
+    await session.release();
+
+    // A synchronous native session constructor would block the event loop, so the spin counter could
+    // only advance a couple of times. Genuine asynchronous construction lets it advance freely.
+    assert.ok(
+      ticksDuringCreate > 5,
+      `expected the event loop to keep running, but it only ticked ${ticksDuringCreate} times`,
+    );
+  });
+
+  it('concurrent session creation', async function () {
+    // eslint-disable-next-line no-invalid-this
+    this.timeout(60000);
+
+    const sessions = await Promise.all([
+      InferenceSession.create(MODEL_PATH, validOptions()),
+      InferenceSession.create(MODEL_PATH, validOptions()),
+      InferenceSession.create(SMALL_MODEL_PATH, validOptions()),
+    ]);
+    for (const session of sessions) {
+      await session.release();
+    }
+  });
+  // #endregion
+
+  // #region model buffer lifetime
+
+  it('the model buffer stays alive until the native session is created', async function () {
+    // eslint-disable-next-line no-invalid-this
+    this.timeout(60000);
+
+    // Wrap the model bytes in a view with a non-zero byteOffset so that the offset handling is covered.
+    const modelBytes = fs.readFileSync(MODEL_PATH);
+    const padded = new Uint8Array(modelBytes.byteLength + 8);
+    padded.set(modelBytes, 8);
+    let modelData: Uint8Array | null = padded.subarray(8);
+
+    const promise = InferenceSession.create(modelData, validOptions());
+    // Drop the only JavaScript reference to the view while the native session is still being created.
+    modelData = null;
+    global.gc?.();
+
+    const session = await promise;
+    assert.deepStrictEqual(session.inputNames, ['data_0']);
+
+    const output = await session.run({
+      data_0: new Tensor('float32', SQUEEZENET_INPUT0_DATA, [1, 3, 224, 224]),
+    });
+    assertTensorEqual(output.softmaxout_1, new Tensor('float32', SQUEEZENET_OUTPUT0_DATA, [1, 1000, 1, 1]));
+    await session.release();
+  });
+
+  it('the model buffer can be transferred after session creation starts', async function () {
+    // eslint-disable-next-line no-invalid-this
+    this.timeout(60000);
+
+    const modelData = new Uint8Array(fs.readFileSync(MODEL_PATH));
+    const session = new binding.InferenceSession();
+    const promise = session.loadModel(modelData.buffer, modelData.byteOffset, modelData.byteLength, validOptions());
+    structuredClone(modelData.buffer, { transfer: [modelData.buffer] });
+    assert.strictEqual(modelData.byteLength, 0);
+
+    await promise;
+    assert.deepStrictEqual(
+      session.inputMetadata.map(({ name }) => name),
+      ['data_0'],
+    );
+    session.dispose();
+  });
+
+  it('EXPECTED FAILURE - empty buffer', async () => {
+    await assert.rejects(
+      async () => {
+        await createAny(new Uint8Array(0), validOptions());
+      },
+      { name: 'Error', message: /Model data pointer is null./ },
+    );
+  });
+  // #endregion
+
+  // #region failed construction and disposal
+
+  it('EXPECTED FAILURE - invalid model path', async () => {
+    await assert.rejects(
+      async () => {
+        await createAny('/this/is/an/invalid/path.onnx', validOptions());
+      },
+      { name: 'Error', message: /failed/ },
+    );
+  });
+
+  it('a failed session creation does not break the next one', async function () {
+    // eslint-disable-next-line no-invalid-this
+    this.timeout(60000);
+
+    for (let i = 0; i < 3; i++) {
+      await assert.rejects(async () => {
+        await createAny('/this/is/an/invalid/path.onnx', validOptions());
+      });
+    }
+
+    const session = await InferenceSession.create(SMALL_MODEL_PATH, validOptions());
+    await session.release();
+  });
+
+  it('release() twice fails', async () => {
+    const session = await InferenceSession.create(SMALL_MODEL_PATH, validOptions());
+    await session.release();
+    await assert.rejects(async () => {
+      await session.release();
+    }, /disposed/);
+  });
+
+  it('the session can be left unreleased', async () => {
+    // The callback state is owned by the session wrapper and released by its finalizer.
+    await InferenceSession.create(SMALL_MODEL_PATH, validOptions());
+  });
+  // #endregion
+});
+
+describe('UnitTests - InferenceSession.SessionOptions.epContextDataRead (standalone process)', () => {
+  const runTest = async (
+    args: string[] = [],
+  ): Promise<{ code: number | null; signal: NodeJS.Signals | null; stdout: string; stderr: string }> =>
+    new Promise((resolve, reject) => {
+      const testFile = path.join(__dirname, '../../standalone/ep-context-data-read-main.js');
+      const child = spawn('node', [testFile, ...args], { stdio: 'pipe' });
+
+      let stdout = '';
+      let stderr = '';
+
+      child.stdout.on('data', (data) => (stdout += data.toString()));
+      child.stderr.on('data', (data) => (stderr += data.toString()));
+
+      child.on('close', (code, signal) => resolve({ code, signal, stdout, stderr }));
+      child.on('error', reject);
+    });
+
+  // The callback must not keep the Node.js event loop alive: these processes never call process.exit(),
+  // so a leaked thread-safe function reference would hang them until the test times out.
+  it('the process exits after a successful session creation', async function () {
+    // eslint-disable-next-line no-invalid-this
+    this.timeout(60000);
+
+    const result = await runTest();
+    assert.strictEqual(result.signal, null, `process terminated by ${result.signal}`);
+    assert.strictEqual(result.code, 0, result.stderr);
+    assert.ok(result.stdout.includes('SUCCESS: Inference completed'), result.stdout);
+  });
+
+  it('the process exits after releasing the session', async function () {
+    // eslint-disable-next-line no-invalid-this
+    this.timeout(60000);
+
+    const result = await runTest(['--release']);
+    assert.strictEqual(result.signal, null, `process terminated by ${result.signal}`);
+    assert.strictEqual(result.code, 0, result.stderr);
+    assert.ok(result.stdout.includes('Session released'), result.stdout);
+  });
+
+  it('the process exits after a failed session creation', async function () {
+    // eslint-disable-next-line no-invalid-this
+    this.timeout(60000);
+
+    const result = await runTest(['--fail-first']);
+    assert.strictEqual(result.signal, null, `process terminated by ${result.signal}`);
+    assert.strictEqual(result.code, 0, result.stderr);
+    assert.ok(result.stdout.includes('SUCCESS: Session creation failed as expected'), result.stdout);
+    assert.ok(result.stdout.includes('SUCCESS: Inference completed'), result.stdout);
+  });
+});

--- a/js/react_native/android/CMakeLists.txt
+++ b/js/react_native/android/CMakeLists.txt
@@ -75,6 +75,8 @@ add_library(
   ${libPath}
   src/main/cpp/cpp-adapter.cpp
   ../cpp/JsiMain.cpp
+  ../cpp/EpContextDataReadCallback.cpp
+  ../cpp/EpContextDataReadPolicy.cpp
   ../cpp/InferenceSessionHostObject.cpp
   ../cpp/JsiUtils.cpp
   ../cpp/SessionUtils.cpp

--- a/js/react_native/android/CMakeLists.txt
+++ b/js/react_native/android/CMakeLists.txt
@@ -78,6 +78,7 @@ add_library(
   ../cpp/EpContextDataReadCallback.cpp
   ../cpp/EpContextDataReadPolicy.cpp
   ../cpp/InferenceSessionHostObject.cpp
+  ../cpp/LoadModelArgumentPolicy.cpp
   ../cpp/JsiUtils.cpp
   ../cpp/SessionUtils.cpp
   ../cpp/TensorUtils.cpp)

--- a/js/react_native/android/src/main/cpp/cpp-adapter.cpp
+++ b/js/react_native/android/src/main/cpp/cpp-adapter.cpp
@@ -5,10 +5,9 @@
 #include <fbjni/fbjni.h>
 #include <jni.h>
 #include <jsi/jsi.h>
+#include <memory>
 
 using namespace facebook;
-
-static std::shared_ptr<onnxruntimejsi::Env> env;
 
 class OnnxruntimeModule
     : public jni::JavaClass<OnnxruntimeModule> {
@@ -25,16 +24,27 @@ class OnnxruntimeModule
   }
 
  private:
-  static void nativeInstall(jni::alias_ref<jni::JObject> thiz,
-                            jlong jsContextNativePointer,
-                            jni::alias_ref<react::CallInvokerHolder::javaobject>
-                                jsCallInvokerHolder) {
+  static jlong nativeInstall(
+      jni::alias_ref<jni::JObject> thiz, jlong jsContextNativePointer,
+      jni::alias_ref<react::CallInvokerHolder::javaobject>
+          jsCallInvokerHolder) {
     auto runtime = reinterpret_cast<jsi::Runtime*>(jsContextNativePointer);
     auto jsCallInvoker = jsCallInvokerHolder->cthis()->getCallInvoker();
-    env = onnxruntimejsi::install(*runtime, jsCallInvoker);
+    auto env = onnxruntimejsi::install(*runtime, jsCallInvoker);
+    return reinterpret_cast<jlong>(
+        new std::shared_ptr<onnxruntimejsi::Env>(std::move(env)));
   }
 
-  static void nativeCleanup(jni::alias_ref<jni::JObject> thiz) { env.reset(); }
+  static void nativeCleanup(jni::alias_ref<jni::JObject> thiz,
+                            jlong envHandle) {
+    auto env = std::unique_ptr<std::shared_ptr<onnxruntimejsi::Env>>(
+        reinterpret_cast<std::shared_ptr<onnxruntimejsi::Env>*>(envHandle));
+    // invalidate() runs first because this hook is not guaranteed to run on the JS thread: it
+    // stops dispatching to a runtime that is going away and releases any thread blocked on it.
+    if (env && *env) {
+      (*env)->invalidate();
+    }
+  }
 };
 
 JNIEXPORT jint JNI_OnLoad(JavaVM* vm, void*) {

--- a/js/react_native/android/src/main/java/ai/onnxruntime/reactnative/OnnxruntimeModule.java
+++ b/js/react_native/android/src/main/java/ai/onnxruntime/reactnative/OnnxruntimeModule.java
@@ -17,6 +17,7 @@ import com.facebook.react.turbomodule.core.CallInvokerHolderImpl;
 @RequiresApi(api = Build.VERSION_CODES.N)
 public class OnnxruntimeModule extends ReactContextBaseJavaModule {
   private static ReactApplicationContext reactContext;
+  private long nativeEnvHandle;
 
   public OnnxruntimeModule(ReactApplicationContext context) {
     super(context);
@@ -29,27 +30,34 @@ public class OnnxruntimeModule extends ReactContextBaseJavaModule {
     return "Onnxruntime";
   }
 
-  native void nativeInstall(long jsiPointer, CallInvokerHolderImpl jsCallInvokerHolder);
+  native long nativeInstall(long jsiPointer, CallInvokerHolderImpl jsCallInvokerHolder);
 
-  native void nativeCleanup();
+  native void nativeCleanup(long envHandle);
 
   @Override
-  public void invalidate() {
+  public synchronized void invalidate() {
     super.invalidate();
-    nativeCleanup();
+    if (nativeEnvHandle != 0) {
+      nativeCleanup(nativeEnvHandle);
+      nativeEnvHandle = 0;
+    }
   }
 
   /**
    * Install onnxruntime JSI API
    */
   @ReactMethod(isBlockingSynchronousMethod = true)
-  public boolean install() {
+  public synchronized boolean install() {
     try {
       System.loadLibrary("onnxruntimejsi");
       JavaScriptContextHolder jsContext = getReactApplicationContext().getJavaScriptContextHolder();
       CallInvokerHolderImpl jsCallInvokerHolder =
         (CallInvokerHolderImpl) getReactApplicationContext().getCatalystInstance().getJSCallInvokerHolder();
-      nativeInstall(jsContext.get(), jsCallInvokerHolder);
+      long newEnvHandle = nativeInstall(jsContext.get(), jsCallInvokerHolder);
+      if (nativeEnvHandle != 0) {
+        nativeCleanup(nativeEnvHandle);
+      }
+      nativeEnvHandle = newEnvHandle;
       return true;
     } catch (Exception e) {
       return false;

--- a/js/react_native/cpp/AsyncWorker.h
+++ b/js/react_native/cpp/AsyncWorker.h
@@ -23,16 +23,8 @@ class AsyncWorker : public HostObject, public std::enable_shared_from_this<Async
  public:
   AsyncWorker(Runtime& rt, std::shared_ptr<Env> env) : rt_(rt), env_(env), cancel_(false) {}
 
-  ~AsyncWorker() {
-    if (worker_.joinable()) {
-      if (worker_.get_id() != std::this_thread::get_id()) {
-        cancel_ = true;
-        onAbort();
-        worker_.join();
-      } else {
-        worker_.detach();
-      }
-    }
+  ~AsyncWorker() override {
+    abortAndJoin();
   }
 
   /**
@@ -79,6 +71,29 @@ class AsyncWorker : public HostObject, public std::enable_shared_from_this<Async
   }
 
  protected:
+  /**
+   * @brief Stop and join the worker while the derived object is still alive.
+   *
+   * A base destructor cannot dispatch virtual calls to a derived onAbort() implementation, so a
+   * derived worker with abortable state calls this from its destructor.
+   */
+  void abortAndJoin() noexcept {
+    if (worker_.joinable()) {
+      if (worker_.get_id() != std::this_thread::get_id()) {
+        cancel_ = true;
+        // Runs from a destructor, so an escaping exception would terminate the process. Ort calls
+        // made by an onAbort() override (e.g. RunOptions::SetTerminate) can throw.
+        try {
+          onAbort();
+        } catch (...) {
+        }
+        worker_.join();
+      } else {
+        worker_.detach();
+      }
+    }
+  }
+
   virtual void execute() = 0;
 
   virtual Value onResolve(Runtime& rt) = 0;

--- a/js/react_native/cpp/Env.h
+++ b/js/react_native/cpp/Env.h
@@ -5,17 +5,32 @@
 #include <functional>
 #include <jsi/jsi.h>
 #include <memory>
+#include <mutex>
 #include "onnxruntime_cxx_api.h"
+#include <thread>
 #include <vector>
 
 namespace onnxruntimejsi {
 
+/**
+ * @brief Notified once the host tears the JSI bindings down.
+ *
+ * Teardown is not guaranteed to happen on the JS thread, so listeners must not touch the runtime.
+ */
+class EnvTeardownListener {
+ public:
+  virtual ~EnvTeardownListener() = default;
+
+  virtual void onEnvTeardown() noexcept = 0;
+};
+
 class Env : public std::enable_shared_from_this<Env> {
  public:
+  // Constructed from install(), which the host always calls on the JS thread.
   Env(std::shared_ptr<facebook::react::CallInvoker> jsInvoker)
-      : jsInvoker_(jsInvoker) {}
+      : jsInvoker_(jsInvoker), jsThreadId_(std::this_thread::get_id()) {}
 
-  ~Env() {}
+  ~Env() { invalidate(); }
 
   inline void initOrtEnv(OrtLoggingLevel logLevel, const char* logid) {
     if (ortEnv_) {
@@ -36,13 +51,70 @@ class Env : public std::enable_shared_from_this<Env> {
 
   inline Ort::Env& getOrtEnv() const { return *ortEnv_; }
 
-  inline void runOnJsThread(std::function<void()>&& func) {
-    if (!jsInvoker_) return;
-    jsInvoker_->invokeAsync(std::move(func));
+  /**
+   * @brief Whether the caller runs on the thread that installed the bindings, i.e. the JS thread.
+   */
+  inline bool isJsThread() const noexcept {
+    return std::this_thread::get_id() == jsThreadId_;
+  }
+
+  /**
+   * @brief Queue work on the JS thread.
+   *
+   * @return false when the bindings were torn down and the work will never run.
+   */
+  inline bool runOnJsThread(std::function<void()>&& func) {
+    std::shared_ptr<facebook::react::CallInvoker> jsInvoker;
+    {
+      std::lock_guard<std::mutex> lock(mutex_);
+      jsInvoker = jsInvoker_;
+    }
+    if (!jsInvoker) return false;
+    jsInvoker->invokeAsync(std::move(func));
+    return true;
+  }
+
+  inline void
+  addTeardownListener(const std::weak_ptr<EnvTeardownListener>& listener) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    teardownListeners_.erase(
+        std::remove_if(teardownListeners_.begin(), teardownListeners_.end(),
+                       [](const std::weak_ptr<EnvTeardownListener>& entry) {
+                         return entry.expired();
+                       }),
+        teardownListeners_.end());
+    teardownListeners_.push_back(listener);
+  }
+
+  /**
+   * @brief Stop dispatching to the JS thread and notify teardown listeners.
+   *
+   * Callable from any thread and more than once. Never touches the runtime, so it is safe to call
+   * from a host teardown hook that does not run on the JS thread.
+   */
+  inline void invalidate() noexcept {
+    std::vector<std::shared_ptr<EnvTeardownListener>> listeners;
+    {
+      std::lock_guard<std::mutex> lock(mutex_);
+      if (!jsInvoker_ && teardownListeners_.empty()) return;
+      for (auto& entry : teardownListeners_) {
+        if (auto listener = entry.lock()) {
+          listeners.push_back(std::move(listener));
+        }
+      }
+      teardownListeners_.clear();
+      jsInvoker_.reset();
+    }
+    for (auto& listener : listeners) {
+      listener->onEnvTeardown();
+    }
   }
 
  private:
+  mutable std::mutex mutex_;
   std::shared_ptr<facebook::react::CallInvoker> jsInvoker_;
+  std::vector<std::weak_ptr<EnvTeardownListener>> teardownListeners_;
+  const std::thread::id jsThreadId_;
   std::shared_ptr<facebook::jsi::WeakObject> tensorConstructor_;
   std::shared_ptr<Ort::Env> ortEnv_;
 };

--- a/js/react_native/cpp/EpContextDataReadCallback.cpp
+++ b/js/react_native/cpp/EpContextDataReadCallback.cpp
@@ -1,0 +1,434 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "EpContextDataReadCallback.h"
+#include "EpContextDataReadPolicy.h"
+#include <algorithm>
+#include <cmath>
+#include <cstring>
+#include <limits>
+#include <utility>
+
+using namespace facebook::jsi;
+
+namespace onnxruntimejsi {
+
+namespace {
+
+OrtStatus* makeStatus(OrtErrorCode code, const std::string& message) noexcept {
+  return Ort::GetApi().CreateStatus(code, message.c_str());
+}
+
+Value getTypedArrayProperty(Runtime& runtime,
+                            const Object& typedArrayPrototype,
+                            const Object& typedArray,
+                            const char* propertyName) {
+  auto objectConstructor =
+      runtime.global().getPropertyAsObject(runtime, "Object");
+  auto getOwnPropertyDescriptor = objectConstructor.getPropertyAsFunction(
+      runtime, "getOwnPropertyDescriptor");
+  auto descriptor =
+      getOwnPropertyDescriptor
+          .call(runtime, typedArrayPrototype,
+                String::createFromAscii(runtime, propertyName))
+          .asObject(runtime);
+  auto getter = descriptor.getPropertyAsFunction(runtime, "get");
+  return getter.callWithThis(runtime, typedArray);
+}
+
+bool toViewIndex(double value, size_t& result) noexcept {
+  if (!std::isfinite(value) || value < 0 || std::trunc(value) != value ||
+      value >= static_cast<double>(std::numeric_limits<size_t>::max())) {
+    return false;
+  }
+  result = static_cast<size_t>(value);
+  return true;
+}
+
+}  // namespace
+
+bool EpContextDataReadCallback::PendingCall::isFinished() noexcept {
+  std::lock_guard<std::mutex> lock(mutex);
+  return finished;
+}
+
+void EpContextDataReadCallback::PendingCall::finish(
+    CallStatus newStatus, std::string newError,
+    std::vector<uint8_t> newData) noexcept {
+  {
+    std::lock_guard<std::mutex> lock(mutex);
+    if (finished) return;
+    finished = true;
+    status = newStatus;
+    error = std::move(newError);
+    data = std::move(newData);
+  }
+  cv.notify_all();
+}
+
+void EpContextDataReadCallback::PendingCall::wait() {
+  std::unique_lock<std::mutex> lock(mutex);
+  cv.wait(lock, [this] { return finished; });
+}
+
+EpContextDataReadCallback::EpContextDataReadCallback(
+    std::shared_ptr<Env> env, Runtime& runtime,
+    std::shared_ptr<Function> callback, size_t maxDataSize)
+    : env_(std::move(env)),
+      maxDataSize_(maxDataSize),
+      runtime_(&runtime),
+      callback_(std::move(callback)) {}
+
+EpContextDataReadCallback::~EpContextDataReadCallback() {
+  invalidate();
+
+  std::shared_ptr<Function> callback;
+  {
+    std::lock_guard<std::mutex> lock(stateMutex_);
+    callback.swap(callback_);
+  }
+  if (callback && !env_->isJsThread()) {
+    // Releasing a jsi::Function writes through the runtime that created it. Off the JS thread that
+    // runtime may already be gone, so hand the last reference to a deliberate leak rather than
+    // invalidate a pointer into freed memory. invalidate() drops the reference on the JS thread in
+    // every expected teardown path, so this is a safety net rather than a routine leak.
+    new std::shared_ptr<Function>(std::move(callback));
+  }
+}
+
+std::shared_ptr<EpContextDataReadCallback>
+EpContextDataReadCallback::createAndRegister(Runtime& runtime,
+                                             const Object& options,
+                                             const std::shared_ptr<Env>& env,
+                                             Ort::SessionOptions& sessionOptions) {
+  if (!options.hasProperty(runtime, "epContextDataRead")) {
+    return nullptr;
+  }
+  auto value = options.getProperty(runtime, "epContextDataRead");
+  if (value.isUndefined() || value.isNull()) {
+    return nullptr;
+  }
+  if (!value.isObject()) {
+    throw JSError(runtime,
+                  "session option \"epContextDataRead\" must be an object");
+  }
+  auto config = value.asObject(runtime);
+
+  auto callbackValue = config.getProperty(runtime, "callback");
+  if (!callbackValue.isObject() ||
+      !callbackValue.asObject(runtime).isFunction(runtime)) {
+    throw JSError(
+        runtime,
+        "session option \"epContextDataRead.callback\" must be a function");
+  }
+
+  auto maxDataSizeValue = config.getProperty(runtime, "maxDataSize");
+  if (!maxDataSizeValue.isNumber()) {
+    throw JSError(runtime,
+                  "session option \"epContextDataRead.maxDataSize\" is "
+                  "required and must be a number");
+  }
+  auto maxDataSize = parseMaxDataSize(maxDataSizeValue.asNumber());
+  if (!maxDataSize.ok) {
+    throw JSError(runtime, maxDataSize.error);
+  }
+
+  auto state = std::make_shared<EpContextDataReadCallback>(
+      env, runtime,
+      std::make_shared<Function>(
+          callbackValue.asObject(runtime).asFunction(runtime)),
+      maxDataSize.value);
+
+  // Publish the state only once ONNX Runtime accepted it. If the setter throws, `state` is
+  // destroyed here on the JS thread and nothing observed a half-registered callback.
+  sessionOptions.SetEpContextDataReadFunc(&EpContextDataReadCallback::read,
+                                          state.get(), maxDataSize.value);
+
+  env->addTeardownListener(state);
+  return state;
+}
+
+OrtStatus* ORT_API_CALL EpContextDataReadCallback::read(
+    void* state, const char* name, OrtAllocator* allocator, void** buffer,
+    size_t* dataSize) noexcept {
+  // Initialize the outputs before anything that can fail so ORT never observes stale values.
+  if (buffer != nullptr) {
+    *buffer = nullptr;
+  }
+  if (dataSize != nullptr) {
+    *dataSize = 0;
+  }
+
+  if (state == nullptr || name == nullptr || allocator == nullptr ||
+      buffer == nullptr || dataSize == nullptr) {
+    return makeStatus(
+        ORT_INVALID_ARGUMENT,
+        "EPContext data read callback received an invalid argument");
+  }
+
+  try {
+    return static_cast<EpContextDataReadCallback*>(state)->readImpl(
+        std::string(name), allocator, buffer, dataSize);
+  } catch (const std::exception& e) {
+    return makeStatus(ORT_FAIL, "EPContext data read callback failed: " +
+                                    std::string(e.what()));
+  } catch (...) {
+    return makeStatus(
+        ORT_FAIL, "EPContext data read callback failed with an unknown error");
+  }
+}
+
+OrtStatus* EpContextDataReadCallback::readImpl(const std::string& name,
+                                               OrtAllocator* allocator,
+                                               void** buffer,
+                                               size_t* dataSize) {
+  // ORT does not serialize calls made by different EP instances or worker threads.
+  std::lock_guard<std::mutex> callLock(callMutex_);
+
+  auto pending = std::make_shared<PendingCall>();
+
+  if (env_->isJsThread()) {
+    // Dispatching from the JS thread would deadlock, so run inline. A single state object belongs
+    // to a single session load, which either runs entirely on the JS thread or entirely off it, so
+    // this branch cannot overlap with a thread waiting for the JS thread to drain.
+    {
+      std::lock_guard<std::mutex> lock(stateMutex_);
+      if (!valid_) {
+        return makeStatus(ORT_FAIL,
+                          "EPContext data read callback was released before "
+                          "\"" +
+                              name + "\" could be read");
+      }
+    }
+    invokeOnJsThread(name, *pending);
+  } else {
+    {
+      std::lock_guard<std::mutex> lock(stateMutex_);
+      if (!valid_) {
+        return makeStatus(ORT_FAIL,
+                          "EPContext data read callback was released before "
+                          "\"" +
+                              name + "\" could be read");
+      }
+      pending_.push_back(pending);
+    }
+
+    std::weak_ptr<EpContextDataReadCallback> weakSelf = weak_from_this();
+    const bool queued = env_->runOnJsThread([weakSelf, pending, name]() {
+      if (pending->isFinished()) return;
+      auto self = weakSelf.lock();
+      if (!self) {
+        pending->finish(CallStatus::Failed,
+                        "EPContext data read callback was released before \"" +
+                            name + "\" could be read");
+        return;
+      }
+      self->invokeOnJsThread(name, *pending);
+    });
+
+    if (!queued) {
+      unregisterPending(pending);
+      return makeStatus(ORT_FAIL,
+                        "ONNX Runtime JSI bindings were torn down before \"" +
+                            name + "\" could be read");
+    }
+
+    // invalidate() finishes every registered call, so teardown cannot leave this thread blocked.
+    pending->wait();
+    unregisterPending(pending);
+  }
+
+  CallStatus status;
+  std::string error;
+  std::vector<uint8_t> data;
+  {
+    std::lock_guard<std::mutex> lock(pending->mutex);
+    status = pending->status;
+    error = std::move(pending->error);
+    data = std::move(pending->data);
+  }
+
+  switch (status) {
+    case CallStatus::Ok:
+      break;
+    case CallStatus::InvalidArgument:
+      return makeStatus(ORT_INVALID_ARGUMENT, error);
+    case CallStatus::Failed:
+      return makeStatus(ORT_FAIL, error);
+  }
+
+  // An empty payload is reported as a null buffer, not as a zero-sized allocation.
+  if (data.empty()) {
+    return nullptr;
+  }
+
+  // The limit is already enforced on the JS thread; re-check before touching the allocator so the
+  // guarantee holds even if the two paths ever diverge.
+  auto sizeCheck = checkDataSize(data.size(), maxDataSize_, name);
+  if (!sizeCheck.ok) {
+    return makeStatus(ORT_INVALID_ARGUMENT, sizeCheck.error);
+  }
+
+  void* allocated = allocator->Alloc(allocator, data.size());
+  if (allocated == nullptr) {
+    return makeStatus(ORT_FAIL, "failed to allocate " +
+                                    std::to_string(data.size()) +
+                                    " bytes for EPContext data \"" + name +
+                                    "\"");
+  }
+  std::memcpy(allocated, data.data(), data.size());
+  *buffer = allocated;
+  *dataSize = data.size();
+  return nullptr;
+}
+
+void EpContextDataReadCallback::invokeOnJsThread(const std::string& name,
+                                                 PendingCall& pending) noexcept {
+  Runtime* runtime = nullptr;
+  std::shared_ptr<Function> callback;
+  {
+    std::lock_guard<std::mutex> lock(stateMutex_);
+    if (!valid_ || runtime_ == nullptr || !callback_) {
+      pending.finish(CallStatus::Failed,
+                     "EPContext data read callback was released before \"" +
+                         name + "\" could be read");
+      return;
+    }
+    runtime = runtime_;
+    callback = callback_;
+  }
+
+  try {
+    auto result =
+        callback->call(*runtime, String::createFromUtf8(*runtime, name));
+    if (!result.isObject()) {
+      pending.finish(CallStatus::InvalidArgument,
+                     "session option \"epContextDataRead.callback\" must "
+                     "return a Uint8Array for \"" +
+                         name + "\"");
+      return;
+    }
+
+    auto resultObject = result.asObject(*runtime);
+    auto uint8ArrayConstructor =
+        runtime->global().getPropertyAsFunction(*runtime, "Uint8Array");
+    if (!resultObject.instanceOf(*runtime, uint8ArrayConstructor)) {
+      pending.finish(CallStatus::InvalidArgument,
+                     "session option \"epContextDataRead.callback\" must "
+                     "return a Uint8Array for \"" +
+                         name + "\"");
+      return;
+    }
+
+    auto uint8ArrayPrototype =
+        uint8ArrayConstructor.getPropertyAsObject(*runtime, "prototype");
+    auto objectConstructor =
+        runtime->global().getPropertyAsObject(*runtime, "Object");
+    auto getPrototypeOf =
+        objectConstructor.getPropertyAsFunction(*runtime, "getPrototypeOf");
+    auto typedArrayPrototype =
+        getPrototypeOf.call(*runtime, uint8ArrayPrototype).asObject(*runtime);
+
+    auto arrayBufferValue = getTypedArrayProperty(
+        *runtime, typedArrayPrototype, resultObject, "buffer");
+    if (!arrayBufferValue.isObject() ||
+        !arrayBufferValue.asObject(*runtime).isArrayBuffer(*runtime)) {
+      pending.finish(
+          CallStatus::InvalidArgument,
+          "session option \"epContextDataRead.callback\" returned a "
+          "Uint8Array with an invalid backing buffer for \"" +
+              name + "\"");
+      return;
+    }
+    auto arrayBuffer =
+        arrayBufferValue.asObject(*runtime).getArrayBuffer(*runtime);
+
+    size_t byteOffset = 0;
+    size_t byteLength = 0;
+    if (!toViewIndex(getTypedArrayProperty(*runtime, typedArrayPrototype,
+                                           resultObject, "byteOffset")
+                         .asNumber(),
+                     byteOffset) ||
+        !toViewIndex(getTypedArrayProperty(*runtime, typedArrayPrototype,
+                                           resultObject, "byteLength")
+                         .asNumber(),
+                     byteLength)) {
+      pending.finish(CallStatus::InvalidArgument,
+                     "session option \"epContextDataRead.callback\" returned a "
+                     "Uint8Array with invalid view bounds for \"" +
+                         name + "\"");
+      return;
+    }
+    if (byteOffset > arrayBuffer.size(*runtime) ||
+        byteLength > arrayBuffer.size(*runtime) - byteOffset) {
+      pending.finish(CallStatus::InvalidArgument,
+                     "session option \"epContextDataRead.callback\" returned a "
+                     "Uint8Array with an unreadable range for \"" +
+                         name + "\"");
+      return;
+    }
+
+    // Reject an oversized payload before copying and before any allocator call.
+    auto sizeCheck = checkDataSize(byteLength, maxDataSize_, name);
+    if (!sizeCheck.ok) {
+      pending.finish(CallStatus::InvalidArgument, sizeCheck.error);
+      return;
+    }
+
+    // Copy while still on the JS thread: the backing store belongs to JavaScript and may be
+    // collected or moved once this function returns.
+    std::vector<uint8_t> data;
+    if (byteLength > 0) {
+      const uint8_t* begin = arrayBuffer.data(*runtime) + byteOffset;
+      data.assign(begin, begin + byteLength);
+    }
+    pending.finish(CallStatus::Ok, {}, std::move(data));
+  } catch (const JSError& e) {
+    pending.finish(CallStatus::Failed,
+                   "session option \"epContextDataRead.callback\" threw while "
+                   "reading \"" +
+                       name + "\": " + e.getMessage());
+  } catch (const std::exception& e) {
+    pending.finish(CallStatus::Failed,
+                   "session option \"epContextDataRead.callback\" failed while "
+                   "reading \"" +
+                       name + "\": " + std::string(e.what()));
+  } catch (...) {
+    pending.finish(CallStatus::Failed,
+                   "session option \"epContextDataRead.callback\" failed with "
+                   "an unknown error while reading \"" +
+                       name + "\"");
+  }
+}
+
+void EpContextDataReadCallback::unregisterPending(
+    const std::shared_ptr<PendingCall>& pending) noexcept {
+  std::lock_guard<std::mutex> lock(stateMutex_);
+  pending_.erase(std::remove(pending_.begin(), pending_.end(), pending),
+                 pending_.end());
+}
+
+void EpContextDataReadCallback::invalidate() noexcept {
+  std::vector<std::shared_ptr<PendingCall>> pending;
+  std::shared_ptr<Function> callback;
+  const bool onJsThread = env_->isJsThread();
+  {
+    std::lock_guard<std::mutex> lock(stateMutex_);
+    if (!valid_) return;
+    valid_ = false;
+    runtime_ = nullptr;
+    pending.swap(pending_);
+    if (onJsThread) {
+      // Safe to drop the JS function here: the runtime is alive on its own thread.
+      callback.swap(callback_);
+    }
+  }
+
+  for (auto& call : pending) {
+    call->finish(CallStatus::Failed,
+                 "EPContext data read callback was released while a read was "
+                 "in flight");
+  }
+}
+
+}  // namespace onnxruntimejsi

--- a/js/react_native/cpp/EpContextDataReadCallback.h
+++ b/js/react_native/cpp/EpContextDataReadCallback.h
@@ -1,0 +1,126 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include "Env.h"
+#include <condition_variable>
+#include <cstddef>
+#include <cstdint>
+#include <jsi/jsi.h>
+#include <memory>
+#include <mutex>
+#include "onnxruntime_cxx_api.h"
+#include <string>
+#include <vector>
+
+namespace onnxruntimejsi {
+
+/**
+ * @brief Bridges OrtReadNamedBufferFunc to the `epContextDataRead.callback` JavaScript function.
+ *
+ * ONNX Runtime may call the read function from any thread while a session is being created and
+ * does not serialize calls made by different EP instances, so every invocation is serialized here
+ * and marshalled to the JS thread unless the caller demonstrably runs on it already.
+ *
+ * An instance owns a strong reference to the JS function for the whole session lifetime and must
+ * outlive the Ort::Session it was registered with.
+ */
+class EpContextDataReadCallback
+    : public EnvTeardownListener,
+      public std::enable_shared_from_this<EpContextDataReadCallback> {
+ public:
+  EpContextDataReadCallback(std::shared_ptr<Env> env,
+                            facebook::jsi::Runtime& runtime,
+                            std::shared_ptr<facebook::jsi::Function> callback,
+                            size_t maxDataSize);
+
+  ~EpContextDataReadCallback() override;
+
+  EpContextDataReadCallback(const EpContextDataReadCallback&) = delete;
+  EpContextDataReadCallback& operator=(const EpContextDataReadCallback&) = delete;
+  EpContextDataReadCallback(EpContextDataReadCallback&&) = delete;
+  EpContextDataReadCallback& operator=(EpContextDataReadCallback&&) = delete;
+
+  /**
+   * @brief Parse `epContextDataRead` and register it with `sessionOptions`.
+   *
+   * Must be called on the JS thread. Returns nullptr when the option is absent, undefined or null,
+   * and throws facebook::jsi::JSError when it is present but malformed.
+   *
+   * Registration is transactional: the state is returned to the caller only after ONNX Runtime
+   * accepted it. The caller must keep the returned state alive for at least as long as the session
+   * created from `sessionOptions`.
+   */
+  static std::shared_ptr<EpContextDataReadCallback>
+  createAndRegister(facebook::jsi::Runtime& runtime,
+                    const facebook::jsi::Object& options,
+                    const std::shared_ptr<Env>& env,
+                    Ort::SessionOptions& sessionOptions);
+
+  /**
+   * @brief OrtReadNamedBufferFunc entry point. No exception ever crosses the C ABI.
+   */
+  static OrtStatus* ORT_API_CALL read(void* state, const char* name,
+                                      OrtAllocator* allocator, void** buffer,
+                                      size_t* dataSize) noexcept;
+
+  /**
+   * @brief Stop serving reads and wake every thread blocked on the JS thread.
+   *
+   * Callable from any thread and more than once. Subsequent reads fail instead of falling back to
+   * any other data source.
+   */
+  void invalidate() noexcept;
+
+  void onEnvTeardown() noexcept override { invalidate(); }
+
+  size_t maxDataSize() const noexcept { return maxDataSize_; }
+
+ private:
+  enum class CallStatus {
+    Ok,
+    // Bad callback result: wrong type, unreadable buffer, or oversized payload.
+    InvalidArgument,
+    // The callback threw, or the bindings were torn down mid-call.
+    Failed,
+  };
+
+  struct PendingCall {
+    std::mutex mutex;
+    std::condition_variable cv;
+    bool finished = false;
+    CallStatus status = CallStatus::Failed;
+    std::string error;
+    std::vector<uint8_t> data;
+
+    bool isFinished() noexcept;
+    void finish(CallStatus status, std::string error,
+                std::vector<uint8_t> data = {}) noexcept;
+    void wait();
+  };
+
+  OrtStatus* readImpl(const std::string& name, OrtAllocator* allocator,
+                      void** buffer, size_t* dataSize);
+
+  // Runs on the JS thread. Fills `pending` with the callback outcome.
+  void invokeOnJsThread(const std::string& name, PendingCall& pending) noexcept;
+
+  void unregisterPending(const std::shared_ptr<PendingCall>& pending) noexcept;
+
+  const std::shared_ptr<Env> env_;
+  const size_t maxDataSize_;
+
+  // Serializes read callbacks so the JS function never observes overlapping calls.
+  std::mutex callMutex_;
+
+  // Guards the members below. Never held while blocking, so invalidate() cannot deadlock against
+  // a read that is waiting on the JS thread.
+  std::mutex stateMutex_;
+  bool valid_ = true;
+  facebook::jsi::Runtime* runtime_;
+  std::shared_ptr<facebook::jsi::Function> callback_;
+  std::vector<std::shared_ptr<PendingCall>> pending_;
+};
+
+}  // namespace onnxruntimejsi

--- a/js/react_native/cpp/EpContextDataReadPolicy.cpp
+++ b/js/react_native/cpp/EpContextDataReadPolicy.cpp
@@ -1,0 +1,69 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "EpContextDataReadPolicy.h"
+
+#include <cmath>
+#include <limits>
+
+namespace onnxruntimejsi {
+
+namespace {
+
+constexpr const char* kMaxDataSizeOption =
+    "session option \"epContextDataRead.maxDataSize\"";
+
+}  // namespace
+
+MaxDataSizeParseResult parseMaxDataSize(double raw) {
+  MaxDataSizeParseResult result;
+
+  if (std::isnan(raw) || std::isinf(raw)) {
+    result.error = std::string(kMaxDataSizeOption) + " must be a finite number";
+    return result;
+  }
+  if (raw != std::trunc(raw)) {
+    result.error = std::string(kMaxDataSizeOption) + " must be an integer";
+    return result;
+  }
+  if (raw <= 0.0) {
+    result.error =
+        std::string(kMaxDataSizeOption) + " must be greater than zero";
+    return result;
+  }
+  if (raw > kMaxSafeInteger) {
+    result.error = std::string(kMaxDataSizeOption) +
+                   " must not exceed Number.MAX_SAFE_INTEGER (9007199254740991)";
+    return result;
+  }
+  // ORT requires a value strictly below SIZE_MAX. On 32-bit targets size_t tops out well below
+  // the safe-integer range, so a valid JavaScript number may still be unrepresentable.
+  if (raw >= static_cast<double>(std::numeric_limits<size_t>::max())) {
+    result.error = std::string(kMaxDataSizeOption) +
+                   " is too large to represent as size_t on this platform";
+    return result;
+  }
+
+  result.ok = true;
+  result.value = static_cast<size_t>(raw);
+  return result;
+}
+
+DataSizeCheckResult checkDataSize(size_t dataSize, size_t maxDataSize,
+                                  const std::string& name) {
+  DataSizeCheckResult result;
+
+  if (dataSize > maxDataSize) {
+    result.error = "EPContext data \"" + name + "\" is " +
+                   std::to_string(dataSize) +
+                   " bytes, which exceeds the configured "
+                   "epContextDataRead.maxDataSize of " +
+                   std::to_string(maxDataSize) + " bytes";
+    return result;
+  }
+
+  result.ok = true;
+  return result;
+}
+
+}  // namespace onnxruntimejsi

--- a/js/react_native/cpp/EpContextDataReadPolicy.h
+++ b/js/react_native/cpp/EpContextDataReadPolicy.h
@@ -1,0 +1,43 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include <cstddef>
+#include <string>
+
+namespace onnxruntimejsi {
+
+/**
+ * @brief Largest integer a JavaScript number represents exactly (Number.MAX_SAFE_INTEGER).
+ */
+inline constexpr double kMaxSafeInteger = 9007199254740991.0;
+
+struct MaxDataSizeParseResult {
+  bool ok = false;
+  size_t value = 0;
+  std::string error;
+};
+
+/**
+ * @brief Validate the `epContextDataRead.maxDataSize` session option.
+ *
+ * The value must be a finite, positive, safe integer that is representable as size_t on the
+ * current platform. size_t is narrower than the safe-integer range on 32-bit targets, so the
+ * representability check is not redundant there.
+ */
+MaxDataSizeParseResult parseMaxDataSize(double raw);
+
+struct DataSizeCheckResult {
+  bool ok = false;
+  std::string error;
+};
+
+/**
+ * @brief Enforce the configured payload limit. Callers must run this before asking the ORT
+ * allocator for memory.
+ */
+DataSizeCheckResult checkDataSize(size_t dataSize, size_t maxDataSize,
+                                  const std::string& name);
+
+}  // namespace onnxruntimejsi

--- a/js/react_native/cpp/InferenceSessionHostObject.cpp
+++ b/js/react_native/cpp/InferenceSessionHostObject.cpp
@@ -3,7 +3,11 @@
 #include "JsiUtils.h"
 #include "SessionUtils.h"
 #include "TensorUtils.h"
+#include <algorithm>
+#include <memory>
 #include <mutex>
+#include <string>
+#include <utility>
 
 using namespace facebook::jsi;
 
@@ -35,31 +39,85 @@ class InferenceSessionHostObject::LoadModelAsyncWorker : public AsyncWorker {
     }
     keepValue(runtime, arguments[0]);
     if (count > 1) {
-      parseSessionOptions(runtime, arguments[1], sessionOptions_);
+      parseSessionOptions(runtime, arguments[1], sessionOptions_, session->env_,
+                          epContextDataRead_);
     }
+    abortEpContextDataRead_ = epContextDataRead_;
+    // The state stays private to this worker until Ort::Session construction succeeds. Nothing is
+    // published to the host object here, so a rejected load releases it deterministically in
+    // onReject() instead of leaving it retained until a later dispose or garbage collection.
   }
+
+  ~LoadModelAsyncWorker() override { abortAndJoin(); }
 
  protected:
   void execute() {
     if (modelPath_.empty()) {
-      session_->session_ = std::make_shared<Ort::Session>(
+      loadedSession_ = std::make_shared<Ort::Session>(
           session_->env_->getOrtEnv(), modelData_, modelDataLength_,
           sessionOptions_);
     } else {
-      session_->session_ = std::make_shared<Ort::Session>(
+      loadedSession_ = std::make_shared<Ort::Session>(
           session_->env_->getOrtEnv(), modelPath_.c_str(), sessionOptions_);
     }
   }
 
-  Value onResolve(Runtime& rt) { return Value::undefined(); }
+  Value onResolve(Runtime& rt) {
+    // Publish only on the JS thread so dispose(), reload, and successful construction cannot race
+    // while reading or replacing the host object's shared_ptr members.
+    session_->session_.reset();
+    previousEpContextDataRead_ = std::move(session_->epContextDataRead_);
+    session_->epContextDataRead_ = std::move(epContextDataRead_);
+    session_->session_ = std::move(loadedSession_);
+
+    // The retired state can no longer be reached by any session; release it here so the JS
+    // function is dropped on the JS thread.
+    releaseState(previousEpContextDataRead_);
+    abortEpContextDataRead_.reset();
+    return Value::undefined();
+  }
+
+  Value onReject(Runtime& rt, const std::string& err) {
+    // Session construction failed, so the state was never published. Release it on the JS thread
+    // rather than waiting for this worker to be collected.
+    releaseState(epContextDataRead_);
+    abortEpContextDataRead_.reset();
+    return AsyncWorker::onReject(rt, err);
+  }
+
+  void onAbort() override {
+    if (abortEpContextDataRead_) {
+      abortEpContextDataRead_->invalidate();
+    }
+  }
 
  private:
+  // Must run on the JS thread: dropping the last reference releases the JS callback function.
+  static void
+  releaseState(std::shared_ptr<EpContextDataReadCallback>& state) noexcept {
+    if (state) {
+      state->invalidate();
+      state.reset();
+    }
+  }
+
   std::string error_;
   std::string modelPath_;
   void* modelData_;
   size_t modelDataLength_;
   std::shared_ptr<InferenceSessionHostObject> session_;
   Ort::SessionOptions sessionOptions_;
+  // Strong snapshot of the state referenced by sessionOptions_, owned solely by this worker until
+  // the session it belongs to exists.
+  std::shared_ptr<EpContextDataReadCallback> epContextDataRead_;
+  // Immutable snapshot used by onAbort() to unblock a worker waiting for the JS thread. execute()
+  // may move epContextDataRead_ into the host concurrently, so the abort path must not access it.
+  std::shared_ptr<EpContextDataReadCallback> abortEpContextDataRead_;
+  // State displaced from the host object by a successful reload, kept alive until the JS thread
+  // can release it.
+  std::shared_ptr<EpContextDataReadCallback> previousEpContextDataRead_;
+  // Declared after every callback-state reference so a worker-local session is destroyed first.
+  std::shared_ptr<Ort::Session> loadedSession_;
   std::shared_ptr<WeakObject> weakResolve_;
   std::shared_ptr<WeakObject> weakReject_;
   std::thread thread_;
@@ -109,6 +167,8 @@ class InferenceSessionHostObject::RunAsyncWorker : public AsyncWorker {
             });
   }
 
+  ~RunAsyncWorker() override { abortAndJoin(); }
+
  protected:
   void execute() {
     auto inputNames = std::vector<const char*>(inputNames_.size());
@@ -145,7 +205,7 @@ class InferenceSessionHostObject::RunAsyncWorker : public AsyncWorker {
     return Value(rt, resultObject);
   }
 
-  void onAbort() {
+  void onAbort() override {
     runOptions_.SetTerminate();
   }
 
@@ -169,7 +229,12 @@ DEFINE_METHOD(InferenceSessionHostObject::run) {
 }
 
 DEFINE_METHOD(InferenceSessionHostObject::dispose) {
+  // Release the session first: ONNX Runtime may still call the read callback while it exists.
   session_.reset();
+  if (epContextDataRead_) {
+    epContextDataRead_->invalidate();
+    epContextDataRead_.reset();
+  }
   return Value::undefined();
 }
 

--- a/js/react_native/cpp/InferenceSessionHostObject.cpp
+++ b/js/react_native/cpp/InferenceSessionHostObject.cpp
@@ -1,26 +1,76 @@
 #include "InferenceSessionHostObject.h"
 #include "AsyncWorker.h"
 #include "JsiUtils.h"
+#include "LoadModelArgumentPolicy.h"
 #include "SessionUtils.h"
 #include "TensorUtils.h"
 #include <algorithm>
+#include <array>
+#include <cmath>
+#include <limits>
 #include <memory>
 #include <mutex>
 #include <string>
 #include <utility>
+#include <vector>
 
 using namespace facebook::jsi;
 
 namespace onnxruntimejsi {
+
+namespace {
+
+LoadModelArgumentType getLoadModelArgumentType(Runtime& runtime,
+                                               const Value& value) {
+  if (value.isString()) {
+    return LoadModelArgumentType::String;
+  }
+  if (value.isNumber()) {
+    return LoadModelArgumentType::Number;
+  }
+  if (value.isObject()) {
+    return value.asObject(runtime).isArrayBuffer(runtime)
+               ? LoadModelArgumentType::ArrayBuffer
+               : LoadModelArgumentType::Object;
+  }
+  return LoadModelArgumentType::Other;
+}
+
+size_t parseBufferIndex(Runtime& runtime, const Value& value,
+                        const char* argumentName) {
+  const double raw = value.asNumber();
+  if (!std::isfinite(raw) || raw < 0 || std::trunc(raw) != raw ||
+      raw >= static_cast<double>(std::numeric_limits<size_t>::max())) {
+    throw JSError(runtime,
+                  std::string("loadModel ") + argumentName +
+                      " must be a non-negative integer representable as size_t");
+  }
+  return static_cast<size_t>(raw);
+}
+
+}  // namespace
 
 class InferenceSessionHostObject::LoadModelAsyncWorker : public AsyncWorker {
  public:
   LoadModelAsyncWorker(Runtime& runtime, const Value* arguments, size_t count,
                        std::shared_ptr<InferenceSessionHostObject> session)
       : AsyncWorker(runtime, session->env_), session_(session) {
-    if (count < 1)
-      throw JSError(runtime, "loadModel requires at least 1 argument");
-    if (arguments[0].isString()) {
+    std::array<LoadModelArgumentType, 4> argumentTypes{};
+    const size_t classifiedCount = std::min(count, argumentTypes.size());
+    for (size_t i = 0; i < classifiedCount; ++i) {
+      argumentTypes[i] = getLoadModelArgumentType(runtime, arguments[i]);
+    }
+    const auto layout = resolveLoadModelArgumentLayout(
+        argumentTypes.data(), classifiedCount);
+    if (!layout.valid || count != classifiedCount) {
+      throw JSError(
+          runtime,
+          "loadModel expects (modelPath, options) or "
+          "(buffer, byteOffset, byteLength, options)");
+    }
+
+    useModelBuffer_ = layout.usesModelBuffer;
+    if (!useModelBuffer_) {
       modelPath_ = arguments[0].asString(runtime).utf8(runtime);
       if (modelPath_.find("file:/") == 0) {
         modelPath_ = modelPath_.substr(5);
@@ -28,20 +78,24 @@ class InferenceSessionHostObject::LoadModelAsyncWorker : public AsyncWorker {
           modelPath_ = modelPath_.substr(2);
         }
       }
-    } else if (arguments[0].isObject() &&
-               arguments[0].asObject(runtime).isArrayBuffer(runtime)) {
+    } else {
       auto arrayBufferObj = arguments[0].asObject(runtime);
       auto arrayBuffer = arrayBufferObj.getArrayBuffer(runtime);
-      modelData_ = arrayBuffer.data(runtime);
-      modelDataLength_ = arrayBuffer.size(runtime);
-    } else {
-      throw JSError(runtime, "Model path or buffer is required");
+      const size_t byteOffset =
+          parseBufferIndex(runtime, arguments[1], "byteOffset");
+      const size_t byteLength =
+          parseBufferIndex(runtime, arguments[2], "byteLength");
+      const size_t bufferSize = arrayBuffer.size(runtime);
+      if (byteOffset > bufferSize || byteLength > bufferSize - byteOffset) {
+        throw JSError(runtime, "loadModel buffer range is out of bounds");
+      }
+      if (byteLength > 0) {
+        const auto* begin = arrayBuffer.data(runtime) + byteOffset;
+        modelData_.assign(begin, begin + byteLength);
+      }
     }
-    keepValue(runtime, arguments[0]);
-    if (count > 1) {
-      parseSessionOptions(runtime, arguments[1], sessionOptions_, session->env_,
-                          epContextDataRead_);
-    }
+    parseSessionOptions(runtime, arguments[layout.optionsIndex], sessionOptions_,
+                        session->env_, epContextDataRead_);
     abortEpContextDataRead_ = epContextDataRead_;
     // The state stays private to this worker until Ort::Session construction succeeds. Nothing is
     // published to the host object here, so a rejected load releases it deterministically in
@@ -52,9 +106,10 @@ class InferenceSessionHostObject::LoadModelAsyncWorker : public AsyncWorker {
 
  protected:
   void execute() {
-    if (modelPath_.empty()) {
+    if (useModelBuffer_) {
       loadedSession_ = std::make_shared<Ort::Session>(
-          session_->env_->getOrtEnv(), modelData_, modelDataLength_,
+          session_->env_->getOrtEnv(),
+          modelData_.empty() ? nullptr : modelData_.data(), modelData_.size(),
           sessionOptions_);
     } else {
       loadedSession_ = std::make_shared<Ort::Session>(
@@ -103,8 +158,8 @@ class InferenceSessionHostObject::LoadModelAsyncWorker : public AsyncWorker {
 
   std::string error_;
   std::string modelPath_;
-  void* modelData_;
-  size_t modelDataLength_;
+  bool useModelBuffer_ = false;
+  std::vector<uint8_t> modelData_;
   std::shared_ptr<InferenceSessionHostObject> session_;
   Ort::SessionOptions sessionOptions_;
   // Strong snapshot of the state referenced by sessionOptions_, owned solely by this worker until

--- a/js/react_native/cpp/InferenceSessionHostObject.h
+++ b/js/react_native/cpp/InferenceSessionHostObject.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "Env.h"
+#include "EpContextDataReadCallback.h"
 #include "JsiHelper.h"
 #include <jsi/jsi.h>
 #include <memory>
@@ -41,6 +42,9 @@ class InferenceSessionHostObject
 
  private:
   std::shared_ptr<Env> env_;
+  // Declared before session_ so the session is destroyed first: ONNX Runtime may call back into
+  // the callback state for as long as the session exists.
+  std::shared_ptr<EpContextDataReadCallback> epContextDataRead_;
   std::shared_ptr<Ort::Session> session_;
 
   DEFINE_METHOD(loadModel);

--- a/js/react_native/cpp/LoadModelArgumentPolicy.cpp
+++ b/js/react_native/cpp/LoadModelArgumentPolicy.cpp
@@ -1,0 +1,27 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "LoadModelArgumentPolicy.h"
+
+namespace onnxruntimejsi {
+
+LoadModelArgumentLayout resolveLoadModelArgumentLayout(
+    const LoadModelArgumentType* argumentTypes, size_t argumentCount) noexcept {
+  if (argumentCount == 2 &&
+      argumentTypes[0] == LoadModelArgumentType::String &&
+      argumentTypes[1] == LoadModelArgumentType::Object) {
+    return {true, false, 1};
+  }
+
+  if (argumentCount == 4 &&
+      argumentTypes[0] == LoadModelArgumentType::ArrayBuffer &&
+      argumentTypes[1] == LoadModelArgumentType::Number &&
+      argumentTypes[2] == LoadModelArgumentType::Number &&
+      argumentTypes[3] == LoadModelArgumentType::Object) {
+    return {true, true, 3};
+  }
+
+  return {};
+}
+
+}  // namespace onnxruntimejsi

--- a/js/react_native/cpp/LoadModelArgumentPolicy.h
+++ b/js/react_native/cpp/LoadModelArgumentPolicy.h
@@ -1,0 +1,30 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include <cstddef>
+
+namespace onnxruntimejsi {
+
+enum class LoadModelArgumentType {
+  String,
+  ArrayBuffer,
+  Number,
+  Object,
+  Other,
+};
+
+struct LoadModelArgumentLayout {
+  bool valid = false;
+  bool usesModelBuffer = false;
+  size_t optionsIndex = 0;
+};
+
+/**
+ * @brief Validate a React Native loadModel overload and identify its options argument.
+ */
+LoadModelArgumentLayout resolveLoadModelArgumentLayout(
+    const LoadModelArgumentType* argumentTypes, size_t argumentCount) noexcept;
+
+}  // namespace onnxruntimejsi

--- a/js/react_native/cpp/SessionUtils.cpp
+++ b/js/react_native/cpp/SessionUtils.cpp
@@ -67,13 +67,19 @@ class ExtendedSessionOptions : public Ort::SessionOptions {
 };
 
 void parseSessionOptions(Runtime& runtime, const Value& optionsValue,
-                         Ort::SessionOptions& sessionOptions) {
+                         Ort::SessionOptions& sessionOptions,
+                         const std::shared_ptr<Env>& env,
+                         std::shared_ptr<EpContextDataReadCallback>& epContextDataRead) {
   if (!optionsValue.isObject())
     return;
 
   auto options = optionsValue.asObject(runtime);
 
   try {
+    // epContextDataRead
+    epContextDataRead = EpContextDataReadCallback::createAndRegister(
+        runtime, options, env, sessionOptions);
+
 #ifdef ORT_ENABLE_EXTENSIONS
     // ortExtLibPath
     if (options.hasProperty(runtime, "ortExtLibPath")) {

--- a/js/react_native/cpp/SessionUtils.h
+++ b/js/react_native/cpp/SessionUtils.h
@@ -1,15 +1,28 @@
 #pragma once
 
+#include "Env.h"
+#include "EpContextDataReadCallback.h"
 #include <jsi/jsi.h>
+#include <memory>
 #include "onnxruntime_cxx_api.h"
+#include <vector>
 
 namespace onnxruntimejsi {
 
 extern const std::vector<const char*> supportedBackends;
 
+/**
+ * @brief Parse the JavaScript session options into `sessionOptions`.
+ *
+ * Must be called on the JS thread. When the options register an `epContextDataRead` callback,
+ * `epContextDataRead` receives the state that backs it; the caller must keep that state alive for
+ * at least as long as the session created from `sessionOptions`.
+ */
 void parseSessionOptions(facebook::jsi::Runtime& runtime,
                          const facebook::jsi::Value& optionsValue,
-                         Ort::SessionOptions& sessionOptions);
+                         Ort::SessionOptions& sessionOptions,
+                         const std::shared_ptr<Env>& env,
+                         std::shared_ptr<EpContextDataReadCallback>& epContextDataRead);
 
 void parseRunOptions(facebook::jsi::Runtime& runtime,
                      const facebook::jsi::Value& optionsValue,

--- a/js/react_native/cpp/test/CMakeLists.txt
+++ b/js/react_native/cpp/test/CMakeLists.txt
@@ -1,0 +1,17 @@
+cmake_minimum_required(VERSION 3.13)
+project(OnnxruntimeReactNativePolicyTests LANGUAGES CXX)
+
+enable_testing()
+
+add_executable(
+  onnxruntime_react_native_policy_test
+  EpContextDataReadPolicyTest.cpp
+  ../EpContextDataReadPolicy.cpp
+  ../LoadModelArgumentPolicy.cpp)
+
+target_include_directories(onnxruntime_react_native_policy_test PRIVATE ..)
+target_compile_features(onnxruntime_react_native_policy_test PRIVATE cxx_std_17)
+
+add_test(
+  NAME onnxruntime_react_native_policy_test
+  COMMAND onnxruntime_react_native_policy_test)

--- a/js/react_native/cpp/test/EpContextDataReadPolicyTest.cpp
+++ b/js/react_native/cpp/test/EpContextDataReadPolicyTest.cpp
@@ -1,0 +1,111 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+// Standalone unit test for the EPContext data read policy helpers. These helpers deliberately have
+// no JSI or ONNX Runtime dependency so they can be compiled and run on any host:
+//
+//   cl /std:c++20 /EHsc /I.. EpContextDataReadPolicyTest.cpp ..\EpContextDataReadPolicy.cpp
+//   g++ -std=c++20 -I.. EpContextDataReadPolicyTest.cpp ../EpContextDataReadPolicy.cpp -o policy_test
+//
+// The file is not part of the shipped library: it is referenced by neither android/CMakeLists.txt
+// nor the podspec source glob.
+
+#include "EpContextDataReadPolicy.h"
+
+#include <cstdint>
+#include <cstdio>
+#include <limits>
+#include <string>
+
+namespace {
+
+int g_failures = 0;
+
+void check(bool condition, const std::string& what) {
+  if (!condition) {
+    ++g_failures;
+    std::printf("FAILED: %s\n", what.c_str());
+  }
+}
+
+void expectRejected(double raw, const std::string& what) {
+  const auto result = onnxruntimejsi::parseMaxDataSize(raw);
+  check(!result.ok, what);
+  check(!result.error.empty(), what + " (reports an error)");
+  check(result.value == 0, what + " (leaves the value zeroed)");
+}
+
+void expectAccepted(double raw, size_t expected, const std::string& what) {
+  const auto result = onnxruntimejsi::parseMaxDataSize(raw);
+  check(result.ok, what);
+  check(result.error.empty(), what + " (reports no error)");
+  check(result.value == expected, what + " (parses the value)");
+}
+
+// Kept out of line so a 32-bit build does not constant-fold a truncating cast in the branch that
+// only ever runs on 64-bit targets.
+size_t toSizeT(double value) { return static_cast<size_t>(value); }
+
+void testParseMaxDataSize() {
+  expectAccepted(1.0, 1, "accepts the smallest positive limit");
+  expectAccepted(1024.0, 1024, "accepts a typical limit");
+  expectAccepted(2147483648.0, toSizeT(2147483648.0),
+                 "accepts a limit above INT32_MAX");
+
+  expectRejected(0.0, "rejects zero");
+  expectRejected(-0.0, "rejects negative zero");
+  expectRejected(-1.0, "rejects a negative limit");
+  expectRejected(1.5, "rejects a fractional limit");
+  expectRejected(std::numeric_limits<double>::infinity(), "rejects infinity");
+  expectRejected(-std::numeric_limits<double>::infinity(),
+                 "rejects negative infinity");
+  expectRejected(std::numeric_limits<double>::quiet_NaN(), "rejects NaN");
+  expectRejected(onnxruntimejsi::kMaxSafeInteger + 2.0,
+                 "rejects a value beyond Number.MAX_SAFE_INTEGER");
+
+  // size_t is narrower than the safe-integer range on 32-bit targets, so the same JavaScript
+  // number is accepted on 64-bit and rejected on 32-bit.
+  if (sizeof(size_t) < sizeof(uint64_t)) {
+    expectRejected(onnxruntimejsi::kMaxSafeInteger,
+                   "rejects a limit that size_t cannot represent");
+  } else {
+    expectAccepted(onnxruntimejsi::kMaxSafeInteger,
+                   toSizeT(onnxruntimejsi::kMaxSafeInteger),
+                   "accepts Number.MAX_SAFE_INTEGER on 64-bit targets");
+  }
+}
+
+void testCheckDataSize() {
+  const auto underLimit = onnxruntimejsi::checkDataSize(10, 16, "ctx");
+  check(underLimit.ok, "accepts a payload below the limit");
+  check(underLimit.error.empty(), "accepts a payload below the limit quietly");
+
+  const auto atLimit = onnxruntimejsi::checkDataSize(16, 16, "ctx");
+  check(atLimit.ok, "accepts a payload exactly at the limit");
+
+  const auto empty = onnxruntimejsi::checkDataSize(0, 1, "ctx");
+  check(empty.ok, "accepts an empty payload");
+
+  const auto overLimit = onnxruntimejsi::checkDataSize(17, 16, "ctx");
+  check(!overLimit.ok, "rejects a payload above the limit");
+  check(overLimit.error.find("ctx") != std::string::npos,
+        "names the data in the limit error");
+  check(overLimit.error.find("17") != std::string::npos,
+        "reports the actual size in the limit error");
+  check(overLimit.error.find("16") != std::string::npos,
+        "reports the configured limit in the limit error");
+}
+
+}  // namespace
+
+int main() {
+  testParseMaxDataSize();
+  testCheckDataSize();
+
+  if (g_failures != 0) {
+    std::printf("%d check(s) failed\n", g_failures);
+    return 1;
+  }
+  std::printf("all checks passed\n");
+  return 0;
+}

--- a/js/react_native/cpp/test/EpContextDataReadPolicyTest.cpp
+++ b/js/react_native/cpp/test/EpContextDataReadPolicyTest.cpp
@@ -1,17 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-// Standalone unit test for the EPContext data read policy helpers. These helpers deliberately have
-// no JSI or ONNX Runtime dependency so they can be compiled and run on any host:
-//
-//   cl /std:c++20 /EHsc /I.. EpContextDataReadPolicyTest.cpp ..\EpContextDataReadPolicy.cpp
-//   g++ -std=c++20 -I.. EpContextDataReadPolicyTest.cpp ../EpContextDataReadPolicy.cpp -o policy_test
-//
-// The file is not part of the shipped library: it is referenced by neither android/CMakeLists.txt
-// nor the podspec source glob.
-
 #include "EpContextDataReadPolicy.h"
+#include "LoadModelArgumentPolicy.h"
 
+#include <array>
 #include <cstdint>
 #include <cstdio>
 #include <limits>
@@ -96,11 +89,54 @@ void testCheckDataSize() {
         "reports the configured limit in the limit error");
 }
 
+void testLoadModelArgumentLayout() {
+  using Type = onnxruntimejsi::LoadModelArgumentType;
+
+  constexpr std::array pathArguments{Type::String, Type::Object};
+  const auto pathLayout = onnxruntimejsi::resolveLoadModelArgumentLayout(
+      pathArguments.data(), pathArguments.size());
+  check(pathLayout.valid, "accepts the path overload");
+  check(!pathLayout.usesModelBuffer, "identifies the path overload");
+  check(pathLayout.optionsIndex == 1,
+        "selects path options from argument 1");
+
+  constexpr std::array bufferArguments{
+      Type::ArrayBuffer, Type::Number, Type::Number, Type::Object};
+  const auto bufferLayout = onnxruntimejsi::resolveLoadModelArgumentLayout(
+      bufferArguments.data(), bufferArguments.size());
+  check(bufferLayout.valid, "accepts the buffer overload");
+  check(bufferLayout.usesModelBuffer, "identifies the buffer overload");
+  check(bufferLayout.optionsIndex == 3,
+        "selects buffer options from argument 3");
+
+  constexpr std::array missingBufferOptions{
+      Type::ArrayBuffer, Type::Number, Type::Number};
+  check(!onnxruntimejsi::resolveLoadModelArgumentLayout(
+             missingBufferOptions.data(), missingBufferOptions.size())
+             .valid,
+        "rejects a buffer overload without options");
+
+  constexpr std::array wrongBufferOffset{
+      Type::ArrayBuffer, Type::Object, Type::Number, Type::Object};
+  check(!onnxruntimejsi::resolveLoadModelArgumentLayout(
+             wrongBufferOffset.data(), wrongBufferOffset.size())
+             .valid,
+        "rejects a non-numeric buffer offset");
+
+  constexpr std::array extraPathArgument{
+      Type::String, Type::Object, Type::Other};
+  check(!onnxruntimejsi::resolveLoadModelArgumentLayout(
+             extraPathArgument.data(), extraPathArgument.size())
+             .valid,
+        "rejects extra path arguments");
+}
+
 }  // namespace
 
 int main() {
   testParseMaxDataSize();
   testCheckDataSize();
+  testLoadModelArgumentLayout();
 
   if (g_failures != 0) {
     std::printf("%d check(s) failed\n", g_failures);

--- a/js/react_native/e2e/src/App.tsx
+++ b/js/react_native/e2e/src/App.tsx
@@ -5,8 +5,9 @@ import * as React from 'react';
 import { Button, SafeAreaView, ScrollView, StyleSheet, Text, View } from 'react-native';
 import MNISTTest from './MNISTTest';
 import BasicTypesTest from './BasicTypesTest';
+import EPContextDataReadTest from './EPContextDataReadTest';
 
-type Page = 'home' | 'mnist' | 'basic-types';
+type Page = 'home' | 'mnist' | 'basic-types' | 'ep-context-data-read';
 
 interface State {
   currentPage: Page;
@@ -91,9 +92,7 @@ export default class App extends React.PureComponent<{}, State> {
                 accessibilityLabel="mnist-test-button"
               />
             </View>
-            <Text style={styles.description}>
-              Test MNIST model with image classification
-            </Text>
+            <Text style={styles.description}>Test MNIST model with image classification</Text>
           </View>
 
           <View style={styles.buttonContainer}>
@@ -104,9 +103,18 @@ export default class App extends React.PureComponent<{}, State> {
                 accessibilityLabel="basic-types-test-button"
               />
             </View>
-            <Text style={styles.description}>
-              Test various data types with basic models
-            </Text>
+            <Text style={styles.description}>Test various data types with basic models</Text>
+          </View>
+
+          <View style={styles.buttonContainer}>
+            <View style={styles.buttonWrapper}>
+              <Button
+                title="EPContext Data Read Test"
+                onPress={() => this.navigateTo('ep-context-data-read')}
+                accessibilityLabel="ep-context-data-read-test-button"
+              />
+            </View>
+            <Text style={styles.description}>Test the epContextDataRead session option and its lifetime</Text>
           </View>
         </ScrollView>
       </SafeAreaView>
@@ -124,6 +132,9 @@ export default class App extends React.PureComponent<{}, State> {
       case 'basic-types':
         testComponent = <BasicTypesTest />;
         break;
+      case 'ep-context-data-read':
+        testComponent = <EPContextDataReadTest />;
+        break;
       default:
         testComponent = <Text>Unknown test</Text>;
     }
@@ -131,15 +142,9 @@ export default class App extends React.PureComponent<{}, State> {
     return (
       <SafeAreaView style={styles.container}>
         <View style={styles.header}>
-          <Button
-            title="← Back to Home"
-            onPress={() => this.navigateTo('home')}
-            accessibilityLabel="back-button"
-          />
+          <Button title="← Back to Home" onPress={() => this.navigateTo('home')} accessibilityLabel="back-button" />
         </View>
-        <ScrollView style={styles.testContent}>
-          {testComponent}
-        </ScrollView>
+        <ScrollView style={styles.testContent}>{testComponent}</ScrollView>
       </SafeAreaView>
     );
   }

--- a/js/react_native/e2e/src/EPContextDataReadTest.tsx
+++ b/js/react_native/e2e/src/EPContextDataReadTest.tsx
@@ -55,6 +55,12 @@ const styles = StyleSheet.create({
   buttonContainer: {
     marginBottom: 20,
   },
+  summary: {
+    fontSize: 16,
+    fontWeight: '600',
+    marginBottom: 12,
+    color: '#333',
+  },
   resultsContainer: {
     flex: 1,
   },
@@ -310,28 +316,33 @@ export default class EPContextDataReadTest extends React.PureComponent<{}, State
 
     try {
       const bytes = await readAsset(MODEL_ASSET);
+      const paddedBytes = Buffer.alloc(bytes.length + 16);
+      bytes.copy(paddedBytes, 8);
+      const modelBytes = paddedBytes.subarray(8, 8 + bytes.length);
 
-      await this.expectRejected(bytes, 0, { epContextDataRead: { maxDataSize: 1024 } });
-      await this.expectRejected(bytes, 1, { epContextDataRead: { callback: 'not-a-function', maxDataSize: 1024 } });
-      await this.expectRejected(bytes, 2, { epContextDataRead: { callback: validCallback } });
-      await this.expectRejected(bytes, 3, { epContextDataRead: { callback: validCallback, maxDataSize: 0 } });
-      await this.expectRejected(bytes, 4, { epContextDataRead: { callback: validCallback, maxDataSize: -1 } });
-      await this.expectRejected(bytes, 5, { epContextDataRead: { callback: validCallback, maxDataSize: 1.5 } });
-      await this.expectRejected(bytes, 6, {
+      await this.expectRejected(modelBytes, 0, { epContextDataRead: { maxDataSize: 1024 } });
+      await this.expectRejected(modelBytes, 1, {
+        epContextDataRead: { callback: 'not-a-function', maxDataSize: 1024 },
+      });
+      await this.expectRejected(modelBytes, 2, { epContextDataRead: { callback: validCallback } });
+      await this.expectRejected(modelBytes, 3, { epContextDataRead: { callback: validCallback, maxDataSize: 0 } });
+      await this.expectRejected(modelBytes, 4, { epContextDataRead: { callback: validCallback, maxDataSize: -1 } });
+      await this.expectRejected(modelBytes, 5, { epContextDataRead: { callback: validCallback, maxDataSize: 1.5 } });
+      await this.expectRejected(modelBytes, 6, {
         epContextDataRead: { callback: validCallback, maxDataSize: Number.POSITIVE_INFINITY },
       });
-      await this.expectRejected(bytes, 7, {
+      await this.expectRejected(modelBytes, 7, {
         epContextDataRead: { callback: validCallback, maxDataSize: Number.MAX_SAFE_INTEGER + 2 },
       });
 
-      await this.runValidOptionCheck(bytes, 8);
-      await this.runLifecycleCheck(bytes, 9);
-      await this.runFailedLoadCheck(bytes, 10);
+      await this.runValidOptionCheck(modelBytes, 8);
+      await this.runLifecycleCheck(modelBytes, 9);
+      await this.runFailedLoadCheck(modelBytes, 10);
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       this.setState((prevState) => ({
         testResults: prevState.testResults.map((result) =>
-          result.status === 'pending' || result.status === 'running' ? { ...result, status: 'error', message } : result
+          result.status === 'pending' || result.status === 'running' ? { ...result, status: 'error', message } : result,
         ),
       }));
     }
@@ -341,6 +352,15 @@ export default class EPContextDataReadTest extends React.PureComponent<{}, State
 
   render(): React.JSX.Element {
     const { testResults, isRunning } = this.state;
+    const successCount = testResults.filter((result) => result.status === 'success').length;
+    const errorCount = testResults.filter((result) => result.status === 'error').length;
+    const summary = isRunning
+      ? `${successCount}/${CHECK_NAMES.length} checks passed`
+      : successCount === CHECK_NAMES.length
+        ? `${successCount}/${CHECK_NAMES.length} checks passed`
+        : errorCount > 0
+          ? `${errorCount} check${errorCount === 1 ? '' : 's'} failed`
+          : 'Ready to run';
 
     return (
       <View style={styles.container}>
@@ -355,6 +375,10 @@ export default class EPContextDataReadTest extends React.PureComponent<{}, State
             accessibilityLabel="run-tests-button"
           />
         </View>
+
+        <Text style={styles.summary} accessibilityLabel="ep-context-data-read-summary">
+          {summary}
+        </Text>
 
         <ScrollView style={styles.resultsContainer}>
           {testResults.map((result) => (

--- a/js/react_native/e2e/src/EPContextDataReadTest.tsx
+++ b/js/react_native/e2e/src/EPContextDataReadTest.tsx
@@ -1,0 +1,394 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import * as React from 'react';
+import { ActivityIndicator, Button, ScrollView, StyleSheet, Text, View, Platform } from 'react-native';
+import { InferenceSession, Tensor } from 'onnxruntime-react-native';
+import { Buffer } from 'buffer';
+import RNFS from 'react-native-fs';
+
+interface TestResult {
+  name: string;
+  status: 'pending' | 'running' | 'success' | 'error';
+  message?: string;
+}
+
+interface State {
+  testResults: TestResult[];
+  isRunning: boolean;
+}
+
+// A plain (non-EPContext) model. Registering the read callback must not disturb a session that
+// never needs external EPContext data.
+const MODEL_ASSET = 'test_types_float.ort';
+
+const CHECK_NAMES = [
+  'Missing callback is rejected',
+  'Non-function callback is rejected',
+  'Missing maxDataSize is rejected',
+  'Zero maxDataSize is rejected',
+  'Negative maxDataSize is rejected',
+  'Fractional maxDataSize is rejected',
+  'Infinite maxDataSize is rejected',
+  'Unsafe integer maxDataSize is rejected',
+  'Valid option loads and runs a session',
+  'Repeated create/release keeps the callback alive',
+  'Failed load releases the callback state',
+];
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    padding: 20,
+  },
+  title: {
+    fontSize: 24,
+    fontWeight: 'bold',
+    marginBottom: 10,
+    color: '#333',
+  },
+  subtitle: {
+    fontSize: 16,
+    marginBottom: 20,
+    color: '#666',
+  },
+  buttonContainer: {
+    marginBottom: 20,
+  },
+  resultsContainer: {
+    flex: 1,
+  },
+  testItem: {
+    backgroundColor: '#fff',
+    padding: 15,
+    marginBottom: 10,
+    borderRadius: 8,
+    borderWidth: 1,
+    borderColor: '#ddd',
+  },
+  testHeader: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginBottom: 5,
+  },
+  testName: {
+    fontSize: 16,
+    fontWeight: '600',
+    color: '#333',
+    flexShrink: 1,
+    paddingRight: 10,
+  },
+  statusSuccess: {
+    fontSize: 24,
+    color: '#4CAF50',
+    fontWeight: 'bold',
+  },
+  statusError: {
+    fontSize: 24,
+    color: '#F44336',
+    fontWeight: 'bold',
+  },
+  statusPending: {
+    fontSize: 24,
+    color: '#999',
+  },
+  successMessage: {
+    fontSize: 12,
+    color: '#4CAF50',
+    marginTop: 5,
+  },
+  errorMessage: {
+    fontSize: 12,
+    color: '#F44336',
+    marginTop: 5,
+  },
+});
+
+const readAsset = async (asset: string): Promise<Buffer> => {
+  if (Platform.OS === 'android') {
+    return Buffer.from(await RNFS.readFileAssets(asset, 'base64'), 'base64');
+  } else {
+    return Buffer.from(await RNFS.readFile(`${RNFS.MainBundlePath}/${asset}`, 'base64'), 'base64');
+  }
+};
+
+// Avoids depending on TextEncoder, which is not available on every JS engine used by React Native.
+const validCallback = (name: string): Uint8Array => {
+  const bytes = new Uint8Array(name.length);
+  for (let i = 0; i < name.length; i++) {
+    bytes[i] = name.charCodeAt(i) % 256;
+  }
+  return bytes;
+};
+
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type
+export default class EPContextDataReadTest extends React.PureComponent<{}, State> {
+  private session: InferenceSession | undefined;
+
+  // eslint-disable-next-line @typescript-eslint/no-empty-object-type
+  constructor(props: {} | Readonly<{}>) {
+    super(props);
+
+    this.state = {
+      testResults: CHECK_NAMES.map((name) => ({ name, status: 'pending' })),
+      isRunning: false,
+    };
+  }
+
+  async componentWillUnmount(): Promise<void> {
+    await this.releaseSession();
+  }
+
+  releaseSession = async (): Promise<void> => {
+    if (this.session) {
+      const session = this.session;
+      this.session = undefined;
+      try {
+        await session.release();
+      } catch (err) {
+        console.error('Error releasing EPContext data read session:', err);
+      }
+    }
+  };
+
+  updateTestResult = (index: number, update: Partial<TestResult>) => {
+    this.setState((prevState) => {
+      const newResults = [...prevState.testResults];
+      newResults[index] = { ...newResults[index], ...update };
+      return { testResults: newResults };
+    });
+  };
+
+  // Asserts that creating a session with the given options fails during option validation.
+  expectRejected = async (bytes: Buffer, index: number, options: unknown): Promise<void> => {
+    this.updateTestResult(index, { status: 'running' });
+    let session: InferenceSession | undefined;
+    try {
+      session = await InferenceSession.create(bytes, options as InferenceSession.SessionOptions);
+    } catch (err) {
+      this.updateTestResult(index, {
+        status: 'success',
+        message: err instanceof Error ? err.message : String(err),
+      });
+      return;
+    } finally {
+      if (session) {
+        await session.release();
+      }
+    }
+    this.updateTestResult(index, {
+      status: 'error',
+      message: 'Session creation unexpectedly succeeded',
+    });
+  };
+
+  runValidOptionCheck = async (bytes: Buffer, index: number): Promise<void> => {
+    this.updateTestResult(index, { status: 'running' });
+    try {
+      let callbackCalls = 0;
+      this.session = await InferenceSession.create(bytes, {
+        epContextDataRead: {
+          callback: (name: string) => {
+            callbackCalls++;
+            return validCallback(name);
+          },
+          maxDataSize: 1024 * 1024,
+        },
+      });
+
+      const feeds: Record<string, Tensor> = {};
+      feeds[this.session.inputNames[0]] = new Tensor('float32', new Float32Array([0, 1, 2, 3, 4]), [1, 5]);
+      const output = await this.session.run(feeds);
+      const outputTensor = output[this.session.outputNames[0]];
+      if (!outputTensor || !outputTensor.data) {
+        throw new Error('No output received');
+      }
+
+      await this.releaseSession();
+
+      // The model has no external EPContext data, so ONNX Runtime must not invoke the callback.
+      if (callbackCalls !== 0) {
+        throw new Error(`Callback was invoked ${callbackCalls} time(s) for a model without EPContext data`);
+      }
+
+      this.updateTestResult(index, {
+        status: 'success',
+        message: `Output shape: [${outputTensor.dims.join(', ')}], callback invocations: ${callbackCalls}`,
+      });
+    } catch (err) {
+      await this.releaseSession();
+      this.updateTestResult(index, {
+        status: 'error',
+        message: err instanceof Error ? err.message : String(err),
+      });
+    }
+  };
+
+  runLifecycleCheck = async (bytes: Buffer, index: number): Promise<void> => {
+    this.updateTestResult(index, { status: 'running' });
+    try {
+      for (let i = 0; i < 5; i++) {
+        const session = await InferenceSession.create(bytes, {
+          epContextDataRead: {
+            callback: validCallback,
+            maxDataSize: 16,
+          },
+        });
+        // Releasing must drop the native callback state without disturbing later sessions.
+        await session.release();
+      }
+      this.updateTestResult(index, {
+        status: 'success',
+        message: 'Created and released 5 sessions',
+      });
+    } catch (err) {
+      this.updateTestResult(index, {
+        status: 'error',
+        message: err instanceof Error ? err.message : String(err),
+      });
+    }
+  };
+
+  // A session that fails to construct must release the callback state right away, and must leave a
+  // subsequent load unaffected.
+  runFailedLoadCheck = async (bytes: Buffer, index: number): Promise<void> => {
+    this.updateTestResult(index, { status: 'running' });
+    try {
+      let callbackCalls = 0;
+      const corrupted = Buffer.from(bytes);
+      corrupted.fill(0, 0, Math.min(32, corrupted.length));
+
+      let rejected = false;
+      let badSession: InferenceSession | undefined;
+      try {
+        badSession = await InferenceSession.create(corrupted, {
+          epContextDataRead: {
+            callback: (name: string) => {
+              callbackCalls++;
+              return validCallback(name);
+            },
+            maxDataSize: 1024,
+          },
+        });
+      } catch {
+        rejected = true;
+      }
+      if (badSession) {
+        await badSession.release();
+      }
+      if (!rejected) {
+        throw new Error('Loading a corrupted model unexpectedly succeeded');
+      }
+      if (callbackCalls !== 0) {
+        throw new Error(`Callback was invoked ${callbackCalls} time(s) for a model that failed to load`);
+      }
+
+      // The next session must still load and release normally.
+      const session = await InferenceSession.create(bytes, {
+        epContextDataRead: { callback: validCallback, maxDataSize: 1024 },
+      });
+      await session.release();
+
+      this.updateTestResult(index, {
+        status: 'success',
+        message: 'Rejected load did not disturb the next session',
+      });
+    } catch (err) {
+      this.updateTestResult(index, {
+        status: 'error',
+        message: err instanceof Error ? err.message : String(err),
+      });
+    }
+  };
+
+  runAllTests = async (): Promise<void> => {
+    this.setState({
+      isRunning: true,
+      testResults: CHECK_NAMES.map((name) => ({ name, status: 'pending' })),
+    });
+
+    try {
+      const bytes = await readAsset(MODEL_ASSET);
+
+      await this.expectRejected(bytes, 0, { epContextDataRead: { maxDataSize: 1024 } });
+      await this.expectRejected(bytes, 1, { epContextDataRead: { callback: 'not-a-function', maxDataSize: 1024 } });
+      await this.expectRejected(bytes, 2, { epContextDataRead: { callback: validCallback } });
+      await this.expectRejected(bytes, 3, { epContextDataRead: { callback: validCallback, maxDataSize: 0 } });
+      await this.expectRejected(bytes, 4, { epContextDataRead: { callback: validCallback, maxDataSize: -1 } });
+      await this.expectRejected(bytes, 5, { epContextDataRead: { callback: validCallback, maxDataSize: 1.5 } });
+      await this.expectRejected(bytes, 6, {
+        epContextDataRead: { callback: validCallback, maxDataSize: Number.POSITIVE_INFINITY },
+      });
+      await this.expectRejected(bytes, 7, {
+        epContextDataRead: { callback: validCallback, maxDataSize: Number.MAX_SAFE_INTEGER + 2 },
+      });
+
+      await this.runValidOptionCheck(bytes, 8);
+      await this.runLifecycleCheck(bytes, 9);
+      await this.runFailedLoadCheck(bytes, 10);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      this.setState((prevState) => ({
+        testResults: prevState.testResults.map((result) =>
+          result.status === 'pending' || result.status === 'running' ? { ...result, status: 'error', message } : result
+        ),
+      }));
+    }
+
+    this.setState({ isRunning: false });
+  };
+
+  render(): React.JSX.Element {
+    const { testResults, isRunning } = this.state;
+
+    return (
+      <View style={styles.container}>
+        <Text style={styles.title}>EPContext Data Read Test</Text>
+        <Text style={styles.subtitle}>Validate the epContextDataRead session option and its native lifetime</Text>
+
+        <View style={styles.buttonContainer}>
+          <Button
+            title={isRunning ? 'Running Tests...' : 'Run All Tests'}
+            onPress={this.runAllTests}
+            disabled={isRunning}
+            accessibilityLabel="run-tests-button"
+          />
+        </View>
+
+        <ScrollView style={styles.resultsContainer}>
+          {testResults.map((result) => (
+            <View key={result.name} style={styles.testItem}>
+              <View style={styles.testHeader}>
+                <Text style={styles.testName}>{result.name}</Text>
+                {result.status === 'running' && (
+                  <ActivityIndicator size="small" color="#007AFF" accessibilityLabel="statusRunning" />
+                )}
+                {result.status === 'success' && (
+                  <Text style={styles.statusSuccess} accessibilityLabel="statusSuccess">
+                    ✓
+                  </Text>
+                )}
+                {result.status === 'error' && (
+                  <Text style={styles.statusError} accessibilityLabel="statusError">
+                    ✗
+                  </Text>
+                )}
+                {result.status === 'pending' && (
+                  <Text style={styles.statusPending} accessibilityLabel="statusPending">
+                    ○
+                  </Text>
+                )}
+              </View>
+              {result.message && (
+                <Text style={result.status === 'error' ? styles.errorMessage : styles.successMessage}>
+                  {result.message}
+                </Text>
+              )}
+            </View>
+          ))}
+        </ScrollView>
+      </View>
+    );
+  }
+}

--- a/js/react_native/e2e/test/OnnxruntimeModuleExample.test.js
+++ b/js/react_native/e2e/test/OnnxruntimeModuleExample.test.js
@@ -74,10 +74,10 @@ describe('OnnxruntimeModuleExample', () => {
     } else {
       await element(by.text('Run All Tests')).tap();
     }
-    await delay(1000);
-
-    // Every check must pass: invalid options are rejected and valid ones load, run and release.
-    await expect(element(by.label('statusError'))).not.toBeVisible();
-    await expect(element(by.label('statusPending'))).not.toBeVisible();
+    // The aggregate stays visible above the results list, so lower off-screen rows cannot make this
+    // assertion pass accidentally. It reaches this exact text only after every check succeeds.
+    await waitFor(element(by.label('ep-context-data-read-summary')))
+      .toHaveText('11/11 checks passed')
+      .withTimeout(120000);
   });
 });

--- a/js/react_native/e2e/test/OnnxruntimeModuleExample.test.js
+++ b/js/react_native/e2e/test/OnnxruntimeModuleExample.test.js
@@ -57,4 +57,27 @@ describe('OnnxruntimeModuleExample', () => {
     // Check have no error
     await expect(element(by.label('statusError'))).not.toBeVisible();
   });
+
+  it('EPContext data read test should run successfully', async () => {
+    // Tap EPContext data read test button
+    if (platform === 'android') {
+      await element(by.label('ep-context-data-read-test-button')).tap();
+    } else {
+      await element(by.text('EPContext Data Read Test')).tap();
+    }
+
+    await delay(500);
+
+    // Run the tests
+    if (platform === 'android') {
+      await element(by.label('run-tests-button')).tap();
+    } else {
+      await element(by.text('Run All Tests')).tap();
+    }
+    await delay(1000);
+
+    // Every check must pass: invalid options are rejected and valid ones load, run and release.
+    await expect(element(by.label('statusError'))).not.toBeVisible();
+    await expect(element(by.label('statusPending'))).not.toBeVisible();
+  });
 });

--- a/js/react_native/ios/OnnxruntimeModule.mm
+++ b/js/react_native/ios/OnnxruntimeModule.mm
@@ -9,12 +9,20 @@
 #import <React/RCTUtils.h>
 #import <ReactCommon/RCTTurboModule.h>
 #import <jsi/jsi.h>
+#include <mutex>
+#include <unordered_map>
+
+namespace {
+
+std::mutex envsMutex;
+std::unordered_map<const void*, std::shared_ptr<onnxruntimejsi::Env>>
+    envs;
+
+}  // namespace
 
 @implementation OnnxruntimeModule
 
 @synthesize bridge = _bridge;
-
-static std::shared_ptr<onnxruntimejsi::Env> env;
 
 RCT_EXPORT_MODULE(Onnxruntime)
 
@@ -39,7 +47,17 @@ RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(install) {
     auto& runtime = *jsiRuntime;
     auto jsiInvoker = _bridge.jsCallInvoker;
 
-    env = onnxruntimejsi::install(runtime, jsiInvoker);
+    auto newEnv = onnxruntimejsi::install(runtime, jsiInvoker);
+    std::shared_ptr<onnxruntimejsi::Env> oldEnv;
+    {
+      std::lock_guard<std::mutex> lock(envsMutex);
+      const auto moduleKey = (__bridge const void*)self;
+      oldEnv = std::move(envs[moduleKey]);
+      envs[moduleKey] = std::move(newEnv);
+    }
+    if (oldEnv) {
+      oldEnv->invalidate();
+    }
 
     return @true;
   } @catch (...) {
@@ -48,7 +66,20 @@ RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(install) {
 }
 
 - (void)dealloc {
-  env.reset();
+  std::shared_ptr<onnxruntimejsi::Env> moduleEnv;
+  {
+    std::lock_guard<std::mutex> lock(envsMutex);
+    auto entry = envs.find((__bridge const void*)self);
+    if (entry != envs.end()) {
+      moduleEnv = std::move(entry->second);
+      envs.erase(entry);
+    }
+  }
+  // dealloc is not guaranteed to run on the JS thread, so stop dispatching to the runtime and
+  // release any thread blocked on it before dropping the environment.
+  if (moduleEnv) {
+    moduleEnv->invalidate();
+  }
 }
 
 @end

--- a/js/react_native/package.json
+++ b/js/react_native/package.json
@@ -88,9 +88,10 @@
   "scripts": {
     "typescript": "tsc --noEmit",
     "prepare": "bob build",
-    "bootstrap-no-pods": "npm run pack-common && npm run unpack-common && npm run pack-libs && npm run unpack-libs && npm run e2e",
+    "bootstrap-no-pods": "npm run test:cpp && npm run pack-common && npm run unpack-common && npm run pack-libs && npm run unpack-libs && npm run e2e",
     "bootstrap": "npm run bootstrap-no-pods && npm run pods",
     "test": "jest",
+    "test:cpp": "cmake -S cpp/test -B build/cpp-test && cmake --build build/cpp-test --config Release && ctest --test-dir build/cpp-test -C Release --output-on-failure",
     "pack-common": "cd ../common && npm pack && mv -f onnxruntime-common-*.tgz ../react_native/e2e/onnxruntime-common.tgz",
     "unpack-common": "npm --prefix e2e install ./e2e/onnxruntime-common.tgz",
     "pack-libs": "npm pack --ort-js-pack-mode=e2e && mv -f onnxruntime-react-native-*.tgz e2e/onnxruntime-react-native.tgz",

--- a/js/react_native/package.json
+++ b/js/react_native/package.json
@@ -62,7 +62,8 @@
     "!android/gradlew",
     "!android/gradlew.bat",
     "!android/gradle/wrapper/*.jar",
-    "!android/libs"
+    "!android/libs",
+    "!cpp/test"
   ],
   "description": "ONNX Runtime bridge for react native",
   "repository": "https://github.com/Microsoft/onnxruntime.git",

--- a/js/web/lib/backend-onnxjs.ts
+++ b/js/web/lib/backend-onnxjs.ts
@@ -5,6 +5,7 @@ import { Backend, InferenceSession, InferenceSessionHandler } from 'onnxruntime-
 
 import { Session } from './onnxjs/session';
 import { OnnxjsSessionHandler } from './onnxjs/session-handler-inference';
+import { validateSessionOptions } from './validate-session-options';
 
 class OnnxjsBackend implements Backend {
   // eslint-disable-next-line @typescript-eslint/no-empty-function
@@ -14,6 +15,7 @@ class OnnxjsBackend implements Backend {
     pathOrBuffer: string | Uint8Array,
     options?: InferenceSession.SessionOptions,
   ): Promise<InferenceSessionHandler> {
+    validateSessionOptions(options);
     // NOTE: Session.Config(from onnx.js) is not compatible with InferenceSession.SessionOptions(from
     // onnxruntime-common).
     //       In future we should remove Session.Config and use InferenceSession.SessionOptions.

--- a/js/web/lib/backend-wasm.ts
+++ b/js/web/lib/backend-wasm.ts
@@ -5,6 +5,7 @@ import { Backend, env, InferenceSession, InferenceSessionHandler } from 'onnxrun
 
 import { initializeOrtEp, initializeWebAssemblyAndOrtRuntime } from './wasm/proxy-wrapper';
 import { OnnxruntimeWebAssemblySessionHandler } from './wasm/session-handler-inference';
+import { validateSessionOptions } from './validate-session-options';
 
 /**
  * This function initializes all flags for WebAssembly.
@@ -87,6 +88,7 @@ export class OnnxruntimeWebAssemblyBackend implements Backend {
     pathOrBuffer: string | Uint8Array,
     options?: InferenceSession.SessionOptions,
   ): Promise<InferenceSessionHandler> {
+    validateSessionOptions(options);
     const handler = new OnnxruntimeWebAssemblySessionHandler();
     await handler.loadModel(pathOrBuffer, options);
     return handler;

--- a/js/web/lib/validate-session-options.ts
+++ b/js/web/lib/validate-session-options.ts
@@ -1,0 +1,10 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import type { InferenceSession } from 'onnxruntime-common';
+
+export const validateSessionOptions = (options?: InferenceSession.SessionOptions): void => {
+  if (options?.epContextDataRead) {
+    throw new Error('session option "epContextDataRead" is not supported by ONNX Runtime Web');
+  }
+};

--- a/js/web/test/unittests/ep-context-data-read.ts
+++ b/js/web/test/unittests/ep-context-data-read.ts
@@ -1,0 +1,20 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { expect } from 'chai';
+
+import { validateSessionOptions } from '../../lib/validate-session-options';
+
+describe('EPContext data read callback', () => {
+  it('is rejected by ONNX Runtime Web backends', () => {
+    expect(() =>
+      validateSessionOptions({
+        epContextDataRead: { callback: () => new Uint8Array(), maxDataSize: 1 },
+      }),
+    ).to.throw('session option "epContextDataRead" is not supported by ONNX Runtime Web');
+  });
+
+  it('does not affect other session options', () => {
+    expect(() => validateSessionOptions({ graphOptimizationLevel: 'all' })).not.to.throw();
+  });
+});

--- a/js/web/test/unittests/index.ts
+++ b/js/web/test/unittests/index.ts
@@ -13,6 +13,8 @@ if (typeof window !== 'undefined') {
 
 require('./backends/wasm/test-model-metadata');
 
+require('./ep-context-data-read');
+
 require('./pool-output-shape');
 
 require('./opset');


### PR DESCRIPTION
## Summary
- add `SessionOptions.epContextDataRead` as a synchronous `(name: string) => Uint8Array` callback with a required finite `maxDataSize`
- implement native callback registration, allocator-owned result marshalling, error mapping, serialized invocation, and deterministic session/runtime lifetimes for Node.js and React Native
- move Node session construction off the JavaScript thread and snapshot model/external initializer buffers before asynchronous work
- reject the option explicitly on Web/WASM; JavaScript still has no model-compilation surface, so no write callback is exposed

## Validation
- common TypeScript/tests: 84 passing, 2 pending
- Node native add-on rebuild: passed; focused callback tests: 31 passing; broader Node suite: passed
- Web focused backend-availability tests: 2 passing
- React Native package build: passed
- React Native callback/policy C++ compile checks: x64 and x86 passed with real React Native headers; policy test passed
- changed JavaScript lint and C++ formatting checks: passed

## Platform limits
- Android/iOS device integration and native platform linking were not available on this Windows host
- Detox could not run without a configured device
- the full React Native TypeScript check retains two pre-existing errors in `e2e/src/MNISTTest.tsx`