### PR TITLE
WebGPU: support local-window PagedAttention with attention sinks

### DIFF
--- a/docs/design/webgpu_paged_attention.md
+++ b/docs/design/webgpu_paged_attention.md
@@ -1,6 +1,6 @@
 # Design: WebGPU PagedAttention
 
-**Status**: v1 landed. Phase 2 partially landed (direct paged decode + fused paged prefill + Unpack/Repack skip fast paths + metadata fast path).
+**Status**: v1 landed. Phase 2 partially landed (direct paged decode + fused paged prefill + Unpack/Repack skip fast paths + metadata fast path + local-window/head-sink fallback).
 **Target**: WebGPU EP, `com.microsoft::PagedAttention` v1
 **Owner**: TBD
 **Precision**: `MLFloat16` only in v1
@@ -377,11 +377,21 @@ metadata readback. This removes the per-node queue flush for current GenAI
 exports; indirect dispatch remains a possible follow-up for tightening work to
 the exact lengths while retaining replay-wide allocations.
 
+**Local-window and head-sink support.** ✅ The generic
+`FlashAttentionProgram` applies `local_window_size` as a per-query left mask
+and composes it with the existing learned `head_sink` softmax term. Local
+windows route through gather-then-flash for both prefill and decode because the
+direct paged shaders do not yet skip old pages. Head-sink-only decode retains
+the direct paged split-reduce path; head-sink prefill falls back to gather until
+the fused paged-prefill shader carries the sink term. This is a correctness
+implementation, not the final local-window optimization: gathering and shader
+traversal still scale with full KV history.
+
 #### Phase 2 items remaining (future work)
 
 **2. Complete deferred Phase 1 feature support.** Add and test the features
-currently rejected by WebGPU: `softcap`, `local_window_size`, `head_sink`,
-`use_smooth_softmax`, `q_norm_weight`, and `k_norm_weight`. Evaluate
+currently rejected by WebGPU: `softcap`, `use_smooth_softmax`,
+`q_norm_weight`, and `k_norm_weight`. Evaluate
 `slot_mapping` including negative-slot skip-write semantics, plus
 `rotary_offset` and non-default `v_head_size` when model compatibility
 requires them. Add `bfloat16` only when target WebGPU adapters provide a
@@ -537,7 +547,7 @@ Feature guards (v1 rejects with `NOT_IMPLEMENTED` and a specific message):
 
 - Any `T_CACHE != T` (quantized).
 - `kv_cache_layout == LATENT`.
-- Non-null `head_sink`, `q_norm_weight`, `k_norm_weight`, `k_scale`, `v_scale`.
+- Non-null `q_norm_weight`, `k_norm_weight`, `k_scale`, `v_scale`.
 - `slot_mapping` containing negative entries.
 
 ---
@@ -573,8 +583,9 @@ Feature guards (v1 rejects with `NOT_IMPLEMENTED` and a specific message):
   `TestPagedAttentionRotaryZeroTokenRegression`) remain the CUDA source of
   truth. `TestPagedAttentionWebGpu` runs the same PyTorch reference
   (`attention_ref`) over a WebGPU-scoped config matrix (rotary + packed QKV +
-  GQA), filtered by `_webgpu_supports_config` to skip `softcap != 0` and
-  `local_window_size != -1` until the WebGPU kernel implements them. Because
+  GQA), plus focused local-window/head-sink tests for GPT-OSS-style prefill,
+  decode, short-history saturation, and independent sink paths. The matrix is
+  filtered by `_webgpu_supports_config` to skip `softcap != 0`. Because
   lavapipe crashes on MatMul, the numerical tests must run on
   **macOS-arm64 Metal** or on a discrete Windows/Linux WebGPU adapter as the
   source of truth (same policy as the expanded-Attention tests).

--- a/onnxruntime/contrib_ops/webgpu/bert/flash_attention.cc
+++ b/onnxruntime/contrib_ops/webgpu/bert/flash_attention.cc
@@ -275,6 +275,7 @@ Status FlashAttentionProgram::GenerateShaderCode(ShaderHelper& shader) const {
                              WGSL_TEMPLATE_PARAMETER(compressed_head_size_u32, compressed_head_size_u32_),
                              WGSL_TEMPLATE_PARAMETER(has_attention_bias, has_attention_bias_),
                              WGSL_TEMPLATE_PARAMETER(has_head_sink, has_head_sink_),
+                             WGSL_TEMPLATE_PARAMETER(has_local_window, has_local_window_),
                              WGSL_TEMPLATE_PARAMETER(is_fp16, is_fp16_),
                              WGSL_TEMPLATE_PARAMETER(is_qualcomm, is_qualcomm_),
                              WGSL_TEMPLATE_PARAMETER(is_unidirectional, is_unidirectional_),
@@ -769,10 +770,11 @@ Status ApplyFlashAttention(const Tensor* Q, const Tensor* K, const Tensor* V, co
                            const Tensor* cos_cache, const Tensor* sin_cache, const Tensor* head_sink,
                            const Tensor* total_seqlen, const Tensor* seqlens_q,
                            const Tensor* block_table, uint32_t block_size, uint32_t max_num_blocks_per_seq,
-                           const Tensor* cumulative_seqlens_q) {
+                           const Tensor* cumulative_seqlens_q, int local_window_size) {
   constexpr uint32_t tile_size = 64;
   const bool use_seqlens_q = seqlens_q != nullptr;
   const bool use_paged_kv_cache = block_table != nullptr;
+  const bool has_local_window = local_window_size > 0;
 
   const bool turbo_quant_enabled = context.KvCacheQuantizationEnabled();
   if (turbo_quant_enabled && (parameters.head_size_ < 8 || (parameters.head_size_ & (parameters.head_size_ - 1)) != 0)) {
@@ -1005,7 +1007,7 @@ Status ApplyFlashAttention(const Tensor* Q, const Tensor* K, const Tensor* V, co
   // Split-reduce wins for short Q (sequence_length < 32) across all KV
   // cache lengths measured: 1.13x-2.07x faster at total_sequence_length
   // 128 / 500 / 2000 on a representative LLM (32 heads, head_size 96).
-  const bool use_split_reduce = parameters.sequence_length_ < 32;
+  const bool use_split_reduce = parameters.sequence_length_ < 32 && !has_local_window;
 
   if (!use_split_reduce) {
     // Ask the shared helper whether the fused paged-prefill shader can run on
@@ -1089,6 +1091,7 @@ Status ApplyFlashAttention(const Tensor* Q, const Tensor* K, const Tensor* V, co
                                     q_BNSH,
                                     use_seqlen_k,
                                     has_head_sink,
+                                    has_local_window,
                                     turbo_quant_enabled,
                                     compressed_head_size_u32,
                                     use_seqlens_q};
@@ -1130,7 +1133,7 @@ Status ApplyFlashAttention(const Tensor* Q, const Tensor* K, const Tensor* V, co
 
       program.SetDispatchGroupSize(parameters.batch_size_ * parameters.num_heads_ * num_seq_tile)
           .SetWorkgroupSize(prefill_tile_size)
-          .CacheHint(has_attention_bias, parameters.head_size_, parameters.num_heads_, parameters.is_unidirectional_, is_qualcomm, is_nvidia, is_apple, has_subgroups, q_BNSH, use_seqlen_k, has_head_sink, turbo_quant_enabled, compressed_head_size_u32, program.max_k_step(), use_seqlens_q)
+          .CacheHint(has_attention_bias, parameters.head_size_, parameters.num_heads_, parameters.is_unidirectional_, is_qualcomm, is_nvidia, is_apple, has_subgroups, q_BNSH, use_seqlen_k, has_head_sink, has_local_window, turbo_quant_enabled, compressed_head_size_u32, program.max_k_step(), use_seqlens_q)
           .AddUniformVariables({{static_cast<uint32_t>(parameters.sequence_length_)},
                                 {static_cast<uint32_t>(parameters.total_sequence_length_)},
                                 {static_cast<uint32_t>(present_sequence_length)},
@@ -1140,7 +1143,8 @@ Status ApplyFlashAttention(const Tensor* Q, const Tensor* K, const Tensor* V, co
                                 {num_seq_tile},
                                 {attn_bias_dim0},
                                 {attn_bias_dim1},
-                                {attn_bias_dim3}});
+                                {attn_bias_dim3},
+                                {static_cast<uint32_t>(has_local_window ? local_window_size : 0)}});
 
       ORT_RETURN_IF_ERROR(context.RunProgram(program));
     }

--- a/onnxruntime/contrib_ops/webgpu/bert/flash_attention.h
+++ b/onnxruntime/contrib_ops/webgpu/bert/flash_attention.h
@@ -100,6 +100,7 @@ class FlashAttentionProgram final : public Program<FlashAttentionProgram> {
                         bool q_BNSH,
                         bool use_seqlen_k = false,
                         bool has_head_sink = false,
+                        bool has_local_window = false,
                         bool turbo_quant = false,
                         int compressed_head_size_u32 = 0,
                         bool use_seqlens_q = false)
@@ -115,6 +116,7 @@ class FlashAttentionProgram final : public Program<FlashAttentionProgram> {
         q_BNSH_(q_BNSH),
         use_seqlen_k_(use_seqlen_k),
         has_head_sink_(has_head_sink),
+        has_local_window_(has_local_window),
         turbo_quant_(turbo_quant),
         compressed_head_size_u32_(compressed_head_size_u32),
         use_seqlens_q_(use_seqlens_q) {
@@ -147,7 +149,8 @@ class FlashAttentionProgram final : public Program<FlashAttentionProgram> {
                                           {"num_seq_tile", ProgramUniformVariableDataType::Uint32},
                                           {"attn_bias_dim0", ProgramUniformVariableDataType::Uint32},
                                           {"attn_bias_dim1", ProgramUniformVariableDataType::Uint32},
-                                          {"attn_bias_dim3", ProgramUniformVariableDataType::Uint32});
+                                          {"attn_bias_dim3", ProgramUniformVariableDataType::Uint32},
+                                          {"local_window_size", ProgramUniformVariableDataType::Uint32});
 
  private:
   bool has_attention_bias_;
@@ -161,6 +164,7 @@ class FlashAttentionProgram final : public Program<FlashAttentionProgram> {
   bool q_BNSH_;
   bool use_seqlen_k_;
   bool has_head_sink_;
+  bool has_local_window_;
   int max_k_step_;
   bool turbo_quant_;
   int compressed_head_size_u32_;
@@ -376,7 +380,7 @@ Status ApplyFlashAttention(const Tensor* Q, const Tensor* K, const Tensor* V, co
                            const Tensor* cos_cache = nullptr, const Tensor* sin_cache = nullptr, const Tensor* head_sink = nullptr,
                            const Tensor* total_seqlen = nullptr, const Tensor* seqlens_q = nullptr,
                            const Tensor* block_table = nullptr, uint32_t block_size = 0, uint32_t max_num_blocks_per_seq = 0,
-                           const Tensor* cumulative_seqlens_q = nullptr);
+                           const Tensor* cumulative_seqlens_q = nullptr, int local_window_size = -1);
 
 // Adapter/config gate for the fused paged-prefill shader
 // (FlashAttentionPagedPrefillProgram). Callers that decide up front whether Q

--- a/onnxruntime/contrib_ops/webgpu/bert/flash_attention.wgsl.template
+++ b/onnxruntime/contrib_ops/webgpu/bert/flash_attention.wgsl.template
@@ -1,6 +1,7 @@
 
 #param has_attention_bias
 #param has_head_sink
+#param has_local_window
 #param is_fp16
 #param is_qualcomm
 #param is_unidirectional
@@ -43,6 +44,10 @@ fn get_total_sequence_length(batch_idx: u32) -> u32 {
   return uniforms.total_sequence_length;
 }
 #endif
+
+fn is_key_visible(k_idx: u32, local_window_start: u32, causal_end: u32) -> bool {
+  return k_idx >= local_window_start && k_idx < causal_end;
+}
 
 #if is_fp16
 const min_value = q_element_t(-65504.0);
@@ -362,6 +367,14 @@ $MAIN {
   let seq_causal_length = total_sequence_length;
 #endif
 
+#if has_local_window
+  let local_window_start = select(seq_causal_length - uniforms.local_window_size,
+                                  0u,
+                                  seq_causal_length <= uniforms.local_window_size);
+#else
+  let local_window_start = 0u;
+#endif
+
 #if use_shm_path
 
   for (var k_start = 0u; k_start < loop_bound; k_start += max_k_step) {
@@ -378,7 +391,8 @@ $MAIN {
  #if has_attention_bias
       score += loadAttentionBias(batch_idx, q_idx_global, k_start + k, head_idx, total_sequence_length);
  #endif
-      qk_scores[k] = select(min_value, score, k_start + k < seq_causal_length);
+      qk_scores[k] = select(min_value, score,
+                is_key_visible(k_start + k, local_window_start, seq_causal_length));
     }
 
     var local_max = min_value;
@@ -491,23 +505,23 @@ $MAIN {
     }
 
     // Neuter qk values where K is out of bounds.
-    qk_1[0] = select(min_value, qk_1[0], k_start + 0 < seq_causal_length);
-    qk_1[1] = select(min_value, qk_1[1], k_start + 1 < seq_causal_length);
-    qk_1[2] = select(min_value, qk_1[2], k_start + 2 < seq_causal_length);
-    qk_1[3] = select(min_value, qk_1[3], k_start + 3 < seq_causal_length);
-    qk_2[0] = select(min_value, qk_2[0], k_start + 4 < seq_causal_length);
-    qk_2[1] = select(min_value, qk_2[1], k_start + 5 < seq_causal_length);
-    qk_2[2] = select(min_value, qk_2[2], k_start + 6 < seq_causal_length);
-    qk_2[3] = select(min_value, qk_2[3], k_start + 7 < seq_causal_length);
+    qk_1[0] = select(min_value, qk_1[0], is_key_visible(k_start + 0, local_window_start, seq_causal_length));
+    qk_1[1] = select(min_value, qk_1[1], is_key_visible(k_start + 1, local_window_start, seq_causal_length));
+    qk_1[2] = select(min_value, qk_1[2], is_key_visible(k_start + 2, local_window_start, seq_causal_length));
+    qk_1[3] = select(min_value, qk_1[3], is_key_visible(k_start + 3, local_window_start, seq_causal_length));
+    qk_2[0] = select(min_value, qk_2[0], is_key_visible(k_start + 4, local_window_start, seq_causal_length));
+    qk_2[1] = select(min_value, qk_2[1], is_key_visible(k_start + 5, local_window_start, seq_causal_length));
+    qk_2[2] = select(min_value, qk_2[2], is_key_visible(k_start + 6, local_window_start, seq_causal_length));
+    qk_2[3] = select(min_value, qk_2[3], is_key_visible(k_start + 7, local_window_start, seq_causal_length));
     if (sg_size > 8) {
-      qk_3[0] = select(min_value, qk_3[0], k_start + 8 < seq_causal_length);
-      qk_3[1] = select(min_value, qk_3[1], k_start + 9 < seq_causal_length);
-      qk_3[2] = select(min_value, qk_3[2], k_start + 10 < seq_causal_length);
-      qk_3[3] = select(min_value, qk_3[3], k_start + 11 < seq_causal_length);
-      qk_4[0] = select(min_value, qk_4[0], k_start + 12 < seq_causal_length);
-      qk_4[1] = select(min_value, qk_4[1], k_start + 13 < seq_causal_length);
-      qk_4[2] = select(min_value, qk_4[2], k_start + 14 < seq_causal_length);
-      qk_4[3] = select(min_value, qk_4[3], k_start + 15 < seq_causal_length);
+      qk_3[0] = select(min_value, qk_3[0], is_key_visible(k_start + 8, local_window_start, seq_causal_length));
+      qk_3[1] = select(min_value, qk_3[1], is_key_visible(k_start + 9, local_window_start, seq_causal_length));
+      qk_3[2] = select(min_value, qk_3[2], is_key_visible(k_start + 10, local_window_start, seq_causal_length));
+      qk_3[3] = select(min_value, qk_3[3], is_key_visible(k_start + 11, local_window_start, seq_causal_length));
+      qk_4[0] = select(min_value, qk_4[0], is_key_visible(k_start + 12, local_window_start, seq_causal_length));
+      qk_4[1] = select(min_value, qk_4[1], is_key_visible(k_start + 13, local_window_start, seq_causal_length));
+      qk_4[2] = select(min_value, qk_4[2], is_key_visible(k_start + 14, local_window_start, seq_causal_length));
+      qk_4[3] = select(min_value, qk_4[3], is_key_visible(k_start + 15, local_window_start, seq_causal_length));
     }
 
     var local_max_temp = max(qk_1, qk_2);

--- a/onnxruntime/contrib_ops/webgpu/bert/paged_attention.cc
+++ b/onnxruntime/contrib_ops/webgpu/bert/paged_attention.cc
@@ -539,15 +539,10 @@ Status PagedAttention::ComputeInternal(onnxruntime::webgpu::ComputeContext& cont
   parameters.do_rotary = do_rotary_;
   parameters.rotary_interleaved = rotary_interleaved_;
 
-  // Feature guards. softcap and local_window_size are rejected until FA gains
-  // the corresponding shader-side support (tracked in the design doc).
+  // Feature guards for combinations not yet implemented by the WebGPU path.
   if (softcap_ != 0.0f) {
     return ORT_MAKE_STATUS(ONNXRUNTIME, NOT_IMPLEMENTED,
                            "PagedAttention (WebGPU): non-zero softcap is not supported yet.");
-  }
-  if (local_window_size_ != -1) {
-    return ORT_MAKE_STATUS(ONNXRUNTIME, NOT_IMPLEMENTED,
-                           "PagedAttention (WebGPU): local_window_size != -1 is not supported yet.");
   }
   if (kv_cache_layout_ != "SEPARATE") {
     return ORT_MAKE_STATUS(ONNXRUNTIME, NOT_IMPLEMENTED,
@@ -582,10 +577,6 @@ Status PagedAttention::ComputeInternal(onnxruntime::webgpu::ComputeContext& cont
   if (slot_mapping != nullptr) {
     return ORT_MAKE_STATUS(ONNXRUNTIME, NOT_IMPLEMENTED,
                            "PagedAttention (WebGPU): slot_mapping input is not supported yet.");
-  }
-  if (head_sink != nullptr) {
-    return ORT_MAKE_STATUS(ONNXRUNTIME, NOT_IMPLEMENTED,
-                           "PagedAttention (WebGPU): head_sink input is not supported yet.");
   }
   if (q_norm_weight != nullptr || k_norm_weight != nullptr) {
     return ORT_MAKE_STATUS(ONNXRUNTIME, NOT_IMPLEMENTED,
@@ -820,7 +811,8 @@ Status PagedAttention::ComputeInternal(onnxruntime::webgpu::ComputeContext& cont
   const uint64_t q_padded_bytes = static_cast<uint64_t>(parameters.batch_size) *
                                   static_cast<uint64_t>(max_seqlen_q) *
                                   static_cast<uint64_t>(parameters.hidden_size) * sizeof(MLFloat16);
-  const bool use_direct_paged_decode = max_seqlen_q < 32;
+  const bool has_local_window = local_window_size_ > 0;
+  const bool use_direct_paged_decode = max_seqlen_q < 32 && !has_local_window;
   // Direct-paged prefill is only safe when the fused paged-prefill shader
   // will actually run for this (adapter, dtype, shape, block_size) tuple.
   // If the helper rejects, dense FA would interpret the paged cache as a
@@ -828,6 +820,7 @@ Status PagedAttention::ComputeInternal(onnxruntime::webgpu::ComputeContext& cont
   const bool is_fp16_q =
       query->GetElementType() == ONNX_NAMESPACE::TensorProto_DataType_FLOAT16;
   const bool use_direct_paged_prefill =
+      !has_local_window && head_sink == nullptr &&
       ShouldRunFusedPagedPrefill(context, is_fp16_q,
                                  static_cast<int>(max_seqlen_q),
                                  parameters.head_size,
@@ -1030,12 +1023,13 @@ Status PagedAttention::ComputeInternal(onnxruntime::webgpu::ComputeContext& cont
       /*past_key=*/use_direct_paged_attention ? key_cache_out : &k_padded, /*present_key=*/nullptr,
       /*past_value=*/use_direct_paged_attention ? value_cache_out : &v_padded, /*present_value=*/nullptr,
       fa_params, context, &seqlen_k_gpu,
-      /*cos_cache=*/nullptr, /*sin_cache=*/nullptr, /*head_sink=*/nullptr,
+      /*cos_cache=*/nullptr, /*sin_cache=*/nullptr, head_sink,
       /*total_seqlen=*/nullptr, /*seqlens_q=*/&seqlens_q_gpu,
       use_direct_paged_attention ? block_table : nullptr,
       use_direct_paged_attention ? static_cast<uint32_t>(parameters.block_size) : 0u,
       use_direct_paged_attention ? static_cast<uint32_t>(parameters.max_num_blocks_per_seq) : 0u,
-      /*cumulative_seqlens_q=*/varlen_mode ? cumulative_seqlens_q : nullptr));
+      /*cumulative_seqlens_q=*/varlen_mode ? cumulative_seqlens_q : nullptr,
+      local_window_size_));
 
   if (!skip_unpack_repack) {
     ORT_RETURN_IF_ERROR(RunRepackOutput(context, parameters, &output_padded,

--- a/onnxruntime/test/python/transformers/test_paged_attention.py
+++ b/onnxruntime/test/python/transformers/test_paged_attention.py
@@ -25,7 +25,19 @@ from onnx import TensorProto, helper
 from packaging import version
 from parameterized import parameterized
 
-from onnxruntime import InferenceSession, OrtValue, SessionOptions, get_available_providers
+from onnxruntime import (
+    GraphOptimizationLevel,
+    InferenceSession,
+    OrtValue,
+    SessionOptions,
+    get_available_providers,
+    get_ep_devices,
+    register_execution_provider_library,
+)
+
+_webgpu_plugin_path = os.environ.get("ORT_WEBGPU_PLUGIN_PATH")
+if _webgpu_plugin_path and "WebGpuExecutionProvider" not in get_available_providers():
+    register_execution_provider_library("webgpu_test", _webgpu_plugin_path)
 
 torch.manual_seed(0)
 
@@ -523,7 +535,14 @@ def paged_attention_func(
         ort_inputs["key_cache"] = OrtValue.ortvalue_from_numpy(key_cache_np, config.ort_device, 0)
         ort_inputs["value_cache"] = OrtValue.ortvalue_from_numpy(value_cache_np, config.ort_device, 0)
     sess_options = SessionOptions()
-    if sdpa_kernel != 0 and config.ep == "CUDAExecutionProvider":
+    if config.ep == "WebGpuExecutionProvider":
+        sess_options.graph_optimization_level = GraphOptimizationLevel.ORT_DISABLE_ALL
+        webgpu_devices = [device for device in get_ep_devices() if device.ep_name == config.ep]
+        if not webgpu_devices:
+            raise RuntimeError("No WebGPU EP device found.")
+        sess_options.add_provider_for_devices([webgpu_devices[0]], {})
+        providers = None
+    elif sdpa_kernel != 0 and config.ep == "CUDAExecutionProvider":
         providers = [(config.ep, {"sdpa_kernel": str(sdpa_kernel)})]
     else:
         providers = [config.ep]
@@ -846,6 +865,7 @@ def parity_check_paged_attention(
     atol=1e-3,
     sdpa_kernel=0,
     new_seqlens_override=None,
+    past_seqlens_override=None,
 ):
     # Generate padded inputs
     q = torch.randn(
@@ -877,13 +897,19 @@ def parity_check_paged_attention(
     )
 
     # Generate random sequence lengths
-    past_seqlens = torch.randint(
-        0,
-        config.total_sequence_length - config.sequence_length + 1,  # one above highest integer to be drawn
-        (config.batch_size,),
-        dtype=torch.int32,
-        device=config.torch_device,
-    )
+    if past_seqlens_override is not None:
+        past_seqlens = past_seqlens_override.to(dtype=torch.int32, device=config.torch_device)
+        assert past_seqlens.shape == (config.batch_size,)
+        assert int(past_seqlens.min().item()) >= 0
+        assert int(past_seqlens.max().item()) <= config.total_sequence_length - config.sequence_length
+    else:
+        past_seqlens = torch.randint(
+            0,
+            config.total_sequence_length - config.sequence_length + 1,  # one above highest integer to be drawn
+            (config.batch_size,),
+            dtype=torch.int32,
+            device=config.torch_device,
+        )
     if new_seqlens_override is not None:
         new_seqlens = new_seqlens_override.to(dtype=torch.int32, device=config.torch_device)
         assert new_seqlens.shape == (config.batch_size,)
@@ -914,7 +940,7 @@ def parity_check_paged_attention(
     if config.use_head_sink:
         # Spread over [-2, 6]: exp(sink) then ranges from negligible to far larger than a typical
         # softmax denominator, so a kernel that ignored the sink could not pass within tolerance.
-        head_sink = (torch.rand(config.num_heads, device="cuda") * 8.0 - 2.0).to(dtype=torch.float16)
+        head_sink = (torch.rand(config.num_heads, device=config.torch_device) * 8.0 - 2.0).to(dtype=torch.float16)
 
     # Optional QK-Norm. The kernel applies RMSNorm to every Q and K head before rotary embedding,
     # so the reference has to normalize before computing q_ro / k_ro below, and the normalized +
@@ -922,8 +948,8 @@ def parity_check_paged_attention(
     q_norm_weight = None
     k_norm_weight = None
     if config.use_qk_norm:
-        q_norm_weight = torch.randn(config.head_size, device="cuda", dtype=torch.float16)
-        k_norm_weight = torch.randn(config.head_size, device="cuda", dtype=torch.float16)
+        q_norm_weight = torch.randn(config.head_size, device=config.torch_device, dtype=torch.float16)
+        k_norm_weight = torch.randn(config.head_size, device=config.torch_device, dtype=torch.float16)
         q = rms_norm_ref(q, q_norm_weight, config.qk_norm_epsilon)
         k_new = rms_norm_ref(k_new, k_norm_weight, config.qk_norm_epsilon)
 
@@ -937,7 +963,9 @@ def parity_check_paged_attention(
     window_size = (-1, -1)
     left_window_size = -1
     if config.local:
-        left_window_size = random.randint(1, config.total_sequence_length - 1)  # random.randint is inclusive
+        left_window_size = getattr(config, "local_window_size", None)
+        if left_window_size is None:
+            left_window_size = random.randint(1, config.total_sequence_length - 1)  # random.randint is inclusive
         window_size = (left_window_size, 0)
     else:
         left_window_size = -1
@@ -1169,13 +1197,11 @@ def has_webgpu_ep() -> bool:
 def _webgpu_supports_config(config: Config) -> bool:
     """Feature guard for the WebGPU PagedAttention op.
 
-    The WebGPU kernel is fp16-only and does not yet implement softcap or
-    sliding-window local attention. Rotary (interleaved and non-interleaved),
-    packed QKV, and GQA are supported.
+    The WebGPU kernel is fp16-only and does not yet implement softcap. Local
+    attention, rotary (interleaved and non-interleaved), packed QKV, GQA, and
+    learned attention sinks are supported.
     """
     if config.softcap != 0.0:
-        return False
-    if config.local:
         return False
     return True
 
@@ -1523,7 +1549,7 @@ def paged_attention_test_cases_webgpu():
                                     n2,
                                     h,
                                     block_size,
-                                    False,  # local - not supported on WebGPU
+                                    False,
                                     rotary,
                                     rotary_interleaved,
                                     packed,
@@ -1566,6 +1592,69 @@ class TestPagedAttentionWebGpu(unittest.TestCase):
         config.attention_metadata_shape = [3]
         config.attention_metadata_override = numpy.array([1, 64, 1], dtype=numpy.int32)
         parity_check_paged_attention(config, rtol=5e-3, atol=5e-3)
+
+    def _gptoss_config(self, sequence_length, *, local=True, use_head_sink=True):
+        config = Config(
+            batch_size=2,
+            sequence_length=sequence_length,
+            total_sequence_length=256,
+            num_heads=64,
+            kv_num_heads=8,
+            head_size=64,
+            paged_kv_block_size=256,
+            local=local,
+            rotary=True,
+            rotary_interleaved=False,
+            packed=True,
+            softcap=0.0,
+            ep="WebGpuExecutionProvider",
+        )
+        config.local_window_size = 128
+        config.use_head_sink = use_head_sink
+        return config
+
+    def test_gptoss_local_window_head_sink_prefill(self):
+        parity_check_paged_attention(
+            self._gptoss_config(sequence_length=16),
+            rtol=5e-3,
+            atol=5e-3,
+            new_seqlens_override=torch.tensor([16, 9], dtype=torch.int32),
+            past_seqlens_override=torch.tensor([240, 192], dtype=torch.int32),
+        )
+
+    def test_gptoss_local_window_head_sink_decode(self):
+        parity_check_paged_attention(
+            self._gptoss_config(sequence_length=1),
+            rtol=5e-3,
+            atol=5e-3,
+            past_seqlens_override=torch.tensor([255, 192], dtype=torch.int32),
+        )
+
+    def test_local_window_short_history(self):
+        parity_check_paged_attention(
+            self._gptoss_config(sequence_length=4, use_head_sink=False),
+            rtol=5e-3,
+            atol=5e-3,
+            new_seqlens_override=torch.tensor([4, 2], dtype=torch.int32),
+            past_seqlens_override=torch.tensor([0, 4], dtype=torch.int32),
+        )
+
+    def test_head_sink_prefill_without_local_window(self):
+        parity_check_paged_attention(
+            self._gptoss_config(sequence_length=32, local=False),
+            rtol=5e-3,
+            atol=5e-3,
+            new_seqlens_override=torch.tensor([32, 17], dtype=torch.int32),
+            past_seqlens_override=torch.tensor([224, 100], dtype=torch.int32),
+        )
+
+    def test_head_sink_decode_without_local_window(self):
+        parity_check_paged_attention(
+            self._gptoss_config(sequence_length=1, local=False),
+            rtol=5e-3,
+            atol=5e-3,
+            past_seqlens_override=torch.tensor([255, 192], dtype=torch.int32),
+        )
 
 
 @unittest.skipIf(not has_cuda_device(), reason="CUDA is not available, skipping tests.")


### PR DESCRIPTION
## Summary
- add per-query local-window masking to the generic WebGPU FlashAttention shader
- enable `local_window_size` and `head_sink` in WebGPU PagedAttention
- preserve direct paged decode for head-sink-only requests, while routing local-window and head-sink prefill through gather plus generic FlashAttention
- add focused GPT-OSS-style prefill/decode, short-history, and independent sink parity tests

## Performance note
This is the correctness implementation. Local-window requests still gather and traverse full KV history before masking old tokens; direct paged local-window kernels remain follow-up work.

## Dependency
Stacked on #32277 so this PR contains only the incremental local-window/head-sink changes. Retarget to `main` after #32277 lands.

Companion WebGPU paged export support: microsoft/onnxruntime-genai#2470 (merged).

## Testing
- `clang-format --dry-run --Werror` and `git diff --check`
- WGSL templates parsed and generated with `tools/python/wgsl_gen.py`
- modified FlashAttention and PagedAttention translation units compiled against the native Dawn build
- focused native Vulkan parity tests: 5 passed, 301 deselected
