### PR TITLE
Add Rust EPContext data callbacks

### DIFF
--- a/rust/BUILD.md
+++ b/rust/BUILD.md
@@ -37,6 +37,15 @@ instead of `onnxruntime/rust/target`.
     RUST_ONNXRUNTIME_LIBRARY_PATH=<absolute path to shared library/libonnxruntime.so> CARGO_TARGET_DIR=build/rust cargo test --manifest-path rust/Cargo.toml --features model-fetching
 ```
 
+When validating against an in-tree or otherwise separate set of C headers, set
+`ORT_RUST_HEADER_LOCATION` to either `onnxruntime_c_api.h` or the include directory
+containing it. A source checkout automatically uses
+`include/onnxruntime/core/session/onnxruntime_c_api.h`; installed packages continue to use
+`<ORT_RUST_LIB_LOCATION>/include/onnxruntime/onnxruntime_c_api.h`.
+
+The download strategy reads the version from the source or vendored `VERSION_NUMBER`.
+Set `ORT_RUST_VERSION` only when neither file is available.
+
 ## cargo test with sanitizer support
 
 **If you are using a nightly Rust compiler and are on one the platforms listed in [Rust sanitizer support](https://doc.rust-lang.org/beta/unstable-book/compiler-flags/sanitizer.html).**

--- a/rust/onnxruntime-sys/build.rs
+++ b/rust/onnxruntime-sys/build.rs
@@ -12,13 +12,6 @@ use std::{
 
 use anyhow::{anyhow, Context, Result};
 
-/// ONNX Runtime version
-///
-/// WARNING: If version is changed, bindings for all platforms will have to be re-generated.
-///          To do so, run this:
-///              cargo build --package onnxruntime-sys --features generate-bindings
-const ORT_VERSION: &str = include_str!("./vendor/onnxruntime-src/VERSION_NUMBER");
-
 /// Base Url from which to download pre-built releases/
 const ORT_RELEASE_BASE_URL: &str = "https://github.com/microsoft/onnxruntime/releases/download";
 
@@ -32,6 +25,10 @@ const ORT_RUST_ENV_STRATEGY: &str = "ORT_RUST_STRATEGY";
 /// Name of environment variable that, if present, contains the location of a pre-built library.
 /// Only used if `ORT_STRATEGY=system`.
 const ORT_RUST_ENV_SYSTEM_LIB_LOCATION: &str = "ORT_RUST_LIB_LOCATION";
+/// Optional path to an ONNX Runtime source/install include directory or onnxruntime_c_api.h.
+const ORT_RUST_ENV_HEADER_LOCATION: &str = "ORT_RUST_HEADER_LOCATION";
+/// Optional ONNX Runtime release version used by the download strategy.
+const ORT_RUST_ENV_VERSION: &str = "ORT_RUST_VERSION";
 /// Name of environment variable that, if present, controls whether to use CUDA or not.
 const ORT_RUST_ENV_GPU: &str = "ORT_RUST_USE_CUDA";
 
@@ -57,14 +54,24 @@ fn main() -> Result<()> {
         "cargo:rerun-if-env-changed={}",
         ORT_RUST_ENV_SYSTEM_LIB_LOCATION
     );
+    println!(
+        "cargo:rerun-if-env-changed={}",
+        ORT_RUST_ENV_HEADER_LOCATION
+    );
+    println!("cargo:rerun-if-env-changed={}", ORT_RUST_ENV_VERSION);
 
-    generate_bindings(&include_dir);
+    generate_bindings(&include_dir)?;
     Ok(())
 }
 
-fn generate_bindings(include_dir: &Path) {
-    let clang_args = &[
+fn generate_bindings(include_dir: &Path) -> Result<()> {
+    let path = find_header(include_dir)?;
+    let header_dir = path
+        .parent()
+        .context("onnxruntime_c_api.h has no parent directory")?;
+    let clang_args = [
         format!("-I{}", include_dir.display()),
+        format!("-I{}", header_dir.display()),
         format!(
             "-I{}",
             include_dir
@@ -75,7 +82,8 @@ fn generate_bindings(include_dir: &Path) {
         ),
     ];
 
-    let path = include_dir.join("onnxruntime").join("onnxruntime_c_api.h");
+    println!("Using ONNX Runtime header: {}", path.display());
+    println!("cargo:rerun-if-changed={}", path.display());
 
     // The bindgen::Builder is the main entry point
     // to bindgen, and lets you build up options for
@@ -103,12 +111,86 @@ fn generate_bindings(include_dir: &Path) {
         // Finish the builder and generate the bindings.
         .generate()
         // Unwrap the Result and panic on failure.
-        .expect("Unable to generate bindings");
+        .context("generating ONNX Runtime bindings")?;
 
-    let generated_file = PathBuf::from(env::var("OUT_DIR").unwrap()).join("bindings.rs");
+    let generated_file =
+        PathBuf::from(env::var("OUT_DIR").context("OUT_DIR is not set")?).join("bindings.rs");
     bindings
         .write_to_file(generated_file)
-        .expect("Couldn't write bindings!");
+        .context("writing ONNX Runtime bindings")?;
+
+    Ok(())
+}
+
+fn find_header(include_dir: &Path) -> Result<PathBuf> {
+    if let Ok(location) = env::var(ORT_RUST_ENV_HEADER_LOCATION) {
+        let path = PathBuf::from(location);
+        return find_header_under(&path).with_context(|| {
+            format!(
+                "finding onnxruntime_c_api.h under {} from {}",
+                path.display(),
+                ORT_RUST_ENV_HEADER_LOCATION
+            )
+        });
+    }
+
+    let manifest_dir =
+        PathBuf::from(env::var("CARGO_MANIFEST_DIR").context("CARGO_MANIFEST_DIR is not set")?);
+    let repository_include = manifest_dir.join("../../include");
+    if let Ok(path) = find_header_under(&repository_include) {
+        return Ok(path);
+    }
+
+    find_header_under(include_dir).with_context(|| {
+        format!(
+            "finding onnxruntime_c_api.h in installed include directory {}",
+            include_dir.display()
+        )
+    })
+}
+
+fn find_header_under(path: &Path) -> Result<PathBuf> {
+    if path.is_file() {
+        return (path.file_name().and_then(|name| name.to_str()) == Some("onnxruntime_c_api.h"))
+            .then(|| path.to_path_buf())
+            .ok_or_else(|| anyhow!("header override is not onnxruntime_c_api.h"));
+    }
+
+    [
+        path.join("onnxruntime_c_api.h"),
+        path.join("onnxruntime").join("onnxruntime_c_api.h"),
+        path.join("onnxruntime")
+            .join("core")
+            .join("session")
+            .join("onnxruntime_c_api.h"),
+    ]
+    .iter()
+    .find(|candidate| candidate.is_file())
+    .cloned()
+    .ok_or_else(|| anyhow!("onnxruntime_c_api.h was not found"))
+}
+
+fn ort_version() -> Result<String> {
+    if let Ok(version) = env::var(ORT_RUST_ENV_VERSION) {
+        return Ok(version);
+    }
+
+    let manifest_dir =
+        PathBuf::from(env::var("CARGO_MANIFEST_DIR").context("CARGO_MANIFEST_DIR is not set")?);
+    for path in [
+        manifest_dir.join("../../VERSION_NUMBER"),
+        manifest_dir.join("vendor/onnxruntime-src/VERSION_NUMBER"),
+    ] {
+        if let Ok(version) = fs::read_to_string(&path) {
+            println!("cargo:rerun-if-changed={}", path.display());
+            return Ok(version.trim().to_owned());
+        }
+    }
+
+    Err(anyhow!(
+        "ONNX Runtime version was not found; set {} explicitly",
+        ORT_RUST_ENV_VERSION
+    ))
 }
 
 fn download<P>(source_url: &str, target_file: P)
@@ -335,7 +417,7 @@ impl OnnxPrebuiltArchive for Triplet {
     }
 }
 
-fn prebuilt_archive_url() -> (PathBuf, String) {
+fn prebuilt_archive_url() -> Result<(PathBuf, String)> {
     let triplet = Triplet {
         os: env::var("CARGO_CFG_TARGET_OS")
             .expect("Unable to get TARGET_OS")
@@ -350,27 +432,29 @@ fn prebuilt_archive_url() -> (PathBuf, String) {
             .parse()
             .unwrap(),
     };
+    let ort_version = ort_version()?;
 
     let prebuilt_archive = format!(
         "onnxruntime-{}-{}.{}",
         triplet.as_onnx_str(),
-        ORT_VERSION,
+        ort_version,
         triplet.os.archive_extension()
     );
     let prebuilt_url = format!(
         "{}/v{}/{}",
-        ORT_RELEASE_BASE_URL, ORT_VERSION, prebuilt_archive
+        ORT_RELEASE_BASE_URL, ort_version, prebuilt_archive
     );
 
-    (PathBuf::from(prebuilt_archive), prebuilt_url)
+    Ok((PathBuf::from(prebuilt_archive), prebuilt_url))
 }
 
-fn prepare_libort_dir_prebuilt() -> PathBuf {
-    let (prebuilt_archive, prebuilt_url) = prebuilt_archive_url();
+fn prepare_libort_dir_prebuilt() -> Result<PathBuf> {
+    let (prebuilt_archive, prebuilt_url) = prebuilt_archive_url()?;
 
     let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
     let extract_dir = out_dir.join(ORT_PREBUILT_EXTRACT_DIR);
     let downloaded_file = out_dir.join(&prebuilt_archive);
+    let extracted_dir = extract_dir.join(prebuilt_archive.file_stem().unwrap());
 
     println!("cargo:rerun-if-changed={}", downloaded_file.display());
 
@@ -386,12 +470,12 @@ fn prepare_libort_dir_prebuilt() -> PathBuf {
         download(&prebuilt_url, &downloaded_file);
     }
 
-    if !extract_dir.exists() {
+    if !extracted_dir.exists() {
         println!("Extracting to {}...", extract_dir.display());
         extract_archive(&downloaded_file, &extract_dir);
     }
 
-    extract_dir.join(prebuilt_archive.file_stem().unwrap())
+    Ok(extracted_dir)
 }
 
 fn prepare_libort_dir() -> Result<PathBuf> {
@@ -401,7 +485,7 @@ fn prepare_libort_dir() -> Result<PathBuf> {
         strategy.as_ref().map_or_else(|_| "unknown", String::as_str)
     );
     match strategy.as_ref().map(String::as_str) {
-        Ok("download") => Ok(prepare_libort_dir_prebuilt()),
+        Ok("download") => prepare_libort_dir_prebuilt(),
         Ok("system") => {
             let location = env::var(ORT_RUST_ENV_SYSTEM_LIB_LOCATION).context(format!(
                 "Could not get value of environment variable {:?}",

--- a/rust/onnxruntime/src/environment.rs
+++ b/rust/onnxruntime/src/environment.rs
@@ -1,7 +1,7 @@
 //! Module containing environment types
 
 use crate::{
-    error::{status_to_result, OrtError, Result},
+    error::{status_to_result_with_api, OrtError, Result},
     onnxruntime::custom_logger,
     session::SessionBuilder,
     LoggingLevel,
@@ -33,6 +33,30 @@ impl _EnvironmentSingleton {
     pub(crate) unsafe fn api(&self) -> sys::OrtApi {
         *self.api
     }
+}
+
+fn ensure_api_available(api: *const sys::OrtApi) -> Result<*const sys::OrtApi> {
+    if api.is_null() {
+        Err(OrtError::UnsupportedApiVersion {
+            requested: ORT_API_VERSION,
+        })
+    } else {
+        Ok(api)
+    }
+}
+
+unsafe fn get_api(lib: &onnxruntime) -> Result<*const sys::OrtApi> {
+    let api_base = lib.OrtGetApiBase();
+    if api_base.is_null() {
+        return Err(OrtError::UnsupportedApiVersion {
+            requested: ORT_API_VERSION,
+        });
+    }
+
+    let get_api = (*api_base).GetApi.ok_or(OrtError::UnsupportedApiVersion {
+        requested: ORT_API_VERSION,
+    })?;
+    ensure_api_available(get_api(ORT_API_VERSION))
 }
 
 unsafe impl Send for _EnvironmentSingleton {}
@@ -126,7 +150,7 @@ impl Environment {
         let env = ENV.get_or_try_init(|| {
             debug!("Environment not yet initialized, creating a new one.");
 
-            let api = unsafe { (*lib.OrtGetApiBase()).GetApi.unwrap()(ORT_API_VERSION) };
+            let api = unsafe { get_api(lib)? };
 
             let mut env_ptr: *mut sys::OrtEnv = std::ptr::null_mut();
 
@@ -145,7 +169,7 @@ impl Environment {
                     &mut env_ptr,
                 );
 
-                status_to_result(status).map_err(OrtError::Environment)?;
+                status_to_result_with_api(status, api).map_err(OrtError::Environment)?;
             }
             debug!(
                 env_ptr = format!("{:?}", env_ptr).as_str(),
@@ -164,7 +188,7 @@ impl Environment {
         if guard.env_ptr.is_null() || guard.api.is_null() {
             debug!("Environment not yet initialized, creating a new one.");
 
-            let api = unsafe { (*lib.OrtGetApiBase()).GetApi.unwrap()(ORT_API_VERSION) };
+            let api = unsafe { get_api(lib)? };
 
             let mut env_ptr: *mut sys::OrtEnv = std::ptr::null_mut();
 
@@ -183,7 +207,7 @@ impl Environment {
                     &mut env_ptr,
                 );
 
-                status_to_result(status).map_err(OrtError::Environment)?;
+                status_to_result_with_api(status, api).map_err(OrtError::Environment)?;
             }
             debug!(
                 env_ptr = format!("{:?}", env_ptr).as_str(),
@@ -290,6 +314,17 @@ pub(crate) mod tests {
     use test_log::test;
 
     pub(crate) static ONNX_RUNTIME_LIBRARY_PATH: &str = "RUST_ONNXRUNTIME_LIBRARY_PATH";
+
+    #[test]
+    fn null_api_is_reported_as_version_mismatch() {
+        let error = ensure_api_available(std::ptr::null()).unwrap_err();
+        assert!(matches!(
+            error,
+            OrtError::UnsupportedApiVersion {
+                requested: ORT_API_VERSION
+            }
+        ));
+    }
 
     #[test]
     fn sequential_environment_creation() {

--- a/rust/onnxruntime/src/error.rs
+++ b/rust/onnxruntime/src/error.rs
@@ -18,6 +18,12 @@ pub enum OrtError {
     /// For errors with libloading
     #[error("Failed to load or call onnxruntime library {0}")]
     Library(#[from] libloading::Error),
+    /// The loaded ONNX Runtime library does not provide the C API version used by these bindings.
+    #[error("Loaded ONNX Runtime does not support C API version {requested}")]
+    UnsupportedApiVersion {
+        /// C API version requested by the generated bindings.
+        requested: u32,
+    },
     /// The C API can message to the caller using a C `char *` which needs to be converted
     /// to Rust's `String`. This operation can fail.
     #[error("Failed to construct String")]
@@ -138,6 +144,21 @@ pub enum OrtError {
     IsTensorCheck,
 }
 
+/// Error returned by an EPContext data read callback.
+///
+/// Callback errors are returned to ONNX Runtime and stop session initialization. They never
+/// cause ONNX Runtime to fall back to reading the requested data from disk.
+#[non_exhaustive]
+#[derive(Error, Debug, Clone, PartialEq, Eq)]
+pub enum EpContextDataCallbackError {
+    /// The requested data name or callback input is invalid.
+    #[error("Invalid EPContext data request: {0}")]
+    InvalidArgument(String),
+    /// The callback could not provide the requested data.
+    #[error("Failed to read EPContext data: {0}")]
+    Fail(String),
+}
+
 /// Error used when dimensions of input (from model and from inference call)
 /// do not match (as they should).
 #[non_exhaustive]
@@ -256,6 +277,26 @@ pub(crate) fn status_to_result(
 ) -> std::result::Result<(), OrtApiError> {
     let status_wrapper: OrtStatusWrapper = status.into();
     status_wrapper.into()
+}
+
+pub(crate) fn status_to_result_with_api(
+    status: *const sys::OrtStatus,
+    api: *const sys::OrtApi,
+) -> std::result::Result<(), OrtApiError> {
+    if status.is_null() {
+        return Ok(());
+    }
+
+    let raw = unsafe { (*api).GetErrorMessage.unwrap()(status) };
+    let result = match char_p_to_string(raw) {
+        Ok(message) => Err(OrtApiError::Msg(message)),
+        Err(OrtError::StringConversion(OrtApiError::IntoStringError(error))) => {
+            Err(OrtApiError::IntoStringError(error))
+        }
+        Err(error) => Err(OrtApiError::Msg(error.to_string())),
+    };
+    unsafe { (*api).ReleaseStatus.unwrap()(status as *mut sys::OrtStatus) };
+    result
 }
 
 /// A wrapper around a function on `OrtApi` that maps the status code into [`OrtApiError`]

--- a/rust/onnxruntime/src/lib.rs
+++ b/rust/onnxruntime/src/lib.rs
@@ -181,7 +181,7 @@ pub mod session;
 pub mod tensor;
 
 // Re-export
-pub use error::{OrtApiError, OrtError, Result};
+pub use error::{EpContextDataCallbackError, OrtApiError, OrtError, Result};
 use sys::OnnxEnumInt;
 
 // Re-export ndarray as it's part of the public API anyway
@@ -341,7 +341,7 @@ pub enum GraphOptimizationLevel {
 
 impl From<GraphOptimizationLevel> for sys::GraphOptimizationLevel {
     fn from(val: GraphOptimizationLevel) -> Self {
-        use GraphOptimizationLevel::{All, Basic, DisableAll, Extended};
+        use GraphOptimizationLevel::{All, Basic, DisableAll, Extended, Layout};
         match val {
             DisableAll => sys::GraphOptimizationLevel::ORT_DISABLE_ALL,
             Basic => sys::GraphOptimizationLevel::ORT_ENABLE_BASIC,

--- a/rust/onnxruntime/src/memory.rs
+++ b/rust/onnxruntime/src/memory.rs
@@ -3,7 +3,7 @@ use tracing::debug;
 use onnxruntime_sys as sys;
 
 use crate::{
-    environment::{Environment, _Environment},
+    environment::{_Environment, Environment},
     error::{assert_not_null_pointer, status_to_result, OrtError, Result},
     AllocatorType, MemType,
 };

--- a/rust/onnxruntime/src/session.rs
+++ b/rust/onnxruntime/src/session.rs
@@ -243,8 +243,12 @@ extern_system_fn! {
         })) {
             Ok(status) => status,
             Err(payload) => {
-                // A user-provided panic payload may itself panic when dropped.
-                std::mem::forget(payload);
+                if let Err(drop_panic) =
+                    catch_unwind(AssertUnwindSafe(|| drop(payload)))
+                {
+                    // A user-provided panic payload may itself panic when dropped.
+                    std::mem::forget(drop_panic);
+                }
                 if !buffer.is_null() {
                     *buffer = ptr::null_mut();
                 }
@@ -1160,17 +1164,21 @@ mod tests {
         }
     }
 
-    struct PanicOnDrop;
+    struct CountedPanicPayload(Arc<AtomicUsize>);
 
-    impl Drop for PanicOnDrop {
+    impl Drop for CountedPanicPayload {
         fn drop(&mut self) {
-            panic!("panic payload drop");
+            self.0.fetch_add(1, Ordering::SeqCst);
         }
     }
 
     #[test]
-    fn trampoline_does_not_drop_panicking_panic_payload() {
-        let registration = test_registration(16, |_| std::panic::panic_any(PanicOnDrop));
+    fn trampoline_drops_owned_panic_payload() {
+        let drop_count = Arc::new(AtomicUsize::new(0));
+        let callback_drop_count = Arc::clone(&drop_count);
+        let registration = test_registration(16, move |_| {
+            std::panic::panic_any(CountedPanicPayload(Arc::clone(&callback_drop_count)))
+        });
         let allocator = default_allocator();
 
         unsafe {
@@ -1185,6 +1193,40 @@ mod tests {
             assert_eq!(code, sys::OrtErrorCode::ORT_FAIL);
             assert_eq!(message, "Rust EPContext data callback panicked");
         }
+        assert_eq!(drop_count.load(Ordering::SeqCst), 1);
+    }
+
+    struct PanicOnDrop(Arc<AtomicUsize>);
+
+    impl Drop for PanicOnDrop {
+        fn drop(&mut self) {
+            self.0.fetch_add(1, Ordering::SeqCst);
+            panic!("panic payload drop");
+        }
+    }
+
+    #[test]
+    fn trampoline_contains_panicking_panic_payload_destructor() {
+        let drop_count = Arc::new(AtomicUsize::new(0));
+        let callback_drop_count = Arc::clone(&drop_count);
+        let registration = test_registration(16, move |_| {
+            std::panic::panic_any(PanicOnDrop(Arc::clone(&callback_drop_count)))
+        });
+        let allocator = default_allocator();
+
+        unsafe {
+            let (status, buffer, data_size) = invoke(
+                &registration,
+                CStr::from_bytes_with_nul(b"panic\0").unwrap(),
+                allocator,
+            );
+            assert!(buffer.is_null());
+            assert_eq!(data_size, 0);
+            let (code, message) = take_status(status);
+            assert_eq!(code, sys::OrtErrorCode::ORT_FAIL);
+            assert_eq!(message, "Rust EPContext data callback panicked");
+        }
+        assert_eq!(drop_count.load(Ordering::SeqCst), 1);
     }
 
     #[repr(C)]

--- a/rust/onnxruntime/src/session.rs
+++ b/rust/onnxruntime/src/session.rs
@@ -1,6 +1,15 @@
 //! Module containing session types
 
-use std::{convert::TryFrom, ffi::CString, fmt::Debug, path::Path};
+use std::{
+    convert::TryFrom,
+    ffi::{CStr, CString},
+    fmt::Debug,
+    os::raw::{c_char, c_void},
+    panic::{catch_unwind, AssertUnwindSafe},
+    path::Path,
+    ptr,
+    sync::Arc,
+};
 
 #[cfg(not(target_family = "windows"))]
 use std::os::unix::ffi::OsStrExt;
@@ -12,10 +21,10 @@ use std::env;
 
 use crate::{
     char_p_to_string,
-    environment::{Environment, _Environment},
+    environment::{_Environment, Environment},
     error::{
-        assert_not_null_pointer, assert_null_pointer, status_to_result, NonMatchingDimensionsError,
-        OrtApiError, OrtError, Result,
+        assert_not_null_pointer, assert_null_pointer, status_to_result, status_to_result_with_api,
+        EpContextDataCallbackError, NonMatchingDimensionsError, OrtApiError, OrtError, Result,
     },
     memory::MemoryInfo,
     tensor::{
@@ -25,12 +34,238 @@ use crate::{
     },
     AllocatorType, GraphOptimizationLevel, MemType, TensorElementDataType,
 };
+use once_cell::sync::OnceCell;
 use onnxruntime_sys as sys;
 
 use tracing::{debug, error};
 
 #[cfg(feature = "model-fetching")]
 use crate::{download::AvailableOnnxModel, error::OrtDownloadError};
+
+type CreateStatusFn = extern_system_fn! {
+    unsafe fn(sys::OrtErrorCode, *const c_char) -> *mut sys::OrtStatus
+};
+type ReleaseSessionFn = extern_system_fn! {
+    unsafe fn(*mut sys::OrtSession)
+};
+type ReleaseEpContextDataReadOptionsFn = extern_system_fn! {
+    unsafe fn(*mut sys::OrtEpContextDataReadOptions)
+};
+
+struct SessionPointerGuard {
+    session_ptr: *mut sys::OrtSession,
+    release_session: ReleaseSessionFn,
+}
+
+impl SessionPointerGuard {
+    fn into_raw(mut self) -> *mut sys::OrtSession {
+        let session_ptr = self.session_ptr;
+        self.session_ptr = ptr::null_mut();
+        session_ptr
+    }
+}
+
+impl Drop for SessionPointerGuard {
+    fn drop(&mut self) {
+        if !self.session_ptr.is_null() {
+            unsafe { (self.release_session)(self.session_ptr) };
+        }
+    }
+}
+
+struct EpContextDataReadOptionsGuard {
+    read_options: *mut sys::OrtEpContextDataReadOptions,
+    release_options: ReleaseEpContextDataReadOptionsFn,
+}
+
+impl Drop for EpContextDataReadOptionsGuard {
+    fn drop(&mut self) {
+        unsafe { (self.release_options)(self.read_options) };
+    }
+}
+
+struct EpContextDataReadRegistration {
+    callback:
+        Box<dyn Fn(&str) -> std::result::Result<Vec<u8>, EpContextDataCallbackError> + Send + Sync>,
+    create_status: CreateStatusFn,
+    max_data_size: usize,
+}
+
+impl Debug for EpContextDataReadRegistration {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("EpContextDataReadRegistration")
+            .field("max_data_size", &self.max_data_size)
+            .finish_non_exhaustive()
+    }
+}
+
+const CALLBACK_PANICKED: &[u8] = b"Rust EPContext data callback panicked\0";
+const CALLBACK_STATE_NULL: &[u8] = b"EPContext callback state must not be null\0";
+static EP_CONTEXT_CREATE_STATUS: OnceCell<CreateStatusFn> = OnceCell::new();
+
+fn static_callback_status(code: sys::OrtErrorCode, message: &'static [u8]) -> *mut sys::OrtStatus {
+    match EP_CONTEXT_CREATE_STATUS.get() {
+        Some(create_status) => unsafe { create_status(code, message.as_ptr().cast()) },
+        None => ptr::null_mut(),
+    }
+}
+
+fn callback_status(
+    registration: &EpContextDataReadRegistration,
+    code: sys::OrtErrorCode,
+    message: &str,
+) -> *mut sys::OrtStatus {
+    let mut sanitized = Vec::with_capacity(message.len() + 1);
+    sanitized.extend(
+        message
+            .bytes()
+            .map(|byte| if byte == 0 { b'?' } else { byte }),
+    );
+    sanitized.push(0);
+    unsafe { (registration.create_status)(code, sanitized.as_ptr().cast()) }
+}
+
+unsafe fn ep_context_data_read_callback_impl(
+    state: *mut c_void,
+    name: *const c_char,
+    allocator: *mut sys::OrtAllocator,
+    buffer: *mut *mut c_void,
+    data_size: *mut usize,
+) -> *mut sys::OrtStatus {
+    if !buffer.is_null() {
+        *buffer = ptr::null_mut();
+    }
+    if !data_size.is_null() {
+        *data_size = 0;
+    }
+
+    if state.is_null() {
+        return static_callback_status(
+            sys::OrtErrorCode::ORT_INVALID_ARGUMENT,
+            CALLBACK_STATE_NULL,
+        );
+    }
+    let registration = &*state.cast::<EpContextDataReadRegistration>();
+
+    if buffer.is_null() || data_size.is_null() {
+        return callback_status(
+            registration,
+            sys::OrtErrorCode::ORT_INVALID_ARGUMENT,
+            "EPContext callback output pointers must not be null",
+        );
+    }
+    if name.is_null() {
+        return callback_status(
+            registration,
+            sys::OrtErrorCode::ORT_INVALID_ARGUMENT,
+            "EPContext data name must not be null",
+        );
+    }
+    if allocator.is_null() {
+        return callback_status(
+            registration,
+            sys::OrtErrorCode::ORT_INVALID_ARGUMENT,
+            "EPContext callback allocator must not be null",
+        );
+    }
+    let alloc = match (*allocator).Alloc {
+        Some(alloc) => alloc,
+        None => {
+            return callback_status(
+                registration,
+                sys::OrtErrorCode::ORT_INVALID_ARGUMENT,
+                "EPContext callback allocator has no allocation function",
+            )
+        }
+    };
+    let name = match CStr::from_ptr(name).to_str() {
+        Ok(name) => name,
+        Err(_) => {
+            return callback_status(
+                registration,
+                sys::OrtErrorCode::ORT_INVALID_ARGUMENT,
+                "EPContext data name is not valid UTF-8",
+            )
+        }
+    };
+
+    let data = match (registration.callback)(name) {
+        Ok(data) => data,
+        Err(EpContextDataCallbackError::InvalidArgument(message)) => {
+            return callback_status(
+                registration,
+                sys::OrtErrorCode::ORT_INVALID_ARGUMENT,
+                &message,
+            )
+        }
+        Err(EpContextDataCallbackError::Fail(message)) => {
+            return callback_status(registration, sys::OrtErrorCode::ORT_FAIL, &message)
+        }
+    };
+
+    if data.len() > registration.max_data_size {
+        return callback_status(
+            registration,
+            sys::OrtErrorCode::ORT_INVALID_ARGUMENT,
+            "EPContext callback data exceeds the configured maximum size",
+        );
+    }
+    if data.is_empty() {
+        return ptr::null_mut();
+    }
+
+    let output = alloc(allocator, data.len());
+    if output.is_null() {
+        return callback_status(
+            registration,
+            sys::OrtErrorCode::ORT_FAIL,
+            "EPContext callback allocator failed",
+        );
+    }
+
+    ptr::copy_nonoverlapping(data.as_ptr(), output.cast(), data.len());
+    *buffer = output;
+    *data_size = data.len();
+    ptr::null_mut()
+}
+
+extern_system_fn! {
+    unsafe fn ep_context_data_read_callback(
+        state: *mut c_void,
+        name: *const c_char,
+        allocator: *mut sys::OrtAllocator,
+        buffer: *mut *mut c_void,
+        data_size: *mut usize,
+    ) -> *mut sys::OrtStatus {
+        match catch_unwind(AssertUnwindSafe(|| {
+            ep_context_data_read_callback_impl(state, name, allocator, buffer, data_size)
+        })) {
+            Ok(status) => status,
+            Err(payload) => {
+                // A user-provided panic payload may itself panic when dropped.
+                std::mem::forget(payload);
+                if !buffer.is_null() {
+                    *buffer = ptr::null_mut();
+                }
+                if !data_size.is_null() {
+                    *data_size = 0;
+                }
+                if state.is_null() {
+                    return static_callback_status(
+                        sys::OrtErrorCode::ORT_FAIL,
+                        CALLBACK_PANICKED,
+                    );
+                }
+                let registration = &*state.cast::<EpContextDataReadRegistration>();
+                (registration.create_status)(
+                    sys::OrtErrorCode::ORT_FAIL,
+                    CALLBACK_PANICKED.as_ptr().cast(),
+                )
+            }
+        }
+    }
+}
 
 /// Type used to create a session using the _builder pattern_
 ///
@@ -78,6 +313,8 @@ pub struct SessionBuilder<'a> {
 
     allocator: AllocatorType,
     memory_type: MemType,
+    // SessionBuilder::drop releases native options before this strong reference is dropped.
+    ep_context_data_read_registration: Option<Arc<EpContextDataReadRegistration>>,
 }
 
 impl<'a> Drop for SessionBuilder<'a> {
@@ -109,6 +346,7 @@ impl<'a> SessionBuilder<'a> {
             session_options_ptr,
             allocator: AllocatorType::Arena,
             memory_type: MemType::Default,
+            ep_context_data_read_registration: None,
         })
     }
 
@@ -158,6 +396,121 @@ impl<'a> SessionBuilder<'a> {
     /// Defaults to [`MemType::Default`](../enum.MemType.html#variant.Default)
     pub fn with_memory_type(mut self, memory_type: MemType) -> Result<SessionBuilder<'a>> {
         self.memory_type = memory_type;
+        Ok(self)
+    }
+
+    /// Register a callback that supplies external EPContext data by logical name.
+    ///
+    /// ONNX Runtime may call the callback concurrently from different execution-provider
+    /// instances or worker threads. The callback must therefore be [`Send`] and [`Sync`].
+    /// The returned [`Vec`] is copied into memory allocated by ONNX Runtime; the vector may be
+    /// dropped as soon as the callback returns. Callback failures stop session initialization
+    /// and do not fall back to reading from disk.
+    /// [`EpContextDataCallbackError::InvalidArgument`] maps to `ORT_INVALID_ARGUMENT`;
+    /// [`EpContextDataCallbackError::Fail`] and callback panics map to `ORT_FAIL`.
+    ///
+    /// `max_data_size` must be greater than zero and less than [`usize::MAX`]. The callback and
+    /// its captured state remain alive for the builder and every successfully created
+    /// [`Session`]. Calling this method again replaces the previous callback only after native
+    /// registration succeeds.
+    ///
+    /// This API reads data referenced by EPContext models. The Rust bindings do not currently
+    /// expose model compilation or an EPContext data write callback.
+    ///
+    /// Available since ONNX Runtime 1.30.
+    pub fn with_ep_context_data_read_callback<F>(
+        mut self,
+        max_data_size: usize,
+        callback: F,
+    ) -> Result<SessionBuilder<'a>>
+    where
+        F: Fn(&str) -> std::result::Result<Vec<u8>, EpContextDataCallbackError>
+            + Send
+            + Sync
+            + 'static,
+    {
+        if max_data_size == 0 || max_data_size == usize::MAX {
+            return Err(OrtError::SessionOptions(OrtApiError::Msg(
+                "EPContext callback maximum data size must be greater than zero and less than usize::MAX"
+                    .to_owned(),
+            )));
+        }
+
+        let api = unsafe { self.env.env().api() };
+        let create_status = api.CreateStatus.ok_or_else(|| {
+            OrtError::SessionOptions(OrtApiError::Msg(
+                "ONNX Runtime CreateStatus function is unavailable".to_owned(),
+            ))
+        })?;
+        let registration = Arc::new(EpContextDataReadRegistration {
+            callback: Box::new(callback),
+            create_status,
+            max_data_size,
+        });
+        let _ = EP_CONTEXT_CREATE_STATUS.set(create_status);
+        let read_func: sys::OrtReadNamedBufferFunc = Some(ep_context_data_read_callback);
+        let state = Arc::as_ptr(&registration) as *mut c_void;
+
+        let create_options = api.CreateEpContextDataReadOptions.ok_or_else(|| {
+            OrtError::SessionOptions(OrtApiError::Msg(
+                "ONNX Runtime EPContext read options API is unavailable".to_owned(),
+            ))
+        })?;
+        let release_options = api.ReleaseEpContextDataReadOptions.ok_or_else(|| {
+            OrtError::SessionOptions(OrtApiError::Msg(
+                "ONNX Runtime EPContext read options release API is unavailable".to_owned(),
+            ))
+        })?;
+        let set_max_data_size = api.EpContextDataReadOptionsSetMaxDataSize.ok_or_else(|| {
+            OrtError::SessionOptions(OrtApiError::Msg(
+                "ONNX Runtime EPContext maximum data size API is unavailable".to_owned(),
+            ))
+        })?;
+        let set_read_func = api.SessionOptionsSetEpContextDataReadFunc.ok_or_else(|| {
+            OrtError::SessionOptions(OrtApiError::Msg(
+                "ONNX Runtime EPContext read callback API is unavailable".to_owned(),
+            ))
+        })?;
+
+        let mut read_options = EpContextDataReadOptionsGuard {
+            read_options: ptr::null_mut(),
+            release_options,
+        };
+        let status = unsafe { create_options(&mut read_options.read_options) };
+        status_to_result_with_api(status, &api).map_err(OrtError::SessionOptions)?;
+
+        let status = unsafe { set_max_data_size(read_options.read_options, max_data_size) };
+        status_to_result_with_api(status, &api).map_err(OrtError::SessionOptions)?;
+
+        let status = unsafe {
+            set_read_func(
+                self.session_options_ptr,
+                read_func,
+                state,
+                read_options.read_options,
+            )
+        };
+        status_to_result_with_api(status, &api).map_err(OrtError::SessionOptions)?;
+
+        self.ep_context_data_read_registration = Some(registration);
+        Ok(self)
+    }
+
+    /// Clear a previously registered EPContext data read callback.
+    ///
+    /// The old callback state is dropped only after ONNX Runtime has successfully cleared the
+    /// native registration. Available since ONNX Runtime 1.30.
+    pub fn without_ep_context_data_read_callback(mut self) -> Result<SessionBuilder<'a>> {
+        let api = unsafe { self.env.env().api() };
+        let set_read_func = api.SessionOptionsSetEpContextDataReadFunc.ok_or_else(|| {
+            OrtError::SessionOptions(OrtApiError::Msg(
+                "ONNX Runtime EPContext read callback API is unavailable".to_owned(),
+            ))
+        })?;
+        let status =
+            unsafe { set_read_func(self.session_options_ptr, None, ptr::null_mut(), ptr::null()) };
+        status_to_result_with_api(status, &api).map_err(OrtError::SessionOptions)?;
+        self.ep_context_data_read_registration = None;
         Ok(self)
     }
 
@@ -223,6 +576,10 @@ impl<'a> SessionBuilder<'a> {
             assert_null_pointer(status, "SessionStatus")?;
             assert_not_null_pointer(session_ptr, "Session")?;
         };
+        let session_guard = SessionPointerGuard {
+            session_ptr,
+            release_session: unsafe { self.env.env().api().ReleaseSession.unwrap() },
+        };
         let mut allocator_ptr: *mut sys::OrtAllocator = std::ptr::null_mut();
         let status = unsafe {
             self.env.env().api().GetAllocatorWithDefaultOptions.unwrap()(&mut allocator_ptr)
@@ -251,9 +608,10 @@ impl<'a> SessionBuilder<'a> {
 
             Ok(Session {
                 env: self.env.env.clone(),
-                session_ptr,
+                session_ptr: session_guard.into_raw(),
                 allocator_ptr,
                 memory_info,
+                _ep_context_data_read_registration: self.ep_context_data_read_registration.clone(),
                 inputs,
                 outputs,
             })
@@ -287,6 +645,10 @@ impl<'a> SessionBuilder<'a> {
             assert_null_pointer(status, "SessionStatus")?;
             assert_not_null_pointer(session_ptr, "Session")?;
         };
+        let session_guard = SessionPointerGuard {
+            session_ptr,
+            release_session: unsafe { self.env.env().api().ReleaseSession.unwrap() },
+        };
         let mut allocator_ptr: *mut sys::OrtAllocator = std::ptr::null_mut();
         let status = unsafe {
             self.env.env().api().GetAllocatorWithDefaultOptions.unwrap()(&mut allocator_ptr)
@@ -315,9 +677,10 @@ impl<'a> SessionBuilder<'a> {
 
             Ok(Session {
                 env: self.env.env.clone(),
-                session_ptr,
+                session_ptr: session_guard.into_raw(),
                 allocator_ptr,
                 memory_info,
+                _ep_context_data_read_registration: self.ep_context_data_read_registration.clone(),
                 inputs,
                 outputs,
             })
@@ -332,6 +695,8 @@ pub struct Session {
     session_ptr: *mut sys::OrtSession,
     allocator_ptr: *mut sys::OrtAllocator,
     memory_info: MemoryInfo,
+    // Dropped after Drop::drop releases the native session.
+    _ep_context_data_read_registration: Option<Arc<EpContextDataReadRegistration>>,
     /// Information about the ONNX's inputs as stored in loaded file
     pub inputs: Vec<Input>,
     /// Information about the ONNX's outputs as stored in loaded file
@@ -626,6 +991,529 @@ unsafe fn get_tensor_dimensions(
     );
     status_to_result(status).map_err(OrtError::GetDimensions)?;
     Ok(node_dims)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{environment::tests::ONNX_RUNTIME_LIBRARY_PATH, LoggingLevel};
+    use std::{
+        env::var,
+        sync::{
+            atomic::{AtomicUsize, Ordering},
+            Mutex, Weak,
+        },
+        thread,
+    };
+
+    static TEST_ENVIRONMENT: OnceCell<Environment> = OnceCell::new();
+
+    fn test_environment() -> &'static Environment {
+        TEST_ENVIRONMENT.get_or_init(|| {
+            let builder = Environment::builder()
+                .with_name("ep_context_data_callback_tests")
+                .with_log_level(LoggingLevel::Warning);
+            match var(ONNX_RUNTIME_LIBRARY_PATH) {
+                Ok(path) => builder.with_library_path(path).build().unwrap(),
+                Err(_) => builder.build().unwrap(),
+            }
+        })
+    }
+
+    fn test_registration<F>(max_data_size: usize, callback: F) -> Arc<EpContextDataReadRegistration>
+    where
+        F: Fn(&str) -> std::result::Result<Vec<u8>, EpContextDataCallbackError>
+            + Send
+            + Sync
+            + 'static,
+    {
+        let create_status = unsafe { test_environment().env().api().CreateStatus.unwrap() };
+        let _ = EP_CONTEXT_CREATE_STATUS.set(create_status);
+        Arc::new(EpContextDataReadRegistration {
+            callback: Box::new(callback),
+            create_status,
+            max_data_size,
+        })
+    }
+
+    fn default_allocator() -> *mut sys::OrtAllocator {
+        let mut allocator = ptr::null_mut();
+        let api = unsafe { test_environment().env().api() };
+        let status = unsafe { api.GetAllocatorWithDefaultOptions.unwrap()(&mut allocator) };
+        status_to_result(status).unwrap();
+        assert!(!allocator.is_null());
+        allocator
+    }
+
+    unsafe fn take_status(status: *mut sys::OrtStatus) -> (sys::OrtErrorCode, String) {
+        assert!(!status.is_null());
+        let api = test_environment().env().api();
+        let code = api.GetErrorCode.unwrap()(status);
+        let message = CStr::from_ptr(api.GetErrorMessage.unwrap()(status))
+            .to_string_lossy()
+            .into_owned();
+        api.ReleaseStatus.unwrap()(status);
+        (code, message)
+    }
+
+    unsafe fn invoke(
+        registration: &Arc<EpContextDataReadRegistration>,
+        name: &CStr,
+        allocator: *mut sys::OrtAllocator,
+    ) -> (*mut sys::OrtStatus, *mut c_void, usize) {
+        let mut buffer = ptr::null_mut();
+        let mut data_size = 0;
+        let status = ep_context_data_read_callback(
+            Arc::as_ptr(registration) as *mut c_void,
+            name.as_ptr(),
+            allocator,
+            &mut buffer,
+            &mut data_size,
+        );
+        (status, buffer, data_size)
+    }
+
+    #[test]
+    fn trampoline_returns_non_empty_and_empty_data() {
+        let requested_names = Arc::new(Mutex::new(Vec::new()));
+        let names = requested_names.clone();
+        let registration = test_registration(16, move |name| {
+            names.lock().unwrap().push(name.to_owned());
+            if name == "empty.bin" {
+                Ok(Vec::new())
+            } else {
+                Ok(vec![1, 2, 3, 4])
+            }
+        });
+        let allocator = default_allocator();
+
+        unsafe {
+            let (status, buffer, data_size) = invoke(
+                &registration,
+                CStr::from_bytes_with_nul(b"context.bin\0").unwrap(),
+                allocator,
+            );
+            assert!(status.is_null());
+            assert_eq!(data_size, 4);
+            assert_eq!(
+                std::slice::from_raw_parts(buffer.cast::<u8>(), data_size),
+                [1, 2, 3, 4]
+            );
+            (*allocator).Free.unwrap()(allocator, buffer);
+
+            let (status, buffer, data_size) = invoke(
+                &registration,
+                CStr::from_bytes_with_nul(b"empty.bin\0").unwrap(),
+                allocator,
+            );
+            assert!(status.is_null());
+            assert!(buffer.is_null());
+            assert_eq!(data_size, 0);
+        }
+        assert_eq!(
+            *requested_names.lock().unwrap(),
+            ["context.bin".to_owned(), "empty.bin".to_owned()]
+        );
+    }
+
+    #[test]
+    fn trampoline_maps_callback_errors_and_contains_panics() {
+        let registration = test_registration(16, |name| match name {
+            "invalid" => Err(EpContextDataCallbackError::InvalidArgument(
+                "bad\0argument".to_owned(),
+            )),
+            "failure" => Err(EpContextDataCallbackError::Fail("read\0failed".to_owned())),
+            "panic" => panic!("callback panic"),
+            _ => Ok(Vec::new()),
+        });
+        let allocator = default_allocator();
+
+        unsafe {
+            let (status, _, _) = invoke(
+                &registration,
+                CStr::from_bytes_with_nul(b"invalid\0").unwrap(),
+                allocator,
+            );
+            let (code, message) = take_status(status);
+            assert_eq!(code, sys::OrtErrorCode::ORT_INVALID_ARGUMENT);
+            assert_eq!(message, "bad?argument");
+
+            let (status, _, _) = invoke(
+                &registration,
+                CStr::from_bytes_with_nul(b"failure\0").unwrap(),
+                allocator,
+            );
+            let (code, message) = take_status(status);
+            assert_eq!(code, sys::OrtErrorCode::ORT_FAIL);
+            assert_eq!(message, "read?failed");
+
+            let (status, buffer, data_size) = invoke(
+                &registration,
+                CStr::from_bytes_with_nul(b"panic\0").unwrap(),
+                allocator,
+            );
+            assert!(buffer.is_null());
+            assert_eq!(data_size, 0);
+            let (code, message) = take_status(status);
+            assert_eq!(code, sys::OrtErrorCode::ORT_FAIL);
+            assert_eq!(message, "Rust EPContext data callback panicked");
+        }
+    }
+
+    struct PanicOnDrop;
+
+    impl Drop for PanicOnDrop {
+        fn drop(&mut self) {
+            panic!("panic payload drop");
+        }
+    }
+
+    #[test]
+    fn trampoline_does_not_drop_panicking_panic_payload() {
+        let registration = test_registration(16, |_| std::panic::panic_any(PanicOnDrop));
+        let allocator = default_allocator();
+
+        unsafe {
+            let (status, buffer, data_size) = invoke(
+                &registration,
+                CStr::from_bytes_with_nul(b"panic\0").unwrap(),
+                allocator,
+            );
+            assert!(buffer.is_null());
+            assert_eq!(data_size, 0);
+            let (code, message) = take_status(status);
+            assert_eq!(code, sys::OrtErrorCode::ORT_FAIL);
+            assert_eq!(message, "Rust EPContext data callback panicked");
+        }
+    }
+
+    #[repr(C)]
+    struct CountingAllocator {
+        allocator: sys::OrtAllocator,
+        allocations: AtomicUsize,
+    }
+
+    extern_system_fn! {
+        unsafe fn counting_alloc(allocator: *mut sys::OrtAllocator, _size: usize) -> *mut c_void {
+            let allocator = &*allocator.cast::<CountingAllocator>();
+            allocator.allocations.fetch_add(1, Ordering::SeqCst);
+            ptr::null_mut()
+        }
+    }
+
+    #[test]
+    fn trampoline_rejects_oversized_data_before_allocator_call() {
+        let registration = test_registration(3, |_| Ok(vec![1, 2, 3, 4]));
+        let mut allocator = CountingAllocator {
+            allocator: unsafe { std::mem::zeroed() },
+            allocations: AtomicUsize::new(0),
+        };
+        allocator.allocator.version = sys::ORT_API_VERSION;
+        allocator.allocator.Alloc = Some(counting_alloc);
+
+        unsafe {
+            let (status, buffer, data_size) = invoke(
+                &registration,
+                CStr::from_bytes_with_nul(b"large\0").unwrap(),
+                &mut allocator.allocator,
+            );
+            assert!(buffer.is_null());
+            assert_eq!(data_size, 0);
+            let (code, _) = take_status(status);
+            assert_eq!(code, sys::OrtErrorCode::ORT_INVALID_ARGUMENT);
+        }
+        assert_eq!(allocator.allocations.load(Ordering::SeqCst), 0);
+    }
+
+    #[test]
+    fn trampoline_maps_allocator_failure() {
+        let registration = test_registration(4, |_| Ok(vec![1, 2, 3, 4]));
+        let mut allocator = CountingAllocator {
+            allocator: unsafe { std::mem::zeroed() },
+            allocations: AtomicUsize::new(0),
+        };
+        allocator.allocator.version = sys::ORT_API_VERSION;
+        allocator.allocator.Alloc = Some(counting_alloc);
+
+        unsafe {
+            let (status, buffer, data_size) = invoke(
+                &registration,
+                CStr::from_bytes_with_nul(b"data\0").unwrap(),
+                &mut allocator.allocator,
+            );
+            assert!(buffer.is_null());
+            assert_eq!(data_size, 0);
+            assert_eq!(take_status(status).0, sys::OrtErrorCode::ORT_FAIL);
+        }
+        assert_eq!(allocator.allocations.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn trampoline_defends_against_null_and_invalid_name_pointers() {
+        let registration = test_registration(16, |_| Ok(Vec::new()));
+        let state = Arc::as_ptr(&registration) as *mut c_void;
+        let allocator = default_allocator();
+        let name = CStr::from_bytes_with_nul(b"context\0").unwrap();
+
+        unsafe {
+            let mut buffer = 1_usize as *mut c_void;
+            let mut data_size = 7;
+            let status = ep_context_data_read_callback(
+                state,
+                ptr::null(),
+                allocator,
+                &mut buffer,
+                &mut data_size,
+            );
+            assert!(buffer.is_null());
+            assert_eq!(data_size, 0);
+            assert_eq!(
+                take_status(status).0,
+                sys::OrtErrorCode::ORT_INVALID_ARGUMENT
+            );
+
+            let status = ep_context_data_read_callback(
+                state,
+                name.as_ptr(),
+                ptr::null_mut(),
+                &mut buffer,
+                &mut data_size,
+            );
+            assert_eq!(
+                take_status(status).0,
+                sys::OrtErrorCode::ORT_INVALID_ARGUMENT
+            );
+
+            let status = ep_context_data_read_callback(
+                state,
+                b"\xff\0".as_ptr().cast(),
+                allocator,
+                &mut buffer,
+                &mut data_size,
+            );
+            assert_eq!(
+                take_status(status).0,
+                sys::OrtErrorCode::ORT_INVALID_ARGUMENT
+            );
+
+            let status = ep_context_data_read_callback(
+                state,
+                name.as_ptr(),
+                allocator,
+                ptr::null_mut(),
+                &mut data_size,
+            );
+            assert_eq!(
+                take_status(status).0,
+                sys::OrtErrorCode::ORT_INVALID_ARGUMENT
+            );
+
+            let status = ep_context_data_read_callback(
+                state,
+                name.as_ptr(),
+                allocator,
+                &mut buffer,
+                ptr::null_mut(),
+            );
+            assert_eq!(
+                take_status(status).0,
+                sys::OrtErrorCode::ORT_INVALID_ARGUMENT
+            );
+
+            let status = ep_context_data_read_callback(
+                ptr::null_mut(),
+                name.as_ptr(),
+                allocator,
+                &mut buffer,
+                &mut data_size,
+            );
+            assert_eq!(
+                take_status(status).0,
+                sys::OrtErrorCode::ORT_INVALID_ARGUMENT
+            );
+        }
+    }
+
+    #[test]
+    fn trampoline_supports_concurrent_calls() {
+        const THREAD_COUNT: usize = 8;
+        let call_count = Arc::new(AtomicUsize::new(0));
+        let callback_count = call_count.clone();
+        let registration = test_registration(16, move |name| {
+            callback_count.fetch_add(1, Ordering::SeqCst);
+            Ok(name.as_bytes().to_vec())
+        });
+        let state = Arc::as_ptr(&registration) as usize;
+        let allocator = default_allocator() as usize;
+
+        let threads: Vec<_> = (0..THREAD_COUNT)
+            .map(|index| {
+                thread::spawn(move || unsafe {
+                    let name = CString::new(format!("data-{index}")).unwrap();
+                    let mut buffer = ptr::null_mut();
+                    let mut data_size = 0;
+                    let status = ep_context_data_read_callback(
+                        state as *mut c_void,
+                        name.as_ptr(),
+                        allocator as *mut sys::OrtAllocator,
+                        &mut buffer,
+                        &mut data_size,
+                    );
+                    assert!(status.is_null());
+                    assert_eq!(
+                        std::slice::from_raw_parts(buffer.cast::<u8>(), data_size),
+                        name.as_bytes()
+                    );
+                    (*(allocator as *mut sys::OrtAllocator)).Free.unwrap()(
+                        allocator as *mut sys::OrtAllocator,
+                        buffer,
+                    );
+                })
+            })
+            .collect();
+        for thread in threads {
+            thread.join().unwrap();
+        }
+        assert_eq!(call_count.load(Ordering::SeqCst), THREAD_COUNT);
+    }
+
+    unsafe fn registered_callback(
+        builder: &SessionBuilder<'_>,
+    ) -> (sys::OrtReadNamedBufferFunc, *mut c_void, usize) {
+        let api = builder.env.env().api();
+        let ep_api = &*api.GetEpApi.unwrap()();
+        let mut config = ptr::null_mut();
+        status_to_result(ep_api.SessionOptionsGetEpContextConfig.unwrap()(
+            builder.session_options_ptr,
+            &mut config,
+        ))
+        .unwrap();
+
+        let mut read_func = None;
+        let mut state = ptr::null_mut();
+        let mut max_data_size = 0;
+        status_to_result(ep_api.EpContextConfigGetEpContextDataReadFunc.unwrap()(
+            config,
+            &mut read_func,
+            &mut state,
+            &mut max_data_size,
+        ))
+        .unwrap();
+        ep_api.ReleaseEpContextConfig.unwrap()(config);
+        (read_func, state, max_data_size)
+    }
+
+    #[test]
+    fn registration_replaces_and_clears_native_callback_transactionally() {
+        let first_lifetime = Arc::new(());
+        let first_weak = Arc::downgrade(&first_lifetime);
+        let first_capture = first_lifetime.clone();
+        let builder = test_environment()
+            .new_session_builder()
+            .unwrap()
+            .with_ep_context_data_read_callback(8, move |_| {
+                let _ = &first_capture;
+                Ok(vec![1])
+            })
+            .unwrap();
+        drop(first_lifetime);
+
+        let (_, first_state, first_max_data_size) = unsafe { registered_callback(&builder) };
+        assert!(!first_state.is_null());
+        assert_eq!(first_max_data_size, 8);
+        assert!(first_weak.upgrade().is_some());
+
+        let second_lifetime = Arc::new(());
+        let second_weak = Arc::downgrade(&second_lifetime);
+        let second_capture = second_lifetime.clone();
+        let requested_name = Arc::new(Mutex::new(None));
+        let callback_name = requested_name.clone();
+        let builder = builder
+            .with_ep_context_data_read_callback(16, move |name| {
+                let _ = &second_capture;
+                *callback_name.lock().unwrap() = Some(name.to_owned());
+                Ok(vec![9])
+            })
+            .unwrap();
+        drop(second_lifetime);
+
+        let (read_func, second_state, second_max_data_size) =
+            unsafe { registered_callback(&builder) };
+        assert!(read_func.is_some());
+        assert!(!second_state.is_null());
+        assert_ne!(first_state, second_state);
+        assert_eq!(second_max_data_size, 16);
+        assert!(first_weak.upgrade().is_none());
+        assert!(second_weak.upgrade().is_some());
+
+        unsafe {
+            let allocator = default_allocator();
+            let mut buffer = ptr::null_mut();
+            let mut data_size = 0;
+            let name = CStr::from_bytes_with_nul(b"native-config.bin\0").unwrap();
+            let status = read_func.unwrap()(
+                second_state,
+                name.as_ptr(),
+                allocator,
+                &mut buffer,
+                &mut data_size,
+            );
+            assert!(status.is_null());
+            assert_eq!(
+                std::slice::from_raw_parts(buffer.cast::<u8>(), data_size),
+                [9]
+            );
+            (*allocator).Free.unwrap()(allocator, buffer);
+        }
+        assert_eq!(
+            *requested_name.lock().unwrap(),
+            Some("native-config.bin".to_owned())
+        );
+
+        let builder = builder.without_ep_context_data_read_callback().unwrap();
+        let (read_func, state, _) = unsafe { registered_callback(&builder) };
+        assert!(read_func.is_none());
+        assert!(state.is_null());
+        assert!(second_weak.upgrade().is_none());
+    }
+
+    #[test]
+    fn registration_rejects_non_finite_maximum_sizes() {
+        let result = test_environment()
+            .new_session_builder()
+            .unwrap()
+            .with_ep_context_data_read_callback(0, |_| Ok(Vec::new()));
+        assert!(matches!(result, Err(OrtError::SessionOptions(_))));
+
+        let result = test_environment()
+            .new_session_builder()
+            .unwrap()
+            .with_ep_context_data_read_callback(usize::MAX, |_| Ok(Vec::new()));
+        assert!(matches!(result, Err(OrtError::SessionOptions(_))));
+    }
+
+    #[test]
+    fn session_retains_callback_registration() {
+        let lifetime = Arc::new(());
+        let weak: Weak<()> = Arc::downgrade(&lifetime);
+        let capture = lifetime.clone();
+        let builder = test_environment()
+            .new_session_builder()
+            .unwrap()
+            .with_ep_context_data_read_callback(16, move |_| {
+                let _ = &capture;
+                Ok(Vec::new())
+            })
+            .unwrap();
+        drop(lifetime);
+
+        let model_path = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../../onnxruntime/test/testdata/mul_1.onnx");
+        let session = builder.with_model_from_file(model_path).unwrap();
+        assert!(weak.upgrade().is_some());
+        drop(session);
+        assert!(weak.upgrade().is_none());
+    }
 }
 
 /// This module contains dangerous functions working on raw pointers.

--- a/rust/onnxruntime/src/tensor/ort_output_tensor.rs
+++ b/rust/onnxruntime/src/tensor/ort_output_tensor.rs
@@ -180,11 +180,7 @@ fn extract_string_tensor(value: OrtOutputTensor) -> Result<WithOutputTensor<Stri
 
     let status = {
         let api = ENV.get().unwrap().lock().unwrap();
-        unsafe {
-            api.api()
-                .GetStringTensorDataLength
-                .unwrap()(value.tensor_ptr, &mut data_len)
-        }
+        unsafe { api.api().GetStringTensorDataLength.unwrap()(value.tensor_ptr, &mut data_len) }
     };
     status_to_result(status).map_err(OrtError::GetStringTensorDataLength)?;
 
@@ -455,7 +451,13 @@ impl TryFrom<OrtOutputTensor> for OrtOutput {
                 | sys::ONNXTensorElementDataType::ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT8E4M3FN
                 | sys::ONNXTensorElementDataType::ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT8E4M3FNUZ
                 | sys::ONNXTensorElementDataType::ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT8E5M2FNUZ
-                | sys::ONNXTensorElementDataType::ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT8E5M2 => {
+                | sys::ONNXTensorElementDataType::ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT8E5M2
+                | sys::ONNXTensorElementDataType::ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT4
+                | sys::ONNXTensorElementDataType::ONNX_TENSOR_ELEMENT_DATA_TYPE_INT4
+                | sys::ONNXTensorElementDataType::ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT4E2M1
+                | sys::ONNXTensorElementDataType::ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT2
+                | sys::ONNXTensorElementDataType::ONNX_TENSOR_ELEMENT_DATA_TYPE_INT2
+                | sys::ONNXTensorElementDataType::ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT8E8M0 => {
                     unimplemented!("{:?}", element_type)
                 }
             }


### PR DESCRIPTION
## Description

Adds complete Rust bindings for the stable EPContext data read callback APIs introduced by #32265.

- adds `EpContextDataCallbackError` and transactional `SessionBuilder` registration/clear APIs
- retains Arc-backed callback state safely across builder/session lifetimes
- implements an unwind-contained, allocator-safe `ORT_API_CALL` trampoline with full status mapping and pointer/size validation
- supports bindgen against current source-tree headers while preserving installed-package behavior
- reports a clear compatibility error when `GetApi(30)` returns null
- adds focused unit coverage for registration, replacement, clear, lifetime, concurrency, errors, panics, allocation, and pointer defenses

## Validation

- `cargo fmt --manifest-path rust\Cargo.toml --all -- --check`
- `cargo test --manifest-path rust\Cargo.toml -p onnxruntime --lib -- --test-threads=1` against a locally built v30 runtime: 31 passed
- high-confidence code review: no actionable findings

All changed paths are under `rust/**` and the branch merge-base is `442ca91b7815c9d27bc01e7081e64763e824d519`.
