### PR TITLE
Remove internal URL from Guardian baseline

### DIFF
--- a/.config/guardian/.gdnbaselines
+++ b/.config/guardian/.gdnbaselines
@@ -1,7 +1,5 @@
 {
-  "properties": {
-    "helpUri": "https://eng.ms/docs/microsoft-security/security/azure-security/cloudai-security-fundamentals-engineering/security-integration/guardian-wiki/microsoft-guardian/general/baselines"
-  },
+  "properties": {},
   "version": "1.0.0",
   "baselines": {
     "default": {


### PR DESCRIPTION
### Description
Remove the internal documentation URL from the Guardian baseline metadata while retaining the expected empty properties object.

### Motivation
The security team requested that internal URLs be removed from the public repository.

### Validation
- Parsed .config/guardian/.gdnbaselines successfully as JSON
- Ran git diff --check