### PR TITLE
[WebGPU] Report copy_tensors misuse instead of terminating the process

### DIFF
--- a/onnxruntime/core/providers/webgpu/webgpu_provider_factory.cc
+++ b/onnxruntime/core/providers/webgpu/webgpu_provider_factory.cc
@@ -412,12 +412,26 @@ struct WebGpuDataTransferImpl : OrtDataTransferImpl {
            (src_type == OrtMemoryInfoDeviceType_CPU && dst_type == OrtMemoryInfoDeviceType_GPU);
   }
 
+  // BufferManager::MemCpy reports misuse by throwing (ORT_ENFORCE), not by returning a Status.
+  // This callback crosses the C ABI and is noexcept, so an escaping exception would terminate the
+  // process. Convert throws to an OrtStatus.
   static OrtStatus* ORT_API_CALL CopyTensorsImpl(
       OrtDataTransferImpl* this_ptr,
       const OrtValue** src_tensors,
       OrtValue** dst_tensors,
-      OrtSyncStream** /*streams*/,
+      OrtSyncStream** streams,
       size_t num_tensors) noexcept {
+    API_IMPL_BEGIN
+    return CopyTensorsOrThrow(this_ptr, src_tensors, dst_tensors, streams, num_tensors);
+    API_IMPL_END
+  }
+
+  static OrtStatus* CopyTensorsOrThrow(
+      OrtDataTransferImpl* this_ptr,
+      const OrtValue** src_tensors,
+      OrtValue** dst_tensors,
+      OrtSyncStream** /*streams*/,
+      size_t num_tensors) {
     auto& impl = *static_cast<WebGpuDataTransferImpl*>(this_ptr);
 
     if (num_tensors == 0) {

--- a/onnxruntime/test/autoep/test_webgpu_allocators.cc
+++ b/onnxruntime/test/autoep/test_webgpu_allocators.cc
@@ -316,6 +316,49 @@ TEST_F(WebGpuPluginSharedAllocatorTest, DeviceTensorDataRoundTripsWithSharedAndS
   }
 }
 
+// BufferManager::MemCpy rejects a self-copy with ORT_ENFORCE, which throws rather than returning a
+// Status. CopyTensorsImpl is a noexcept C ABI callback, so before the throw was converted to an
+// OrtStatus this ended the process instead of reporting the misuse.
+TEST_F(WebGpuPluginSharedAllocatorTest, DeviceTensorSelfCopyIsReportedInsteadOfTerminating) {
+  constexpr std::array<int64_t, 1> shape{8};
+  std::array<float, 8> input_data{1.0f, -2.0f, 3.5f, 4.0f, -5.25f, 6.0f, 7.75f, -8.0f};
+  auto cpu_memory_info = Ort::MemoryInfo::CreateCpu(OrtArenaAllocator, OrtMemTypeDefault);
+
+  for (const auto& ep_device : EpDevices()) {
+    auto device_memory_info = ep_device.GetMemoryInfo(OrtDeviceMemoryType_DEFAULT);
+    ASSERT_NE(device_memory_info, nullptr);
+    SCOPED_TRACE(::testing::Message() << "device " << device_memory_info.GetDeviceId());
+
+    Ort::KeyValuePairs allocator_options;
+    auto shared_allocator = Env().CreateSharedAllocator(
+        ep_device, OrtDeviceMemoryType_DEFAULT, OrtDeviceAllocator, allocator_options);
+    ASSERT_NE(shared_allocator, nullptr);
+
+    Ort::SessionOptions session_options;
+    Ort::KeyValuePairs ep_options;
+    session_options.AppendExecutionProvider_V2(Env(), {ep_device}, ep_options);
+    Ort::Session session(Env(), ORT_TSTR("testdata/mul_1.onnx"), session_options);
+
+    auto device_tensor = Ort::Value::CreateTensor<float>(shared_allocator, shape.data(), shape.size());
+
+    // Source and destination resolve to the same WGPUBuffer, which MemCpy refuses.
+    Ort::Status self_copy = Env().CopyTensor(device_tensor, device_tensor, nullptr);
+    ASSERT_FALSE(self_copy.IsOK());
+    EXPECT_THAT(self_copy.GetErrorMessage(), ::testing::HasSubstr("must be different"));
+
+    // The misuse was reported, not fatal: the same tensor still round trips.
+    std::array<float, 8> output_data{};
+    auto cpu_input = Ort::Value::CreateTensor<float>(
+        cpu_memory_info, input_data.data(), input_data.size(), shape.data(), shape.size());
+    auto cpu_output = Ort::Value::CreateTensor<float>(
+        cpu_memory_info, output_data.data(), output_data.size(), shape.data(), shape.size());
+
+    ASSERT_ORTSTATUS_OK(Env().CopyTensor(cpu_input, device_tensor, nullptr));
+    ASSERT_ORTSTATUS_OK(Env().CopyTensor(device_tensor, cpu_output, nullptr));
+    EXPECT_EQ(output_data, input_data);
+  }
+}
+
 // Manual Task Manager test. This intentionally reserves substantial GPU memory and runs for an extended period.
 // Enable explicitly with --gtest_also_run_disabled_tests and this test's full name.
 TEST_F(WebGpuPluginSharedAllocatorTest, DISABLED_ManualPerDeviceMemoryAndComputeLoad) {


### PR DESCRIPTION
### Description

`BufferManager::MemCpy` reports misuse with `ORT_ENFORCE`, which throws: an aliased src/dst
pair, an undersized destination and a still-mapped buffer all throw rather than returning a
Status. The shared data transfer reaches it through `WebGpuDataTransferImpl::CopyTensorsImpl`,
which is a `noexcept` C ABI callback and only handled a returned non-OK Status. The exception
escaped a `noexcept` frame, so `std::terminate` took the process down with no message and no
stack.

This wraps the callback body so any throw becomes an `OrtStatus`, which is what the
surrounding C API already expects.

The two sibling callbacks are deliberately left alone: `CanCopyImpl` only calls C ABI function
pointers, and `ReleaseImpl` returns void, so converting a throw there would mean swallowing it
rather than reporting it, which is a separate decision from this one.

### Motivation and Context

Not currently reachable from Python, because `copy_tensors` rejects every WebGPU OrtValue
outright. It becomes reachable as soon as the supported copies are allowed, which is what
#32074 does, so it is worth fixing at the boundary on its own rather than landing inside a
larger change.

The regression test for it uses the session-scoped allocation APIs under discussion in #32074
and is held there rather than duplicated here.
