### PR TITLE
[WebGPU] Select the pooling path by occupancy rather than output size

### DIFF
--- a/onnxruntime/core/providers/webgpu/nn/pool.cc
+++ b/onnxruntime/core/providers/webgpu/nn/pool.cc
@@ -95,7 +95,7 @@ Status PoolProgram::GenerateShaderCode(ShaderHelper& shader) const {
     var_decl_code = SS_GET(var_decl_ss);
 
     sampling_code = "      value = max(value, x_val);\n";
-    if (are_small_output_big_kernel_) {
+    if (use_parallel_reduction_) {
       downsampling_code = "  sum_or_max_shared[local_idx] = value;\n";
     }
   } else {
@@ -118,7 +118,7 @@ Status PoolProgram::GenerateShaderCode(ShaderHelper& shader) const {
                         : "    if (!is_pad) {\n      count++;\n    }\n";
 
     SS(downsampling_ss, kStringInitialSize);
-    if (are_small_output_big_kernel_) {
+    if (use_parallel_reduction_) {
       downsampling_ss << "  sum_or_max_shared[local_idx] = value;\n"
                       << "  count_shared[local_idx] = count;\n";
     } else {
@@ -165,7 +165,7 @@ Status PoolProgram::GenerateShaderCode(ShaderHelper& shader) const {
   std::string pad_break_code = overflow_check_code.empty() ? "        break;\n" : "";
 
   std::string sum_or_max_shared;
-  if (are_small_output_big_kernel_) {
+  if (use_parallel_reduction_) {
     shader.AdditionalImplementation()
         << "var<workgroup> sum_or_max_shared : array<" << (is_float16_ ? "f16" : "f32") << ",workgroup_size_x >;\n"
         << (!is_max_pool_ ? "var<workgroup> count_shared : array<u32, workgroup_size_x>;\n" : "");
@@ -192,10 +192,10 @@ Status PoolProgram::GenerateShaderCode(ShaderHelper& shader) const {
               << "  }\n";
     sum_or_max_shared = SS_GET(shared_ss);
   }
-  std::string kernel_loop_decl_code = are_small_output_big_kernel_ ? "  for (var i: u32 = local_idx; i < uniforms.kernel_size; i += workgroup_size_x) {\n" : "  for (var i: u32 = 0; i < uniforms.kernel_size; i++) {\n";
+  std::string kernel_loop_decl_code = use_parallel_reduction_ ? "  for (var i: u32 = local_idx; i < uniforms.kernel_size; i += workgroup_size_x) {\n" : "  for (var i: u32 = 0; i < uniforms.kernel_size; i++) {\n";
 
   SS(output_ss, kStringInitialSize);
-  if (are_small_output_big_kernel_) {
+  if (use_parallel_reduction_) {
     output_ss << "  if (local_idx == 0) {\n"
               << "    value = sum_or_max_shared[0];\n";
     if (!is_max_pool_) {
@@ -212,8 +212,8 @@ Status PoolProgram::GenerateShaderCode(ShaderHelper& shader) const {
   std::string output_code = SS_GET(output_ss);
 
   auto& body = shader.MainFunctionBody();
-  body << (are_small_output_big_kernel_ ? "" : shader.GuardAgainstOutOfBoundsWorkgroupSizes("uniforms.output_size"))
-       << "  let y_indices = " << output.OffsetToIndices((are_small_output_big_kernel_ ? "workgroup_idx" : "global_idx")) << ";\n"
+  body << (use_parallel_reduction_ ? "" : shader.GuardAgainstOutOfBoundsWorkgroupSizes("uniforms.output_size"))
+       << "  let y_indices = " << output.OffsetToIndices((use_parallel_reduction_ ? "workgroup_idx" : "global_idx")) << ";\n"
        << "  var x_indices = y_indices;\n"
        << "  var k_indices: array<u32, " << kernel_rank << ">;\n"
        << var_decl_code
@@ -259,6 +259,13 @@ Status PoolProgram::GenerateShaderCode(ShaderHelper& shader) const {
 
   return Status::OK();
 }
+
+// Threads a parallel-reduction workgroup uses to co-operate on one output element's kernel window.
+constexpr uint32_t kParallelReductionWorkgroupSize = 128;
+
+// Below this many workgroups a dispatch leaves compute units idle. WebGPU reports no compute-unit
+// count, so this is a fixed value chosen to sit under discrete GPUs and over integrated ones.
+constexpr uint32_t kMinDispatchGroupsToFillDevice = 64;
 
 template <typename PoolType, bool is_nhwc>
 Status Pool<PoolType, is_nhwc>::ComputeInternal(ComputeContext& context) const {
@@ -327,10 +334,16 @@ Status Pool<PoolType, is_nhwc>::ComputeInternal(ComputeContext& context) const {
   const auto strides_u32 = NarrowToU32(strides);
   const auto dilations_u32 = NarrowToU32(dilations);
 
-  bool are_small_output_big_kernel = output_size <= 128 && kernel_size >= 128;
-  PoolProgram program{is_max_pool, is_nhwc, kernel_shape, is_float16, count_include_pad, are_small_output_big_kernel};
+  const uint32_t serial_dispatch_groups = static_cast<uint32_t>((output_size + WORKGROUP_SIZE - 1) / WORKGROUP_SIZE);
+  // The serial path gives each output element one thread that loops the whole window, so its
+  // parallelism is output_size alone. The parallel path spends a workgroup per output element and
+  // reduces the window across its threads. Select on whether the serial path fills the device, not
+  // on output size: a small output with a large window holds plenty of work either way.
+  const bool use_parallel_reduction =
+      serial_dispatch_groups < kMinDispatchGroupsToFillDevice && kernel_size >= kParallelReductionWorkgroupSize;
+  PoolProgram program{is_max_pool, is_nhwc, kernel_shape, is_float16, count_include_pad, use_parallel_reduction};
 
-  program.CacheHint(kernel_shape.size(), is_max_pool, is_nhwc, is_float16, count_include_pad, are_small_output_big_kernel)
+  program.CacheHint(kernel_shape.size(), is_max_pool, is_nhwc, is_float16, count_include_pad, use_parallel_reduction)
       .AddInputs({{X, ProgramTensorMetadataDependency::TypeAndRank}})
       .AddOutputs({{Y}})
       .AddUniformVariables({output_size, kernel_size,
@@ -339,11 +352,11 @@ Status Pool<PoolType, is_nhwc>::ComputeInternal(ComputeContext& context) const {
                             gsl::span<const uint32_t>(strides_u32.data(), strides_u32.size()),
                             gsl::span<const uint32_t>(dilations_u32.data(), dilations_u32.size())});
 
-  if (are_small_output_big_kernel) {
-    program.SetWorkgroupSize(128)
+  if (use_parallel_reduction) {
+    program.SetWorkgroupSize(kParallelReductionWorkgroupSize)
         .SetDispatchGroupSize(output_size);
   } else {
-    program.SetDispatchGroupSize((output_size + WORKGROUP_SIZE - 1) / WORKGROUP_SIZE);
+    program.SetDispatchGroupSize(serial_dispatch_groups);
   }
 
   return context.RunProgram(program);

--- a/onnxruntime/core/providers/webgpu/nn/pool.h
+++ b/onnxruntime/core/providers/webgpu/nn/pool.h
@@ -14,14 +14,14 @@ namespace webgpu {
 class PoolProgram final : public Program<PoolProgram> {
  public:
   PoolProgram(bool is_max_pool, bool is_nhwc, const TensorShapeVector& kernel_shape, bool is_float16,
-              bool count_include_pad, bool are_small_output_big_kernel)
+              bool count_include_pad, bool use_parallel_reduction)
       : Program{"Pool"},
         is_max_pool_{is_max_pool},
         is_nhwc_{is_nhwc},
         kernel_shape_{kernel_shape},
         is_float16_{is_float16},
         count_include_pad_{count_include_pad},
-        are_small_output_big_kernel_{are_small_output_big_kernel} {}
+        use_parallel_reduction_{use_parallel_reduction} {}
 
   Status GenerateShaderCode(ShaderHelper& sh) const override;
 
@@ -40,7 +40,7 @@ class PoolProgram final : public Program<PoolProgram> {
   const TensorShapeVector kernel_shape_;
   const bool is_float16_;
   const bool count_include_pad_;
-  const bool are_small_output_big_kernel_;
+  const bool use_parallel_reduction_;
 };
 
 template <typename PoolType, bool is_nhwc>

--- a/onnxruntime/test/providers/cpu/nn/pool_op_test.cc
+++ b/onnxruntime/test/providers/cpu/nn/pool_op_test.cc
@@ -1847,6 +1847,69 @@ TEST(PoolTest, GlobalAveragePool_Large_256) {
   test.Run(OpTester::ExpectResult::kExpectSuccess, "", {});
 }
 
+// The WebGPU EP runs a pool as a workgroup-cooperative reduction when the serial path would not
+// fill the device and the kernel window is large. Global pooling only reaches that path with a
+// single output element per channel, which leaves two things unexercised: an output index taken
+// from workgroup_idx, and a divisor that has to be reduced across the workgroup.
+static void RunWebGpuLargeKernelPoolTest(const char* op_type, int opset, bool is_max_pool) {
+  auto webgpu_ep = DefaultWebGpuExecutionProvider();
+  if (webgpu_ep == nullptr) {
+    GTEST_SKIP() << "WebGPU EP is not available in this build.";
+  }
+
+  // A 12x12 window with pad 2 over a 24x24 input: kernel_size 144, output_size 578.
+  constexpr int64_t kChannels = 2, kSpatial = 24, kKernel = 12, kPad = 2;
+  constexpr int64_t kOutSpatial = kSpatial + 2 * kPad - kKernel + 1;
+
+  std::vector<float> x_vals(kChannels * kSpatial * kSpatial);
+  for (size_t i = 0; i < x_vals.size(); ++i) {
+    x_vals[i] = static_cast<float>(i) * 0.01f;
+  }
+
+  std::vector<float> expected_vals(kChannels * kOutSpatial * kOutSpatial);
+  for (int64_t c = 0; c < kChannels; ++c) {
+    for (int64_t oh = 0; oh < kOutSpatial; ++oh) {
+      for (int64_t ow = 0; ow < kOutSpatial; ++ow) {
+        float acc = is_max_pool ? std::numeric_limits<float>::lowest() : 0.0f;
+        int64_t count = 0;
+        for (int64_t kh = 0; kh < kKernel; ++kh) {
+          for (int64_t kw = 0; kw < kKernel; ++kw) {
+            const int64_t ih = oh + kh - kPad;
+            const int64_t iw = ow + kw - kPad;
+            if (ih < 0 || ih >= kSpatial || iw < 0 || iw >= kSpatial) {
+              continue;
+            }
+            const float v = x_vals[static_cast<size_t>((c * kSpatial + ih) * kSpatial + iw)];
+            acc = is_max_pool ? (v > acc ? v : acc) : acc + v;
+            ++count;
+          }
+        }
+        expected_vals[static_cast<size_t>((c * kOutSpatial + oh) * kOutSpatial + ow)] =
+            is_max_pool ? acc : acc / static_cast<float>(count);
+      }
+    }
+  }
+
+  OpTester test(op_type, opset);
+  test.AddAttribute("kernel_shape", std::vector<int64_t>{kKernel, kKernel});
+  test.AddAttribute("pads", std::vector<int64_t>{kPad, kPad, kPad, kPad});
+  test.AddInput<float>("X", {1, kChannels, kSpatial, kSpatial}, x_vals);
+  test.AddOutput<float>("Y", {1, kChannels, kOutSpatial, kOutSpatial}, expected_vals,
+                        /*sort_output=*/false, /*rel_error=*/1e-3f, /*abs_error=*/1e-2f);
+
+  std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
+  execution_providers.push_back(std::move(webgpu_ep));
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {}, nullptr, &execution_providers);
+}
+
+TEST(PoolTest, AveragePool_LargeKernelMultiElementOutput_WebGpu) {
+  RunWebGpuLargeKernelPoolTest("AveragePool", 11, /*is_max_pool=*/false);
+}
+
+TEST(PoolTest, MaxPool_LargeKernelMultiElementOutput_WebGpu) {
+  RunWebGpuLargeKernelPoolTest("MaxPool", 12, /*is_max_pool=*/true);
+}
+
 TEST(PoolTest, LpPool) {
   OpTester test("LpPool");
 


### PR DESCRIPTION
### Description

Pool picks between a serial path, where one invocation loops over the whole kernel window,
and a workgroup-cooperative path that splits the window across invocations and reduces in
shared memory. The choice was made on output size, which does not describe how much of the
GPU either path will fill.

This selects on occupancy instead: the serial path is only competitive when the output is
large enough to keep the device busy on its own, and the cooperative path is what recovers a
large kernel window over a small output.

### Motivation and Context

EfficientNet-B0 has a global average pool that reduces the entire feature map to one pixel
per channel, which is the shape the old heuristic handled worst: a small output that the
serial path cannot parallelise over, with a long reduction behind it.

Measured on an NVIDIA TITAN V, driver 560.94:

- EfficientNet-B0 native end to end: 3.73 ms -> 1.78 ms
- Pool as a share of GPU time: 54.6% -> 11.1%

Numerically identical output; this only changes how the reduction is scheduled.