### PR TITLE
[WebGPU] Forward -i provider options to the WebGPU EP in perf_test

### DIFF
--- a/onnxruntime/test/perftest/ort_test_session.cc
+++ b/onnxruntime/test/perftest/ort_test_session.cc
@@ -607,7 +607,17 @@ select from 'TF8', 'TF16', 'UINT8', 'FLOAT', 'ITENSOR'. \n)");
 #endif
   } else if (provider_name_ == onnxruntime::kWebGpuExecutionProvider) {
 #ifdef USE_WEBGPU
-    session_options.AppendExecutionProvider("WebGPU", {});
+    // Use the short key form here: -i "enableGraphCapture|1". AppendExecutionProvider prefixes
+    // provider-option keys with "ep.webgpuexecutionprovider." itself, so a fully qualified key is
+    // double-prefixed and silently ignored. Session config entries (-C) do not reach the EP
+    // factory, which reads these at append time.
+#ifdef _MSC_VER
+    std::string option_string = ToUTF8String(performance_test_config.run_config.ep_runtime_config_string);
+#else
+    std::string option_string = performance_test_config.run_config.ep_runtime_config_string;
+#endif
+    ParseSessionConfigs(option_string, provider_options);
+    session_options.AppendExecutionProvider("WebGPU", provider_options);
 #else
     ORT_THROW("WebGPU is not supported in this build\n");
 #endif


### PR DESCRIPTION
### Description

`perf_test -i` did not forward provider options to the WebGPU EP, so options passed that way
were accepted and then silently ignored. This parses them the way every other EP branch in
the file already does and hands them to `AppendExecutionProvider`.

The comment also records the short key form, because the fully-qualified
`ep.webgpuexecutionprovider.<name>` form gets double-prefixed and dropped without a warning.

### Motivation and Context

Both were found while trying to sweep WebGPU EP settings from `perf_test`. The failure mode is
quiet in both cases: the run completes, reports a plausible number, and uses the default value.
A dispatch-window sweep had to be discarded and re-run after hitting the second one.