### PR TITLE
Make workspace input shapes optional-aware

### DIFF
--- a/docs/annotated_partitioning/future_directions_constrained_env.md
+++ b/docs/annotated_partitioning/future_directions_constrained_env.md
@@ -1053,7 +1053,9 @@ introduce a separate `WorkspacePattern` or allocate a persistent execution buffe
    `GetScratchBuffer()`.
 5. ORT caches one pattern containing both activation and workspace blocks. On later runs with a
    compatible feed-shape key, the execution frame allocates the normal per-run pattern backing buffer
-   and returns `backing_buffer + workspace_offset`.
+   and returns `backing_buffer + workspace_offset`. The planned offset and returned pointer must
+   satisfy the requirement's binding `alignment_bytes` value, or the allocator's default alignment
+   when that value is zero.
 6. If the pattern is unavailable or the runtime request exceeds the declared capacity,
    `GetPreallocatedWorkspace(slot_id, requested_bytes)` returns no pointer and the kernel retains its
    dynamic `GetScratchBuffer()` fallback.
@@ -1076,8 +1078,9 @@ two internal regions:
 
 PMHA, whose Q/K/V inputs are already projected, naturally exposes one attention root. PA/PMHA root
 retrieval and slicing and the `SupportsPreallocatedWorkspace()` opt-in must land atomically. Until
-then, the current two dynamic `GetScratchBuffer()` allocations remain unchanged while Level 1 and
-Level 2 agree on the single-root declaration. This does not require multi-slot planner support.
+then, PA retains its two dynamic projection and Attention allocations, PMHA retains its one dynamic
+Attention allocation, and Level 1 and Level 2 agree on each operator's single-root declaration. This
+does not require multi-slot planner support.
 
 **Future stronger mode:** allocating and retaining the complete execution buffer during session
 initialization would be a separate feature. Such a mode would need trustworthy static or bounded

--- a/docs/annotated_partitioning/future_directions_constrained_env.md
+++ b/docs/annotated_partitioning/future_directions_constrained_env.md
@@ -1063,21 +1063,21 @@ This reduces allocator traffic and lets workspace reuse memory occupied by non-o
 activations after the warm-up run. It does not protect the first run from OOM, guarantee that the
 per-run backing-buffer allocation succeeds, or provide initialize-time persistent allocation.
 
-**Current one-slot limitation:** although `DeclareWorkspaceRequirements()` can return multiple slots,
-#32071 currently preplans only kernels that opt in with `SupportsPreallocatedWorkspace()` and declare
-exactly one slot. This is sufficient for the current MatMulNBits pilot and for PMHA's single attention
-workspace allocation. PackedAttention preserves two simultaneously live allocations in #32283:
+**Current one-slot limitation:** `WorkspaceRequirement` and
+`DeclareWorkspaceRequirements()` retain generic multi-slot support, but #32071 Phase A opts in only
+kernels that declare exactly one slot. This is sufficient for the current MatMulNBits pilot and both
+packed-attention operators. PackedAttention can expose one 256-byte-aligned, operator-owned root with
+two internal regions:
 
 ```text
-slot 0: projection output/workspace
-slot 1: selected Attention backend workspace
+[0, aligned projection end): projection region and alignment padding
+[aligned projection end, root end): selected Attention backend workspace
 ```
 
-Its Level-1 reservation is `projection_bytes + max(feasible Attention route bytes)`, and its Level-2
-declaration must preserve the two slots. Combining them into one declaration would change the runtime
-allocation topology. Before PackedAttention can use #32071 preallocation, the planner must accept and
-trace multiple slots for one kernel instance; until then, PackedAttention remains on its existing
-`GetScratchBuffer()` fallback. PMHA can be integrated first with the current one-slot pilot.
+PMHA, whose Q/K/V inputs are already projected, naturally exposes one attention root. The existing
+runtime may continue using separate dynamic `GetScratchBuffer()` allocations while Level 1 and Level 2
+agree on the single-root declaration. Retrieving that root at runtime and splitting it into the
+operator's internal regions remains follow-up work; it does not require multi-slot planner support.
 
 **Future stronger mode:** allocating and retaining the complete execution buffer during session
 initialization would be a separate feature. Such a mode would need trustworthy static or bounded

--- a/docs/annotated_partitioning/future_directions_constrained_env.md
+++ b/docs/annotated_partitioning/future_directions_constrained_env.md
@@ -389,6 +389,7 @@ Not the same function pointer (different signatures — one has a kernel instanc
 static std::optional<size_t> ComputeIllustrativeBshdAttentionWorkspace(
     int64_t batch, int64_t sequence, int64_t heads, int64_t head_size) {
   const int64_t dimensions[] = {batch, sequence, heads, head_size};
+  // A zero extent fixes this product at zero even if another extent is unknown.
   for (const int64_t dimension : dimensions) {
     if (dimension == 0) {
       return 0;
@@ -401,6 +402,7 @@ static std::optional<size_t> ComputeIllustrativeBshdAttentionWorkspace(
     }
   }
   try {
+    // size_t matches the allocator contract; SafeInt rejects values above the platform's SIZE_MAX.
     SafeInt<size_t> bytes{sizeof(float)};
     for (const int64_t dimension : dimensions) {
       bytes *= SafeInt<size_t>(dimension);

--- a/docs/annotated_partitioning/future_directions_constrained_env.md
+++ b/docs/annotated_partitioning/future_directions_constrained_env.md
@@ -1002,14 +1002,13 @@ kernel retains its dynamic allocation fallback. Zero-sized requirements are also
 planner must define the semantics of an explicit, proven-zero slot before the interface gains a zero
 marker; this PR intentionally adds neither a marker nor new provenance state.
 
-**`alignment_bytes` (added in PR #29811):** reserved for a future shared-arena packer that co-locates
-multiple kernels' declared slots and needs per-slot alignment metadata. Unused by any kernel today — the
-CUDA allocator's default ≥256-byte alignment already satisfies every current kernel's needs (each gets
-its own `GetScratchBuffer` call, or — like GQA's unfused path — hand-rolls sub-offsets assuming the
-outer buffer is already ≥256-byte aligned). A plain `size_t` with a `0` sentinel is used rather than
-`std::optional<size_t>` because this struct is meant to be usable across a plugin-DLL boundary
-eventually, and `std::optional`'s layout is not guaranteed stable across compilers/STL versions the way
-a scalar with a sentinel value is.
+**`alignment_bytes` (added in PR #29811):** `0` requests the allocator's default alignment. Any
+nonzero value is a binding alignment requirement on the returned slot buffer (or operator-owned root)
+that a planner must honor. The stacked PA/PMHA declaration uses an explicit 256-byte root alignment;
+this ensures that its relatively aligned internal subregions are also absolutely aligned. A plain
+`size_t` with a `0` sentinel is used rather than `std::optional<size_t>` because this POD is meant to
+be usable across a plugin-DLL boundary eventually, and `std::optional`'s layout is not guaranteed
+stable across compilers/STL versions the way a scalar with a sentinel value is.
 
 **Shape source wiring:** framework callers resolve presence-aware entries from two shape sources:
 
@@ -1064,8 +1063,9 @@ activations after the warm-up run. It does not protect the first run from OOM, g
 per-run backing-buffer allocation succeeds, or provide initialize-time persistent allocation.
 
 **Current one-slot limitation:** `WorkspaceRequirement` and
-`DeclareWorkspaceRequirements()` retain generic multi-slot support, but #32071 Phase A opts in only
-kernels that declare exactly one slot. This is sufficient for the current MatMulNBits pilot and both
+`DeclareWorkspaceRequirements()` retain generic multi-slot support, but #32071 opts in only kernels
+that both explicitly override `SupportsPreallocatedWorkspace()` and declare exactly one slot. A
+declaration alone is not planner opt-in. This is sufficient for the current MatMulNBits pilot and both
 packed-attention operators. PackedAttention can expose one 256-byte-aligned, operator-owned root with
 two internal regions:
 
@@ -1074,10 +1074,10 @@ two internal regions:
 [aligned projection end, root end): selected Attention backend workspace
 ```
 
-PMHA, whose Q/K/V inputs are already projected, naturally exposes one attention root. The existing
-runtime may continue using separate dynamic `GetScratchBuffer()` allocations while Level 1 and Level 2
-agree on the single-root declaration. Retrieving that root at runtime and splitting it into the
-operator's internal regions remains follow-up work; it does not require multi-slot planner support.
+PMHA, whose Q/K/V inputs are already projected, naturally exposes one attention root. PA/PMHA root
+retrieval and slicing and the `SupportsPreallocatedWorkspace()` opt-in must land atomically. Until
+then, the current two dynamic `GetScratchBuffer()` allocations remain unchanged while Level 1 and
+Level 2 agree on the single-root declaration. This does not require multi-slot planner support.
 
 **Future stronger mode:** allocating and retaining the complete execution buffer during session
 initialization would be a separate feature. Such a mode would need trustworthy static or bounded

--- a/docs/annotated_partitioning/future_directions_constrained_env.md
+++ b/docs/annotated_partitioning/future_directions_constrained_env.md
@@ -1034,144 +1034,56 @@ planning/allocation, and integration with resource accounting remain deferred; n
 partition budgets or replaces the runtime scratch-allocation path yet. Phase-B planner/accounting
 integration remains in the scope of #32071.
 
-A kernel can declare multiple workspace slots (e.g., attention needs separate Q transpose buffer, output buffer, seqlens buffer). The `slot_id` is defined by the kernel author and is stable across calls — it identifies *which* buffer within that kernel's logic.
+A kernel can declare multiple workspace slots. The `slot_id` is defined by the kernel author and is
+stable across calls; `(NodeIndex, slot_id)` identifies one internal buffer for one kernel instance.
+The interface capability and the current planner capability are intentionally distinct.
 
-**Key constraint:** Multiple nodes may use the same kernel class. Each node instance gets its own set of workspace slots. The unique key for retrieval is `(NodeIndex, slot_id)` — the framework supplies `NodeIndex`, the kernel supplies `slot_id`.
+##### Current Phase-B strategy in #32071
 
-**Memory reuse via liveness-based offset planning:**
+#32071 integrates opted-in workspace with ORT's existing activation `MemoryPattern`; it does not
+introduce a separate `WorkspacePattern` or allocate a persistent execution buffer during
+`FinalizeSessionState()`:
 
-Workspace buffers are live only during their kernel's execution step. This means workspaces from non-overlapping steps can share the same physical memory — exactly the same liveness analysis already used for activation tensors. The offset planner assigns overlapping offsets to workspaces whose liveness intervals don't intersect:
+1. Level 1 contributes an operator workspace reservation to partition resource accounting.
+2. After kernel creation and prepacking, Level 2 is compared with that reservation and registers
+   usable requirements in the sequential execution plan.
+3. Each registered `(NodeIndex, slot_id)` receives a negative synthetic pattern ID, disjoint from
+   graph `OrtValue` indices.
+4. On the first run for a feed-shape memory-pattern key, the execution frame traces the synthetic
+   workspace allocation/free lifetime. The kernel still receives no planned pointer and falls back to
+   `GetScratchBuffer()`.
+5. ORT caches one pattern containing both activation and workspace blocks. On later runs with a
+   compatible feed-shape key, the execution frame allocates the normal per-run pattern backing buffer
+   and returns `backing_buffer + workspace_offset`.
+6. If the pattern is unavailable or the runtime request exceeds the declared capacity,
+   `GetPreallocatedWorkspace(slot_id, requested_bytes)` returns no pointer and the kernel retains its
+   dynamic `GetScratchBuffer()` fallback.
 
-```
-Step 0: Node A workspace (slots 0,1) → offsets [0, 4096]
-Step 1: Node B workspace (slot 0)    → offset [0]  ← reuses Node A's memory
-Step 2: Node C workspace (slots 0,1) → offsets [0, 8192]  ← reuses again
-```
+This reduces allocator traffic and lets workspace reuse memory occupied by non-overlapping
+activations after the warm-up run. It does not protect the first run from OOM, guarantee that the
+per-run backing-buffer allocation succeeds, or provide initialize-time persistent allocation.
 
-Peak workspace memory = max over all steps of (sum of workspace slots for that step), not the sum of all workspaces across all nodes.
+**Current one-slot limitation:** although `DeclareWorkspaceRequirements()` can return multiple slots,
+#32071 currently preplans only kernels that opt in with `SupportsPreallocatedWorkspace()` and declare
+exactly one slot. This is sufficient for the current MatMulNBits pilot and for PMHA's single attention
+workspace allocation. PackedAttention preserves two simultaneously live allocations in #32283:
 
-**Concurrency model (multiple concurrent `Run()` calls):**
-
-The existing memory pattern system already handles this correctly:
-- The **pattern** (offset/size map) is computed once during `Initialize()` and cached in `SessionState` — shared, read-only.
-- The **actual buffer** is allocated per-`Run()` by each `ExecutionFrame` using the pattern as a blueprint.
-- Each concurrent `Run()` gets its own `ExecutionFrame` with its own workspace buffer — no sharing, no synchronization needed.
-
-Workspace pre-allocation follows the same model:
-- `DeclareWorkspaceRequirements()` is called during `FinalizeSessionState()` → produces a workspace offset plan (shared, immutable).
-- Each `Run()` allocates a workspace buffer of `peak_workspace_size` bytes and uses offsets from the plan.
-- Concurrent runs each get their own buffer — safe without locks.
-
-**Note on CUDA:** In practice, concurrent `Run()` on the same CUDA session is uncommon (users don't typically do this). But the design should remain thread-safe by following the same per-run buffer pattern.
-
-**Single-thread pre-allocation mode (eliminating runtime OOM):**
-
-Even with workspace planning, the per-`Run()` buffer allocation can still OOM if device memory is fragmented or consumed by other processes since `Initialize()`. For constrained environments, this is the last remaining point of failure.
-
-Most constrained-environment users run **single-threaded inference** — one `Run()` at a time. ORT already has a concurrent-run counter (`InferenceSession::current_num_runs_`). If the session is configured to disallow concurrency, the execution buffer (which includes workspace slots) can be **allocated once at initialization and reused for every `Run()` call**.
-
-**Proposed** (not currently implemented): a session option such as `session.pre_allocate_execution_buffers = "1"` would enable this behavior.
-
-When enabled:
-1. After `FinalizeSessionState()` computes the memory pattern (including workspace offsets from `DeclareWorkspaceRequirements`), allocate the peak buffer once: `IAllocator::Alloc(peak_size)` per EP.
-2. Store the pre-allocated buffer pointer on `SessionState`.
-3. Each `Run()` reuses the same buffer — no allocation, no OOM possible.
-4. Enforce `max_concurrent_runs = 1`: if a second `Run()` arrives, fail fast.
-
-```cpp
-if (pre_allocate_mode_ && current_num_runs_.fetch_add(1) > 0) {
-    current_num_runs_.fetch_sub(1);
-    return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL,
-        "Concurrent Run() not allowed with pre-allocated execution buffers.");
-}
+```text
+slot 0: projection output/workspace
+slot 1: selected Attention backend workspace
 ```
 
-**What this guarantees:** If `Initialize()` succeeds, `Run()` cannot OOM — all device memory (weights + intermediates + workspace) is already resident. The budget at partition time accounts for all three: `budget ≥ weights_on_device + peak_execution_buffer`.
+Its Level-1 reservation is `projection_bytes + max(feasible Attention route bytes)`, and its Level-2
+declaration must preserve the two slots. Combining them into one declaration would change the runtime
+allocation topology. Before PackedAttention can use #32071 preallocation, the planner must accept and
+trace multiple slots for one kernel instance; until then, PackedAttention remains on its existing
+`GetScratchBuffer()` fallback. PMHA can be integrated first with the current one-slot pilot.
 
-**What already exists:** `MemoryPattern` computation is done, `MemoryPatternGroup::GetPeakAllocSize()` gives peak size, `current_num_runs_` counter exists, per-EP allocators exist. The `ExecutionFrame` already uses offset-based placement into a contiguous block — the change is to not free/reallocate that block between calls.
-
-**Scope:** Single-threaded only. For concurrent inference, multiple buffers are needed (defeating the guarantee).
-
-**Interaction with dynamic shapes:** `pre_allocate_execution_buffers` is fundamentally a **static-shape-only** feature. With dynamic shapes, `ExecutionFrame` must allocate buffers on every `Run()` because activation tensor sizes are unknown until the input arrives — there is no way to pre-compute a total buffer size at `Initialize()` time. Even if some kernels' workspace slots are shape-independent, the activation portion (which typically dominates) still requires per-`Run()` allocation, so the OOM-elimination guarantee cannot hold.
-
-Furthermore, the arena allocator already handles repeated allocations efficiently (same-size blocks are recycled without syscalls), so pre-allocating just the workspace portion while leaving activations dynamic would add complexity for negligible gain.
-
-**Summary:** For dynamic-shape models, the value of `DeclareWorkspaceRequirements` is in **budget estimation** (Level 1/Level 2, using worst-case or max-batch sizes to decide how many nodes fit on the device), not in runtime pre-allocation.
-
-**Planning flow (during FinalizeSessionState):**
-
-1. For each kernel in the execution plan (when shapes are static), call `DeclareWorkspaceRequirements()` with the inferred input shapes.
-2. Record `{NodeIndex, slot_id} → size_bytes` in the execution plan.
-3. Run liveness analysis: workspace for node N is live only during step N's execution.
-4. Compute offsets (same algorithm as activation patterns) → yields `peak_workspace_size` and per-slot offsets.
-5. Store workspace pattern as a **separate `WorkspacePattern`** in `SessionState`.
-
-**Why workspace buffers are separate from `MemoryPattern` (activations):**
-
-Although the offset planning algorithm is the same (liveness → assign offsets → compute peak), workspace buffers differ in allocation and retrieval:
-
-| Aspect | MemoryPattern (activations) | WorkspacePattern |
-|--------|---------------------------|------------------|
-| **Addressing** | `MLValueIndex` — framework-assigned, part of graph IR | `(NodeIndex, slot_id)` — kernel-defined, opaque to framework |
-| **Who queries** | Framework automatically when creating output `OrtValue`s | Kernel explicitly via `GetPreallocatedWorkspace(slot_id)` |
-| **Lifetime** | Multi-step — output lives until its last consumer executes | Single-step — live only during the owning kernel's step |
-| **What's returned** | An `OrtValue` (typed tensor with shape metadata) | Raw `void*` — kernel interprets the bytes internally |
-| **Graph visibility** | Framework manages these as edges between nodes | Invisible to graph — internal scratch memory |
-| **Size determination** | Inferred from output shape × element_size | Declared by kernel (may be unrelated to any tensor shape) |
-
-Concretely, this means:
-- `WorkspacePattern` is a new class (not reusing `MemoryPatternGroup`) with its own lookup: `GetOffset(NodeIndex, slot_id) → {offset, size}`.
-- The workspace buffer is allocated separately from the activation buffer. They could share physical memory (workspace is always single-step, so it never overlaps with itself across steps), but keeping them separate simplifies accounting and makes budget tracking unambiguous: `peak_total = peak_activations + peak_workspace`.
-- In pre-allocation mode, both buffers are allocated once at init. In normal mode, both are allocated per-`Run()` from the arena. But they remain distinct allocations with distinct query paths.
-
-**Per-Run retrieval (during Compute):**
-
-Each `ExecutionFrame` allocates a workspace buffer of `peak_workspace_size` via the EP's allocator and provides offset-based access through a dedicated query interface (not the existing OrtValue/MLValue machinery):
-
-**Alternative A: Transparent fallback in GetScratchBuffer**
-
-Modify `GetScratchBuffer<T>(slot_id, size, stream)` to check for a pre-planned buffer first:
-
-```cpp
-template <typename T>
-IAllocatorUniquePtr<T> GetScratchBuffer(int slot_id, size_t count_or_bytes, Stream* stream) const {
-  // Check if workspace was pre-planned for this node + slot
-  void* preallocated = context_.GetPreallocatedWorkspace(slot_id);
-  if (preallocated) {
-    // Return non-owning pointer (buffer lifetime managed by the frame)
-    return IAllocatorUniquePtr<T>(static_cast<T*>(preallocated), [](T*){});
-  }
-  // Fall back to arena (dynamic shapes, or DeclareWorkspaceRequirements not implemented)
-  return IAllocator::MakeUniquePtr<T>(allocator_, count_or_bytes, false, stream);
-}
-```
-
-Pro: Minimal kernel code changes — just add `slot_id` parameter. Con: Overloads `GetScratchBuffer` semantics; non-owning vs owning pointer distinction is subtle.
-
-**Alternative B: Separate retrieval path**
-
-Keep `GetScratchBuffer()` unchanged for arena allocation. Add a new method:
-
-```cpp
-// In OpKernelContext:
-void* GetPreallocatedWorkspace(int slot_id) const;
-// Returns nullptr if not pre-planned → kernel must call GetScratchBuffer() instead
-
-// Kernel usage:
-void* ws = context->GetPreallocatedWorkspace(0);
-if (!ws) {
-  scratch_buffer_ = GetScratchBuffer<void>(workspace_size, stream);
-  ws = scratch_buffer_.get();
-}
-```
-
-Pro: Clear separation, no ambiguity about ownership. Con: Kernels need explicit fallback logic (but this is a one-time pattern per kernel).
-
-**Compatibility with dynamic shapes:** Both alternatives are opt-in. If `DeclareWorkspaceRequirements()` is not overridden or returns empty (dynamic shapes), everything falls back to `GetScratchBuffer()` → arena, exactly as today. Same kernel binary works for both static and dynamic models.
-
-**Incremental adoption:** Start with the highest-impact ops (attention, convolution, GEMM) which account for the majority of workspace. Less common ops continue using the arena with a reduced safety multiplier in `IResourceAccountant`.
-
-**Buffer strategy:** Workspace offsets can share the activation buffer (liveness doesn't overlap — workspace is live only during its step, activations may span steps). Alternatively, a separate workspace buffer is simpler initially and easier to account for in memory limits.
+**Future stronger mode:** allocating and retaining the complete execution buffer during session
+initialization would be a separate feature. Such a mode would need trustworthy static or bounded
+shapes, runtime bound enforcement, a concurrency policy, and no dynamic-allocation fallback before it
+could claim that a successful `Initialize()` prevents allocation-time OOM during `Run()`. #32071 does
+not provide that guarantee.
 
 ##### EP Plugin C ABI Surface for Workspace Pre-declaration
 

--- a/docs/annotated_partitioning/future_directions_constrained_env.md
+++ b/docs/annotated_partitioning/future_directions_constrained_env.md
@@ -384,42 +384,70 @@ cudnnHandle_t handle = cuda_ep->GetCudnnHandle();
 Not the same function pointer (different signatures — one has a kernel instance, one doesn't). But the **core computation logic can be a shared static helper** called from both:
 
 ```cpp
-// Shared static helper (no instance needed):
-static size_t ComputeAttentionWorkspace(int batch, int seq, int heads,
-                                         int head_size, int num_SMs) {
-    auto [num_splits, slse_size, o_size] = flash::get_num_splits_and_buffer_sizes(
-        batch, seq, seq, heads, head_size, num_SMs);
-    return flash::get_softmax_lse_size(seq, batch, heads) + slse_size + o_size;
+// Illustrative BSHD Attention formula: one float accumulation value per element.
+// A real kernel substitutes its exact formula but keeps this checked-arithmetic pattern.
+static std::optional<size_t> ComputeIllustrativeBshdAttentionWorkspace(
+    int64_t batch, int64_t sequence, int64_t heads, int64_t head_size) {
+  const int64_t dimensions[] = {batch, sequence, heads, head_size};
+  for (const int64_t dimension : dimensions) {
+    if (dimension == 0) {
+      return 0;
+    }
+  }
+
+  for (const int64_t dimension : dimensions) {
+    if (dimension < 0) {
+      return std::nullopt;
+    }
+  }
+  try {
+    SafeInt<size_t> bytes{sizeof(float)};
+    for (const int64_t dimension : dimensions) {
+      bytes *= SafeInt<size_t>(dimension);
+    }
+    return static_cast<size_t>(bytes);
+  } catch (const OnnxRuntimeException&) {
+    return std::nullopt;
+  }
 }
 
-// Estimation function (no kernel instance — called during GetCapability):
-OrtStatus* EstimateAttentionWorkspace(const OrtEpApi* api, const OrtNode* node,
-                                       const OrtEp* ep, size_t* out) {
-    const int64_t* shape; size_t rank;
-    api->Node_GetInputShape(node, 0, &shape, &rank);
-    int64_t num_heads;
-    api->Node_GetAttributeInt(node, "num_heads", &num_heads);
-
-    // EP-specific: cast to concrete type to access device properties
-    auto* cuda_ep = static_cast<const CudaEp*>(ep);
-    int num_SMs = cuda_ep->GetDeviceProp().multiProcessorCount;
-
-    *out = ComputeAttentionWorkspace(shape[0], shape[1], num_heads, shape[3], num_SMs);
-    return nullptr;
+// Level 1's graph parser extracts the illustrative BSHD input shape.
+static std::optional<size_t> EstimateAttentionWorkspace(
+    gsl::span<const int64_t> input_shape) {
+  if (input_shape.size() != 4) {
+    return std::nullopt;
+  }
+  return ComputeIllustrativeBshdAttentionWorkspace(
+      input_shape[0], input_shape[1], input_shape[2], input_shape[3]);
 }
 
-// DeclareWorkspaceRequirements (has kernel instance — called during FinalizeSessionState):
-Status Attention::DeclareWorkspaceRequirements(span<const TensorShape> shapes,
-                                               InlinedVector<WorkspaceRequirement>& reqs) {
-    int num_SMs = GetDeviceProp().multiProcessorCount;
-    size_t total = ComputeAttentionWorkspace(
-        shapes[0][0], shapes[0][1], num_heads_, head_size_, num_SMs);
-    reqs.push_back({total, kSlotFlashWorkspace});
+// Level 2 (has kernel instance; called during FinalizeSessionState):
+Status Attention::DeclareWorkspaceRequirements(
+    gsl::span<const WorkspaceInputShape> input_shapes,
+    InlinedVector<WorkspaceRequirement>& reqs) const {
+  reqs.clear();
+  const TensorShape* input_shape = GetWorkspaceInputShape(input_shapes, 0).GetShape();
+  if (input_shape == nullptr || input_shape->NumDimensions() != 4) {
+    // Missing/unusable metadata is not a session-initialization error. Schema validation is
+    // separate; retain the runtime allocation fallback.
     return Status::OK();
+  }
+
+  const auto total = ComputeIllustrativeBshdAttentionWorkspace(
+      (*input_shape)[0], (*input_shape)[1], (*input_shape)[2], (*input_shape)[3]);
+  if (!total.has_value()) {
+    return Status::OK();  // Valid partial/large shape: retain runtime allocation fallback.
+  }
+  if (*total != 0) {
+    reqs.push_back({*total, kSlotFlashWorkspace, /*alignment_bytes=*/0});
+  }
+  return Status::OK();
 }
 ```
 
-Both call the same `ComputeAttentionWorkspace()` — producing **identical results**. The estimation function gets device properties from the EP; the kernel method gets them from its stored EP reference. Same data, same computation, same answer.
+Both wrappers call the same checked helper and therefore produce identical results. Production helpers
+may also take already-extracted device properties, but every product, sum, conversion, and rounding
+operation must remain inside checked arithmetic.
 
 **For cuDNN-based ops**, the estimation function can also be precise — it calls `build_plans()` using the EP's handle and the node's shapes/attributes. Level 2 re-check serves as a diagnostic safety net — if the post-fusion total exceeds the budget, a warning is logged indicating that the Level 1 estimate was too optimistic (e.g., cuDNN returning different workspace sizes due to driver version differences or fusion changing the algorithm selection).
 
@@ -718,12 +746,15 @@ For most LLM models (which are repetitive transformer blocks with minimal fusion
 **When static shapes are unavailable:**
 
 If the model has dynamic shapes and no usable shape hint, the estimation function cannot compute workspace. In this case:
-- The estimation function returns a failure status or a sentinel value indicating "unknown."
+- Level 1 returns no estimate, and Level 2 returns `Status::OK()` with an empty requirements list.
+  Valid but unestimable metadata is never fatal to session initialization.
 - `ComputeNodeCostForBudget()` falls back to the 1.5x heuristic multiplier on base cost.
 - The user may need to **tune the memory budget by trial and error** — setting a conservative budget and adjusting based on observed OOM or under-utilization. This is analogous to llama.cpp's `-ngl` flag: the user picks a layer count and adjusts based on whether it fits.
 - `session.max_shape_override` can provide input-shape hints (for example, maximum batch and sequence length). ORT propagates them through a disposable shadow graph for Level 1 and Level 2 estimation without changing runtime input constraints. As noted above, propagated shapes are estimates rather than proven upper bounds.
 
-**Plugin C ABI for Level 1:**
+**Proposed plugin C ABI for Level 1 (deferred):**
+
+This PR does not add or wire the following C ABI; it is a future design sketch.
 
 ```c
 // Workspace estimation function type (no kernel instance needed):
@@ -860,94 +891,29 @@ ep_api->KernelRegistry_AddKernelV2(registry, conv_kernel_def, CreateConvKernel,
 
 #### Implementation: `DeclareWorkspaceRequirements` (Level 2 — after kernel creation)
 
-**In-tree path:**
-
-Straightforward — add a virtual method to `OpKernel`:
+**Current in-tree path:**
 
 ```cpp
 // In include/onnxruntime/core/framework/op_kernel.h:
 [[nodiscard]] virtual Status DeclareWorkspaceRequirements(
-    gsl::span<const TensorShape> input_shapes,
+    gsl::span<const WorkspaceInputShape> input_shapes,
     InlinedVector<WorkspaceRequirement>& requirements) const {
+  requirements.clear();
   return Status::OK();  // Default: no workspace declared
 }
 ```
 
-In-tree kernels override this just like they override `PrePack()`. Called during `FinalizeSessionState()` after kernel instances exist.
+In-tree kernels override this method like `PrePack()`, and `FinalizeSessionState()` calls it after
+kernel instances are created. The authoritative positional three-state input contract and lockstep
+signature-replacement decision are specified once under
+[Phase A](#phase-a-workspace-pre-declaration-declareworkspacerequirements).
 
-**Plugin (shared source) path:**
-
-The `CudaKernelAdapter<T>` already bridges virtual calls to the underlying kernel class. The adapter forwards `DeclareWorkspaceRequirements` to the underlying kernel's implementation:
-
-```cpp
-// In cuda_kernel_adapter.h — adapter already forwards PrePack similarly:
-Status DeclareWorkspaceRequirements(
-    gsl::span<const TensorShape> input_shapes,
-    InlinedVector<WorkspaceRequirement>& requirements) const override {
-  // The underlying kernel class (compiled in the plugin DLL) implements this directly.
-  // CudaKernelAdapter<T> inherits from T, so T::DeclareWorkspaceRequirements is accessible.
-  return T::DeclareWorkspaceRequirements(input_shapes, requirements);
-}
-```
-
-Since plugin shared-source kernels ARE the same C++ class (just compiled in a different DLL), they implement `DeclareWorkspaceRequirements` as a regular virtual override — no ABI translation needed.
-
-**Pure ABI path (third-party EP):**
-
-Add an optional function pointer to `OrtKernelImpl`:
-
-```c
-// In onnxruntime_ep_c_api.h, extend OrtKernelImpl:
-struct OrtKernelImpl {
-  // ... existing fields (Compute, Release, PrePackWeight, ...) ...
-
-  // NEW — optional workspace declaration (ORT >= 1.XX):
-  ORT_API2_STATUS(DeclareWorkspaceRequirements,
-      _In_ OrtKernelImpl* this_ptr,
-      _In_ const int64_t* const* input_shapes,  // array of shape arrays
-      _In_ const size_t* input_ranks,            // rank of each input
-      _In_ size_t num_inputs,
-      _Out_ OrtWorkspaceRequirement** requirements,  // allocated by kernel
-      _Out_ size_t* num_requirements);
-};
-```
-
-The `PluginEpOpKernel` adapter (in `ep_kernel_registration.cc`) bridges this to the virtual call:
-
-```cpp
-// In PluginEpOpKernel:
-Status DeclareWorkspaceRequirements(
-    gsl::span<const TensorShape> input_shapes,
-    InlinedVector<WorkspaceRequirement>& requirements) const override {
-  // Version guard (same pattern as PrePack):
-  if (kernel_impl_->ort_version_supported < XX ||
-      kernel_impl_->DeclareWorkspaceRequirements == nullptr) {
-    return Status::OK();  // No declaration — fall back to arena
-  }
-
-  // Convert TensorShape spans to C arrays
-  InlinedVector<const int64_t*> shape_ptrs;
-  InlinedVector<size_t> ranks;
-  for (const auto& shape : input_shapes) {
-    shape_ptrs.push_back(shape.GetDims().data());
-    ranks.push_back(shape.NumDimensions());
-  }
-
-  OrtWorkspaceRequirement* reqs = nullptr;
-  size_t num_reqs = 0;
-  ORT_RETURN_IF_ERROR(ToStatusAndRelease(
-      kernel_impl_->DeclareWorkspaceRequirements(
-          kernel_impl_, shape_ptrs.data(), ranks.data(),
-          shape_ptrs.size(), &reqs, &num_reqs)));
-
-  // Convert C results to C++ vector
-  for (size_t i = 0; i < num_reqs; ++i) {
-    requirements.push_back({reqs[i].size_bytes, reqs[i].slot_id});
-  }
-  // Free C allocation (kernel used OrtAllocator or static buffer)
-  return Status::OK();
-}
-```
+**Plugin and pure-C ABI paths are deferred.** The adapter `OpKernel` header mirrors the in-tree
+signature and default no-op only so shared kernel source continues to compile in the plugin build.
+There is no `CudaKernelAdapter` forwarding implementation, no `OrtKernelImpl` function pointer, and
+no host-side bridge for this virtual. In particular, the plugin host does not invoke
+`DeclareWorkspaceRequirements`; plugin-compiled kernels currently keep the adapter default no-op and
+continue allocating workspace dynamically.
 
 #### Summary: Where Each Piece Lives
 
@@ -955,8 +921,8 @@ Status DeclareWorkspaceRequirements(
 |-----------|---------|----------------------|----------|
 | **Workspace estimation func** | Static member on kernel class; stored in `KernelCreateInfo::workspace_estimate_func` | Same static function, registered via `KernelRegistry_AddKernelV2` | C function pointer, registered via `KernelRegistry_AddKernelV2` |
 | **Who calls estimation** | EP's `GetCapability()` loop via `ComputeNodeCostForBudget()` helper | Host bridge via same `ComputeNodeCostForBudget()` helper | Host bridge (same) |
-| **DeclareWorkspaceRequirements** | Virtual override on `OpKernel` | Virtual override (same C++ class in plugin DLL) | `OrtKernelImpl::DeclareWorkspaceRequirements` function pointer → `PluginEpOpKernel` adapter |
-| **Who calls DeclareWorkspace** | `FinalizeSessionState()` | `FinalizeSessionState()` (same) | `FinalizeSessionState()` via adapter |
+| **DeclareWorkspaceRequirements** | Virtual override on core `OpKernel` | Adapter default no-op only; forwarding deferred | Not present; C-ABI design deferred |
+| **Who calls DeclareWorkspace** | In-tree `FinalizeSessionState()` | Nobody across the plugin boundary | Nobody |
 | **Device property access** | `static_cast<CUDAExecutionProvider*>(ep)->GetDeviceProp()` | `static_cast<const CudaEp*>(ep)->GetDeviceProp()` | `static_cast<const MyEp*>(ep)->GetDeviceProps()` |
 | **cuDNN handle access** | `static_cast<CUDAExecutionProvider*>(ep)->PerThreadDefaultCudnnHandle()` | `static_cast<const CudaEp*>(ep)->GetCudnnHandle()` | N/A (EP-specific) |
 
@@ -967,7 +933,9 @@ The **estimation function** signature differs between in-tree and plugin paths:
 - **In-tree:** `static size_t EstimateWorkspace(const IExecutionProvider* ep, const Node& node)` — C++ types, direct EP access
 - **Plugin/ABI:** `OrtStatus* EstimateWorkspace(const OrtEpApi*, const OrtNode*, const OrtEp*, size_t*)` — C ABI, opaque types
 
-But both compute the same result. For shared-source kernels (compiled both in-tree and as plugin), a single static helper function (e.g., `ComputeAttentionWorkspace()`) is called from both wrappers — ensuring the estimate is identical regardless of build configuration.
+But both compute the same result. For shared-source kernels, both wrappers call one checked,
+graph-type-free math helper, ensuring identical estimates without carrying in-tree graph types across
+the plugin boundary.
 
 **Implementation-confirmed boundary (issue #29775 Phase-A pilot, PR #29811, MatMulNBits):** the split above
 is sharper than "same function, different signature" — it is two functions with different reusability.
@@ -999,11 +967,40 @@ struct WorkspaceRequirement {
 
 // Optional override on OpKernel (called during FinalizeSessionState):
 virtual Status DeclareWorkspaceRequirements(
-    gsl::span<const TensorShape> input_shapes,
+    gsl::span<const WorkspaceInputShape> input_shapes,
     InlinedVector<WorkspaceRequirement>& requirements) const {
+  requirements.clear();
   return Status::OK();  // Default: no declaration (fall back to arena)
 }
 ```
+
+`WorkspaceInputShape` is positional and presence-aware:
+
+- `Missing` means the optional input was omitted.
+- `PresentWithShape` includes scalars, zero extents, and partial shapes. Every unknown dimension is
+  represented by `-1`. Negative proto dimensions also normalize to `-1`; multiple `-1` dimensions
+  are independent unknowns and do not imply symbolic equality.
+- `PresentWithoutShape` means the input exists but rank/dimension metadata is unavailable.
+
+The span aligns with `Node::InputDefs()` and `OpKernelContext::Input(i)`; implicit inputs are excluded.
+Callers preserve internal and trailing optional-input holes, and kernels may ignore missing/shapeless
+inputs that are unrelated to their workspace formula.
+
+The former `gsl::span<const TensorShape>` pilot signature was removed rather than retained as an
+overload. This direct C++ signature replacement is intentional and requires a lockstep rebuild of the
+core and in-tree providers. The virtual is unreleased; stable binary compatibility is provided by the
+C API, which was not changed for this pilot.
+
+`WorkspaceInputShape` deliberately carries no shape-provenance field in Phase A. Consumers cannot
+distinguish executable-graph shapes from values propagated from `session.max_shape_override`.
+Before Phase B uses declarations for allocation, the planner design must decide whether provenance
+is required and define the corresponding runtime bound check and allocation fallback. This PR does
+not add speculative provenance state.
+
+An empty Level-2 requirements list currently means that no requirement can be declared and the
+kernel retains its dynamic allocation fallback. Zero-sized requirements are also omitted. A future
+planner must define the semantics of an explicit, proven-zero slot before the interface gains a zero
+marker; this PR intentionally adds neither a marker nor new provenance state.
 
 **`alignment_bytes` (added in PR #29811):** reserved for a future shared-arena packer that co-locates
 multiple kernels' declared slots and needs per-slot alignment metadata. Unused by any kernel today — the
@@ -1014,20 +1011,28 @@ outer buffer is already ≥256-byte aligned). A plain `size_t` with a `0` sentin
 eventually, and `std::optional`'s layout is not guaranteed stable across compilers/STL versions the way
 a scalar with a sentinel value is.
 
-**Shape source wiring:** framework callers now resolve shapes from two sources:
+**Shape source wiring:** framework callers resolve presence-aware entries from two shape sources:
 
-- Fully concrete shapes already present on the executable graph are used directly.
+- Rank/dimension metadata already present on the executable graph is retained, including partial
+  shapes with `-1` unknown dimensions.
 - For dynamic models, `session.max_shape_override` is applied to a disposable shadow graph. Normal ORT
   shape inference propagates those input hints to intermediate values without changing executable-graph
-  metadata or runtime input validation.
+  metadata or runtime input validation. These propagated values are estimates, not proven upper
+  bounds, because operator shape transformations are not necessarily monotonic.
 
 Level 1 consumes the current shadow result during `GetCapability()`. It reuses that result for the second
 capability pass when layout transformation reports no modification and rebuilds it after known graph
 mutations. Level 2 creates a final result after partitioning because EP fusion and transformation can
 change NodeArgs, generated schemas, and subgraph identities. Reusing a pre-mutation result across those
 stages would be incorrect; deeper caching requires a reliable graph-mutation generation rather than
-assuming equal topology. Nodes whose inputs remain unresolved use the existing estimation/allocation
-fallback.
+assuming equal topology. The resolver still calls kernels with `Missing` or `PresentWithoutShape`
+entries; each kernel decides whether the inputs needed by its formula are estimable. Returning no
+requirements preserves the existing dynamic allocation fallback.
+
+This Phase-A pilot only gathers declarations. Plugin C-ABI forwarding, workspace offset
+planning/allocation, and integration with resource accounting remain deferred; no declaration changes
+partition budgets or replaces the runtime scratch-allocation path yet. Phase-B planner/accounting
+integration remains in the scope of #32071.
 
 A kernel can declare multiple workspace slots (e.g., attention needs separate Q transpose buffer, output buffer, seqlens buffer). The `slot_id` is defined by the kernel author and is stable across calls — it identifies *which* buffer within that kernel's logic.
 
@@ -1170,124 +1175,21 @@ Pro: Clear separation, no ambiguity about ownership. Con: Kernels need explicit 
 
 ##### EP Plugin C ABI Surface for Workspace Pre-declaration
 
-In the plugin architecture, `DeclareWorkspaceRequirements` crosses the C ABI boundary. This section defines the concrete API additions.
+The issue #29775 Phase-A pilot does **not** add this surface. Plugin/C-ABI forwarding remains deferred:
 
-**Declaration side — new optional function pointer on `OrtKernelImpl`:**
+- The adapter `OpKernel` declaration mirrors the in-tree C++ signature and default no-op so
+  plugin-compiled shared source builds, but the host does not bridge or invoke that virtual.
+- `OrtKernelImpl` and `OrtEpApi` have no workspace-declaration/retrieval additions from this pilot.
+- Plugin kernels therefore continue to use the existing dynamic scratch-allocation path.
 
-```c
-// Added to OrtKernelImpl (optional, like PrePackWeight):
-ORT_API2_STATUS(DeclareWorkspaceRequirements,
-    _In_ OrtKernelImpl* this_ptr,
-    _In_reads_(num_inputs) const int64_t* const* input_shapes,   // shape per input
-    _In_reads_(num_inputs) const size_t* input_shape_ranks,      // rank per input
-    _In_ size_t num_inputs,
-    _Out_writes_all_(max_slots) OrtWorkspaceSlot* slots,         // pre-allocated by ORT
-    _In_ size_t max_slots,                                        // capacity (e.g., 8)
-    _Out_ size_t* num_slots);                                     // actual count filled
+A future C-ABI design must preserve the Phase-A positional input-shape contract rather than collapsing
+omitted inputs, rank-0 tensors, and absent shape metadata into ambiguous shape/rank arrays. It must
+also define ownership/lifetime for returned slot descriptors, retrieval fallback behavior, and
+versioning before any host bridge is implemented.
 
-// Slot descriptor (C struct, no inheritance):
-typedef struct OrtWorkspaceSlot {
-  int slot_id;          // Kernel-defined, stable identifier (0, 1, 2, ...)
-  size_t size_bytes;    // Required size for this slot
-} OrtWorkspaceSlot;
-```
-
-If `DeclareWorkspaceRequirements` is NULL on the `OrtKernelImpl`, ORT skips the kernel during workspace planning (falls back to arena at runtime).
-
-**Retrieval side — new function in `OrtEpApi`:**
-
-```c
-// Added to OrtEpApi (called by plugin kernels during Compute):
-ORT_API2_STATUS(KernelContext_GetPreallocatedWorkspace,
-    _In_ const OrtKernelContext* context,
-    _In_ int slot_id,
-    _Outptr_result_maybenull_ void** buffer);   // NULL if not pre-planned
-```
-
-Returns a pointer into the pre-allocated workspace buffer at the offset computed during planning. Returns NULL if no workspace was pre-planned for this kernel+slot (dynamic shapes, or kernel didn't declare). The pointer is valid for the duration of the `Compute()` call.
-
-**Slot ID provisioning — how kernels define unique slot_ids:**
-
-Slot IDs are **kernel-author-defined constants**, not dynamically allocated. Each kernel class defines its slots as an enum or set of constants in its implementation:
-
-```cpp
-// Example: CUDA Attention kernel (inside the plugin DLL)
-namespace cuda {
-class AttentionKernel : public OrtKernelImplBase {
-  // Slot IDs are private constants — stable across versions, used as array indices
-  static constexpr size_t kSlotQTranspose = 0;
-  static constexpr size_t kSlotKTranspose = 1;
-  static constexpr size_t kSlotVTranspose = 2;
-  static constexpr size_t kSlotSoftmaxWorkspace = 3;
-  static constexpr size_t kNumSlots = 4;
-
-  OrtStatus* DeclareWorkspaceRequirements(...) override {
-    slots[kSlotQTranspose] = {kSlotQTranspose, batch * heads * seq * head_dim * sizeof(half)};
-    slots[kSlotKTranspose] = {kSlotKTranspose, batch * heads * seq * head_dim * sizeof(half)};
-    slots[kSlotVTranspose] = {kSlotVTranspose, batch * heads * seq * head_dim * sizeof(half)};
-    slots[kSlotSoftmaxWorkspace] = {kSlotSoftmaxWorkspace, cudnn_workspace_size};
-    *num_slots = kNumSlots;
-    return nullptr;
-  }
-
-  OrtStatus* Compute(OrtKernelContext* ctx) override {
-    void* q_buf = nullptr;
-    // Uses pre-planned workspace if available, falls back to arena otherwise
-    api_->KernelContext_GetScratchBuffer(ctx, kSlotQTranspose, q_transpose_size, &q_buf);
-    // ... use q_buf ...
-  }
-};
-}  // namespace cuda
-```
-
-**Key design properties:**
-
-| Property | Design Choice | Rationale |
-|----------|--------------|-----------|
-| Slot ID scope | Per kernel *instance* (node) | Same kernel class on different nodes gets separate buffers; ORT disambiguates via `(NodeIndex, slot_id)` |
-| Slot ID assignment | Static constants in kernel code | No registry, no runtime allocation, no cross-kernel coordination needed |
-| Slot ID range | `[0, max_slots)` — small integers | Simple array indexing in the offset plan; `max_slots` = 8 is generous for any single kernel |
-| Uniqueness guarantee | Kernel author's responsibility | Same convention as `input_index` in `PrePackWeight` — the kernel knows its own buffer layout |
-| Stability across versions | Expected (like enum values) | Slot IDs are internal to the kernel; not exposed to users or other kernels |
-
-**Where state lives:**
-
-| State | Location | Lifetime |
-|-------|----------|----------|
-| Slot definitions (id + size) | Returned by `DeclareWorkspaceRequirements` → stored in `ExecutionPlan` | Session lifetime (computed once at `Initialize()`) |
-| Offset map `{(NodeIndex, slot_id) → offset}` | `SessionState::workspace_pattern_` (new field, analogous to `mem_patterns_`) | Session lifetime (shared, read-only) |
-| Peak workspace size per EP/device | `SessionState::workspace_pattern_` | Session lifetime |
-| Actual workspace buffer | `ExecutionFrame` (allocated per-`Run()` via `Reserve()`) | Single `Run()` invocation |
-
-**No global slot registry needed.** Unlike input indices which are defined by the ONNX op schema, slot IDs are entirely internal to the kernel implementation. Two different kernel classes can both use `slot_id=0` without conflict — the framework always qualifies with `NodeIndex`. This means:
-- No coordination between kernel authors
-- No registration step during plugin initialization
-- No versioning concerns (IDs never cross the plugin boundary as semantic values)
-
-##### Cost of a Real Plugin-Side Override (Deferred)
-
-The issue #29775 Phase-A pilot (PR #29811, MatMulNBits) deliberately implemented Level 1 and Level 2
-**only** for the in-tree CUDA EP, and left the plugin-side path unimplemented — the C ABI surface above
-describes the *design*, not something that pilot built or exercised. This was an explicit scope decision
-made when the pilot's design doc (issue #29810) was written, for these reasons, which remain the
-concrete cost of picking this up next:
-
-1. **DLL-boundary verification.** The shared math helper (e.g. `ComputeFpAIntBGemmWorkspaceSize`) needs
-   to actually be confirmed to link and execute correctly when called from the plugin DLL — the struct
-   crossing the ABI boundary compiling is not the same as the helper function being callable/linked
-   there.
-2. **A second build configuration's worth of test infrastructure.** The plugin EP is a separate CMake
-   build configuration from the in-tree CUDA EP; verifying Level 1/2 for a plugin kernel means building
-   and testing under that configuration too, which this pilot's test infra does not cover.
-3. **Wiring the plugin EP's own, separate memory-budget consumer.** `ep_plugin_provider_interfaces.cc`
-   (around line 356) has its own existing budget loop, independent of the in-tree `IResourceAccountant`
-   path, currently using a flat 1.5x safety multiplier. Having Level 1/2 estimates available does not by
-   itself make the plugin EP use them — that loop needs to be updated to consume the estimates, which is
-   a separate piece of work from declaring the estimates.
-
-None of the above is started. A kernel author picking up plugin-side workspace estimation should expect
-to do all three, not just implement the `DeclareWorkspaceRequirements` override on the plugin kernel
-class.
+That future work also requires DLL-boundary validation of shared pure-math helpers, a separate plugin
+build/test configuration, and explicit host-side forwarding. None of those pieces is implemented by
+the pilot, and the presence of the adapter default must not be interpreted as host support.
 
 #### Phase B: Eliminate Arena for Static-Shape Models
 

--- a/include/onnxruntime/core/framework/op_kernel.h
+++ b/include/onnxruntime/core/framework/op_kernel.h
@@ -10,6 +10,7 @@
 // as it doesn't include any pb headers.
 #include "core/framework/buffer_deleter.h"
 #include "core/framework/prepacked_weights_container.h"
+#include "core/framework/workspace_input_shape.h"
 #include "core/framework/workspace_requirement.h"
 
 #ifndef SHARED_PROVIDER
@@ -106,16 +107,20 @@ class OpKernel {
     return Status::OK();
   }
 
-  // Phase-A memory roadmap (issue microsoft/onnxruntime#29775). Declare Compute()-time scratch
-  // ("workspace") that can be sized statically from shape metadata alone (no live OpKernelContext /
-  // real tensors). Default: declare nothing -> callers MUST fall back to today's dynamic
-  // GetScratchBuffer path. Adding this MUST NOT change behavior for any kernel that does not
-  // override it.
+  // Phase-A memory roadmap (issue microsoft/onnxruntime#29775). Declares Compute()-time scratch
+  // ("workspace") that can be sized from shape metadata alone, without live tensors. The positional
+  // span corresponds to Node::InputDefs() and OpKernelContext::Input(i); implicit inputs are
+  // excluded. The default declares nothing, so callers fall back to today's dynamic GetScratchBuffer
+  // path and behavior is unchanged for kernels that do not override this method.
   //
   // Called during FinalizeSessionState() after kernel instances are created, when input shapes
   // are known (static models) or max shape hints are provided via session.max_shape_override.
+  // Max-shape inference produces estimation hints, not proven upper bounds; declarations based on
+  // them must retain runtime validation and allocation fallback.
+  // A valid input that cannot be estimated returns OK with no requirements. A non-OK status is
+  // fatal to session initialization.
   [[nodiscard]] virtual Status DeclareWorkspaceRequirements(
-      gsl::span<const TensorShape> /*input_shapes*/,
+      gsl::span<const WorkspaceInputShape> /*input_shapes*/,
       /*out*/ InlinedVector<WorkspaceRequirement>& requirements) const {
     requirements.clear();  // defensive: never attribute a prior kernel's slots to a no-op kernel
     return Status::OK();

--- a/include/onnxruntime/core/framework/workspace_input_shape.h
+++ b/include/onnxruntime/core/framework/workspace_input_shape.h
@@ -1,0 +1,81 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include <cstddef>
+#include <utility>
+
+#include <gsl/span>
+
+#include "core/framework/tensor_shape.h"
+
+namespace onnxruntime {
+
+// Shape metadata for one positional node input used when declaring workspace requirements.
+enum class WorkspaceInputShapeState {
+  // The optional input is omitted at this position.
+  Missing,
+  // The input is present and rank/dimension metadata is available. This includes rank-0 scalars,
+  // zero extents, and partial shapes. Unknown dimensions are encoded as -1; multiple -1 dimensions
+  // are independent unknowns and do not imply symbolic equality. TensorShape::Size() returns -1
+  // for a partial shape, so consumers must inspect dimensions rather than convert Size() to an
+  // unsigned byte/count value.
+  PresentWithShape,
+  // The input is present, but no rank or dimension metadata is available.
+  PresentWithoutShape,
+};
+
+// A PresentWithShape value may come from executable-graph metadata or max-shape inference. The
+// latter is an estimation hint, not a proven upper bound, so consumers must retain runtime checks
+// and allocation fallbacks. This Phase-A type intentionally carries no provenance state; deciding
+// whether Phase-B allocation planning needs it is deferred until that runtime fallback contract is
+// designed.
+class WorkspaceInputShape {
+ public:
+  WorkspaceInputShape() = default;
+
+  static WorkspaceInputShape PresentWithShape(const TensorShape& shape) {
+    // TensorShape can be a non-owning view created by FromExistingBuffer(). Always copy the
+    // dimensions so this value remains valid independently of the caller's storage.
+    return WorkspaceInputShape{
+        WorkspaceInputShapeState::PresentWithShape, TensorShape{shape.GetDims()}};
+  }
+
+  static WorkspaceInputShape PresentWithoutShape() {
+    return WorkspaceInputShape{WorkspaceInputShapeState::PresentWithoutShape, TensorShape{}};
+  }
+
+  WorkspaceInputShapeState GetState() const noexcept {
+    return state_;
+  }
+
+  const TensorShape* GetShape() const& noexcept {
+    return state_ == WorkspaceInputShapeState::PresentWithShape ? &shape_ : nullptr;
+  }
+
+  // A pointer into a temporary WorkspaceInputShape would dangle immediately.
+  const TensorShape* GetShape() const&& = delete;
+
+ private:
+  WorkspaceInputShape(WorkspaceInputShapeState state, TensorShape shape)
+      : state_{state}, shape_{std::move(shape)} {
+  }
+
+  WorkspaceInputShapeState state_{WorkspaceInputShapeState::Missing};
+  TensorShape shape_;
+};
+
+// Node inputs are positional. A caller may omit trailing optional inputs from the span; querying one
+// of those positions has the same meaning as an explicit Missing entry.
+inline const WorkspaceInputShape& GetWorkspaceInputShape(
+    gsl::span<const WorkspaceInputShape> input_shapes, size_t input_index) {
+  if (input_index < input_shapes.size()) {
+    return input_shapes[input_index];
+  }
+
+  static const WorkspaceInputShape missing_input;
+  return missing_input;
+}
+
+}  // namespace onnxruntime

--- a/include/onnxruntime/core/framework/workspace_requirement.h
+++ b/include/onnxruntime/core/framework/workspace_requirement.h
@@ -21,11 +21,9 @@ struct WorkspaceRequirement {
   size_t size_bytes;  // upper-bound scratch bytes for this slot
   int slot_id;        // kernel-defined, stable across runs; unique within one kernel instance
 
-  // Pointer-alignment requirement for this slot's buffer, in bytes (e.g. 128, 256). 0 means "the
-  // allocator's default alignment is sufficient" - true for every kernel using this API today, since
-  // CUDA's allocator already guarantees >= 256-byte aligned allocations. Reserved for a future kernel
-  // with a stricter/exotic alignment need, or a future shared-arena packer that co-locates multiple
-  // kernels' slots (see the "shared per-node memory-budget tracker" direction in issue #29775).
+  // Pointer-alignment requirement for this slot's buffer, in bytes (e.g. 128, 256). 0 requests the
+  // allocator's default alignment. Any nonzero value is a binding requirement on the returned
+  // buffer/root that a planner must honor.
   // A plain size_t (not std::optional<size_t>) is used deliberately: this struct is meant to be usable
   // across a plugin-DLL boundary eventually, and std::optional's layout is not guaranteed stable across
   // compilers/STL versions the way a scalar with a sentinel value is.

--- a/include/onnxruntime/ep/adapter/op_kernel.h
+++ b/include/onnxruntime/ep/adapter/op_kernel.h
@@ -17,6 +17,7 @@
 #include "core/common/inlined_containers.h"
 #include "core/framework/allocator.h"
 #include "core/framework/tensor.h"
+#include "core/framework/workspace_input_shape.h"
 #include "core/framework/workspace_requirement.h"
 
 #include "node.h"
@@ -62,12 +63,12 @@ struct OpKernel {
     return Status::OK();
   }
 
-  // Phase-A memory roadmap (issue microsoft/onnxruntime#29775). Mirrors the in-tree
-  // onnxruntime::OpKernel::DeclareWorkspaceRequirements default no-op so that kernels compiled into
-  // the plugin (BUILD_CUDA_EP_AS_PLUGIN) hierarchy still build. See
-  // core/framework/workspace_requirement.h.
+  // Mirrors the in-tree OpKernel default so shared kernel source compiled for the plugin hierarchy
+  // continues to build. The plugin host does not bridge or invoke this virtual; plugin/C-ABI
+  // forwarding is deferred, so this adapter declaration remains a default no-op. See the core
+  // framework OpKernel header for the in-tree FinalizeSessionState contract.
   [[nodiscard]] virtual Status DeclareWorkspaceRequirements(
-      gsl::span<const TensorShape> /*input_shapes*/,
+      gsl::span<const WorkspaceInputShape> /*input_shapes*/,
       /*out*/ InlinedVector<WorkspaceRequirement>& requirements) const {
     requirements.clear();
     return Status::OK();

--- a/onnxruntime/contrib_ops/cuda/llm/fpA_intB_gemm/fpA_intB_gemm.h
+++ b/onnxruntime/contrib_ops/cuda/llm/fpA_intB_gemm/fpA_intB_gemm.h
@@ -112,6 +112,16 @@ class CutlassFpAIntBGemmRunnerInterface {
 // overflow; on overflow this returns std::nullopt instead of throwing.
 inline std::optional<size_t> ComputeFpAIntBGemmWorkspaceSize(int m, int n, int /*k*/, int sm,
                                                              int multi_processor_count) {
+  // Empty output never reaches tactic selection or workspace allocation. Handle it before the
+  // architecture-specific formulas: the native SM90 formula otherwise depends only on the SM count
+  // and would return a large positive estimate. Negative dimensions are unknown/invalid, not empty.
+  if (m < 0 || n < 0) {
+    return std::nullopt;
+  }
+  if (m == 0 || n == 0) {
+    return 0;
+  }
+
   try {
     using Interface = CutlassFpAIntBGemmRunnerInterface;
 #ifndef EXCLUDE_SM_90

--- a/onnxruntime/contrib_ops/cuda/quantization/matmul_nbits.cc
+++ b/onnxruntime/contrib_ops/cuda/quantization/matmul_nbits.cc
@@ -181,35 +181,17 @@ bool CheckFpAIntBEligibility(int32_t input0_elem_type, int64_t N, int64_t K,
   return true;
 }
 
-// Product of all leading (non-K) dimensions of input A, i.e. the GEMM "m". Returns nullopt when the
-// shape is missing or any leading dimension is not statically known (dynamic-shape fallback).
-static std::optional<int64_t> StaticLeadingDimProduct(const NodeArg* input_a) {
-  if (input_a == nullptr) {
-    return std::nullopt;
-  }
-  const ONNX_NAMESPACE::TensorShapeProto* shape = input_a->Shape();
-  if (shape == nullptr || shape->dim_size() < 1) {
-    return std::nullopt;
-  }
-  SafeInt<int64_t> m(1);
-  // All dims except the last (which is K).
-  for (int i = 0; i + 1 < shape->dim_size(); ++i) {
-    const auto& dim = shape->dim(i);
-    if (!dim.has_dim_value()) {
-      return std::nullopt;
-    }
-    try {
-      m *= dim.dim_value();
-    } catch (const OnnxRuntimeException&) {
-      return std::nullopt;
-    }
-  }
-  return static_cast<int64_t>(m);
-}
-
-static std::optional<int64_t> LeadingDimProduct(gsl::span<const int64_t> input_a_shape) {
+std::optional<int64_t> ComputeMatMulNBitsLeadingDimProduct(gsl::span<const int64_t> input_a_shape) {
   if (input_a_shape.empty()) {
     return std::nullopt;
+  }
+
+  // Establish a known-empty output before rejecting unknown dimensions or doing arithmetic.
+  // This also avoids reporting overflow for a huge prefix whose later leading dimension is zero.
+  for (size_t i = 0; i + 1 < input_a_shape.size(); ++i) {
+    if (input_a_shape[i] == 0) {
+      return 0;
+    }
   }
 
   SafeInt<int64_t> m(1);
@@ -225,6 +207,30 @@ static std::optional<int64_t> LeadingDimProduct(gsl::span<const int64_t> input_a
   }
 
   return static_cast<int64_t>(m);
+}
+
+// Product of all leading (non-K) dimensions of input A, i.e. the GEMM "m". Returns nullopt when the
+// shape is missing or any non-zero leading dimension is not statically known.
+static std::optional<int64_t> StaticLeadingDimProduct(const NodeArg* input_a) {
+  if (input_a == nullptr) {
+    return std::nullopt;
+  }
+  const ONNX_NAMESPACE::TensorShapeProto* shape = input_a->Shape();
+  if (shape == nullptr || shape->dim_size() < 1) {
+    return std::nullopt;
+  }
+
+  TensorShapeVector dimensions;
+  dimensions.reserve(static_cast<size_t>(shape->dim_size()));
+  for (const auto& dimension : shape->dim()) {
+    if (!dimension.has_dim_value()) {
+      dimensions.push_back(-1);
+    } else {
+      dimensions.push_back(dimension.dim_value());
+    }
+  }
+
+  return ComputeMatMulNBitsLeadingDimProduct(dimensions);
 }
 
 static std::optional<size_t> EstimateMatMulNBitsWorkspaceImpl(
@@ -321,7 +327,8 @@ std::optional<size_t> EstimateMatMulNBitsWorkspace(const Node& node, const cudaD
 
 std::optional<size_t> EstimateMatMulNBitsWorkspace(
     const Node& node, gsl::span<const int64_t> input_a_shape, const cudaDeviceProp& device_prop) {
-  return EstimateMatMulNBitsWorkspaceImpl(node, device_prop, LeadingDimProduct(input_a_shape));
+  return EstimateMatMulNBitsWorkspaceImpl(
+      node, device_prop, ComputeMatMulNBitsLeadingDimProduct(input_a_shape));
 }
 
 template <typename T>
@@ -618,55 +625,45 @@ Status MatMulNBits<T>::PrePack_ZeroPoint([[maybe_unused]] const Tensor& tensor,
 #endif
 
 #if USE_FPA_INTB_GEMM && !defined(BUILD_CUDA_EP_AS_PLUGIN)
-// Level 2 (Phase-A memory roadmap, issue microsoft/onnxruntime#29775). Uses the same constructed
-// runner state and effective arch that ComputeInternal() uses, so the returned size equals the real
-// runtime request when the queried input-A shape equals the runtime input shape. Returns empty
-// (dynamic fallback) when the node does not take the fpA_intB CUTLASS-GEMM path, when the leading
-// (m) dimension of input A is not statically known, or when the size formula overflows.
+// Level 2 (Phase-A memory roadmap, issue microsoft/onnxruntime#29775). Uses the constructed runner
+// state and effective arch from ComputeInternal(). The size is exact for its CUTLASS GEMM branch.
+// Runtime may instead select the CUDA GEMV tactic, which requests no workspace; in that case this is
+// a safe upper bound. Unknown/negative dimensions and arithmetic overflow use dynamic fallback.
+// The shared formula returns zero for empty output; a zero-sized requirement is omitted.
 template <typename T>
 Status MatMulNBits<T>::DeclareWorkspaceRequirements(
-    gsl::span<const TensorShape> input_shapes,
+    gsl::span<const WorkspaceInputShape> input_shapes,
     /*out*/ InlinedVector<WorkspaceRequirement>& requirements) const {
   requirements.clear();
   if (!has_fpA_intB_gemm_ || weightOnlyGemmRunner_ == nullptr) {
     return Status::OK();
   }
-  if (input_shapes.empty()) {
-    return Status::OK();
-  }
-  // input_shapes[0] is input A, the same tensor as ctx->Input(0) in Compute(). m = product of all
-  // its dims except the last (K). A symbolic/unknown dim (negative) triggers the dynamic fallback.
-  const TensorShape& a_shape = input_shapes[0];
-  const size_t rank = a_shape.NumDimensions();
-  if (rank < 1) {
-    return Status::OK();
-  }
-  int64_t m64 = 1;
-  try {
-    SafeInt<int64_t> m(1);
-    for (size_t i = 0; i + 1 < rank; ++i) {
-      const int64_t d = a_shape[i];
-      if (d < 0) {
-        return Status::OK();
-      }
-      m *= d;
-    }
-    m64 = static_cast<int64_t>(m);
-  } catch (const OnnxRuntimeException&) {
+
+  // Input A is the only input needed for this estimate. Missing or unknown unrelated optional
+  // inputs do not suppress declaration.
+  const TensorShape* a_shape = GetWorkspaceInputShape(input_shapes, 0).GetShape();
+  if (a_shape == nullptr) {
     return Status::OK();
   }
 
-  // Use the same packing/workspace architecture rule as the runtime request.
+  // Input A is the same tensor as ctx->Input(0) in Compute(). m = product of all its dims except
+  // the last (K), which comes from the kernel attribute and may remain unknown here.
+  const std::optional<int64_t> m64 =
+      ComputeMatMulNBitsLeadingDimProduct(a_shape->GetDims());
+  if (!m64.has_value()) {
+    return Status::OK();
+  }
+  // Feed the SAME effective arch the runner resolved after setArch() - not the raw sm_ member.
   const int effective_sm = FpAIntBPackingSmForKernel();
   std::optional<size_t> ws;
   try {
     ws = onnxruntime::llm::kernels::cutlass_kernels::ComputeFpAIntBGemmWorkspaceSize(
-        SafeInt<int>(m64), SafeInt<int>(N_), SafeInt<int>(K_),
+        SafeInt<int>(*m64), SafeInt<int>(N_), SafeInt<int>(K_),
         effective_sm, this->GetDeviceProp().multiProcessorCount);
   } catch (const OnnxRuntimeException&) {
     return Status::OK();
   }
-  if (!ws.has_value()) {
+  if (!ws.has_value() || *ws == 0) {
     return Status::OK();
   }
   requirements.push_back(WorkspaceRequirement{*ws, /*slot_id=*/0, /*alignment_bytes=*/0});
@@ -676,6 +673,12 @@ Status MatMulNBits<T>::DeclareWorkspaceRequirements(
 
 template <typename T>
 Status MatMulNBits<T>::ComputeInternal(OpKernelContext* ctx) const {
+#if USE_FPA_INTB_GEMM
+  // TEST verification hook only. Record every invocation, including validation failures, empty
+  // outputs, and GEMV/non-fpA_intB paths, so the value always describes the latest call.
+  last_compute_workspace_bytes_.store(0, std::memory_order_relaxed);
+#endif
+
   if constexpr (std::is_same_v<T, BFloat16>) {
     if (sm_ < 80) {
       return ORT_MAKE_STATUS(ONNXRUNTIME, NOT_IMPLEMENTED,
@@ -830,11 +833,11 @@ Status MatMulNBits<T>::ComputeInternal(OpKernelContext* ctx) const {
         onnxruntime::llm::kernels::fpA_intB_gemv::kernel_launcher(FpAIntBPackingSmForKernel(), params, stream);
       } else {
         const size_t workspace_size = weightOnlyGemmRunner_->getWorkspaceSize(m, n, k);
+        auto workspace_buffer = this->template GetScratchBuffer<void>(workspace_size, this->GetComputeStream(ctx));
         // TEST verification hook only. Relaxed ordering is sufficient: the pilot's single-threaded
         // tests only read this after the compute call has returned, so no cross-thread happens-before
         // relationship needs to be established here.
         last_compute_workspace_bytes_.store(workspace_size, std::memory_order_relaxed);
-        auto workspace_buffer = this->template GetScratchBuffer<void>(workspace_size, this->GetComputeStream(ctx));
 
         weightOnlyGemmRunner_->gemm(
             a_data,

--- a/onnxruntime/contrib_ops/cuda/quantization/matmul_nbits.h
+++ b/onnxruntime/contrib_ops/cuda/quantization/matmul_nbits.h
@@ -14,6 +14,7 @@
 #include <vector>
 #include "core/common/safeint.h"
 #include "core/common/string_utils.h"
+#include "core/framework/workspace_input_shape.h"
 #include "core/providers/cuda/cuda_kernel.h"
 #include "core/providers/cuda/shared_inc/fpgeneric.h"
 #include "contrib_ops/cuda/llm/fpA_intB_gemm_profiler.h"
@@ -259,25 +260,23 @@ class MatMulNBits final : public CudaKernel {
 #if USE_FPA_INTB_GEMM
 #ifndef BUILD_CUDA_EP_AS_PLUGIN
   // Level 2 (Phase-A memory roadmap, issue microsoft/onnxruntime#29775): instance-level workspace
-  // estimate, callable after CreateKernels(). Uses the same packing/workspace architecture rule as
-  // ComputeInternal(), so it equals the real runtime request when the queried input-A shape equals
-  // the runtime input shape. Declared only for the in-tree hierarchy; the plugin build inherits the
-  // adapter OpKernel's default no-op. See DeclareWorkspaceRequirements in op_kernel.h.
+  // estimate, callable after CreateKernels(). It is exact when runtime selects the CUTLASS GEMM
+  // branch for the queried input-A shape. If runtime instead selects the CUDA GEMV tactic, which
+  // requests no workspace, the declaration is a safe upper bound. Declared only for the in-tree
+  // hierarchy; the plugin build inherits the adapter OpKernel's unbridged default no-op.
   Status DeclareWorkspaceRequirements(
-      gsl::span<const TensorShape> input_shapes,
+      gsl::span<const WorkspaceInputShape> input_shapes,
       /*out*/ InlinedVector<WorkspaceRequirement>& requirements) const override;
 #endif
 
-  // TEST INSTRUMENTATION ONLY - not a runtime API. Records the workspace size the CUTLASS runner
-  // requested on the most recent ComputeInternal() call so a test can verify the Level-2 estimate
-  // against the real runtime request. This atomic is not correlated to a specific Run() when
+  // TEST INSTRUMENTATION ONLY - not a runtime API. Records the workspace size requested by the most
+  // recent ComputeInternal() call (zero when it requested none) so a test can verify the Level-2
+  // estimate against the real runtime request. This atomic is not correlated to a specific Run() when
   // concurrent Run()s share one kernel instance; it is only meant for this pilot's single-threaded
   // tests. Do not build anything on top of it.
   //
-  // STALENESS: the value is only updated on the fpA_intB CUTLASS GEMM branch of ComputeInternal().
-  // It is therefore only meaningful immediately after a call that took that branch; a subsequent
-  // call that takes the GEMV (cuda-kernel) path or the non-fpA_intB path leaves it holding the old
-  // value from the previous GEMM call. It is NOT reset between calls.
+  // Every ComputeInternal() invocation first stores zero. The CUTLASS GEMM branch replaces it with
+  // the requested byte count; all early-return and no-workspace paths therefore remain zero.
   size_t LastComputeWorkspaceBytes() const { return last_compute_workspace_bytes_.load(std::memory_order_relaxed); }
 #endif
 

--- a/onnxruntime/contrib_ops/cuda/quantization/matmul_nbits_workspace_estimate.h
+++ b/onnxruntime/contrib_ops/cuda/quantization/matmul_nbits_workspace_estimate.h
@@ -35,6 +35,11 @@ namespace onnxruntime {
 namespace contrib {
 namespace cuda {
 
+// Product of all input-A dimensions except the final K dimension. A known zero takes precedence
+// over unknown/negative dimensions and potential overflow elsewhere in the leading dimensions.
+// This graph-type-free helper is shared by the Level-1 shape wrappers and Level-2 TensorShape path.
+std::optional<int64_t> ComputeMatMulNBitsLeadingDimProduct(gsl::span<const int64_t> input_a_shape);
+
 std::optional<size_t> EstimateMatMulNBitsWorkspace(const Node& node, const cudaDeviceProp& device_prop);
 // Uses an estimation-only input A shape, such as one propagated from maximum graph inputs.
 std::optional<size_t> EstimateMatMulNBitsWorkspace(

--- a/onnxruntime/core/framework/node_shape_resolver.h
+++ b/onnxruntime/core/framework/node_shape_resolver.h
@@ -3,57 +3,60 @@
 
 #pragma once
 
-#include <optional>
-
 #include "core/common/inlined_containers.h"
 #include "core/framework/max_shape_override.h"
-#include "core/framework/tensor_shape.h"
+#include "core/framework/workspace_input_shape.h"
 
 namespace onnxruntime {
 
 /// Resolves the input shapes for a node using a max-shape shadow-inference result.
-/// For each input:
+/// For each explicit input:
+///   - Preserve its position and mark an omitted optional input as Missing.
 ///   - Use the concrete shape propagated through the shadow graph when available.
-///   - Otherwise use a fully static shape from the executable graph.
-///   - If any input remains dynamic, return nullopt.
+///   - Otherwise preserve the rank and dimensions from the executable graph's shape proto,
+///     representing each symbolic, absent, or negative dimension as -1. Multiple -1 dimensions
+///     are independent unknowns and do not imply symbolic equality.
+///   - Mark a present input without rank or dimension metadata as PresentWithoutShape.
+/// Shapes propagated from max-shape overrides are estimation hints, not proven upper bounds.
 ///
 /// @param node             The node whose input shapes to resolve.
 /// @param graph_identity   Address of the node's containing graph.
 /// @param inferred_shapes  Shapes propagated from maximum graph inputs.
-/// @return                 Vector of shapes for each input, or nullopt if any input has unresolvable dims.
+/// @return                 One presence-aware shape entry per Node::InputDefs() element. Implicit
+///                         inputs are excluded, matching OpKernelContext::Input(i).
 template <typename TNode>
-inline std::optional<InlinedVector<TensorShape>> ResolveNodeInputShapes(
+inline InlinedVector<WorkspaceInputShape> ResolveNodeInputShapes(
     const TNode& node,
     const void* graph_identity,
     const MaxShapeInferenceResult& inferred_shapes) {
-  InlinedVector<TensorShape> result;
+  InlinedVector<WorkspaceInputShape> result;
   result.reserve(node.InputDefs().size());
 
   for (const auto* input_def : node.InputDefs()) {
     if (!input_def || !input_def->Exists()) {
-      return std::nullopt;  // Cannot resolve shape for this input
+      result.emplace_back();
+      continue;
     }
 
     if (const TensorShape* inferred_shape = inferred_shapes.GetShape(graph_identity, input_def->Name())) {
-      result.push_back(*inferred_shape);
+      result.push_back(WorkspaceInputShape::PresentWithShape(*inferred_shape));
       continue;
     }
 
     const auto* shape_proto = input_def->Shape();
-    if (!shape_proto) return std::nullopt;
+    if (!shape_proto) {
+      result.push_back(WorkspaceInputShape::PresentWithoutShape());
+      continue;
+    }
 
     TensorShapeVector dims;
     dims.reserve(shape_proto->dim_size());
 
     for (const auto& dim : shape_proto->dim()) {
-      if (dim.has_dim_value() && dim.dim_value() >= 0) {
-        dims.push_back(dim.dim_value());
-      } else {
-        return std::nullopt;
-      }
+      dims.push_back(dim.has_dim_value() && dim.dim_value() >= 0 ? dim.dim_value() : -1);
     }
 
-    result.emplace_back(dims);
+    result.push_back(WorkspaceInputShape::PresentWithShape(TensorShape{dims}));
   }
 
   return result;

--- a/onnxruntime/core/framework/session_state.cc
+++ b/onnxruntime/core/framework/session_state.cc
@@ -1861,7 +1861,8 @@ Status SessionState::FinalizeSessionStateImpl(const std::basic_string<PATH_CHAR_
       // For now, log the declarations so we can verify the wiring works.
       for (const auto& req : requirements) {
         LOGS(logger_, VERBOSE) << "  slot_id=" << req.slot_id
-                               << " size=" << req.size_bytes << " bytes";
+                               << " size=" << req.size_bytes << " bytes"
+                               << " alignment=" << req.alignment_bytes << " bytes";
       }
     }
   }

--- a/onnxruntime/core/framework/session_state.cc
+++ b/onnxruntime/core/framework/session_state.cc
@@ -1841,7 +1841,7 @@ Status SessionState::FinalizeSessionStateImpl(const std::basic_string<PATH_CHAR_
   }
 
   // Level-2 workspace declaration: after kernels are created and PrePack'd, call
-  // DeclareWorkspaceRequirements() on each kernel whose input shapes can be resolved.
+  // DeclareWorkspaceRequirements() on each kernel with positional input presence/shape metadata.
   // Static graph shapes remain usable when no max-shape inference result is available.
   // This collects workspace slot requirements for future offset planning.
   for (const auto& node : graph_viewer_->Nodes()) {
@@ -1849,11 +1849,10 @@ Status SessionState::FinalizeSessionStateImpl(const std::basic_string<PATH_CHAR_
     if (kernel == nullptr) continue;
 
     auto resolved = ResolveNodeInputShapes(node, &graph_, max_shape_inference_result);
-    if (!resolved.has_value()) continue;
 
     InlinedVector<WorkspaceRequirement> requirements;
     ORT_RETURN_IF_ERROR(kernel->DeclareWorkspaceRequirements(
-        gsl::make_span(resolved->data(), resolved->size()), requirements));
+        gsl::make_span(resolved), requirements));
 
     if (!requirements.empty()) {
       LOGS(logger_, VERBOSE) << "Level-2 workspace: node '" << node.Name()

--- a/onnxruntime/test/framework/max_shape_override_test.cc
+++ b/onnxruntime/test/framework/max_shape_override_test.cc
@@ -13,6 +13,7 @@
 #include "core/framework/max_shape_inference.h"
 #include "core/framework/max_shape_override.h"
 #include "core/framework/node_shape_resolver.h"
+#include "core/framework/workspace_input_shape.h"
 #include "core/framework/workspace_requirement.h"
 #include "core/graph/constants.h"
 #include "core/graph/model.h"
@@ -218,9 +219,135 @@ TEST(MaxShapeOverride, ResolveNodeInputShapesAcceptsStaticZeroExtent) {
   MaxShapeInferenceResult inferred_shapes;
   const Node& identity = *model.MainGraph().Nodes().begin();
   const auto resolved = ResolveNodeInputShapes(identity, &model.MainGraph(), inferred_shapes);
-  ASSERT_TRUE(resolved.has_value());
-  ASSERT_EQ(resolved->size(), 1u);
-  EXPECT_EQ((*resolved)[0], TensorShape({0, 4}));
+  ASSERT_EQ(resolved.size(), 1u);
+  EXPECT_EQ(resolved[0].GetState(), WorkspaceInputShapeState::PresentWithShape);
+  ASSERT_NE(resolved[0].GetShape(), nullptr);
+  EXPECT_EQ(*resolved[0].GetShape(), TensorShape({0, 4}));
+}
+
+TEST(MaxShapeOverride, ResolveNodeInputShapesAcceptsRankZeroScalar) {
+  std::unordered_map<std::string, int> domain_to_version{{kOnnxDomain, 18}};
+  Model model("scalar", true, ModelMetaData(), PathString(),
+              IOnnxRuntimeOpSchemaRegistryList(), domain_to_version,
+              std::vector<ONNX_NAMESPACE::FunctionProto>{}, DefaultLoggingManager().DefaultLogger());
+  ModelTestBuilder builder(model.MainGraph());
+  NodeArg* input = builder.MakeInput<float>(std::vector<int64_t>{}, "input");
+  NodeArg* output = builder.MakeOutput<float>(std::nullopt);
+  builder.AddNode("Identity", {input}, {output});
+  builder.SetGraphOutputs();
+  ASSERT_STATUS_OK(model.MainGraph().Resolve());
+
+  MaxShapeInferenceResult inferred_shapes;
+  const Node& identity = *model.MainGraph().Nodes().begin();
+  const auto resolved = ResolveNodeInputShapes(identity, &model.MainGraph(), inferred_shapes);
+  ASSERT_EQ(resolved.size(), 1u);
+  EXPECT_EQ(resolved[0].GetState(), WorkspaceInputShapeState::PresentWithShape);
+  ASSERT_NE(resolved[0].GetShape(), nullptr);
+  EXPECT_EQ(resolved[0].GetShape()->NumDimensions(), 0u);
+}
+
+TEST(MaxShapeOverride, ResolveNodeInputShapesPreservesInternalHoles) {
+  std::unordered_map<std::string, int> domain_to_version{{kOnnxDomain, 18}};
+  Model model("internal_holes", true, ModelMetaData(), PathString(),
+              IOnnxRuntimeOpSchemaRegistryList(), domain_to_version,
+              std::vector<ONNX_NAMESPACE::FunctionProto>{}, DefaultLoggingManager().DefaultLogger());
+  Graph& graph = model.MainGraph();
+  ModelTestBuilder builder(graph);
+  NodeArg* first = builder.MakeInput<float>(std::vector<int64_t>{2, 3}, "first");
+  NodeArg* after_hole = builder.MakeInput<float>(std::vector<int64_t>{5}, "after_hole");
+  NodeArg* explicit_missing = builder.MakeOptionalTensor();
+  const std::vector<NodeArg*> inputs{first, nullptr, after_hole, explicit_missing};
+  const std::vector<NodeArg*> outputs;
+  // Graph::AddNode dereferences every input argument and cannot accept a nullptr hole. Construct
+  // Node directly to verify that the resolver preserves the positional layout in Node::InputDefs().
+  Node node("shape_probe", "ShapeProbe", "", inputs, outputs, nullptr, kOnnxDomain);
+
+  MaxShapeInferenceResult inferred_shapes;
+  const auto resolved = ResolveNodeInputShapes(node, &graph, inferred_shapes);
+  ASSERT_EQ(resolved.size(), inputs.size());
+  EXPECT_EQ(resolved[0].GetState(), WorkspaceInputShapeState::PresentWithShape);
+  EXPECT_EQ(resolved[1].GetState(), WorkspaceInputShapeState::Missing);
+  EXPECT_EQ(resolved[2].GetState(), WorkspaceInputShapeState::PresentWithShape);
+  ASSERT_NE(resolved[2].GetShape(), nullptr);
+  EXPECT_EQ(*resolved[2].GetShape(), TensorShape({5}));
+  EXPECT_EQ(resolved[3].GetState(), WorkspaceInputShapeState::Missing);
+}
+
+TEST(MaxShapeOverride, MissingTrailingInputAndOutOfRangeAccessorAreMissing) {
+  std::unordered_map<std::string, int> domain_to_version{{kOnnxDomain, 18}};
+  Model model("trailing_missing", true, ModelMetaData(), PathString(),
+              IOnnxRuntimeOpSchemaRegistryList(), domain_to_version,
+              std::vector<ONNX_NAMESPACE::FunctionProto>{}, DefaultLoggingManager().DefaultLogger());
+  Graph& graph = model.MainGraph();
+  ModelTestBuilder builder(graph);
+  NodeArg* present = builder.MakeInput<float>(std::vector<int64_t>{2}, "present");
+  NodeArg* trailing_missing = builder.MakeOptionalTensor();
+  const std::vector<NodeArg*> inputs{present, trailing_missing};
+  const std::vector<NodeArg*> outputs;
+  Node& node = graph.AddNode("shape_probe", "ShapeProbe", "", inputs, outputs);
+
+  MaxShapeInferenceResult inferred_shapes;
+  const auto resolved = ResolveNodeInputShapes(node, &graph, inferred_shapes);
+  ASSERT_EQ(resolved.size(), inputs.size());
+  EXPECT_EQ(GetWorkspaceInputShape(resolved, 1).GetState(), WorkspaceInputShapeState::Missing);
+  EXPECT_EQ(GetWorkspaceInputShape(resolved, 2).GetState(), WorkspaceInputShapeState::Missing);
+  EXPECT_EQ(GetWorkspaceInputShape(resolved, 100).GetState(), WorkspaceInputShapeState::Missing);
+}
+
+TEST(MaxShapeOverride, ResolveNodeInputShapesDistinguishesAbsentMetadataFromPartialShapes) {
+  std::unordered_map<std::string, int> domain_to_version{{kOnnxDomain, 18}};
+  Model model("partial_shapes", true, ModelMetaData(), PathString(),
+              IOnnxRuntimeOpSchemaRegistryList(), domain_to_version,
+              std::vector<ONNX_NAMESPACE::FunctionProto>{}, DefaultLoggingManager().DefaultLogger());
+  Graph& graph = model.MainGraph();
+  ModelTestBuilder builder(graph);
+  NodeArg* no_shape = builder.MakeInput<float>(std::nullopt, "no_shape");
+  NodeArg* symbolic = builder.MakeSymbolicInput<float>({std::string{"batch"}, int64_t{4}});
+  NodeArg* negative = builder.MakeInput<float>(std::nullopt, "negative");
+  ONNX_NAMESPACE::TensorShapeProto negative_shape;
+  negative_shape.add_dim()->set_dim_value(-2);
+  negative_shape.add_dim()->set_dim_value(4);
+  negative->SetShape(negative_shape);
+  const std::vector<NodeArg*> inputs{no_shape, symbolic, negative};
+  const std::vector<NodeArg*> outputs;
+  Node& node = graph.AddNode("shape_probe", "ShapeProbe", "", inputs, outputs);
+
+  MaxShapeInferenceResult inferred_shapes;
+  const auto resolved = ResolveNodeInputShapes(node, &graph, inferred_shapes);
+  ASSERT_EQ(resolved.size(), inputs.size());
+  EXPECT_EQ(resolved[0].GetState(), WorkspaceInputShapeState::PresentWithoutShape);
+  EXPECT_EQ(resolved[0].GetShape(), nullptr);
+
+  EXPECT_EQ(resolved[1].GetState(), WorkspaceInputShapeState::PresentWithShape);
+  ASSERT_NE(resolved[1].GetShape(), nullptr);
+  EXPECT_EQ(*resolved[1].GetShape(), TensorShape({-1, 4}));
+
+  EXPECT_EQ(resolved[2].GetState(), WorkspaceInputShapeState::PresentWithShape);
+  ASSERT_NE(resolved[2].GetShape(), nullptr);
+  EXPECT_EQ(*resolved[2].GetShape(), TensorShape({-1, 4}));
+}
+
+TEST(MaxShapeOverride, ResolveNodeInputShapesUsesMaxShapeOnlyForMatchingGraphIdentity) {
+  auto model = MakeDynamicIdentityModel();
+  Graph& graph = model->MainGraph();
+  MaxShapeOverrideMap overrides;
+  overrides.emplace("input", TensorShape({8, 4}));
+  MaxShapeInferenceResult inferred_shapes;
+  ASSERT_STATUS_OK(InferMaxShapes(graph, overrides, inferred_shapes));
+
+  const Node& identity = *graph.Nodes().begin();
+  const auto matching_graph_shapes = ResolveNodeInputShapes(identity, &graph, inferred_shapes);
+  ASSERT_EQ(matching_graph_shapes.size(), 1u);
+  EXPECT_EQ(matching_graph_shapes[0].GetState(), WorkspaceInputShapeState::PresentWithShape);
+  ASSERT_NE(matching_graph_shapes[0].GetShape(), nullptr);
+  EXPECT_EQ(*matching_graph_shapes[0].GetShape(), TensorShape({8, 4}));
+
+  int other_graph_identity = 0;
+  const auto other_graph_shapes = ResolveNodeInputShapes(identity, &other_graph_identity, inferred_shapes);
+  ASSERT_EQ(other_graph_shapes.size(), 1u);
+  EXPECT_EQ(other_graph_shapes[0].GetState(), WorkspaceInputShapeState::PresentWithShape);
+  ASSERT_NE(other_graph_shapes[0].GetShape(), nullptr);
+  EXPECT_EQ(*other_graph_shapes[0].GetShape(), TensorShape({-1, 4}));
 }
 
 TEST(MaxShapeOverride, InferRejectsUnknownInput) {
@@ -287,6 +414,21 @@ TEST(MaxShapeOverride, InferMatchesParallelControlFlowSubgraphsByStableIdentity)
   ASSERT_NE(shape_b, nullptr);
   EXPECT_EQ(*shape_a, TensorShape({8, 4}));
   EXPECT_EQ(*shape_b, TensorShape({16, 2}));
+}
+
+// ============================================================================
+// WorkspaceInputShape tests
+// ============================================================================
+
+TEST(WorkspaceInputShape, PresentShapeDeepCopiesExternalPartialDimensions) {
+  std::vector<int64_t> dimensions{2, -1};
+  const auto input_shape =
+      WorkspaceInputShape::PresentWithShape(TensorShape::FromExistingBuffer(dimensions));
+
+  dimensions[0] = 9;
+  dimensions[1] = 3;
+  ASSERT_NE(input_shape.GetShape(), nullptr);
+  EXPECT_EQ(*input_shape.GetShape(), TensorShape({2, -1}));
 }
 
 // ============================================================================

--- a/onnxruntime/test/framework/session_state_test.cc
+++ b/onnxruntime/test/framework/session_state_test.cc
@@ -17,6 +17,7 @@
 #include "core/framework/ep_context_options.h"
 #include "core/framework/resource_accountant.h"
 #include "core/framework/session_state.h"
+#include "core/framework/workspace_input_shape.h"
 #include "core/graph/graph_utils.h"
 #include "core/graph/graph_viewer.h"
 #include "core/graph/model.h"
@@ -139,6 +140,51 @@ class TestOpKernel : public OpKernel {
     return Status::OK();
   }
 };
+
+TEST(OpKernelTest, DefaultDeclareWorkspaceRequirementsClearsOutput) {
+  Model model("default_workspace_declaration", false, DefaultLoggingManager().DefaultLogger());
+  Graph& graph = model.MainGraph();
+
+  TypeProto tensor_type;
+  tensor_type.mutable_tensor_type()->set_elem_type(TensorProto_DataType_FLOAT);
+  tensor_type.mutable_tensor_type()->mutable_shape()->add_dim()->set_dim_value(1);
+  NodeArg input_arg("input", &tensor_type);
+  NodeArg output_arg("output", &tensor_type);
+  Node& node = graph.AddNode("identity", "Identity", "", {&input_arg}, {&output_arg});
+  ASSERT_STATUS_OK(graph.Resolve());
+
+  ExecutionProviders execution_providers;
+  auto cpu_execution_provider = std::make_unique<CPUExecutionProvider>(CPUExecutionProviderInfo(false));
+  CPUExecutionProvider* cpu_execution_provider_ptr = cpu_execution_provider.get();
+  ASSERT_STATUS_OK(execution_providers.Add(kCpuExecutionProvider, std::move(cpu_execution_provider)));
+
+  DataTransferManager data_transfer_manager;
+  ExternalDataLoaderManager external_data_loader_manager;
+  profiling::Profiler profiler;
+  SessionOptions session_options;
+  SessionState session_state(graph, execution_providers, nullptr, nullptr, data_transfer_manager,
+                             external_data_loader_manager, DefaultLoggingManager().DefaultLogger(),
+                             profiler, session_options);
+
+  auto kernel_def = KernelDefBuilder()
+                        .SetName("Identity")
+                        .Provider(kCpuExecutionProvider)
+                        .SinceVersion(1)
+                        .Build();
+  OpKernelInfo kernel_info(node, *kernel_def, *cpu_execution_provider_ptr,
+                           session_state.GetConstantInitializedTensors(),
+                           session_state.GetOrtValueNameIdxMap(), session_state.GetDataTransferMgr(),
+                           session_state.GetAllocators(), session_state.GetSessionOptions().config_options);
+  TestOpKernel kernel(kernel_info);
+
+  InlinedVector<WorkspaceInputShape> input_shapes;
+  input_shapes.push_back(WorkspaceInputShape::PresentWithoutShape());
+  InlinedVector<WorkspaceRequirement> requirements;
+  requirements.push_back(WorkspaceRequirement{123, /*slot_id=*/7, /*alignment_bytes=*/0});
+  ASSERT_STATUS_OK(kernel.DeclareWorkspaceRequirements(gsl::make_span(input_shapes), requirements));
+  EXPECT_TRUE(requirements.empty());
+}
+
 class SessionStateAddGetKernelTest : public testing::TestWithParam<int> {};
 
 TEST_P(SessionStateAddGetKernelTest, AddGetKernelTest) {

--- a/onnxruntime/test/providers/cuda/test_cases/matmul_nbits_e2e_workspace_test.cc
+++ b/onnxruntime/test/providers/cuda/test_cases/matmul_nbits_e2e_workspace_test.cc
@@ -80,8 +80,9 @@ constexpr int64_t kE2eBlockSize = 32;
 constexpr int64_t kE2eBits = 4;
 constexpr uint16_t kHalfOne = 0x3C00;  // 1.0 in IEEE-754 half precision.
 
-// Builds a minimal single-node MatMulNBits model with the valid optional-input layout
-// [A, B, scales, "", "", bias] and returns its serialized ModelProto bytes.
+// Builds a minimal single-node MatMulNBits model and returns its serialized ModelProto bytes.
+// The compact fpA_intB path does not support bias. Other builds use the valid optional-input
+// layout [A, B, scales, "", "", bias] to exercise positional Level-2 shape resolution.
 //
 // When `m_dim_param` is null (default), input A's leading dimension is the fully-static `kE2eM`.
 // When it is non-null, the leading dimension is instead symbolic.
@@ -150,13 +151,15 @@ std::string BuildMatMulNBitsModelBytes(const char* m_dim_param = nullptr) {
   }
   *scales->mutable_raw_data() = std::move(scale_raw);
 
-  // bias initializer: fp16 {N}, zero-filled. Supplying it after two omitted optional inputs is the
+#if !USE_COMPACT_FPA_INTB_GEMM
+  // Bias initializer: fp16 {N}, zero-filled. Supplying it after two omitted optional inputs is the
   // regression layout for positional Level-2 input-shape resolution.
   auto* bias = graph->add_initializer();
   bias->set_name("bias");
   bias->set_data_type(ONNX_NAMESPACE::TensorProto_DataType_FLOAT16);
   bias->add_dims(kE2eN);
   bias->mutable_raw_data()->assign(static_cast<size_t>(kE2eN * sizeof(uint16_t)), '\0');
+#endif
 
   // MatMulNBits node.
   auto* node = graph->add_node();
@@ -168,7 +171,11 @@ std::string BuildMatMulNBitsModelBytes(const char* m_dim_param = nullptr) {
   node->add_input("scales");
   node->add_input("");
   node->add_input("");
+#if USE_COMPACT_FPA_INTB_GEMM
+  node->add_input("");
+#else
   node->add_input("bias");
+#endif
   node->add_output("Y");
   auto add_int_attr = [node](const char* name, int64_t v) {
     auto* attr = node->add_attribute();
@@ -411,12 +418,16 @@ TEST(MatMulNBitsWorkspace, EndToEndWorkspaceAgreement) {
 
   const auto input_shapes =
       ResolveNodeInputShapes(*mm_node, &graph, positive_inferred_shapes);
-  ASSERT_EQ(input_shapes.size(), 6u);
   ASSERT_NE(input_shapes[0].GetShape(), nullptr);
   EXPECT_EQ(*input_shapes[0].GetShape(), TensorShape({kE2eM, kE2eK}));
+  ASSERT_EQ(input_shapes.size(), 6u);
   EXPECT_EQ(input_shapes[3].GetState(), WorkspaceInputShapeState::Missing);
   EXPECT_EQ(input_shapes[4].GetState(), WorkspaceInputShapeState::Missing);
+#if USE_COMPACT_FPA_INTB_GEMM
+  EXPECT_EQ(input_shapes[5].GetState(), WorkspaceInputShapeState::Missing);
+#else
   EXPECT_EQ(input_shapes[5].GetState(), WorkspaceInputShapeState::PresentWithShape);
+#endif
   InlinedVector<WorkspaceRequirement> requirements;
   // DeclareWorkspaceRequirements is virtual on OpKernel; this dispatches into the MatMulNBits override.
   ASSERT_STATUS_OK(op_kernel->DeclareWorkspaceRequirements(gsl::make_span(input_shapes), requirements));
@@ -514,12 +525,16 @@ TEST(MatMulNBitsWorkspace, EndToEndWorkspaceAgreement) {
   // resolver used for shape hints. The two optional holes and the bias must retain their positions.
   const auto zero_m_input_shapes =
       ResolveNodeInputShapes(*mm_node, &graph, zero_m_inferred_shapes);
-  ASSERT_EQ(zero_m_input_shapes.size(), 6u);
   ASSERT_NE(zero_m_input_shapes[0].GetShape(), nullptr);
   EXPECT_EQ(*zero_m_input_shapes[0].GetShape(), zero_m_a_shape);
+  ASSERT_EQ(zero_m_input_shapes.size(), 6u);
   EXPECT_EQ(zero_m_input_shapes[3].GetState(), WorkspaceInputShapeState::Missing);
   EXPECT_EQ(zero_m_input_shapes[4].GetState(), WorkspaceInputShapeState::Missing);
+#if USE_COMPACT_FPA_INTB_GEMM
+  EXPECT_EQ(zero_m_input_shapes[5].GetState(), WorkspaceInputShapeState::Missing);
+#else
   EXPECT_EQ(zero_m_input_shapes[5].GetState(), WorkspaceInputShapeState::PresentWithShape);
+#endif
 
   InlinedVector<WorkspaceRequirement> zero_m_requirements;
   ASSERT_STATUS_OK(op_kernel->DeclareWorkspaceRequirements(

--- a/onnxruntime/test/providers/cuda/test_cases/matmul_nbits_e2e_workspace_test.cc
+++ b/onnxruntime/test/providers/cuda/test_cases/matmul_nbits_e2e_workspace_test.cc
@@ -35,6 +35,7 @@
 #include <array>
 #include <cstring>
 #include <iostream>
+#include <limits>
 #include <optional>
 #include <string>
 #include <vector>
@@ -42,11 +43,12 @@
 #include <cuda_runtime_api.h>
 
 #include "core/common/inlined_containers.h"
-#include "core/common/span_utils.h"
+#include "core/framework/max_shape_inference.h"
+#include "core/framework/max_shape_override.h"
+#include "core/framework/node_shape_resolver.h"
 #include "core/framework/op_kernel.h"
 #include "core/framework/session_state.h"
 #include "core/framework/tensor_shape.h"
-#include "core/framework/tensorprotoutils.h"
 #include "core/framework/workspace_requirement.h"
 #include "core/graph/graph.h"
 #include "core/graph/onnx_protobuf.h"
@@ -78,14 +80,11 @@ constexpr int64_t kE2eBlockSize = 32;
 constexpr int64_t kE2eBits = 4;
 constexpr uint16_t kHalfOne = 0x3C00;  // 1.0 in IEEE-754 half precision.
 
-// Builds a minimal single-node MatMulNBits model (A[M,K] fp16, B int4 initializer, scales fp16
-// initializer, Y[M,N] fp16) and returns its serialized ModelProto bytes.
+// Builds a minimal single-node MatMulNBits model with the valid optional-input layout
+// [A, B, scales, "", "", bias] and returns its serialized ModelProto bytes.
 //
-// When `m_dim_param` is null (default), input A's leading dimension is the fully-static value
-// `kE2eM` (a concrete dim_value). When `m_dim_param` is non-null, that leading dimension is instead
-// a *symbolic* dim (dim_param, e.g. "seq") with NO dim_value -- a genuinely dynamic shape. This is
-// used by Test D (dynamic, no override -> graceful fallback) and by Test C, where a
-// FreeDimensionOverrideByName later rewrites the symbolic dim into a concrete value at session init.
+// When `m_dim_param` is null (default), input A's leading dimension is the fully-static `kE2eM`.
+// When it is non-null, the leading dimension is instead symbolic.
 std::string BuildMatMulNBitsModelBytes(const char* m_dim_param = nullptr) {
   const int64_t k_blocks = (kE2eK + kE2eBlockSize - 1) / kE2eBlockSize;  // 32
   const int64_t blob_size = (kE2eBlockSize * kE2eBits + 7) / 8;          // 16
@@ -151,6 +150,14 @@ std::string BuildMatMulNBitsModelBytes(const char* m_dim_param = nullptr) {
   }
   *scales->mutable_raw_data() = std::move(scale_raw);
 
+  // bias initializer: fp16 {N}, zero-filled. Supplying it after two omitted optional inputs is the
+  // regression layout for positional Level-2 input-shape resolution.
+  auto* bias = graph->add_initializer();
+  bias->set_name("bias");
+  bias->set_data_type(ONNX_NAMESPACE::TensorProto_DataType_FLOAT16);
+  bias->add_dims(kE2eN);
+  bias->mutable_raw_data()->assign(static_cast<size_t>(kE2eN * sizeof(uint16_t)), '\0');
+
   // MatMulNBits node.
   auto* node = graph->add_node();
   node->set_op_type("MatMulNBits");
@@ -159,6 +166,9 @@ std::string BuildMatMulNBitsModelBytes(const char* m_dim_param = nullptr) {
   node->add_input("A");
   node->add_input("B");
   node->add_input("scales");
+  node->add_input("");
+  node->add_input("");
+  node->add_input("bias");
   node->add_output("Y");
   auto add_int_attr = [node](const char* name, int64_t v) {
     auto* attr = node->add_attribute();
@@ -253,7 +263,86 @@ const Node* FindNodeByOpType(const Graph& graph, const std::string& op_type) {
   return nullptr;
 }
 
+std::optional<size_t> EstimateWorkspaceFromGraphProtoShape(
+    gsl::span<const int64_t> input_a_shape) {
+  ONNX_NAMESPACE::TypeProto input_type;
+  auto* tensor_type = input_type.mutable_tensor_type();
+  tensor_type->set_elem_type(ONNX_NAMESPACE::TensorProto_DataType_FLOAT16);
+  auto* shape = tensor_type->mutable_shape();
+  for (const int64_t dimension : input_a_shape) {
+    shape->add_dim()->set_dim_value(dimension);
+  }
+  NodeArg input_a{"A", &input_type};
+
+  NodeAttributes attributes;
+  auto add_int_attribute = [&attributes](const char* name, int64_t value) {
+    ONNX_NAMESPACE::AttributeProto attribute;
+    attribute.set_name(name);
+    attribute.set_type(ONNX_NAMESPACE::AttributeProto_AttributeType_INT);
+    attribute.set_i(value);
+    attributes.emplace(name, std::move(attribute));
+  };
+  add_int_attribute("N", kE2eN);
+  add_int_attribute("K", kE2eK);
+  add_int_attribute("block_size", kE2eBlockSize);
+  add_int_attribute("bits", kE2eBits);
+
+  const std::vector<NodeArg*> inputs{&input_a};
+  const std::vector<NodeArg*> outputs;
+  Node node{"matmul_nbits", "MatMulNBits", "", inputs, outputs, &attributes, "com.microsoft"};
+
+  cudaDeviceProp device_prop{};
+  device_prop.major = 8;
+  device_prop.minor = 0;
+  device_prop.multiProcessorCount = 100;
+  return onnxruntime::contrib::cuda::EstimateMatMulNBitsWorkspace(node, device_prop);
+}
+
 }  // namespace
+
+TEST(MatMulNBitsWorkspace, KnownZeroPartialLeadingShapesLevel1GraphProto) {
+  ScopedEnvironmentVariables scoped_env(EnvVarMap{{"ORT_FPA_INTB_GEMM", optional<std::string>{"1"}}});
+
+  const std::vector<TensorShapeVector> known_zero_shapes{
+      {0, -1, kE2eK},
+      {-1, 0, kE2eK},
+      {std::numeric_limits<int64_t>::max(), 2, 0, kE2eK},
+  };
+  for (const auto& shape : known_zero_shapes) {
+    SCOPED_TRACE(TensorShape{shape}.ToString());
+    EXPECT_EQ(EstimateWorkspaceFromGraphProtoShape(shape), std::optional<size_t>{0});
+  }
+
+  const TensorShapeVector unknown_shape{-1, 2, kE2eK};
+  EXPECT_FALSE(EstimateWorkspaceFromGraphProtoShape(unknown_shape).has_value());
+  const TensorShapeVector overflowing_shape{
+      std::numeric_limits<int64_t>::max(), 2, kE2eK};
+  EXPECT_FALSE(EstimateWorkspaceFromGraphProtoShape(overflowing_shape).has_value());
+}
+
+TEST(MatMulNBitsWorkspace, KnownZeroPartialLeadingShapesLevel2TensorShape) {
+  const std::vector<TensorShapeVector> known_zero_shapes{
+      {0, -1, kE2eK},
+      {-1, 0, kE2eK},
+      {std::numeric_limits<int64_t>::max(), 2, 0, kE2eK},
+  };
+  for (const auto& dimensions : known_zero_shapes) {
+    const TensorShape shape{dimensions};
+    SCOPED_TRACE(shape.ToString());
+    EXPECT_EQ(onnxruntime::contrib::cuda::ComputeMatMulNBitsLeadingDimProduct(shape.GetDims()),
+              std::optional<int64_t>{0});
+  }
+
+  const TensorShape unknown_shape({-1, 2, kE2eK});
+  EXPECT_FALSE(onnxruntime::contrib::cuda::ComputeMatMulNBitsLeadingDimProduct(
+                   unknown_shape.GetDims())
+                   .has_value());
+  const TensorShape overflowing_shape(
+      {std::numeric_limits<int64_t>::max(), 2, kE2eK});
+  EXPECT_FALSE(onnxruntime::contrib::cuda::ComputeMatMulNBitsLeadingDimProduct(
+                   overflowing_shape.GetDims())
+                   .has_value());
+}
 
 TEST(MatMulNBitsWorkspace, EndToEndWorkspaceAgreement) {
   const int device_sm = CudaDeviceComputeCapabilityOrNegative();
@@ -271,7 +360,9 @@ TEST(MatMulNBitsWorkspace, EndToEndWorkspaceAgreement) {
   // and the kernel constructor observe it enabled, keeping the two eligibility decisions in sync.
   ScopedEnvironmentVariables scoped_env(EnvVarMap{{"ORT_FPA_INTB_GEMM", optional<std::string>{"1"}}});
 
-  const std::string model_bytes = BuildMatMulNBitsModelBytes();
+  // Keep M dynamic so the same session and kernel instance can execute both the ordinary and
+  // empty-output cases.
+  const std::string model_bytes = BuildMatMulNBitsModelBytes("seq");
 
   SessionOptions so;
   so.session_logid = "MatMulNBitsWorkspaceE2E";
@@ -280,6 +371,21 @@ TEST(MatMulNBitsWorkspace, EndToEndWorkspaceAgreement) {
   auto cuda_ep = std::make_shared<CUDAExecutionProvider>(CUDAExecutionProviderInfo{});
   ASSERT_STATUS_OK(session.RegisterExecutionProvider(cuda_ep));
   ASSERT_STATUS_OK(session.Load(model_bytes.data(), static_cast<int>(model_bytes.size())));
+
+  // Production computes estimation-only shadow shapes before initialization can prepack and remove
+  // initializer data from the executable graph. Do the same for the ordinary and empty shapes.
+  const TensorShape positive_a_shape({kE2eM, kE2eK});
+  MaxShapeOverrideMap positive_shape_override;
+  positive_shape_override.emplace("A", positive_a_shape);
+  MaxShapeInferenceResult positive_inferred_shapes;
+  ASSERT_STATUS_OK(InferMaxShapes(session.GetGraph(), positive_shape_override, positive_inferred_shapes));
+
+  const TensorShape zero_m_a_shape({0, kE2eK});
+  MaxShapeOverrideMap zero_m_shape_override;
+  zero_m_shape_override.emplace("A", zero_m_a_shape);
+  MaxShapeInferenceResult zero_m_inferred_shapes;
+  ASSERT_STATUS_OK(InferMaxShapes(session.GetGraph(), zero_m_shape_override, zero_m_inferred_shapes));
+
   ASSERT_STATUS_OK(session.Initialize());
 
   // Locate the MatMulNBits node and confirm it was assigned to the CUDA EP (fpA_intB eligible).
@@ -289,23 +395,83 @@ TEST(MatMulNBitsWorkspace, EndToEndWorkspaceAgreement) {
   ASSERT_EQ(mm_node->GetExecutionProviderType(), onnxruntime::kCudaExecutionProvider)
       << "MatMulNBits node was not assigned to the CUDA EP.";
 
-  // ---- Level 1: the estimator function GetCapability() uses, invoked directly on the node + device
-  //      properties (this is not a full GetCapability()-driven partition-time run). ----
+  // ---- Level 1: the estimator function GetCapability() uses, invoked with the concrete estimation
+  //      shape for this run (this is not a full GetCapability()-driven partition-time run). ----
   const std::optional<size_t> level1 =
-      onnxruntime::contrib::cuda::EstimateMatMulNBitsWorkspace(*mm_node, cuda_ep->GetDeviceProp());
+      onnxruntime::contrib::cuda::EstimateMatMulNBitsWorkspace(
+          *mm_node, positive_a_shape.GetDims(), cuda_ep->GetDeviceProp());
   ASSERT_TRUE(level1.has_value()) << "Level-1 estimate returned nullopt for an eligible node.";
+  EXPECT_EQ(*level1, 1792u);
 
-  // ---- Level 2: instance-level estimate from the constructed kernel + static input shape. ----
+  // ---- Level 2: instance-level estimate from the constructed kernel and production positional
+  //      shape resolver. The two internal missing inputs must not prevent the override from being
+  //      reached, and the known bias after those holes must retain index 5. ----
   const OpKernel* op_kernel = session.GetSessionState().GetKernel(mm_node->Index());
   ASSERT_NE(op_kernel, nullptr) << "No kernel constructed for the MatMulNBits node.";
 
-  const std::vector<TensorShape> input_shapes{TensorShape({kE2eM, kE2eK})};
+  const auto input_shapes =
+      ResolveNodeInputShapes(*mm_node, &graph, positive_inferred_shapes);
+  ASSERT_EQ(input_shapes.size(), 6u);
+  ASSERT_NE(input_shapes[0].GetShape(), nullptr);
+  EXPECT_EQ(*input_shapes[0].GetShape(), TensorShape({kE2eM, kE2eK}));
+  EXPECT_EQ(input_shapes[3].GetState(), WorkspaceInputShapeState::Missing);
+  EXPECT_EQ(input_shapes[4].GetState(), WorkspaceInputShapeState::Missing);
+  EXPECT_EQ(input_shapes[5].GetState(), WorkspaceInputShapeState::PresentWithShape);
   InlinedVector<WorkspaceRequirement> requirements;
   // DeclareWorkspaceRequirements is virtual on OpKernel; this dispatches into the MatMulNBits override.
-  ASSERT_STATUS_OK(op_kernel->DeclareWorkspaceRequirements(AsSpan(input_shapes), requirements));
+  ASSERT_STATUS_OK(op_kernel->DeclareWorkspaceRequirements(gsl::make_span(input_shapes), requirements));
   ASSERT_EQ(requirements.size(), static_cast<size_t>(1))
       << "Level-2 DeclareWorkspaceRequirements did not report exactly one workspace slot.";
   const size_t level2 = requirements[0].size_bytes;
+  EXPECT_EQ(level2, 1792u);
+
+  auto shapeless_optional_shapes = input_shapes;
+  shapeless_optional_shapes[3] = WorkspaceInputShape::PresentWithoutShape();
+  InlinedVector<WorkspaceRequirement> shapeless_optional_requirements;
+  ASSERT_STATUS_OK(op_kernel->DeclareWorkspaceRequirements(
+      gsl::make_span(shapeless_optional_shapes), shapeless_optional_requirements));
+  ASSERT_EQ(shapeless_optional_requirements.size(), 1u);
+  EXPECT_EQ(shapeless_optional_requirements[0].size_bytes, level2);
+
+  // K comes from the kernel attribute, so a partial input-A shape with an unknown final K dimension
+  // remains estimable as long as every leading dimension is known.
+  const std::array<WorkspaceInputShape, 1> unknown_k_shapes{
+      WorkspaceInputShape::PresentWithShape(TensorShape({4, -1}))};
+  InlinedVector<WorkspaceRequirement> unknown_k_requirements;
+  ASSERT_STATUS_OK(op_kernel->DeclareWorkspaceRequirements(
+      gsl::make_span(unknown_k_shapes), unknown_k_requirements));
+  ASSERT_EQ(unknown_k_requirements.size(), 1u);
+  EXPECT_GT(unknown_k_requirements[0].size_bytes, 0u);
+
+  // A zero in any leading dimension proves m == 0 even if another leading dimension is unknown
+  // or a huge earlier prefix would overflow. Level 2 omits zero-sized slots by contract.
+  const std::vector<TensorShapeVector> known_zero_partial_shapes{
+      {0, -1, kE2eK},
+      {-1, 0, kE2eK},
+      {std::numeric_limits<int64_t>::max(), 2, 0, kE2eK},
+  };
+  for (const auto& dimensions : known_zero_partial_shapes) {
+    SCOPED_TRACE(TensorShape{dimensions}.ToString());
+    const std::array<WorkspaceInputShape, 1> shapes{
+        WorkspaceInputShape::PresentWithShape(TensorShape{dimensions})};
+    InlinedVector<WorkspaceRequirement> known_zero_requirements;
+    ASSERT_STATUS_OK(op_kernel->DeclareWorkspaceRequirements(
+        gsl::make_span(shapes), known_zero_requirements));
+    EXPECT_TRUE(known_zero_requirements.empty());
+  }
+
+  const std::array<WorkspaceInputShape, 1> shapeless_a{
+      WorkspaceInputShape::PresentWithoutShape()};
+  InlinedVector<WorkspaceRequirement> shapeless_a_requirements;
+  ASSERT_STATUS_OK(op_kernel->DeclareWorkspaceRequirements(
+      gsl::make_span(shapeless_a), shapeless_a_requirements));
+  EXPECT_TRUE(shapeless_a_requirements.empty());
+
+  const std::array<WorkspaceInputShape, 1> missing_a{WorkspaceInputShape{}};
+  InlinedVector<WorkspaceRequirement> missing_a_requirements;
+  ASSERT_STATUS_OK(op_kernel->DeclareWorkspaceRequirements(
+      gsl::make_span(missing_a), missing_a_requirements));
+  EXPECT_TRUE(missing_a_requirements.empty());
 
   // ---- Runtime: run once and read the workspace size the CUTLASS runner actually requested. ----
   std::vector<MLFloat16> a_data(static_cast<size_t>(kE2eM * kE2eK), MLFloat16(0.0f));
@@ -335,6 +501,48 @@ TEST(MatMulNBitsWorkspace, EndToEndWorkspaceAgreement) {
       << "Level 2 (" << level2 << ") != runtime request (" << runtime << "). A runtime value of 0 "
       << "usually means the GEMV path was taken instead of the CUTLASS GEMM branch.";
   EXPECT_EQ(*level1, runtime) << "Level 1 (" << *level1 << ") != runtime request (" << runtime << ")";
+
+  // ---- Empty-output parity on the same dynamic-shape session and kernel. ----
+  // Level 1 knows that m == 0 and must return a known zero, including for native SM90.
+  const std::optional<size_t> zero_m_level1 =
+      onnxruntime::contrib::cuda::EstimateMatMulNBitsWorkspace(
+          *mm_node, zero_m_a_shape.GetDims(), cuda_ep->GetDeviceProp());
+  ASSERT_TRUE(zero_m_level1.has_value());
+  EXPECT_EQ(*zero_m_level1, 0u);
+
+  // Resolve the concrete empty shape through the same production shadow-inference and positional
+  // resolver used for shape hints. The two optional holes and the bias must retain their positions.
+  const auto zero_m_input_shapes =
+      ResolveNodeInputShapes(*mm_node, &graph, zero_m_inferred_shapes);
+  ASSERT_EQ(zero_m_input_shapes.size(), 6u);
+  ASSERT_NE(zero_m_input_shapes[0].GetShape(), nullptr);
+  EXPECT_EQ(*zero_m_input_shapes[0].GetShape(), zero_m_a_shape);
+  EXPECT_EQ(zero_m_input_shapes[3].GetState(), WorkspaceInputShapeState::Missing);
+  EXPECT_EQ(zero_m_input_shapes[4].GetState(), WorkspaceInputShapeState::Missing);
+  EXPECT_EQ(zero_m_input_shapes[5].GetState(), WorkspaceInputShapeState::PresentWithShape);
+
+  InlinedVector<WorkspaceRequirement> zero_m_requirements;
+  ASSERT_STATUS_OK(op_kernel->DeclareWorkspaceRequirements(
+      gsl::make_span(zero_m_input_shapes), zero_m_requirements));
+  EXPECT_TRUE(zero_m_requirements.empty());
+
+  MLFloat16 unused_zero_m_storage{};
+  OrtValue zero_m_a_value;
+  CreateMLValue<MLFloat16>(std::array<int64_t, 2>{0, kE2eK}, &unused_zero_m_storage,
+                           OrtMemoryInfo(), &zero_m_a_value);
+  NameMLValMap zero_m_feeds;
+  zero_m_feeds.emplace("A", zero_m_a_value);
+  std::vector<OrtValue> zero_m_fetches;
+  ASSERT_STATUS_OK(session.Run(zero_m_feeds, output_names, &zero_m_fetches));
+  ASSERT_EQ(zero_m_fetches.size(), 1u);
+  ASSERT_TRUE(zero_m_fetches[0].IsTensor());
+  EXPECT_EQ(zero_m_fetches[0].Get<Tensor>().Shape(), TensorShape({0, kE2eN}));
+
+  const size_t zero_m_runtime = GetMatMulNBitsLastComputeWorkspaceBytes(op_kernel);
+  std::cout << "[ WORKSPACE ZERO-M ] Level1=" << *zero_m_level1
+            << " bytes, Level2=empty, runtime(request)=" << zero_m_runtime << " bytes" << std::endl;
+  EXPECT_EQ(zero_m_runtime, 0u)
+      << "The same kernel must replace its prior positive capture with zero for an m == 0 run.";
 }
 
 // ---------------------------------------------------------------------------
@@ -398,18 +606,20 @@ TEST(MatMulNBitsWorkspace, FixedShapeViaFreeDimensionOverride) {
   ASSERT_TRUE(level1.has_value())
       << "Level-1 estimate returned nullopt after the fixed override made the shape static.";
 
-  // ---- Level 2: constructed-kernel estimate for the same fixed shape. Derive the TensorShape from
-  //      the actual (overridden) NodeArg proto via the SAME production converter Level-2 wiring would
-  //      use, so this exercises the real TensorShapeProto -> TensorShape path (not a hand-built copy).
+  // ---- Level 2: constructed-kernel estimate for the same fixed shape, using the production
+  //      positional shape resolver.
   const OpKernel* op_kernel = session.GetSessionState().GetKernel(mm_node->Index());
   ASSERT_NE(op_kernel, nullptr) << "No kernel constructed for the MatMulNBits node.";
-  const TensorShape a_tensor_shape = onnxruntime::utils::GetTensorShapeFromTensorShapeProto(*a_shape);
-  ASSERT_EQ(a_tensor_shape.NumDimensions(), static_cast<size_t>(2));
-  ASSERT_EQ(a_tensor_shape[0], kOverrideM)
+  MaxShapeInferenceResult inferred_shapes;
+  const auto input_shapes = ResolveNodeInputShapes(*mm_node, &graph, inferred_shapes);
+  ASSERT_FALSE(input_shapes.empty());
+  const TensorShape* resolved_a_shape = input_shapes[0].GetShape();
+  ASSERT_NE(resolved_a_shape, nullptr);
+  ASSERT_EQ(resolved_a_shape->NumDimensions(), static_cast<size_t>(2));
+  ASSERT_EQ((*resolved_a_shape)[0], kOverrideM)
       << "Overridden NodeArg leading dim did not convert to the fixed value " << kOverrideM << ".";
-  const std::vector<TensorShape> input_shapes{a_tensor_shape};
   InlinedVector<WorkspaceRequirement> requirements;
-  ASSERT_STATUS_OK(op_kernel->DeclareWorkspaceRequirements(AsSpan(input_shapes), requirements));
+  ASSERT_STATUS_OK(op_kernel->DeclareWorkspaceRequirements(gsl::make_span(input_shapes), requirements));
   ASSERT_EQ(requirements.size(), static_cast<size_t>(1))
       << "Level-2 DeclareWorkspaceRequirements did not report exactly one workspace slot.";
   // MatMulNBits::DeclareWorkspaceRequirements assigns the single split-K workspace slot_id 0.
@@ -498,18 +708,22 @@ TEST(MatMulNBitsWorkspace, DynamicShapeNoOverrideFallsBack) {
           *mm_node, max_input_shape.GetDims(), cuda_ep->GetDeviceProp());
   EXPECT_TRUE(bounded_level1.has_value());
 
-  // ---- Level 2: derive the TensorShape from the actual NodeArg proto via the SAME production
-  //      converter Level-2 wiring would use. A symbolic dim must convert to a negative extent (-1),
-  //      which drives the dynamic fallback -> empty requirements. ----
+  // ---- Level 2: the production resolver preserves rank and converts the symbolic leading
+  //      dimension to -1, which drives the dynamic fallback -> empty requirements. ----
   const OpKernel* op_kernel = session.GetSessionState().GetKernel(mm_node->Index());
   ASSERT_NE(op_kernel, nullptr) << "No kernel constructed for the MatMulNBits node.";
-  const TensorShape a_tensor_shape = onnxruntime::utils::GetTensorShapeFromTensorShapeProto(*a_shape);
-  ASSERT_EQ(a_tensor_shape.NumDimensions(), static_cast<size_t>(2));
-  ASSERT_LT(a_tensor_shape[0], 0)
+  MaxShapeInferenceResult inferred_shapes;
+  const auto input_shapes = ResolveNodeInputShapes(*mm_node, &graph, inferred_shapes);
+  ASSERT_FALSE(input_shapes.empty());
+  EXPECT_EQ(input_shapes[0].GetState(), WorkspaceInputShapeState::PresentWithShape);
+  const TensorShape* resolved_a_shape = input_shapes[0].GetShape();
+  ASSERT_NE(resolved_a_shape, nullptr);
+  ASSERT_EQ(resolved_a_shape->NumDimensions(), static_cast<size_t>(2));
+  ASSERT_LT((*resolved_a_shape)[0], 0)
       << "Symbolic NodeArg leading dim did not convert to a negative (unknown) extent.";
-  const std::vector<TensorShape> input_shapes{a_tensor_shape};
+  EXPECT_EQ((*resolved_a_shape)[1], kE2eK);
   InlinedVector<WorkspaceRequirement> requirements;
-  ASSERT_STATUS_OK(op_kernel->DeclareWorkspaceRequirements(AsSpan(input_shapes), requirements));
+  ASSERT_STATUS_OK(op_kernel->DeclareWorkspaceRequirements(gsl::make_span(input_shapes), requirements));
   EXPECT_TRUE(requirements.empty())
       << "Level-2 DeclareWorkspaceRequirements must be empty for an unknown (symbolic) leading dim.";
 
@@ -567,11 +781,13 @@ TEST(MatMulNBitsWorkspace, NonMatMulNBitsKernelDeclaresNoWorkspace) {
   ASSERT_NE(op_kernel, nullptr) << "No kernel constructed for the Add node.";
 
   // Add does not override DeclareWorkspaceRequirements -> base-class no-op: OK() + empty output.
-  const std::vector<TensorShape> input_shapes{TensorShape({kAddM, kAddN}), TensorShape({kAddM, kAddN})};
+  MaxShapeInferenceResult inferred_shapes;
+  const auto input_shapes = ResolveNodeInputShapes(*add_node, &graph, inferred_shapes);
+  ASSERT_EQ(input_shapes.size(), 2u);
   InlinedVector<WorkspaceRequirement> requirements;
   // Pre-populate to prove the no-op default clears rather than appends.
   requirements.push_back(WorkspaceRequirement{123, /*slot_id=*/7, /*alignment_bytes=*/0});
-  ASSERT_STATUS_OK(op_kernel->DeclareWorkspaceRequirements(AsSpan(input_shapes), requirements));
+  ASSERT_STATUS_OK(op_kernel->DeclareWorkspaceRequirements(gsl::make_span(input_shapes), requirements));
   EXPECT_TRUE(requirements.empty())
       << "A kernel that does not override DeclareWorkspaceRequirements must report no workspace.";
 }

--- a/onnxruntime/test/providers/cuda/test_cases/matmul_nbits_workspace_test.cc
+++ b/onnxruntime/test/providers/cuda/test_cases/matmul_nbits_workspace_test.cc
@@ -107,11 +107,29 @@ TEST(MatMulNBitsWorkspace, FormulaSm90DependsOnMultiProcessorCount) {
   EXPECT_EQ(ComputeFpAIntBGemmWorkspaceSize(1, 1, 0, 90, 20),
             ComputeFpAIntBGemmWorkspaceSize(9999, 9999, 0, 90, 20));
 }
+
 #endif
+
+TEST(MatMulNBitsWorkspace, FormulaEmptyOutputIsZeroBeforeSm90Math) {
+  // The native SM90 formula normally depends only on the SM count. Empty output must be handled
+  // first so it cannot reserve the multi-megabyte stream-K workspace. Keep this test enabled when
+  // SM90 kernels are excluded: the shared early guard is intentionally architecture-independent.
+  EXPECT_EQ(ComputeFpAIntBGemmWorkspaceSize(/*m=*/0, /*n=*/256, /*k=*/1024,
+                                            /*sm=*/90, /*mpc=*/132),
+            std::optional<size_t>{0});
+  EXPECT_EQ(ComputeFpAIntBGemmWorkspaceSize(/*m=*/256, /*n=*/0, /*k=*/1024,
+                                            /*sm=*/90, /*mpc=*/132),
+            std::optional<size_t>{0});
+}
 
 TEST(MatMulNBitsWorkspace, FormulaReturnsNulloptOnInvalidNegativeDim) {
   // A negative dimension cannot be represented as an unsigned size and must yield nullopt (not throw).
   EXPECT_FALSE(ComputeFpAIntBGemmWorkspaceSize(-1, 64, 0, 80, 100).has_value());
+  EXPECT_FALSE(ComputeFpAIntBGemmWorkspaceSize(64, -1, 0, 80, 100).has_value());
+#ifndef EXCLUDE_SM_90
+  EXPECT_FALSE(ComputeFpAIntBGemmWorkspaceSize(-1, 64, 0, 90, 100).has_value());
+  EXPECT_FALSE(ComputeFpAIntBGemmWorkspaceSize(64, -1, 0, 90, 100).has_value());
+#endif
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Why

`DeclareWorkspaceRequirements()` currently receives a dense `span<const TensorShape>`. That loses positional correspondence when an optional input is omitted and prevents Level 2 workspace estimation for valid signatures with an internal hole, for example:

- PackedMultiHeadAttention: missing `bias` with later `token_offset` / `cumulative_sequence_length`
- GroupQueryAttention: missing `seqlens_k` with later `total_sequence_length`
- MatMulNBits: missing optional `g_idx` with later `bias`

The resolver also dropped partial shapes wholesale, conflating “input is missing”, “input is present but shape metadata is unavailable”, and “input is present with unknown dimensions”.

## What changed

- Add an owned, positional `WorkspaceInputShape` descriptor with three explicit states:
  - `Missing`
  - `PresentWithShape`
  - `PresentWithoutShape`
- Preserve rank-0 tensors, zero extents, partial shapes (`-1` per unknown dimension), and optional holes.
- Deep-copy dimensions so descriptors remain valid after graph/shadow-graph teardown.
- Replace the unreleased C++ virtual directly; no compatibility overload is retained.
- Update MatMulNBits Level 2 to consume the new contract while preserving Level 1/Level 2/runtime workspace parity.
- Preserve the adapter-side default no-op. Plugin C-ABI forwarding/invocation remains deferred.

## MatMulNBits parity

The shared workspace formula now handles known-empty outputs before architecture-specific arithmetic:

- ordinary case: Level 1 = Level 2 = runtime = 1792 bytes
- empty output: Level 1 = 0, Level 2 emits no slot, runtime = 0
- known-zero partial shapes such as `[0, unknown, K]` are recognized as empty
- invalid negative dimensions and checked-arithmetic overflow remain unavailable/error paths

## #32071 integration constraints

#32071 uses Level-2 declarations as synthetic negative allocation IDs in the existing activation `MemoryPattern`.
The first run for a compatible feed-shape key traces workspace allocation/free while the kernel still uses
`GetScratchBuffer()`. Later compatible runs can return an offset in the normal per-run pattern backing buffer;
an unavailable pattern or a request larger than the declared capacity falls back to `GetScratchBuffer()`.
This is not persistent `Initialize()`-time allocation and does not protect the first run from OOM.

The current #32071 pilot preplans only kernels that explicitly opt in and declare exactly one slot.
The PA/PMHA follow-up uses that contract for both operators:

- PackedAttention declares one 256-byte-aligned root containing projection and Attention regions.
- PackedMultiHeadAttention declares one 256-byte-aligned Attention root.

The declarations alone do not opt either kernel into planning. The future integration must atomically add
`SupportsPreallocatedWorkspace()`, retrieve slot 0, and split PA's root at its declared aligned Attention offset.
Until then, PA retains its two dynamic allocations and PMHA retains its one dynamic allocation. Generic multi-slot
framework support remains available, but PA does not require a multi-slot planner extension.

## Deferred Phase-B semantics

This PR intentionally does **not** add:

- max-shape provenance to the descriptor
- a distinct marker for “proven zero” versus “unavailable”
- plugin C ABI forwarding
- workspace offset planning/allocation
- partition/resource-accounting policy

Those semantics belong to the planner/accounting integration, where runtime bound checks and fallback behavior can be defined coherently.

## Compatibility with #32071

This PR should merge first. #32071 should then rebase and update its Level-2 caller to pass the same positional `WorkspaceInputShape` span while retaining its reservation verification and execution-plan registration.

## Validation

- CPU framework/session targeted tests: 29 passed
- CUDA MatMulNBits workspace tests: 16 passed
- same-session positive-`M` then zero-`M` runtime coverage
- SM90 empty-output host regression
- core and adapter header-isolation probes
- C++ formatting and `git diff --check`

Design tracking: #29775
