### PR TITLE
[WebGPU] Reject foreign GPU handles in the built-in data transfer

### DIFF
--- a/onnxruntime/core/providers/webgpu/data_transfer.cc
+++ b/onnxruntime/core/providers/webgpu/data_transfer.cc
@@ -36,10 +36,23 @@ common::Status DataTransferImpl::CopyTensor(void const* src_data,
   return Status::OK();
 }
 
-bool DataTransfer::CanCopy(const OrtDevice& src_device, const OrtDevice& dst_device) const {
+bool DataTransfer::IsSupportedDevicePair(const OrtDevice& src_device, const OrtDevice& dst_device) {
+  // WebGPU allocations carry VendorIds::NONE. A vendor-tagged GPU handle belongs to another EP, and
+  // reinterpreting it as a WGPUBuffer would be unsafe. The plugin EP transfer applies the same rule.
+  if (src_device.Type() == OrtDevice::GPU && src_device.Vendor() != OrtDevice::VendorIds::NONE) {
+    return false;
+  }
+  if (dst_device.Type() == OrtDevice::GPU && dst_device.Vendor() != OrtDevice::VendorIds::NONE) {
+    return false;
+  }
+
   return (dst_device.Type() == OrtDevice::GPU && src_device.Type() == OrtDevice::CPU) ||
          (dst_device.Type() == OrtDevice::GPU && src_device.Type() == OrtDevice::GPU) ||
          (dst_device.Type() == OrtDevice::CPU && src_device.Type() == OrtDevice::GPU);
+}
+
+bool DataTransfer::CanCopy(const OrtDevice& src_device, const OrtDevice& dst_device) const {
+  return IsSupportedDevicePair(src_device, dst_device);
 }
 
 common::Status DataTransfer::CopyTensor(const Tensor& src, Tensor& dst) const {

--- a/onnxruntime/core/providers/webgpu/data_transfer.h
+++ b/onnxruntime/core/providers/webgpu/data_transfer.h
@@ -33,6 +33,10 @@ class DataTransfer : public IDataTransfer {
   DataTransfer(const BufferManager& buffer_manager) : impl_{buffer_manager} {};
   ~DataTransfer() {};
 
+  // Device-compatibility half of CanCopy, split out because it needs no BufferManager and so can
+  // be tested without a live device.
+  static bool IsSupportedDevicePair(const OrtDevice& src_device, const OrtDevice& dst_device);
+
   bool CanCopy(const OrtDevice& src_device, const OrtDevice& dst_device) const override;
 
   common::Status CopyTensor(const Tensor& src, Tensor& dst) const override;

--- a/onnxruntime/test/providers/webgpu/data_transfer_test.cc
+++ b/onnxruntime/test/providers/webgpu/data_transfer_test.cc
@@ -1,0 +1,61 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "gtest/gtest.h"
+
+#include "core/framework/ortdevice.h"
+#include "core/providers/webgpu/data_transfer.h"
+
+namespace onnxruntime {
+namespace test {
+namespace {
+
+constexpr OrtDevice Cpu() {
+  return OrtDevice(OrtDevice::CPU, OrtDevice::MemType::DEFAULT, OrtDevice::VendorIds::NONE, 0);
+}
+
+// WebGPU buffers are allocated as generic GPU memory with no vendor id (see webgpu::WebGpuDevice).
+constexpr OrtDevice WebGpu(OrtDevice::DeviceId device_id = 0) {
+  return OrtDevice(OrtDevice::GPU, OrtDevice::MemType::DEFAULT, OrtDevice::VendorIds::NONE, device_id);
+}
+
+constexpr OrtDevice VendorGpu(OrtDevice::VendorId vendor_id) {
+  return OrtDevice(OrtDevice::GPU, OrtDevice::MemType::DEFAULT, vendor_id, 0);
+}
+
+bool CanCopy(const OrtDevice& src, const OrtDevice& dst) {
+  return webgpu::DataTransfer::IsSupportedDevicePair(src, dst);
+}
+
+}  // namespace
+
+TEST(WebGpuDataTransferTest, AcceptsHostAndWebGpuEndpoints) {
+  EXPECT_TRUE(CanCopy(Cpu(), WebGpu()));
+  EXPECT_TRUE(CanCopy(WebGpu(), Cpu()));
+  EXPECT_TRUE(CanCopy(WebGpu(), WebGpu()));
+  // The predicate ignores device id.
+  EXPECT_TRUE(CanCopy(WebGpu(1), WebGpu(0)));
+}
+
+TEST(WebGpuDataTransferTest, RejectsHostToHost) {
+  // CPU-to-CPU copies belong to the CPU data transfer, not this one.
+  EXPECT_FALSE(CanCopy(Cpu(), Cpu()));
+}
+
+TEST(WebGpuDataTransferTest, RejectsForeignGpuVendors) {
+  // A vendor-tagged GPU handle belongs to another EP, so this transfer must not claim it.
+  for (const auto vendor_id : {OrtDevice::VendorIds::NVIDIA,
+                               OrtDevice::VendorIds::AMD,
+                               OrtDevice::VendorIds::INTEL,
+                               OrtDevice::VendorIds::MICROSOFT}) {
+    const OrtDevice foreign = VendorGpu(vendor_id);
+    EXPECT_FALSE(CanCopy(Cpu(), foreign)) << "vendor " << vendor_id;
+    EXPECT_FALSE(CanCopy(foreign, Cpu())) << "vendor " << vendor_id;
+    EXPECT_FALSE(CanCopy(WebGpu(), foreign)) << "vendor " << vendor_id;
+    EXPECT_FALSE(CanCopy(foreign, WebGpu())) << "vendor " << vendor_id;
+    EXPECT_FALSE(CanCopy(foreign, foreign)) << "vendor " << vendor_id;
+  }
+}
+
+}  // namespace test
+}  // namespace onnxruntime


### PR DESCRIPTION
### Description

`WebGpuDataTransferImpl::CanCopyImpl`, the plugin EP path, rejects GPU devices whose vendor id
is not `VendorIds::NONE`, on the grounds that they belong to another EP. The built-in
`DataTransfer::CanCopy` has no such check and returns true for any GPU device, so in a build
with another GPU EP registered it can claim a handle it would then reinterpret as a WGPUBuffer.

This applies the same rule in both places, and splits the device-compatibility half of the
predicate into a static so it can be covered without a live device.

### Motivation and Context

Found while testing the WebGPU data transfer directly. The two paths encode the same policy and
had drifted; the plugin one already carries a comment explaining why the vendor check is needed.