### PR TITLE
Add Objective-C EPContext data callbacks

### DIFF
--- a/cmake/onnxruntime_objectivec.cmake
+++ b/cmake/onnxruntime_objectivec.cmake
@@ -125,6 +125,8 @@ if(onnxruntime_BUILD_UNIT_TESTS)
         ${onnxruntime_objc_headers}
         ${onnxruntime_objc_test_srcs})
 
+    target_link_libraries(onnxruntime_objc_test PRIVATE onnxruntime)
+
     onnxruntime_configure_target(onnxruntime_objc_test)
 
     target_include_directories(onnxruntime_objc_test

--- a/objectivec/docs/main_page.md
+++ b/objectivec/docs/main_page.md
@@ -3,3 +3,7 @@
 ONNX Runtime provides an Objective-C API.
 
 It can be used from Objective-C/C++ or Swift with a bridging header.
+
+Starting in 1.30, `ORTSessionOptions` can register an application-side callback that supplies external EPContext data
+during session initialization. The Objective-C API does not currently expose model compilation, so it exposes the
+EPContext data read callback but not the write callback.

--- a/objectivec/include/ort_session.h
+++ b/objectivec/include/ort_session.h
@@ -14,6 +14,19 @@ NS_ASSUME_NONNULL_BEGIN
 @class ORTValue;
 
 /**
+ * A block that supplies application-managed external EPContext data.
+ *
+ * Available since 1.30.
+ *
+ * The block may be called concurrently from arbitrary ONNX Runtime threads and must be thread-safe.
+ *
+ * @param name The logical name of the requested EPContext data.
+ * @param error Error information to set when returning nil.
+ * @return The requested data. Zero-length data is a successful empty payload. Return nil only on failure and set error.
+ */
+typedef NSData* _Nullable (^ORTEpContextDataReadBlock)(NSString* name, NSError** error);
+
+/**
  * An ORT session loads and runs a model.
  */
 @interface ORTSession : NSObject
@@ -188,6 +201,44 @@ NS_ASSUME_NONNULL_BEGIN
 - (BOOL)addConfigEntryWithKey:(NSString*)key
                         value:(NSString*)value
                         error:(NSError**)error;
+
+/**
+ * Registers a block that supplies application-managed external EPContext data during session initialization.
+ *
+ * Available since 1.30.
+ *
+ * The block is copied and retained by these options. Each `ORTSession` created from the options takes its own strong
+ * registration snapshot for the session lifetime, so replacing or clearing the block only affects future sessions.
+ * ONNX Runtime may invoke the block concurrently from arbitrary threads; the block and any captured state must be
+ * thread-safe. The returned bytes are copied before the block's returned `NSData` is released.
+ *
+ * Return zero-length `NSData` for a successful empty payload. Return nil only on failure and set the provided error.
+ * Returning nil without an error produces an ONNX Runtime failure status. Data larger than `maxDataSize` is rejected
+ * before the native output buffer is allocated.
+ *
+ * The Objective-C API exposes only the application-side read callback. It does not currently expose model compilation,
+ * so the EPContext data write callback is not applicable.
+ *
+ * @param block The synchronous block used to read EPContext data.
+ * @param maxDataSize A finite maximum payload size in bytes. Must be greater than zero and less than `NSUIntegerMax`.
+ * @param error Optional error information set if registration fails.
+ * @return Whether the block was registered successfully.
+ */
+- (BOOL)setEpContextDataReadBlock:(ORTEpContextDataReadBlock)block
+                      maxDataSize:(NSUInteger)maxDataSize
+                            error:(NSError**)error;
+
+/**
+ * Clears the block that supplies application-managed external EPContext data for future sessions.
+ *
+ * Available since 1.30.
+ *
+ * Sessions already created from these options retain their registration snapshot for the session lifetime.
+ *
+ * @param error Optional error information set if clearing fails.
+ * @return Whether the block was cleared successfully.
+ */
+- (BOOL)clearEpContextDataReadBlockWithError:(NSError**)error;
 
 /**
  * Registers custom ops for use with `ORTSession`s using this SessionOptions by calling the specified

--- a/objectivec/ort_session.mm
+++ b/objectivec/ort_session.mm
@@ -27,11 +27,11 @@ OrtStatus* CreateCallbackStatus(OrtErrorCode code, NSString* message) {
   return Ort::GetApi().CreateStatus(code, messageCstr != nullptr ? messageCstr : "EPContext data read block failed");
 }
 
-OrtStatus* ORT_API_CALL EpContextDataReadCallback(void* state,
-                                                  const char* name,
-                                                  OrtAllocator* allocator,
-                                                  void** buffer,
-                                                  size_t* dataSize);
+OrtStatus* _Nullable ORT_API_CALL EpContextDataReadCallback(void* state,
+                                                            const char* name,
+                                                            OrtAllocator* allocator,
+                                                            void** buffer,
+                                                            size_t* dataSize);
 }  // namespace
 
 NS_ASSUME_NONNULL_BEGIN
@@ -62,11 +62,11 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 namespace {
-OrtStatus* ORT_API_CALL EpContextDataReadCallback(void* state,
-                                                  const char* name,
-                                                  OrtAllocator* allocator,
-                                                  void** buffer,
-                                                  size_t* dataSize) {
+OrtStatus* _Nullable ORT_API_CALL EpContextDataReadCallback(void* state,
+                                                            const char* name,
+                                                            OrtAllocator* allocator,
+                                                            void** buffer,
+                                                            size_t* dataSize) {
   if (buffer == nullptr || dataSize == nullptr) {
     return Ort::GetApi().CreateStatus(ORT_INVALID_ARGUMENT,
                                       "EPContext data read callback received null output parameters");

--- a/objectivec/ort_session.mm
+++ b/objectivec/ort_session.mm
@@ -3,6 +3,8 @@
 
 #import "ort_session_internal.h"
 
+#include <cstring>
+#include <limits>
 #include <optional>
 #include <vector>
 
@@ -19,12 +21,139 @@ enum class NamedValueType {
   OverridableInitializer,
   Output,
 };
+
+OrtStatus* CreateCallbackStatus(OrtErrorCode code, NSString* message) {
+  const char* messageCstr = message.UTF8String;
+  return Ort::GetApi().CreateStatus(code, messageCstr != nullptr ? messageCstr : "EPContext data read block failed");
+}
+
+OrtStatus* ORT_API_CALL EpContextDataReadCallback(void* state,
+                                                  const char* name,
+                                                  OrtAllocator* allocator,
+                                                  void** buffer,
+                                                  size_t* dataSize);
 }  // namespace
 
 NS_ASSUME_NONNULL_BEGIN
 
+@interface ORTEpContextDataReadRegistration : NSObject
+
+@property(nonatomic, copy, readonly) ORTEpContextDataReadBlock block;
+@property(nonatomic, readonly) size_t maxDataSize;
+
+- (instancetype)initWithBlock:(ORTEpContextDataReadBlock)block
+                  maxDataSize:(size_t)maxDataSize;
+
+@end
+
+@implementation ORTEpContextDataReadRegistration
+
+- (instancetype)initWithBlock:(ORTEpContextDataReadBlock)block
+                  maxDataSize:(size_t)maxDataSize {
+  if ((self = [super init]) == nil) {
+    return nil;
+  }
+
+  _block = [block copy];
+  _maxDataSize = maxDataSize;
+  return self;
+}
+
+@end
+
+namespace {
+OrtStatus* ORT_API_CALL EpContextDataReadCallback(void* state,
+                                                  const char* name,
+                                                  OrtAllocator* allocator,
+                                                  void** buffer,
+                                                  size_t* dataSize) {
+  if (buffer == nullptr || dataSize == nullptr) {
+    return Ort::GetApi().CreateStatus(ORT_INVALID_ARGUMENT,
+                                      "EPContext data read callback received null output parameters");
+  }
+
+  *buffer = nullptr;
+  *dataSize = 0;
+
+  if (state == nullptr || name == nullptr || allocator == nullptr) {
+    return Ort::GetApi().CreateStatus(ORT_INVALID_ARGUMENT,
+                                      "EPContext data read callback received invalid input parameters");
+  }
+
+  try {
+    @try {
+      @autoreleasepool {
+        ORTEpContextDataReadRegistration* registration =
+            (__bridge ORTEpContextDataReadRegistration*)state;
+        NSString* dataName = [NSString stringWithUTF8String:name];
+        if (dataName == nil) {
+          return Ort::GetApi().CreateStatus(ORT_INVALID_ARGUMENT,
+                                            "EPContext data name is not valid UTF-8");
+        }
+
+        NSError* callbackError = nil;
+        NSData* data = registration.block(dataName, &callbackError);
+        if (data == nil) {
+          if (callbackError == nil) {
+            return Ort::GetApi().CreateStatus(
+                ORT_FAIL, "EPContext data read block returned nil without setting an error");
+          }
+
+          NSString* message =
+              [NSString stringWithFormat:@"EPContext data read block failed for '%@': %@",
+                                         dataName, callbackError.localizedDescription];
+          return CreateCallbackStatus(ORT_FAIL, message);
+        }
+
+        if (![data isKindOfClass:[NSData class]]) {
+          return Ort::GetApi().CreateStatus(ORT_INVALID_ARGUMENT,
+                                            "EPContext data read block returned an object that is not NSData");
+        }
+
+        const NSUInteger length = data.length;
+        if (length > registration.maxDataSize) {
+          return Ort::GetApi().CreateStatus(
+              ORT_INVALID_ARGUMENT,
+              "EPContext data returned by the read block exceeds maxDataSize");
+        }
+        if (length == 0) {
+          return nullptr;
+        }
+
+        const void* bytes = data.bytes;
+        if (bytes == nullptr) {
+          return Ort::GetApi().CreateStatus(
+              ORT_INVALID_ARGUMENT,
+              "EPContext data read block returned non-empty NSData with null bytes");
+        }
+
+        void* allocatedBuffer = allocator->Alloc(allocator, static_cast<size_t>(length));
+        if (allocatedBuffer == nullptr) {
+          return Ort::GetApi().CreateStatus(ORT_FAIL,
+                                            "Failed to allocate the EPContext data output buffer");
+        }
+
+        std::memcpy(allocatedBuffer, bytes, length);
+        *buffer = allocatedBuffer;
+        *dataSize = static_cast<size_t>(length);
+        return nullptr;
+      }
+    } @catch (NSException* /*exception*/) {
+      return Ort::GetApi().CreateStatus(
+          ORT_FAIL, "EPContext data read block raised an Objective-C exception");
+    }
+  } catch (const std::exception& exception) {
+    return Ort::GetApi().CreateStatus(ORT_FAIL, exception.what());
+  } catch (...) {
+    return Ort::GetApi().CreateStatus(ORT_FAIL,
+                                      "EPContext data read callback raised an unknown exception");
+  }
+}
+}  // namespace
+
 @implementation ORTSession {
   ORTEnv* _env;  // keep a strong reference so the ORTEnv doesn't get destroyed before this does
+  id _epContextDataReadRegistration;
   std::optional<Ort::Session> _session;
 }
 
@@ -46,14 +175,30 @@ NS_ASSUME_NONNULL_BEGIN
       }
     }
 
-    _env = env;
-    _session = Ort::Session{[env CXXAPIOrtEnv],
-                            path.UTF8String,
-                            [sessionOptions CXXAPIOrtSessionOptions]};
+    id registrationSnapshot;
+    Ort::SessionOptions sessionOptionsSnapshot{nullptr};
+    @synchronized(sessionOptions) {
+      registrationSnapshot = [sessionOptions epContextDataReadRegistrationSnapshot];
+      sessionOptionsSnapshot = [sessionOptions CXXAPIOrtSessionOptions].Clone();
+    }
 
+    std::optional<Ort::Session> session;
+    session.emplace([env CXXAPIOrtEnv],
+                    path.UTF8String,
+                    sessionOptionsSnapshot);
+
+    _env = env;
+    _epContextDataReadRegistration = registrationSnapshot;
+    _session = std::move(session);
     return self;
   }
   ORT_OBJC_API_IMPL_CATCH_RETURNING_NULLABLE(error)
+}
+
+- (void)dealloc {
+  // Execution providers may retain the raw callback state, so release the native session first.
+  _session.reset();
+  _epContextDataReadRegistration = nil;
 }
 
 - (BOOL)runWithInputs:(NSDictionary<NSString*, ORTValue*>*)inputs
@@ -211,6 +356,7 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 @implementation ORTSessionOptions {
+  ORTEpContextDataReadRegistration* _epContextDataReadRegistration;
   std::optional<Ort::SessionOptions> _sessionOptions;
 }
 
@@ -302,6 +448,47 @@ NS_ASSUME_NONNULL_BEGIN
   ORT_OBJC_API_IMPL_CATCH_RETURNING_BOOL(error)
 }
 
+- (BOOL)setEpContextDataReadBlock:(ORTEpContextDataReadBlock)block
+                      maxDataSize:(NSUInteger)maxDataSize
+                            error:(NSError**)error {
+  try {
+    if (block == nil) {
+      ORT_CXX_API_THROW("EPContext data read block must not be nil", ORT_INVALID_ARGUMENT);
+    }
+    if (maxDataSize == 0 || maxDataSize == std::numeric_limits<NSUInteger>::max()) {
+      ORT_CXX_API_THROW("maxDataSize must be finite and greater than zero", ORT_INVALID_ARGUMENT);
+    }
+
+    @synchronized(self) {
+      ORTEpContextDataReadRegistration* registration =
+          [[ORTEpContextDataReadRegistration alloc] initWithBlock:block
+                                                      maxDataSize:static_cast<size_t>(maxDataSize)];
+      if (registration == nil) {
+        ORT_CXX_API_THROW("Failed to create EPContext data read block registration", ORT_FAIL);
+      }
+      _sessionOptions->SetEpContextDataReadFunc(
+          EpContextDataReadCallback, (__bridge void*)registration,
+          registration.maxDataSize);
+      _epContextDataReadRegistration = registration;
+    }
+
+    return YES;
+  }
+  ORT_OBJC_API_IMPL_CATCH_RETURNING_BOOL(error)
+}
+
+- (BOOL)clearEpContextDataReadBlockWithError:(NSError**)error {
+  try {
+    @synchronized(self) {
+      _sessionOptions->ClearEpContextDataReadFunc();
+      _epContextDataReadRegistration = nil;
+    }
+
+    return YES;
+  }
+  ORT_OBJC_API_IMPL_CATCH_RETURNING_BOOL(error)
+}
+
 - (BOOL)registerCustomOpsUsingFunction:(NSString*)registrationFuncName
                                  error:(NSError**)error {
   try {
@@ -336,6 +523,12 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (Ort::SessionOptions&)CXXAPIOrtSessionOptions {
   return *_sessionOptions;
+}
+
+- (nullable id)epContextDataReadRegistrationSnapshot {
+  @synchronized(self) {
+    return _epContextDataReadRegistration;
+  }
 }
 
 @end

--- a/objectivec/ort_session_internal.h
+++ b/objectivec/ort_session_internal.h
@@ -11,6 +11,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (Ort::SessionOptions&)CXXAPIOrtSessionOptions;
 
+- (nullable id)epContextDataReadRegistrationSnapshot;
+
 @end
 
 @interface ORTRunOptions ()

--- a/objectivec/ort_training_session.mm
+++ b/objectivec/ort_training_session.mm
@@ -21,6 +21,7 @@ NS_ASSUME_NONNULL_BEGIN
 @implementation ORTTrainingSession {
   ORTEnv* _env;  // keep a strong reference so the ORTEnv doesn't get destroyed before this does
   ORTCheckpoint* _checkpoint;
+  id _epContextDataReadRegistration;
   std::optional<Ort::TrainingSession> _session;
 }
 
@@ -50,19 +51,35 @@ NS_ASSUME_NONNULL_BEGIN
     std::optional<std::string> evalPath = utils::toStdOptionalString(evalModelPath);
     std::optional<std::string> optimizerPath = utils::toStdOptionalString(optimizerModelPath);
 
-    _env = env;
-    _checkpoint = checkpoint;
-    _session = Ort::TrainingSession{
+    id registrationSnapshot;
+    Ort::SessionOptions sessionOptionsSnapshot{nullptr};
+    @synchronized(sessionOptions) {
+      registrationSnapshot = [sessionOptions epContextDataReadRegistrationSnapshot];
+      sessionOptionsSnapshot = [sessionOptions CXXAPIOrtSessionOptions].Clone();
+    }
+
+    std::optional<Ort::TrainingSession> session;
+    session.emplace(
         [env CXXAPIOrtEnv],
-        [sessionOptions CXXAPIOrtSessionOptions],
+        sessionOptionsSnapshot,
         [checkpoint CXXAPIOrtCheckpoint],
         trainModelPath.UTF8String,
         evalPath,
-        optimizerPath};
+        optimizerPath);
 
+    _env = env;
+    _checkpoint = checkpoint;
+    _epContextDataReadRegistration = registrationSnapshot;
+    _session = std::move(session);
     return self;
   }
   ORT_OBJC_API_IMPL_CATCH_RETURNING_NULLABLE(error)
+}
+
+- (void)dealloc {
+  // Execution providers may retain the raw callback state, so release the native session first.
+  _session.reset();
+  _epContextDataReadRegistration = nil;
 }
 
 - (nullable NSArray<ORTValue*>*)trainStepWithInputValues:(NSArray<ORTValue*>*)inputs

--- a/objectivec/test/ort_session_test.mm
+++ b/objectivec/test/ort_session_test.mm
@@ -33,6 +33,20 @@ EpContextReadRegistration GetEpContextReadRegistration(ORTSessionOptions* sessio
   return registration;
 }
 
+BOOL SetEpContextDataReadBlockCapturingObject(ORTSessionOptions* sessionOptions,
+                                              NSObject* __weak* weakCapturedObject,
+                                              NSError** error) {
+  NSObject* capturedObject = [[NSObject alloc] init];
+  *weakCapturedObject = capturedObject;
+  return [sessionOptions
+      setEpContextDataReadBlock:^NSData*(NSString* /*name*/, NSError** /*error*/) {
+        (void)capturedObject;
+        return [NSData data];
+      }
+                    maxDataSize:1
+                          error:error];
+}
+
 NSString* StatusMessage(const Ort::Status& status) {
   const std::string message = status.GetErrorMessage();
   NSString* result = [NSString stringWithUTF8String:message.c_str()];
@@ -566,20 +580,10 @@ static OrtStatus* _Nullable DummyRegisterCustomOpsFn(OrtSessionOptions* /*sessio
 
 - (void)testSessionRetainsEpContextDataReadBlockRegistration {
   ORTSessionOptions* sessionOptions = [ORTSessionTest makeSessionOptions];
-  NSObject* capturedObject = [[NSObject alloc] init];
-  NSObject* __weak weakCapturedObject = capturedObject;
-  ORTEpContextDataReadBlock __nullable block =
-      ^NSData*(NSString* /*name*/, NSError** /*error*/) {
-        (void)capturedObject;
-        return [NSData data];
-      };
+  NSObject* __weak weakCapturedObject = nil;
   NSError* err = nil;
-  BOOL result = [sessionOptions setEpContextDataReadBlock:block
-                                              maxDataSize:1
-                                                    error:&err];
+  BOOL result = SetEpContextDataReadBlockCapturingObject(sessionOptions, &weakCapturedObject, &err);
   ORTAssertBoolResultSuccessful(result, err);
-  capturedObject = nil;
-  block = nil;
   XCTAssertNotNil(weakCapturedObject);
 
   ORTSession* session = [[ORTSession alloc] initWithEnv:self.ortEnv
@@ -599,20 +603,10 @@ static OrtStatus* _Nullable DummyRegisterCustomOpsFn(OrtSessionOptions* /*sessio
 
 - (void)testFailedSessionConstructionReleasesEpContextDataReadBlockSnapshot {
   ORTSessionOptions* sessionOptions = [ORTSessionTest makeSessionOptions];
-  NSObject* capturedObject = [[NSObject alloc] init];
-  NSObject* __weak weakCapturedObject = capturedObject;
-  ORTEpContextDataReadBlock __nullable block =
-      ^NSData*(NSString* /*name*/, NSError** /*error*/) {
-        (void)capturedObject;
-        return [NSData data];
-      };
+  NSObject* __weak weakCapturedObject = nil;
   NSError* err = nil;
-  BOOL result = [sessionOptions setEpContextDataReadBlock:block
-                                              maxDataSize:1
-                                                    error:&err];
+  BOOL result = SetEpContextDataReadBlockCapturingObject(sessionOptions, &weakCapturedObject, &err);
   ORTAssertBoolResultSuccessful(result, err);
-  capturedObject = nil;
-  block = nil;
   XCTAssertNotNil(weakCapturedObject);
 
   ORTSession* session = [[ORTSession alloc] initWithEnv:self.ortEnv

--- a/objectivec/test/ort_session_test.mm
+++ b/objectivec/test/ort_session_test.mm
@@ -9,11 +9,36 @@
 #import "ort_session.h"
 #import "ort_value.h"
 
+#import "cxx_api.h"
+#import "ort_session_internal.h"
 #import "test/assertion_utils.h"
 
+#include <limits>
+#include <string>
 #include <vector>
 
 NS_ASSUME_NONNULL_BEGIN
+
+namespace {
+struct EpContextReadRegistration {
+  OrtReadNamedBufferFunc function = nullptr;
+  void* state = nullptr;
+  size_t maxDataSize = 0;
+};
+
+EpContextReadRegistration GetEpContextReadRegistration(ORTSessionOptions* sessionOptions) {
+  Ort::EpContextConfig config{[sessionOptions CXXAPIOrtSessionOptions]};
+  EpContextReadRegistration registration;
+  config.GetReadFunc(registration.function, registration.state, registration.maxDataSize);
+  return registration;
+}
+
+NSString* StatusMessage(const Ort::Status& status) {
+  const std::string message = status.GetErrorMessage();
+  NSString* result = [NSString stringWithUTF8String:message.c_str()];
+  return result ?: @"";
+}
+}  // namespace
 
 @interface ORTSessionTest : XCTestCase
 
@@ -286,6 +311,312 @@ static OrtStatus* _Nullable DummyRegisterCustomOpsFn(OrtSessionOptions* /*sessio
   ORTAssertBoolResultSuccessful(registerResult, err);
 
   XCTAssertEqual(gDummyRegisterCustomOpsFnCalled, true);
+}
+
+- (void)testEpContextDataReadBlockReturnsData {
+  ORTSessionOptions* sessionOptions = [ORTSessionTest makeSessionOptions];
+  NSData* expectedData = [@"epcontext" dataUsingEncoding:NSUTF8StringEncoding];
+  __block NSString* receivedName = nil;
+  NSError* err = nil;
+  BOOL result = [sessionOptions
+      setEpContextDataReadBlock:^NSData*(NSString* name, NSError** /*error*/) {
+        receivedName = name;
+        return expectedData;
+      }
+                    maxDataSize:1024
+                          error:&err];
+  ORTAssertBoolResultSuccessful(result, err);
+
+  const EpContextReadRegistration registration = GetEpContextReadRegistration(sessionOptions);
+  XCTAssertNotEqual(registration.function, nullptr);
+  XCTAssertNotEqual(registration.state, nullptr);
+  XCTAssertEqual(registration.maxDataSize, 1024U);
+
+  Ort::AllocatorWithDefaultOptions allocator;
+  void* buffer = reinterpret_cast<void*>(0x1);
+  size_t dataSize = 1;
+  Ort::Status status{
+      registration.function(registration.state, "model.ctx", allocator, &buffer, &dataSize)};
+  XCTAssertTrue(status.IsOK(), @"%@", StatusMessage(status));
+  XCTAssertEqualObjects(receivedName, @"model.ctx");
+  XCTAssertEqual(dataSize, expectedData.length);
+
+  NSData* actualData = [NSData dataWithBytes:buffer length:dataSize];
+  allocator.Free(buffer);
+  XCTAssertEqualObjects(actualData, expectedData);
+}
+
+- (void)testEpContextDataReadBlockAllowsEmptyData {
+  ORTSessionOptions* sessionOptions = [ORTSessionTest makeSessionOptions];
+  NSError* err = nil;
+  BOOL result = [sessionOptions
+      setEpContextDataReadBlock:^NSData*(NSString* /*name*/, NSError** /*error*/) {
+        return [NSData data];
+      }
+                    maxDataSize:1
+                          error:&err];
+  ORTAssertBoolResultSuccessful(result, err);
+
+  const EpContextReadRegistration registration = GetEpContextReadRegistration(sessionOptions);
+  Ort::AllocatorWithDefaultOptions allocator;
+  void* buffer = reinterpret_cast<void*>(0x1);
+  size_t dataSize = 1;
+  Ort::Status status{
+      registration.function(registration.state, "empty.ctx", allocator, &buffer, &dataSize)};
+  XCTAssertTrue(status.IsOK(), @"%@", StatusMessage(status));
+  XCTAssertEqual(buffer, nullptr);
+  XCTAssertEqual(dataSize, 0U);
+}
+
+- (void)testEpContextDataReadBlockRejectsInvalidAndOversizedLimits {
+  ORTSessionOptions* sessionOptions = [ORTSessionTest makeSessionOptions];
+  ORTEpContextDataReadBlock block = ^NSData*(NSString* /*name*/, NSError** /*error*/) {
+    return [@"large" dataUsingEncoding:NSUTF8StringEncoding];
+  };
+
+  NSError* err = nil;
+  XCTAssertFalse([sessionOptions setEpContextDataReadBlock:block maxDataSize:0 error:&err]);
+  XCTAssertNotNil(err);
+
+  err = nil;
+  XCTAssertFalse([sessionOptions setEpContextDataReadBlock:block maxDataSize:NSUIntegerMax error:&err]);
+  XCTAssertNotNil(err);
+
+  err = nil;
+  BOOL result = [sessionOptions setEpContextDataReadBlock:block maxDataSize:4 error:&err];
+  ORTAssertBoolResultSuccessful(result, err);
+
+  const EpContextReadRegistration registration = GetEpContextReadRegistration(sessionOptions);
+  Ort::AllocatorWithDefaultOptions allocator;
+  void* buffer = reinterpret_cast<void*>(0x1);
+  size_t dataSize = 1;
+  Ort::Status status{
+      registration.function(registration.state, "large.ctx", allocator, &buffer, &dataSize)};
+  XCTAssertFalse(status.IsOK());
+  XCTAssertEqual(status.GetErrorCode(), ORT_INVALID_ARGUMENT);
+  XCTAssertTrue([StatusMessage(status) containsString:@"exceeds maxDataSize"]);
+  XCTAssertEqual(buffer, nullptr);
+  XCTAssertEqual(dataSize, 0U);
+}
+
+- (void)testEpContextDataReadBlockPropagatesNSError {
+  ORTSessionOptions* sessionOptions = [ORTSessionTest makeSessionOptions];
+  NSError* err = nil;
+  BOOL result = [sessionOptions
+      setEpContextDataReadBlock:^NSData*(NSString* /*name*/, NSError** error) {
+        *error = [NSError errorWithDomain:@"EpContextReadTest"
+                                     code:7
+                                 userInfo:@{NSLocalizedDescriptionKey : @"read failed"}];
+        return nil;
+      }
+                    maxDataSize:1024
+                          error:&err];
+  ORTAssertBoolResultSuccessful(result, err);
+
+  const EpContextReadRegistration registration = GetEpContextReadRegistration(sessionOptions);
+  Ort::AllocatorWithDefaultOptions allocator;
+  void* buffer = reinterpret_cast<void*>(0x1);
+  size_t dataSize = 1;
+  Ort::Status status{
+      registration.function(registration.state, "error.ctx", allocator, &buffer, &dataSize)};
+  XCTAssertFalse(status.IsOK());
+  XCTAssertEqual(status.GetErrorCode(), ORT_FAIL);
+  XCTAssertTrue([StatusMessage(status) containsString:@"read failed"]);
+  XCTAssertEqual(buffer, nullptr);
+  XCTAssertEqual(dataSize, 0U);
+}
+
+- (void)testEpContextDataReadBlockRejectsNilWithoutNSError {
+  ORTSessionOptions* sessionOptions = [ORTSessionTest makeSessionOptions];
+  NSError* err = nil;
+  BOOL result = [sessionOptions
+      setEpContextDataReadBlock:^NSData*(NSString* /*name*/, NSError** /*error*/) {
+        return nil;
+      }
+                    maxDataSize:1024
+                          error:&err];
+  ORTAssertBoolResultSuccessful(result, err);
+
+  const EpContextReadRegistration registration = GetEpContextReadRegistration(sessionOptions);
+  Ort::AllocatorWithDefaultOptions allocator;
+  void* buffer = reinterpret_cast<void*>(0x1);
+  size_t dataSize = 1;
+  Ort::Status status{
+      registration.function(registration.state, "nil.ctx", allocator, &buffer, &dataSize)};
+  XCTAssertFalse(status.IsOK());
+  XCTAssertEqual(status.GetErrorCode(), ORT_FAIL);
+  XCTAssertTrue([StatusMessage(status) containsString:@"without setting an error"]);
+  XCTAssertEqual(buffer, nullptr);
+  XCTAssertEqual(dataSize, 0U);
+}
+
+- (void)testEpContextDataReadBlockRejectsInvalidData {
+  ORTSessionOptions* sessionOptions = [ORTSessionTest makeSessionOptions];
+  NSError* err = nil;
+  BOOL result = [sessionOptions
+      setEpContextDataReadBlock:^NSData*(NSString* /*name*/, NSError** /*error*/) {
+        return (NSData*)(id) @"not data";
+      }
+                    maxDataSize:1024
+                          error:&err];
+  ORTAssertBoolResultSuccessful(result, err);
+
+  const EpContextReadRegistration registration = GetEpContextReadRegistration(sessionOptions);
+  Ort::AllocatorWithDefaultOptions allocator;
+  void* buffer = reinterpret_cast<void*>(0x1);
+  size_t dataSize = 1;
+  Ort::Status status{
+      registration.function(registration.state, "invalid.ctx", allocator, &buffer, &dataSize)};
+  XCTAssertFalse(status.IsOK());
+  XCTAssertEqual(status.GetErrorCode(), ORT_INVALID_ARGUMENT);
+  XCTAssertTrue([StatusMessage(status) containsString:@"not NSData"]);
+  XCTAssertEqual(buffer, nullptr);
+  XCTAssertEqual(dataSize, 0U);
+}
+
+- (void)testEpContextDataReadBlockContainsNSException {
+  ORTSessionOptions* sessionOptions = [ORTSessionTest makeSessionOptions];
+  NSError* err = nil;
+  BOOL result = [sessionOptions
+      setEpContextDataReadBlock:^NSData*(NSString* /*name*/, NSError** /*error*/) {
+        @throw [NSException exceptionWithName:@"EpContextReadException"
+                                       reason:@"callback failed"
+                                     userInfo:nil];
+      }
+                    maxDataSize:1024
+                          error:&err];
+  ORTAssertBoolResultSuccessful(result, err);
+
+  const EpContextReadRegistration registration = GetEpContextReadRegistration(sessionOptions);
+  Ort::AllocatorWithDefaultOptions allocator;
+  void* buffer = reinterpret_cast<void*>(0x1);
+  size_t dataSize = 1;
+  Ort::Status status{
+      registration.function(registration.state, "exception.ctx", allocator, &buffer, &dataSize)};
+  XCTAssertFalse(status.IsOK());
+  XCTAssertEqual(status.GetErrorCode(), ORT_FAIL);
+  XCTAssertTrue([StatusMessage(status) containsString:@"Objective-C exception"]);
+  XCTAssertEqual(buffer, nullptr);
+  XCTAssertEqual(dataSize, 0U);
+}
+
+- (void)testEpContextDataReadBlockCanBeReplacedAndCleared {
+  ORTSessionOptions* sessionOptions = [ORTSessionTest makeSessionOptions];
+  NSError* err = nil;
+  BOOL result = [sessionOptions
+      setEpContextDataReadBlock:^NSData*(NSString* /*name*/, NSError** /*error*/) {
+        return [@"first" dataUsingEncoding:NSUTF8StringEncoding];
+      }
+                    maxDataSize:16
+                          error:&err];
+  ORTAssertBoolResultSuccessful(result, err);
+
+  err = nil;
+  result = [sessionOptions
+      setEpContextDataReadBlock:^NSData*(NSString* /*name*/, NSError** /*error*/) {
+        return [@"discarded" dataUsingEncoding:NSUTF8StringEncoding];
+      }
+                    maxDataSize:0
+                          error:&err];
+  XCTAssertFalse(result);
+  XCTAssertNotNil(err);
+
+  EpContextReadRegistration registration = GetEpContextReadRegistration(sessionOptions);
+  XCTAssertEqual(registration.maxDataSize, 16U);
+
+  Ort::AllocatorWithDefaultOptions allocator;
+  void* buffer = nullptr;
+  size_t dataSize = 0;
+  Ort::Status status{
+      registration.function(registration.state, "original.ctx", allocator, &buffer, &dataSize)};
+  XCTAssertTrue(status.IsOK(), @"%@", StatusMessage(status));
+  NSData* actualData = [NSData dataWithBytes:buffer length:dataSize];
+  allocator.Free(buffer);
+  XCTAssertEqualObjects(actualData, [@"first" dataUsingEncoding:NSUTF8StringEncoding]);
+
+  err = nil;
+  result = [sessionOptions
+      setEpContextDataReadBlock:^NSData*(NSString* /*name*/, NSError** /*error*/) {
+        return [@"second" dataUsingEncoding:NSUTF8StringEncoding];
+      }
+                    maxDataSize:8
+                          error:&err];
+  ORTAssertBoolResultSuccessful(result, err);
+
+  registration = GetEpContextReadRegistration(sessionOptions);
+  XCTAssertEqual(registration.maxDataSize, 8U);
+
+  buffer = nullptr;
+  dataSize = 0;
+  status = Ort::Status{
+      registration.function(registration.state, "replacement.ctx", allocator, &buffer, &dataSize)};
+  XCTAssertTrue(status.IsOK(), @"%@", StatusMessage(status));
+  actualData = [NSData dataWithBytes:buffer length:dataSize];
+  allocator.Free(buffer);
+  XCTAssertEqualObjects(actualData, [@"second" dataUsingEncoding:NSUTF8StringEncoding]);
+
+  result = [sessionOptions clearEpContextDataReadBlockWithError:&err];
+  ORTAssertBoolResultSuccessful(result, err);
+
+  registration = GetEpContextReadRegistration(sessionOptions);
+  XCTAssertEqual(registration.function, nullptr);
+  XCTAssertEqual(registration.state, nullptr);
+  XCTAssertEqual(registration.maxDataSize, std::numeric_limits<size_t>::max());
+}
+
+- (void)testSessionRetainsEpContextDataReadBlockRegistration {
+  ORTSessionOptions* sessionOptions = [ORTSessionTest makeSessionOptions];
+  NSObject* capturedObject = [[NSObject alloc] init];
+  NSObject* __weak weakCapturedObject = capturedObject;
+  NSError* err = nil;
+  BOOL result = [sessionOptions
+      setEpContextDataReadBlock:^NSData*(NSString* /*name*/, NSError** /*error*/) {
+        (void)capturedObject;
+        return [NSData data];
+      }
+                    maxDataSize:1
+                          error:&err];
+  ORTAssertBoolResultSuccessful(result, err);
+  capturedObject = nil;
+
+  ORTSession* session = [[ORTSession alloc] initWithEnv:self.ortEnv
+                                              modelPath:[ORTSessionTest getAddModelPath]
+                                         sessionOptions:sessionOptions
+                                                  error:&err];
+  ORTAssertNullableResultSuccessful(session, err);
+
+  result = [sessionOptions clearEpContextDataReadBlockWithError:&err];
+  ORTAssertBoolResultSuccessful(result, err);
+  sessionOptions = nil;
+  XCTAssertNotNil(weakCapturedObject);
+
+  session = nil;
+  XCTAssertNil(weakCapturedObject);
+}
+
+- (void)testFailedSessionConstructionReleasesEpContextDataReadBlockSnapshot {
+  ORTSessionOptions* sessionOptions = [ORTSessionTest makeSessionOptions];
+  NSObject* capturedObject = [[NSObject alloc] init];
+  NSObject* __weak weakCapturedObject = capturedObject;
+  NSError* err = nil;
+  BOOL result = [sessionOptions
+      setEpContextDataReadBlock:^NSData*(NSString* /*name*/, NSError** /*error*/) {
+        (void)capturedObject;
+        return [NSData data];
+      }
+                    maxDataSize:1
+                          error:&err];
+  ORTAssertBoolResultSuccessful(result, err);
+  capturedObject = nil;
+
+  ORTSession* session = [[ORTSession alloc] initWithEnv:self.ortEnv
+                                              modelPath:@"invalid/path/to/model.onnx"
+                                         sessionOptions:sessionOptions
+                                                  error:&err];
+  ORTAssertNullableResultUnsuccessful(session, err);
+
+  sessionOptions = nil;
+  XCTAssertNil(weakCapturedObject);
 }
 
 - (void)testStringInputs {

--- a/objectivec/test/ort_session_test.mm
+++ b/objectivec/test/ort_session_test.mm
@@ -566,18 +566,22 @@ static OrtStatus* _Nullable DummyRegisterCustomOpsFn(OrtSessionOptions* /*sessio
 
 - (void)testSessionRetainsEpContextDataReadBlockRegistration {
   ORTSessionOptions* sessionOptions = [ORTSessionTest makeSessionOptions];
-  NSObject* capturedObject = [[NSObject alloc] init];
-  NSObject* __weak weakCapturedObject = capturedObject;
+  NSObject* __weak weakCapturedObject = nil;
   NSError* err = nil;
-  BOOL result = [sessionOptions
-      setEpContextDataReadBlock:^NSData*(NSString* /*name*/, NSError** /*error*/) {
-        (void)capturedObject;
-        return [NSData data];
-      }
-                    maxDataSize:1
-                          error:&err];
-  ORTAssertBoolResultSuccessful(result, err);
-  capturedObject = nil;
+  BOOL result;
+  @autoreleasepool {
+    NSObject* capturedObject = [[NSObject alloc] init];
+    weakCapturedObject = capturedObject;
+    result = [sessionOptions
+        setEpContextDataReadBlock:^NSData*(NSString* /*name*/, NSError** /*error*/) {
+          (void)capturedObject;
+          return [NSData data];
+        }
+                      maxDataSize:1
+                            error:&err];
+    ORTAssertBoolResultSuccessful(result, err);
+  }
+  XCTAssertNotNil(weakCapturedObject);
 
   ORTSession* session = [[ORTSession alloc] initWithEnv:self.ortEnv
                                               modelPath:[ORTSessionTest getAddModelPath]
@@ -596,18 +600,21 @@ static OrtStatus* _Nullable DummyRegisterCustomOpsFn(OrtSessionOptions* /*sessio
 
 - (void)testFailedSessionConstructionReleasesEpContextDataReadBlockSnapshot {
   ORTSessionOptions* sessionOptions = [ORTSessionTest makeSessionOptions];
-  NSObject* capturedObject = [[NSObject alloc] init];
-  NSObject* __weak weakCapturedObject = capturedObject;
+  NSObject* __weak weakCapturedObject = nil;
   NSError* err = nil;
-  BOOL result = [sessionOptions
-      setEpContextDataReadBlock:^NSData*(NSString* /*name*/, NSError** /*error*/) {
-        (void)capturedObject;
-        return [NSData data];
-      }
-                    maxDataSize:1
-                          error:&err];
-  ORTAssertBoolResultSuccessful(result, err);
-  capturedObject = nil;
+  @autoreleasepool {
+    NSObject* capturedObject = [[NSObject alloc] init];
+    weakCapturedObject = capturedObject;
+    BOOL result = [sessionOptions
+        setEpContextDataReadBlock:^NSData*(NSString* /*name*/, NSError** /*error*/) {
+          (void)capturedObject;
+          return [NSData data];
+        }
+                      maxDataSize:1
+                            error:&err];
+    ORTAssertBoolResultSuccessful(result, err);
+  }
+  XCTAssertNotNil(weakCapturedObject);
 
   ORTSession* session = [[ORTSession alloc] initWithEnv:self.ortEnv
                                               modelPath:@"invalid/path/to/model.onnx"

--- a/objectivec/test/ort_session_test.mm
+++ b/objectivec/test/ort_session_test.mm
@@ -566,21 +566,20 @@ static OrtStatus* _Nullable DummyRegisterCustomOpsFn(OrtSessionOptions* /*sessio
 
 - (void)testSessionRetainsEpContextDataReadBlockRegistration {
   ORTSessionOptions* sessionOptions = [ORTSessionTest makeSessionOptions];
-  NSObject* __weak weakCapturedObject = nil;
+  NSObject* capturedObject = [[NSObject alloc] init];
+  NSObject* __weak weakCapturedObject = capturedObject;
+  ORTEpContextDataReadBlock __nullable block =
+      ^NSData*(NSString* /*name*/, NSError** /*error*/) {
+        (void)capturedObject;
+        return [NSData data];
+      };
   NSError* err = nil;
-  BOOL result;
-  @autoreleasepool {
-    NSObject* capturedObject = [[NSObject alloc] init];
-    weakCapturedObject = capturedObject;
-    result = [sessionOptions
-        setEpContextDataReadBlock:^NSData*(NSString* /*name*/, NSError** /*error*/) {
-          (void)capturedObject;
-          return [NSData data];
-        }
-                      maxDataSize:1
-                            error:&err];
-    ORTAssertBoolResultSuccessful(result, err);
-  }
+  BOOL result = [sessionOptions setEpContextDataReadBlock:block
+                                              maxDataSize:1
+                                                    error:&err];
+  ORTAssertBoolResultSuccessful(result, err);
+  capturedObject = nil;
+  block = nil;
   XCTAssertNotNil(weakCapturedObject);
 
   ORTSession* session = [[ORTSession alloc] initWithEnv:self.ortEnv
@@ -600,20 +599,20 @@ static OrtStatus* _Nullable DummyRegisterCustomOpsFn(OrtSessionOptions* /*sessio
 
 - (void)testFailedSessionConstructionReleasesEpContextDataReadBlockSnapshot {
   ORTSessionOptions* sessionOptions = [ORTSessionTest makeSessionOptions];
-  NSObject* __weak weakCapturedObject = nil;
+  NSObject* capturedObject = [[NSObject alloc] init];
+  NSObject* __weak weakCapturedObject = capturedObject;
+  ORTEpContextDataReadBlock __nullable block =
+      ^NSData*(NSString* /*name*/, NSError** /*error*/) {
+        (void)capturedObject;
+        return [NSData data];
+      };
   NSError* err = nil;
-  @autoreleasepool {
-    NSObject* capturedObject = [[NSObject alloc] init];
-    weakCapturedObject = capturedObject;
-    BOOL result = [sessionOptions
-        setEpContextDataReadBlock:^NSData*(NSString* /*name*/, NSError** /*error*/) {
-          (void)capturedObject;
-          return [NSData data];
-        }
-                      maxDataSize:1
-                            error:&err];
-    ORTAssertBoolResultSuccessful(result, err);
-  }
+  BOOL result = [sessionOptions setEpContextDataReadBlock:block
+                                              maxDataSize:1
+                                                    error:&err];
+  ORTAssertBoolResultSuccessful(result, err);
+  capturedObject = nil;
+  block = nil;
   XCTAssertNotNil(weakCapturedObject);
 
   ORTSession* session = [[ORTSession alloc] initWithEnv:self.ortEnv

--- a/objectivec/test/ort_session_test.mm
+++ b/objectivec/test/ort_session_test.mm
@@ -579,43 +579,47 @@ static OrtStatus* _Nullable DummyRegisterCustomOpsFn(OrtSessionOptions* /*sessio
 }
 
 - (void)testSessionRetainsEpContextDataReadBlockRegistration {
-  ORTSessionOptions* sessionOptions = [ORTSessionTest makeSessionOptions];
   NSObject* __weak weakCapturedObject = nil;
-  NSError* err = nil;
-  BOOL result = SetEpContextDataReadBlockCapturingObject(sessionOptions, &weakCapturedObject, &err);
-  ORTAssertBoolResultSuccessful(result, err);
-  XCTAssertNotNil(weakCapturedObject);
+  @autoreleasepool {
+    ORTSessionOptions* sessionOptions = [ORTSessionTest makeSessionOptions];
+    NSError* err = nil;
+    BOOL result = SetEpContextDataReadBlockCapturingObject(sessionOptions, &weakCapturedObject, &err);
+    ORTAssertBoolResultSuccessful(result, err);
+    XCTAssertNotNil(weakCapturedObject);
 
-  ORTSession* session = [[ORTSession alloc] initWithEnv:self.ortEnv
-                                              modelPath:[ORTSessionTest getAddModelPath]
-                                         sessionOptions:sessionOptions
-                                                  error:&err];
-  ORTAssertNullableResultSuccessful(session, err);
+    ORTSession* session = [[ORTSession alloc] initWithEnv:self.ortEnv
+                                                modelPath:[ORTSessionTest getAddModelPath]
+                                           sessionOptions:sessionOptions
+                                                    error:&err];
+    ORTAssertNullableResultSuccessful(session, err);
 
-  result = [sessionOptions clearEpContextDataReadBlockWithError:&err];
-  ORTAssertBoolResultSuccessful(result, err);
-  sessionOptions = nil;
-  XCTAssertNotNil(weakCapturedObject);
+    result = [sessionOptions clearEpContextDataReadBlockWithError:&err];
+    ORTAssertBoolResultSuccessful(result, err);
+    sessionOptions = nil;
+    XCTAssertNotNil(weakCapturedObject);
 
-  session = nil;
+    session = nil;
+  }
   XCTAssertNil(weakCapturedObject);
 }
 
 - (void)testFailedSessionConstructionReleasesEpContextDataReadBlockSnapshot {
-  ORTSessionOptions* sessionOptions = [ORTSessionTest makeSessionOptions];
   NSObject* __weak weakCapturedObject = nil;
-  NSError* err = nil;
-  BOOL result = SetEpContextDataReadBlockCapturingObject(sessionOptions, &weakCapturedObject, &err);
-  ORTAssertBoolResultSuccessful(result, err);
-  XCTAssertNotNil(weakCapturedObject);
+  @autoreleasepool {
+    ORTSessionOptions* sessionOptions = [ORTSessionTest makeSessionOptions];
+    NSError* err = nil;
+    BOOL result = SetEpContextDataReadBlockCapturingObject(sessionOptions, &weakCapturedObject, &err);
+    ORTAssertBoolResultSuccessful(result, err);
+    XCTAssertNotNil(weakCapturedObject);
 
-  ORTSession* session = [[ORTSession alloc] initWithEnv:self.ortEnv
-                                              modelPath:@"invalid/path/to/model.onnx"
-                                         sessionOptions:sessionOptions
-                                                  error:&err];
-  ORTAssertNullableResultUnsuccessful(session, err);
+    ORTSession* session = [[ORTSession alloc] initWithEnv:self.ortEnv
+                                                modelPath:@"invalid/path/to/model.onnx"
+                                           sessionOptions:sessionOptions
+                                                    error:&err];
+    ORTAssertNullableResultUnsuccessful(session, err);
 
-  sessionOptions = nil;
+    sessionOptions = nil;
+  }
   XCTAssertNil(weakCapturedObject);
 }
 


### PR DESCRIPTION
## Summary
- add `ORTEpContextDataReadBlock` and `ORTSessionOptions` registration/clear APIs for stable EPContext reads
- bridge callback results through the supplied ORT allocator with size limits and Objective-C/C++ exception containment
- retain atomic callback/native-options snapshots for `ORTSession` and `ORTTrainingSession` lifetimes
- add focused XCTest coverage for data, empty payloads, invalid/oversized results, errors, exceptions, replacement, clearing, and lifetime

## Validation
- `clang-format --dry-run --Werror` on all changed Objective-C/Objective-C++ files
- `git diff --check`
- high-confidence code-review pass

Objective-C compilation and XCTest execution were not available in the Windows workspace because Apple Clang, Foundation/XCTest SDKs, Xcode, and Jazzy are unavailable.