### PR TITLE
Add packed attention workspace estimates

### DIFF
--- a/docs/annotated_partitioning/attention_workspace_estimation.md
+++ b/docs/annotated_partitioning/attention_workspace_estimation.md
@@ -206,8 +206,8 @@ operator-owned root. PA places its simultaneously-live projection and Attention 
 has only the Attention region:
 
 ```text
-PA attention offset = align_up(projection bytes, 256)
-PA root bytes        = attention offset + max(feasible attention routes)
+PA attention offset   = align_up(projection bytes, 256)
+PA root bytes         = attention offset + max(feasible attention routes)
 PMHA attention offset = 0
 PMHA root bytes        = max(feasible attention routes)
 ```
@@ -218,5 +218,6 @@ framework's generic multi-slot capability.
 
 Runtime allocation topology is unchanged: PA continues to make separate dynamic projection and Attention
 `GetScratchBuffer()` allocations, and PMHA continues to dynamically allocate its Attention workspace. Future #32071
-integration must atomically opt in to planned-root retrieval and slice the root at the declared Attention offset;
-declaring the root does not itself change runtime allocation behavior.
+integration must atomically add the explicit `SupportsPreallocatedWorkspace()` planner opt-in, retrieve the planned
+root, and slice it at the declared Attention offset. A declaration alone is not planner opt-in and does not itself
+change runtime allocation behavior.

--- a/docs/annotated_partitioning/attention_workspace_estimation.md
+++ b/docs/annotated_partitioning/attention_workspace_estimation.md
@@ -5,9 +5,9 @@
 This work provides operator-specific workspace estimation for the CUDA Attention family. It defines how an
 Attention kernel derives a workspace recipe from a plain problem description and a selected backend.
 
-The generic memory-estimation framework is a separate work track and is out of scope here. That track includes L1/L2
-callback plumbing, kernel registration, shape and max-shape infrastructure, optional-input contracts at the framework
-boundary, partition budgeting, memory planning, and planned-root or preallocation integration.
+The generic memory-estimation framework is a separate work track. PA and PMHA now use its Level-1 and Level-2
+declaration points, but partition budgeting, memory planning, and planned-root or preallocation integration remain
+outside this operator-specific work.
 
 The Attention work owns:
 
@@ -146,7 +146,7 @@ The planned operator-specific sequence is:
 3. `PagedAttention`.
 4. High-value decoder-specific variants.
 5. Separate memory models for Linear, Sparse, Longformer, quantized, and ONNX Attention operators.
-6. Thin Attention-specific adapters to the generic framework after its API stabilizes.
+6. Continue the generic planner integration after its budget and multi-slot contracts stabilize.
 
 MHA and GQA are high-value coverage targets and have high estimation-drift risk. Their runtime behavior can include
 dynamic internal backend dispatch, cache lifecycle and aliasing, optional inputs, non-monotonic fallback paths, and
@@ -170,3 +170,37 @@ Each Attention family must provide:
 - no dependency from the reusable recipe on graph or CUDA runtime types.
 
 This document defines operator-estimation work tracks and invariants. It does not prescribe a public framework API.
+
+## PA/PMHA framework follow-up
+
+The PA/PMHA follow-up connects the graph-free recipes to the current Phase-A framework:
+
+- **Level 1:** CUDA EP `GetCapability()` translates positional node inputs, uses max-shape inference when available
+  (and graph metadata otherwise), enumerates routes that can be reached by some valid runtime geometry up to the
+  supplied shape, and logs the aggregate. This estimate is
+  currently **log-only**. It does not change the resource-accountant value or the partition accept/reject decision.
+- **Level 2:** constructed PA and PMHA kernels translate `WorkspaceInputShape` entries and declare nonzero workspace
+  slots. Missing mandatory inputs, present inputs without required shape metadata, partial required dimensions,
+  malformed geometry, and checked overflow produce no declaration rather than a zero-byte estimate.
+- **Zero-shaped hints:** `WorkspaceInputShape` does not identify whether a shape came from concrete graph metadata or
+  max-shape inference. The adapter therefore treats any zero extent as unavailable and emits no declaration rather
+  than interpreting it as a proven empty runtime output. The current Level-2 requirements boundary represents both
+  unavailable estimates and explicit zero estimates as an empty requirement list, so it cannot expose that
+  distinction. Exact-zero behavior remains available in the graph-free single-route recipe.
+
+Route aggregation does not evaluate the runtime cascade only at the supplied maximum sequence length: dispatch gates
+such as Flash and FP32 MEA thresholds or attention-bias alignment are non-monotonic across smaller runtime shapes.
+Every backend that can be reached for some valid shape up to the supplied geometry is sized at that maximum geometry.
+Unfused is always retained as a possible fallback for a nonempty problem, including alongside Flash, MEA, and
+TensorRT candidates. If any included route cannot be safely bounded, estimation is unavailable. Mutually exclusive
+route workspaces are combined with `max`, never `sum`. PA then adds its simultaneously-live projection allocation:
+
+```text
+PA   = projection + max(feasible attention routes)
+PMHA = max(feasible attention routes)
+```
+
+Level-2 slot IDs are stable: PA uses slot 0 for projection and slot 1 for Attention; PMHA uses slot 0 for Attention.
+All slots use `alignment_bytes=0`, meaning allocator-default alignment. No planner consumes these declarations yet;
+future planner work must preserve PA's multiple simultaneously-live slots. Runtime continues to allocate both buffers
+dynamically with `GetScratchBuffer`; this work adds no preallocated-workspace API.

--- a/docs/annotated_partitioning/attention_workspace_estimation.md
+++ b/docs/annotated_partitioning/attention_workspace_estimation.md
@@ -206,10 +206,10 @@ operator-owned root. PA places its simultaneously-live projection and Attention 
 has only the Attention region:
 
 ```text
-PA attention offset   = align_up(projection bytes, 256)
-PA root bytes         = attention offset + max(feasible attention routes)
+PA attention offset = align_up(projection bytes, 256)
+PA root bytes = attention offset + max(feasible attention routes)
 PMHA attention offset = 0
-PMHA root bytes        = max(feasible attention routes)
+PMHA root bytes = max(feasible attention routes)
 ```
 
 The PA alignment gap is intentional, so its root can be up to 255 bytes larger than the unaligned sum. Level 2 emits

--- a/docs/annotated_partitioning/attention_workspace_estimation.md
+++ b/docs/annotated_partitioning/attention_workspace_estimation.md
@@ -9,6 +9,14 @@ The generic memory-estimation framework is a separate work track. PA and PMHA no
 declaration points, but partition budgeting, memory planning, and planned-root or preallocation integration remain
 outside this operator-specific work.
 
+Related design and rollout:
+
+- [Constrained-environment memory roadmap](https://github.com/microsoft/onnxruntime/issues/29775)
+- [Generic workspace framework and future allocation modes](future_directions_constrained_env.md#phase-a-workspace-pre-declaration-declareworkspacerequirements)
+- [Optional-aware Level-2 input-shape contract](https://github.com/microsoft/onnxruntime/pull/32312)
+- [Activation memory-pattern planner](https://github.com/microsoft/onnxruntime/pull/32071)
+- [PA/PMHA Level-1 and Level-2 adapters](https://github.com/microsoft/onnxruntime/pull/32321)
+
 The Attention work owns:
 
 - graph-free problem descriptions and checked workspace recipes;

--- a/docs/annotated_partitioning/attention_workspace_estimation.md
+++ b/docs/annotated_partitioning/attention_workspace_estimation.md
@@ -36,23 +36,29 @@ Runtime sizing can be exact because the kernel first selects a backend and then 
 concrete inputs -> runtime dispatch -> selected backend -> exact workspace recipe
 ```
 
-Ahead-of-time (AOT) estimation cannot assume that the same selection is known. Backend feasibility can depend on
+Ahead-of-time (AOT) estimation cannot assume that the same selection is known. Backend reachability can depend on
 optional inputs, build and runtime options, cache state, runner availability, device properties, and concrete dynamic
-sequence lengths. When the exact backend cannot be proven, AOT estimation must enumerate the feasible backend recipes
+sequence lengths. When the exact backend cannot be proven, AOT estimation must enumerate the reachable backend recipes
 and take a safe upper bound:
 
 ```text
-shapes and bounds -> feasible backends -> recipe per backend -> maximum workspace
+shapes and bounds -> reachable backends -> recipe per backend -> maximum workspace
 ```
 
 An estimator must not copy the runtime dispatch cascade or assume that dispatch is monotonic with shape. For example,
 a larger shape may use a fused backend with small workspace while a nearby smaller shape falls back to an unfused
-backend with an `S^2` attention buffer.
+backend with an `S^2` attention buffer. Head eligibility is also non-monotonic: a componentwise upper bound can exceed
+a backend's supported head range while a smaller runtime head remains supported, and equal-head routes can be reachable
+under unequal Q/K and V bounds. Each route reachable at a positive runtime geometry within the bounds must therefore be
+sized using the original componentwise maximum geometry, whose current workspace terms are monotonic. PA's
+`qkv_hidden_sizes` values are immutable node attributes, not shape bounds, so their derived head sizes retain exact
+runtime eligibility checks. Only PA geometry derived without that attribute and PMHA geometry supplied through
+`WorkspaceInputShape` use bounded head reachability.
 
 An AOT result should therefore be classified as:
 
 - **Exact:** the backend and all governing dimensions are proven.
-- **Safe bound:** the maximum workspace across all feasible backend recipes.
+- **Safe bound:** the maximum workspace across all reachable backend recipes.
 - **Unavailable:** a required shape, optional-input, capability, or recipe contract is not available.
 
 ## Recipe architecture
@@ -172,7 +178,7 @@ Each Attention family must provide:
 - a runtime source of truth for the selected backend's workspace and layout;
 - checked arithmetic and ABI, grid, alignment, and containment validation;
 - byte-total and view-layout parity with runtime allocation;
-- tests for feasible backend routes and fallback boundaries;
+- tests for reachable backend routes and fallback boundaries;
 - explicit exact, safe-bound, or unavailable estimation semantics;
 - no copied runtime dispatch cascade; and
 - no dependency from the reusable recipe on graph or CUDA runtime types.
@@ -200,16 +206,18 @@ Route aggregation does not evaluate the runtime cascade only at the supplied max
 such as Flash and FP32 MEA thresholds or attention-bias alignment are non-monotonic across smaller runtime shapes.
 Every backend that can be reached for some valid shape up to the supplied geometry is sized at that maximum geometry.
 Unfused is always retained as a possible fallback for a nonempty problem, including alongside Flash, MEA, and
-TensorRT candidates. If any included route cannot be safely bounded, estimation is unavailable. Mutually exclusive
-route workspaces are combined with `max`, never `sum`. The Level-1 aggregate describes one 256-byte-aligned,
-operator-owned root. PA places its simultaneously-live projection and Attention regions in that root; PMHA naturally
-has only the Attention region:
+TensorRT candidates. Bound aggregates deliberately bypass exact equal-head recipe gates because an equal-head route
+can be reachable below unequal maximum bounds; the recipe is still checked at those original maximum bounds. If a
+newly reachable route's max-geometry recipe is invalid, or any included route otherwise cannot be safely bounded,
+estimation is unavailable rather than silently omitting the route. Mutually exclusive route workspaces are combined
+with `max`, never `sum`. The Level-1 aggregate describes one 256-byte-aligned, operator-owned root. PA places its
+simultaneously-live projection and Attention regions in that root; PMHA naturally has only the Attention region:
 
 ```text
 PA attention offset = align_up(projection bytes, 256)
-PA root bytes = attention offset + max(feasible attention routes)
+PA root bytes = attention offset + max(reachable attention routes)
 PMHA attention offset = 0
-PMHA root bytes = max(feasible attention routes)
+PMHA root bytes = max(reachable attention routes)
 ```
 
 The PA alignment gap is intentional, so its root can be up to 255 bytes larger than the unaligned sum. Level 2 emits

--- a/docs/annotated_partitioning/attention_workspace_estimation.md
+++ b/docs/annotated_partitioning/attention_workspace_estimation.md
@@ -201,14 +201,22 @@ such as Flash and FP32 MEA thresholds or attention-bias alignment are non-monoto
 Every backend that can be reached for some valid shape up to the supplied geometry is sized at that maximum geometry.
 Unfused is always retained as a possible fallback for a nonempty problem, including alongside Flash, MEA, and
 TensorRT candidates. If any included route cannot be safely bounded, estimation is unavailable. Mutually exclusive
-route workspaces are combined with `max`, never `sum`. PA then adds its simultaneously-live projection allocation:
+route workspaces are combined with `max`, never `sum`. The Level-1 aggregate describes one 256-byte-aligned,
+operator-owned root. PA places its simultaneously-live projection and Attention regions in that root; PMHA naturally
+has only the Attention region:
 
 ```text
-PA   = projection + max(feasible attention routes)
-PMHA = max(feasible attention routes)
+PA attention offset = align_up(projection bytes, 256)
+PA root bytes        = attention offset + max(feasible attention routes)
+PMHA attention offset = 0
+PMHA root bytes        = max(feasible attention routes)
 ```
 
-Level-2 slot IDs are stable: PA uses slot 0 for projection and slot 1 for Attention; PMHA uses slot 0 for Attention.
-All slots use `alignment_bytes=0`, meaning allocator-default alignment. No planner consumes these declarations yet;
-future planner work must preserve PA's multiple simultaneously-live slots. Runtime continues to allocate both buffers
-dynamically with `GetScratchBuffer`; this work adds no preallocated-workspace API.
+The PA alignment gap is intentional, so its root can be up to 255 bytes larger than the unaligned sum. Level 2 emits
+exactly one slot-0 requirement for either operator, with explicit `alignment_bytes=256`. This does not depend on the
+framework's generic multi-slot capability.
+
+Runtime allocation topology is unchanged: PA continues to make separate dynamic projection and Attention
+`GetScratchBuffer()` allocations, and PMHA continues to dynamically allocate its Attention workspace. Future #32071
+integration must atomically opt in to planned-root retrieval and slice the root at the declared Attention offset;
+declaring the root does not itself change runtime allocation behavior.

--- a/docs/annotated_partitioning/cuda_kernel_workspace_inventory.md
+++ b/docs/annotated_partitioning/cuda_kernel_workspace_inventory.md
@@ -331,6 +331,11 @@ cache state, and device properties including SM version and `multiProcessorCount
 **Static determinability:** 🔀 — Runtime-exact when sizing receives the backend selected by the CUDA kernel. For AOT,
 use the maximum workspace across feasible backend recipes when exact selection is not provable, or report estimation
 as unavailable when a required contract is missing. See the linked roadmap for the exact/safe-bound/unavailable model.
+PA and PMHA have Level-1 CUDA EP estimates (currently log-only) and Level-2 declarations. PA declares projection
+slot 0 plus Attention slot 1 when nonzero; PMHA declares Attention slot 0. Planner budget consumption and PA
+multi-slot placement remain follow-up work. The current Level-2 boundary represents both unavailable and explicit-zero
+results with no requirements; because `WorkspaceInputShape` has no shape provenance, the PA/PMHA adapter treats
+zero-shaped hints as unavailable.
 
 ---
 

--- a/docs/annotated_partitioning/cuda_kernel_workspace_inventory.md
+++ b/docs/annotated_partitioning/cuda_kernel_workspace_inventory.md
@@ -309,7 +309,7 @@ This document catalogs all CUDA kernels in ONNX Runtime that allocate temporary/
 allocate lean-attention synchronization, Flash split/LSE/output-accumulator, and sequence-length buffers.
 PackedAttention currently makes separate dynamic projection and Attention allocations; PackedMultiHeadAttention has
 no projection allocation. Their planning declaration is one 256-byte-aligned operator-owned root. PA places the
-projection region first and the Attention region at the next 256-byte boundary; PMHA's root is only its Attention
+projection region first and the Attention region at a 256-byte-aligned offset; PMHA's root is only its Attention
 region. See the roadmap for the packed recipe and layout contract.
 
 **Size model:** Depends on operator inputs and the selected Attention algorithm:
@@ -336,8 +336,9 @@ as unavailable when a required contract is missing. See the linked roadmap for t
 PA and PMHA have Level-1 CUDA EP estimates (currently log-only) and Level-2 declarations. Each nonzero estimate emits
 exactly one slot-0 root with explicit 256-byte alignment; PA's root includes projection-to-Attention alignment padding.
 This design has no multi-slot planner dependency. Runtime still uses the existing dynamic allocation topology. Future
-#32071 integration must atomically opt in to root retrieval and slice PA's projection and Attention regions. The
-current Level-2 boundary represents both unavailable and explicit-zero results with no requirements; because
+#32071 integration must atomically add `SupportsPreallocatedWorkspace()`, retrieve the root, and slice PA's projection
+and Attention regions. Declaration alone is not planner opt-in. The current Level-2 boundary represents both
+unavailable and explicit-zero results with no requirements; because
 `WorkspaceInputShape` has no shape provenance, the PA/PMHA adapter treats zero-shaped hints as unavailable.
 
 ---

--- a/docs/annotated_partitioning/cuda_kernel_workspace_inventory.md
+++ b/docs/annotated_partitioning/cuda_kernel_workspace_inventory.md
@@ -331,15 +331,20 @@ routes without bias. See the roadmap for the precise layout and eligibility boun
 cache state, and device properties including SM version and `multiProcessorCount`.
 
 **Static determinability:** 🔀 — Runtime-exact when sizing receives the backend selected by the CUDA kernel. For AOT,
-use the maximum workspace across feasible backend recipes when exact selection is not provable, or report estimation
-as unavailable when a required contract is missing. See the linked roadmap for the exact/safe-bound/unavailable model.
+enumerate every backend reachable at a positive runtime geometry within the supplied bounds, evaluate each checked
+recipe at the original componentwise maximum geometry, and take the maximum workspace. PA head sizes derived from the
+immutable `qkv_hidden_sizes` attribute remain exact; PA without that attribute and PMHA use bounded head reachability
+because `WorkspaceInputShape` does not preserve provenance. If a reachable route's checked recipe is invalid at the
+maximum geometry, estimation is unavailable rather than silently omitting that route. See the linked roadmap for the
+exact/safe-bound/unavailable model.
+
 PA and PMHA have Level-1 CUDA EP estimates (currently log-only) and Level-2 declarations. Each nonzero estimate emits
 exactly one slot-0 root with explicit 256-byte alignment; PA's root includes projection-to-Attention alignment padding.
 This design has no multi-slot planner dependency. Runtime still uses the existing dynamic allocation topology. Future
 #32071 integration must atomically add `SupportsPreallocatedWorkspace()`, retrieve the root, and slice PA's projection
 and Attention regions. Declaration alone is not planner opt-in. The current Level-2 boundary represents both
-unavailable and explicit-zero results with no requirements; because
-`WorkspaceInputShape` has no shape provenance, the PA/PMHA adapter treats zero-shaped hints as unavailable.
+unavailable and explicit-zero results with no requirements; because `WorkspaceInputShape` has no shape provenance,
+the PA/PMHA adapter treats zero-shaped hints as unavailable.
 
 ---
 

--- a/docs/annotated_partitioning/cuda_kernel_workspace_inventory.md
+++ b/docs/annotated_partitioning/cuda_kernel_workspace_inventory.md
@@ -307,8 +307,10 @@ This document catalogs all CUDA kernels in ONNX Runtime that allocate temporary/
 
 **Buffers:** Dense Attention uses the `GetAttentionWorkspaceSize()` helper. MultiHeadAttention can additionally
 allocate lean-attention synchronization, Flash split/LSE/output-accumulator, and sequence-length buffers.
-PackedAttention has separate projection and Attention allocations; PackedMultiHeadAttention has no projection
-allocation. See the roadmap for the packed recipe and layout contract.
+PackedAttention currently makes separate dynamic projection and Attention allocations; PackedMultiHeadAttention has
+no projection allocation. Their planning declaration is one 256-byte-aligned operator-owned root. PA places the
+projection region first and the Attention region at the next 256-byte boundary; PMHA's root is only its Attention
+region. See the roadmap for the packed recipe and layout contract.
 
 **Size model:** Depends on operator inputs and the selected Attention algorithm:
 
@@ -331,11 +333,12 @@ cache state, and device properties including SM version and `multiProcessorCount
 **Static determinability:** 🔀 — Runtime-exact when sizing receives the backend selected by the CUDA kernel. For AOT,
 use the maximum workspace across feasible backend recipes when exact selection is not provable, or report estimation
 as unavailable when a required contract is missing. See the linked roadmap for the exact/safe-bound/unavailable model.
-PA and PMHA have Level-1 CUDA EP estimates (currently log-only) and Level-2 declarations. PA declares projection
-slot 0 plus Attention slot 1 when nonzero; PMHA declares Attention slot 0. Planner budget consumption and PA
-multi-slot placement remain follow-up work. The current Level-2 boundary represents both unavailable and explicit-zero
-results with no requirements; because `WorkspaceInputShape` has no shape provenance, the PA/PMHA adapter treats
-zero-shaped hints as unavailable.
+PA and PMHA have Level-1 CUDA EP estimates (currently log-only) and Level-2 declarations. Each nonzero estimate emits
+exactly one slot-0 root with explicit 256-byte alignment; PA's root includes projection-to-Attention alignment padding.
+This design has no multi-slot planner dependency. Runtime still uses the existing dynamic allocation topology. Future
+#32071 integration must atomically opt in to root retrieval and slice PA's projection and Attention regions. The
+current Level-2 boundary represents both unavailable and explicit-zero results with no requirements; because
+`WorkspaceInputShape` has no shape provenance, the PA/PMHA adapter treats zero-shaped hints as unavailable.
 
 ---
 

--- a/onnxruntime/contrib_ops/cuda/bert/cutlass_fmha/memory_efficient_attention.h
+++ b/onnxruntime/contrib_ops/cuda/bert/cutlass_fmha/memory_efficient_attention.h
@@ -4,6 +4,8 @@
 
 #if USE_MEMORY_EFFICIENT_ATTENTION
 
+#include <algorithm>
+
 #include "core/providers/cuda/cuda_common.h"
 #include "contrib_ops/cpu/bert/attention_common.h"
 
@@ -71,6 +73,22 @@ inline bool has_memory_efficient_attention(int32_t sm, bool is_half, bool is_bf1
          (qk_head_size & 7) == 0 &&
          (v_head_size & 7) == 0 &&
          qk_head_size <= kEfficientAttentionMaxHeadSize && v_head_size <= kEfficientAttentionMaxHeadSize;
+}
+
+inline bool has_memory_efficient_attention_for_head_size_bounds(
+    int32_t sm, bool is_half, bool is_bf16,
+    int qk_head_size_bound, int v_head_size_bound) {
+  const int qk_search_limit = std::min(qk_head_size_bound, kEfficientAttentionMaxHeadSize);
+  const int v_search_limit = std::min(v_head_size_bound, kEfficientAttentionMaxHeadSize);
+  for (int qk_head_size = 8; qk_head_size <= qk_search_limit; qk_head_size += 8) {
+    for (int v_head_size = 8; v_head_size <= v_search_limit; v_head_size += 8) {
+      if (has_memory_efficient_attention(sm, is_half, is_bf16, qk_head_size, v_head_size)) {
+        return true;
+      }
+    }
+  }
+
+  return false;
 }
 
 void run_memory_efficient_attention_sm80(const MemoryEfficientAttentionParams& params);

--- a/onnxruntime/contrib_ops/cuda/bert/flash_attention/flash_api.cc
+++ b/onnxruntime/contrib_ops/cuda/bert/flash_attention/flash_api.cc
@@ -433,7 +433,8 @@ Status mha_varlen_fwd(const cudaDeviceProp& dprops,
 }
 
 bool is_supported(const cudaDeviceProp& dprops, size_t head_size, size_t num_heads, size_t num_heads_k) {
-  return (dprops.major >= 8) && (head_size % 8 == 0) && (head_size <= 256) && (num_heads % num_heads_k == 0);
+  return (dprops.major >= 8) && (head_size % 8 == 0) &&
+         (head_size <= kFlashAttentionMaxHeadSize) && (num_heads % num_heads_k == 0);
 }
 
 // This API is used when past key and value are present... since cached, these are assumed to have sequence length

--- a/onnxruntime/contrib_ops/cuda/bert/flash_attention/flash_api.h
+++ b/onnxruntime/contrib_ops/cuda/bert/flash_attention/flash_api.h
@@ -39,6 +39,8 @@
 namespace onnxruntime {
 namespace flash {
 
+constexpr size_t kFlashAttentionMaxHeadSize = 256;
+
 Status mha_fwd(const cudaDeviceProp& dprops,
                cudaStream_t stream,
                void* q,            // batch_size x seqlen_q x num_heads x head_size
@@ -154,6 +156,22 @@ bool is_supported(const cudaDeviceProp& dprops, size_t head_size, size_t num_hea
   }
 #endif
   return is_supported(dprops, head_size, num_heads, num_heads_k);
+}
+
+template <typename T>
+bool is_any_supported_head_size(const cudaDeviceProp& dprops,
+                                size_t max_head_size,
+                                size_t num_heads,
+                                size_t num_heads_k) {
+  const size_t search_limit =
+      max_head_size < kFlashAttentionMaxHeadSize ? max_head_size : kFlashAttentionMaxHeadSize;
+  for (size_t head_size = 1; head_size <= search_limit; ++head_size) {
+    if (is_supported<T>(dprops, head_size, num_heads, num_heads_k)) {
+      return true;
+    }
+  }
+
+  return false;
 }
 
 }  // namespace flash

--- a/onnxruntime/contrib_ops/cuda/bert/packed_attention.cc
+++ b/onnxruntime/contrib_ops/cuda/bert/packed_attention.cc
@@ -10,6 +10,10 @@
 #include "contrib_ops/cuda/bert/bert_padding.h"
 #include "contrib_ops/cuda/bert/cutlass_fmha/memory_efficient_attention.h"
 
+#if !defined(DISABLE_CONTRIB_OPS) && !defined(BUILD_CUDA_EP_AS_PLUGIN)
+#include "contrib_ops/cuda/bert/packed_attention_workspace_estimate.h"
+#endif
+
 using namespace onnxruntime::cuda;
 using namespace ::onnxruntime::common;
 using namespace ONNX_NAMESPACE;
@@ -165,6 +169,34 @@ Status PackedAttention<T>::CheckInputs(const TensorShape& input_shape,
 
   return Status::OK();
 }
+
+#if !defined(DISABLE_CONTRIB_OPS) && !defined(BUILD_CUDA_EP_AS_PLUGIN)
+// An unavailable adapter estimate is represented by no Level-2 requirements.
+template <typename T>
+Status PackedAttention<T>::DeclareWorkspaceRequirements(
+    gsl::span<const WorkspaceInputShape> input_shapes,
+    /*out*/ InlinedVector<WorkspaceRequirement>& requirements) const {
+  requirements.clear();
+
+  PackedAttentionWorkspaceEstimateConfig config;
+  config.op = PackedAttentionWorkspaceOperator::PackedAttention;
+  config.element_size = sizeof(T);
+  config.num_heads = num_heads_;
+  config.qkv_hidden_sizes_count = qkv_hidden_sizes_.size();
+  for (size_t i = 0;
+       i < qkv_hidden_sizes_.size() && i < config.qkv_hidden_sizes.size();
+       ++i) {
+    config.qkv_hidden_sizes[i] = qkv_hidden_sizes_[i];
+  }
+
+  const auto estimate = EstimatePackedAttentionWorkspace(
+      config, input_shapes, this->GetDeviceProp(), *this->kernel_options_);
+  if (estimate.has_value()) {
+    SetPackedAttentionWorkspaceRequirements(config.op, *estimate, requirements);
+  }
+  return Status::OK();
+}
+#endif
 
 template <typename T>
 Status PackedAttention<T>::ComputeInternal(OpKernelContext* context) const {

--- a/onnxruntime/contrib_ops/cuda/bert/packed_attention.cc
+++ b/onnxruntime/contrib_ops/cuda/bert/packed_attention.cc
@@ -192,7 +192,7 @@ Status PackedAttention<T>::DeclareWorkspaceRequirements(
   const auto estimate = EstimatePackedAttentionWorkspace(
       config, input_shapes, this->GetDeviceProp(), *this->kernel_options_);
   if (estimate.has_value()) {
-    SetPackedAttentionWorkspaceRequirements(config.op, *estimate, requirements);
+    SetPackedAttentionWorkspaceRequirements(*estimate, requirements);
   }
   return Status::OK();
 }

--- a/onnxruntime/contrib_ops/cuda/bert/packed_attention.h
+++ b/onnxruntime/contrib_ops/cuda/bert/packed_attention.h
@@ -47,6 +47,12 @@ class PackedAttention final : public TrtFusedAttention<T> {
   PackedAttention(const OpKernelInfo& info);
   Status ComputeInternal(OpKernelContext* context) const override;
 
+#if !defined(DISABLE_CONTRIB_OPS) && !defined(BUILD_CUDA_EP_AS_PLUGIN)
+  Status DeclareWorkspaceRequirements(
+      gsl::span<const WorkspaceInputShape> input_shapes,
+      /*out*/ InlinedVector<WorkspaceRequirement>& requirements) const override;
+#endif
+
  private:
   Status CheckInputs(const TensorShape& input_shape,
                      const TensorShape& weights_shape,

--- a/onnxruntime/contrib_ops/cuda/bert/packed_attention_workspace.cc
+++ b/onnxruntime/contrib_ops/cuda/bert/packed_attention_workspace.cc
@@ -1394,8 +1394,16 @@ PackedAttentionWorkspaceAggregate AggregatePackedAttentionWorkspace(
     return result;
   }
 
+  result.status = CheckedPackedAttentionAlign(
+      result.projection_bytes, kPackedAttentionWorkspaceAlignment,
+      result.attention_workspace_offset_bytes);
+  if (!result.status.IsOK()) {
+    return result;
+  }
+
   result.status = CheckedPackedAttentionAdd(
-      result.projection_bytes, result.attention_workspace_bytes, result.total_workspace_bytes);
+      result.attention_workspace_offset_bytes, result.attention_workspace_bytes,
+      result.total_workspace_bytes);
   return result;
 }
 

--- a/onnxruntime/contrib_ops/cuda/bert/packed_attention_workspace.cc
+++ b/onnxruntime/contrib_ops/cuda/bert/packed_attention_workspace.cc
@@ -1304,6 +1304,123 @@ PackedAttentionWorkspaceResult GetPackedMultiHeadAttentionWorkspaceRecipe(
   return result;
 }
 
+namespace {
+
+constexpr uint32_t kAllPackedAttentionBackendBits =
+    static_cast<uint32_t>(PackedAttentionBackendMask::Trt) |
+    static_cast<uint32_t>(PackedAttentionBackendMask::Flash) |
+    static_cast<uint32_t>(PackedAttentionBackendMask::MemoryEfficient) |
+    static_cast<uint32_t>(PackedAttentionBackendMask::Unfused);
+
+bool IsProvenEmpty(const PackedAttentionProblem& problem) noexcept {
+  return problem.token_count == 0 || problem.v_hidden_size == 0;
+}
+
+bool IsProvenEmpty(const PackedMultiHeadAttentionProblem& problem) noexcept {
+  return problem.token_count == 0 || problem.v_hidden_size == 0;
+}
+
+template <typename TProblem, typename TRecipeBuilder>
+PackedAttentionWorkspaceAggregate AggregatePackedAttentionWorkspace(
+    const TProblem& problem,
+    PackedAttentionBackendMask feasible_backends,
+    bool allow_flash_backend,
+    TRecipeBuilder build_recipe) noexcept {
+  PackedAttentionWorkspaceAggregate result;
+  const uint32_t mask_bits = static_cast<uint32_t>(feasible_backends);
+  if ((mask_bits & ~kAllPackedAttentionBackendBits) != 0 ||
+      (!allow_flash_backend &&
+       HasPackedAttentionBackend(feasible_backends, PackedAttentionBackend::Flash))) {
+    result.status = Invalid("Packed attention feasible-backend mask is invalid.");
+    return result;
+  }
+
+  const bool proven_empty = IsProvenEmpty(problem);
+  if (proven_empty) {
+    TProblem validation_problem = problem;
+    validation_problem.backend = PackedAttentionBackend::Unfused;
+    validation_problem.trt_runner_available = false;
+    const auto validation_result = build_recipe(validation_problem);
+    if (!validation_result.status.IsOK()) {
+      result.status = validation_result.status;
+      return result;
+    }
+
+    // A valid empty problem does not execute a backend, so the route mask is
+    // irrelevant after its bit pattern has been validated.
+    result.status = Ok();
+    return result;
+  }
+
+  if (feasible_backends == PackedAttentionBackendMask::None) {
+    result.status = Invalid("A non-empty packed attention problem must have a feasible backend.");
+    return result;
+  }
+
+  bool found_route = false;
+  for (PackedAttentionBackend backend :
+       {PackedAttentionBackend::Trt, PackedAttentionBackend::Flash,
+        PackedAttentionBackend::MemoryEfficient, PackedAttentionBackend::Unfused}) {
+    if (!HasPackedAttentionBackend(feasible_backends, backend)) {
+      continue;
+    }
+
+    TProblem route_problem = problem;
+    route_problem.backend = backend;
+    // A set TRT bit means the support predicate admitted a candidate. Runtime
+    // IsValid() can still reject it, which is why a fallback route is included.
+    route_problem.trt_runner_available = backend == PackedAttentionBackend::Trt;
+    const auto route_result = build_recipe(route_problem);
+    if (!route_result.status.IsOK()) {
+      result.status = route_result.status;
+      return result;
+    }
+
+    if (!found_route) {
+      result.projection_bytes = route_result.recipe.projection_bytes;
+      found_route = true;
+    } else if (result.projection_bytes != route_result.recipe.projection_bytes) {
+      result.status = Invalid("Packed attention route recipes disagree on projection workspace.");
+      return result;
+    }
+
+    if (route_result.recipe.attention_workspace_bytes > result.attention_workspace_bytes) {
+      result.attention_workspace_bytes = route_result.recipe.attention_workspace_bytes;
+    }
+  }
+
+  if (!found_route) {
+    result.status = Invalid("Packed attention feasible-backend mask has no usable route.");
+    return result;
+  }
+
+  result.status = CheckedPackedAttentionAdd(
+      result.projection_bytes, result.attention_workspace_bytes, result.total_workspace_bytes);
+  return result;
+}
+
+}  // namespace
+
+PackedAttentionWorkspaceAggregate GetPackedAttentionWorkspaceAggregate(
+    const PackedAttentionProblem& problem,
+    PackedAttentionBackendMask feasible_backends) noexcept {
+  return AggregatePackedAttentionWorkspace(
+      problem, feasible_backends, /*allow_flash_backend=*/false,
+      [](const PackedAttentionProblem& route_problem) {
+        return GetPackedAttentionWorkspaceRecipe(route_problem);
+      });
+}
+
+PackedAttentionWorkspaceAggregate GetPackedMultiHeadAttentionWorkspaceAggregate(
+    const PackedMultiHeadAttentionProblem& problem,
+    PackedAttentionBackendMask feasible_backends) noexcept {
+  return AggregatePackedAttentionWorkspace(
+      problem, feasible_backends, /*allow_flash_backend=*/true,
+      [](const PackedMultiHeadAttentionProblem& route_problem) {
+        return GetPackedMultiHeadAttentionWorkspaceRecipe(route_problem);
+      });
+}
+
 }  // namespace cuda
 }  // namespace contrib
 }  // namespace onnxruntime

--- a/onnxruntime/contrib_ops/cuda/bert/packed_attention_workspace.cc
+++ b/onnxruntime/contrib_ops/cuda/bert/packed_attention_workspace.cc
@@ -1144,8 +1144,19 @@ PackedAttentionProblemResult<PackedMultiHeadAttentionProblem> BuildPackedMultiHe
   return result;
 }
 
-PackedAttentionWorkspaceResult GetPackedAttentionWorkspaceRecipe(
-    const PackedAttentionProblem& problem) noexcept {
+namespace {
+
+enum class PackedAttentionRecipeGeometry {
+  ExactRuntime,
+  UpperBound,
+};
+
+// Exact runtime calls retain route eligibility checks. An aggregate instead
+// evaluates a route reachable below the bounds at the original componentwise
+// maximum geometry, which need not itself satisfy equal-head route gates.
+PackedAttentionWorkspaceResult GetPackedAttentionWorkspaceRecipeImpl(
+    const PackedAttentionProblem& problem,
+    PackedAttentionRecipeGeometry geometry) noexcept {
   PackedAttentionWorkspaceResult result;
 
   auto status = ValidateElementSize(problem.element_size);
@@ -1178,7 +1189,8 @@ PackedAttentionWorkspaceResult GetPackedAttentionWorkspaceRecipe(
       return result;
     }
 
-    if (problem.qk_head_size != problem.v_head_size) {
+    if (geometry == PackedAttentionRecipeGeometry::ExactRuntime &&
+        problem.qk_head_size != problem.v_head_size) {
       result.status = Invalid("The packed TRT route requires equal Q/K and V head sizes.");
       return result;
     }
@@ -1235,8 +1247,9 @@ PackedAttentionWorkspaceResult GetPackedAttentionWorkspaceRecipe(
   return result;
 }
 
-PackedAttentionWorkspaceResult GetPackedMultiHeadAttentionWorkspaceRecipe(
-    const PackedMultiHeadAttentionProblem& problem) noexcept {
+PackedAttentionWorkspaceResult GetPackedMultiHeadAttentionWorkspaceRecipeImpl(
+    const PackedMultiHeadAttentionProblem& problem,
+    PackedAttentionRecipeGeometry geometry) noexcept {
   PackedAttentionWorkspaceResult result;
 
   auto status = ValidateElementSize(problem.element_size);
@@ -1265,14 +1278,17 @@ PackedAttentionWorkspaceResult GetPackedMultiHeadAttentionWorkspaceRecipe(
       return result;
     }
 
-    if (problem.qk_head_size != problem.v_head_size) {
+    if (geometry == PackedAttentionRecipeGeometry::ExactRuntime &&
+        problem.qk_head_size != problem.v_head_size) {
       result.status = Invalid("The packed TRT route requires equal Q/K and V head sizes.");
       return result;
     }
   }
 
   if (problem.backend == PackedAttentionBackend::Flash) {
-    if (problem.qk_head_size != problem.v_head_size || problem.has_attention_bias) {
+    if ((geometry == PackedAttentionRecipeGeometry::ExactRuntime &&
+         problem.qk_head_size != problem.v_head_size) ||
+        problem.has_attention_bias) {
       result.status = Invalid("The packed Flash route requires equal head sizes and no attention bias.");
       return result;
     }
@@ -1304,6 +1320,20 @@ PackedAttentionWorkspaceResult GetPackedMultiHeadAttentionWorkspaceRecipe(
   return result;
 }
 
+}  // namespace
+
+PackedAttentionWorkspaceResult GetPackedAttentionWorkspaceRecipe(
+    const PackedAttentionProblem& problem) noexcept {
+  return GetPackedAttentionWorkspaceRecipeImpl(
+      problem, PackedAttentionRecipeGeometry::ExactRuntime);
+}
+
+PackedAttentionWorkspaceResult GetPackedMultiHeadAttentionWorkspaceRecipe(
+    const PackedMultiHeadAttentionProblem& problem) noexcept {
+  return GetPackedMultiHeadAttentionWorkspaceRecipeImpl(
+      problem, PackedAttentionRecipeGeometry::ExactRuntime);
+}
+
 namespace {
 
 constexpr uint32_t kAllPackedAttentionBackendBits =
@@ -1323,15 +1353,15 @@ bool IsProvenEmpty(const PackedMultiHeadAttentionProblem& problem) noexcept {
 template <typename TProblem, typename TRecipeBuilder>
 PackedAttentionWorkspaceAggregate AggregatePackedAttentionWorkspace(
     const TProblem& problem,
-    PackedAttentionBackendMask feasible_backends,
+    PackedAttentionBackendMask reachable_backends,
     bool allow_flash_backend,
     TRecipeBuilder build_recipe) noexcept {
   PackedAttentionWorkspaceAggregate result;
-  const uint32_t mask_bits = static_cast<uint32_t>(feasible_backends);
+  const uint32_t mask_bits = static_cast<uint32_t>(reachable_backends);
   if ((mask_bits & ~kAllPackedAttentionBackendBits) != 0 ||
       (!allow_flash_backend &&
-       HasPackedAttentionBackend(feasible_backends, PackedAttentionBackend::Flash))) {
-    result.status = Invalid("Packed attention feasible-backend mask is invalid.");
+       HasPackedAttentionBackend(reachable_backends, PackedAttentionBackend::Flash))) {
+    result.status = Invalid("Packed attention reachable-backend mask is invalid.");
     return result;
   }
 
@@ -1352,8 +1382,8 @@ PackedAttentionWorkspaceAggregate AggregatePackedAttentionWorkspace(
     return result;
   }
 
-  if (feasible_backends == PackedAttentionBackendMask::None) {
-    result.status = Invalid("A non-empty packed attention problem must have a feasible backend.");
+  if (reachable_backends == PackedAttentionBackendMask::None) {
+    result.status = Invalid("A non-empty packed attention problem must have a reachable backend.");
     return result;
   }
 
@@ -1361,7 +1391,7 @@ PackedAttentionWorkspaceAggregate AggregatePackedAttentionWorkspace(
   for (PackedAttentionBackend backend :
        {PackedAttentionBackend::Trt, PackedAttentionBackend::Flash,
         PackedAttentionBackend::MemoryEfficient, PackedAttentionBackend::Unfused}) {
-    if (!HasPackedAttentionBackend(feasible_backends, backend)) {
+    if (!HasPackedAttentionBackend(reachable_backends, backend)) {
       continue;
     }
 
@@ -1390,7 +1420,7 @@ PackedAttentionWorkspaceAggregate AggregatePackedAttentionWorkspace(
   }
 
   if (!found_route) {
-    result.status = Invalid("Packed attention feasible-backend mask has no usable route.");
+    result.status = Invalid("Packed attention reachable-backend mask has no usable route.");
     return result;
   }
 
@@ -1409,23 +1439,25 @@ PackedAttentionWorkspaceAggregate AggregatePackedAttentionWorkspace(
 
 }  // namespace
 
-PackedAttentionWorkspaceAggregate GetPackedAttentionWorkspaceAggregate(
+PackedAttentionWorkspaceAggregate GetPackedAttentionWorkspaceAggregateForBounds(
     const PackedAttentionProblem& problem,
-    PackedAttentionBackendMask feasible_backends) noexcept {
+    PackedAttentionBackendMask reachable_backends) noexcept {
   return AggregatePackedAttentionWorkspace(
-      problem, feasible_backends, /*allow_flash_backend=*/false,
+      problem, reachable_backends, /*allow_flash_backend=*/false,
       [](const PackedAttentionProblem& route_problem) {
-        return GetPackedAttentionWorkspaceRecipe(route_problem);
+        return GetPackedAttentionWorkspaceRecipeImpl(
+            route_problem, PackedAttentionRecipeGeometry::UpperBound);
       });
 }
 
-PackedAttentionWorkspaceAggregate GetPackedMultiHeadAttentionWorkspaceAggregate(
+PackedAttentionWorkspaceAggregate GetPackedMultiHeadAttentionWorkspaceAggregateForBounds(
     const PackedMultiHeadAttentionProblem& problem,
-    PackedAttentionBackendMask feasible_backends) noexcept {
+    PackedAttentionBackendMask reachable_backends) noexcept {
   return AggregatePackedAttentionWorkspace(
-      problem, feasible_backends, /*allow_flash_backend=*/true,
+      problem, reachable_backends, /*allow_flash_backend=*/true,
       [](const PackedMultiHeadAttentionProblem& route_problem) {
-        return GetPackedMultiHeadAttentionWorkspaceRecipe(route_problem);
+        return GetPackedMultiHeadAttentionWorkspaceRecipeImpl(
+            route_problem, PackedAttentionRecipeGeometry::UpperBound);
       });
 }
 

--- a/onnxruntime/contrib_ops/cuda/bert/packed_attention_workspace.h
+++ b/onnxruntime/contrib_ops/cuda/bert/packed_attention_workspace.h
@@ -233,12 +233,20 @@ struct PackedAttentionWorkspaceResult {
   PackedAttentionWorkspaceRecipe recipe;
 };
 
-// AOT routes are mutually exclusive. The attention component is therefore the
-// maximum single-route recipe, while PA's projection is simultaneously live
-// with that component.
+// AOT routes are mutually exclusive, so the attention component is the maximum
+// single-route recipe. A successful nonempty aggregate describes one
+// operator-owned, 256-byte-aligned root with this graph-free layout:
+//   projection: [0, projection_bytes)
+//   attention:  [attention_workspace_offset_bytes,
+//                attention_workspace_offset_bytes + attention_workspace_bytes)
+// The attention offset is projection_bytes rounded up to
+// kPackedAttentionWorkspaceAlignment, and total_workspace_bytes is the end of
+// the attention region. PMHA has no projection or padding, so its attention
+// offset is zero. A valid empty aggregate has all size and offset fields zero.
 struct PackedAttentionWorkspaceAggregate {
   PackedAttentionWorkspaceStatus status;
   size_t projection_bytes = 0;
+  size_t attention_workspace_offset_bytes = 0;
   size_t attention_workspace_bytes = 0;
   size_t total_workspace_bytes = 0;
 };

--- a/onnxruntime/contrib_ops/cuda/bert/packed_attention_workspace.h
+++ b/onnxruntime/contrib_ops/cuda/bert/packed_attention_workspace.h
@@ -234,8 +234,13 @@ struct PackedAttentionWorkspaceResult {
 };
 
 // AOT routes are mutually exclusive, so the attention component is the maximum
-// single-route recipe. A successful nonempty aggregate describes one
-// operator-owned, 256-byte-aligned root with this graph-free layout:
+// single-route recipe. These bound aggregates deliberately skip exact-runtime
+// equal-head route gates: a route may be reachable only at a smaller equal-head
+// geometry, but its checked recipe is evaluated at the supplied componentwise
+// maximum bounds. If any included route's max-geometry recipe is invalid,
+// aggregation fails rather than omitting that route. A successful nonempty
+// aggregate describes one operator-owned, 256-byte-aligned root with this
+// graph-free layout:
 //   projection: [0, projection_bytes)
 //   attention:  [attention_workspace_offset_bytes,
 //                attention_workspace_offset_bytes + attention_workspace_bytes)
@@ -273,13 +278,13 @@ PackedAttentionWorkspaceResult GetPackedAttentionWorkspaceRecipe(
 PackedAttentionWorkspaceResult GetPackedMultiHeadAttentionWorkspaceRecipe(
     const PackedMultiHeadAttentionProblem& problem) noexcept;
 
-PackedAttentionWorkspaceAggregate GetPackedAttentionWorkspaceAggregate(
+PackedAttentionWorkspaceAggregate GetPackedAttentionWorkspaceAggregateForBounds(
     const PackedAttentionProblem& problem,
-    PackedAttentionBackendMask feasible_backends) noexcept;
+    PackedAttentionBackendMask reachable_backends) noexcept;
 
-PackedAttentionWorkspaceAggregate GetPackedMultiHeadAttentionWorkspaceAggregate(
+PackedAttentionWorkspaceAggregate GetPackedMultiHeadAttentionWorkspaceAggregateForBounds(
     const PackedMultiHeadAttentionProblem& problem,
-    PackedAttentionBackendMask feasible_backends) noexcept;
+    PackedAttentionBackendMask reachable_backends) noexcept;
 
 PackedAttentionWorkspaceStatus ValidatePackedAttentionWorkspaceRecipe(
     const PackedAttentionWorkspaceRecipe& recipe) noexcept;

--- a/onnxruntime/contrib_ops/cuda/bert/packed_attention_workspace.h
+++ b/onnxruntime/contrib_ops/cuda/bert/packed_attention_workspace.h
@@ -20,6 +20,43 @@ enum class PackedAttentionBackend {
   Unfused,
 };
 
+enum class PackedAttentionBackendMask : uint32_t {
+  None = 0,
+  Trt = 1U << 0,
+  Flash = 1U << 1,
+  MemoryEfficient = 1U << 2,
+  Unfused = 1U << 3,
+};
+
+constexpr PackedAttentionBackendMask operator|(PackedAttentionBackendMask left,
+                                               PackedAttentionBackendMask right) noexcept {
+  return static_cast<PackedAttentionBackendMask>(
+      static_cast<uint32_t>(left) | static_cast<uint32_t>(right));
+}
+
+constexpr bool HasPackedAttentionBackend(PackedAttentionBackendMask mask,
+                                         PackedAttentionBackend backend) noexcept {
+  PackedAttentionBackendMask flag = PackedAttentionBackendMask::None;
+  switch (backend) {
+    case PackedAttentionBackend::Trt:
+      flag = PackedAttentionBackendMask::Trt;
+      break;
+    case PackedAttentionBackend::Flash:
+      flag = PackedAttentionBackendMask::Flash;
+      break;
+    case PackedAttentionBackend::MemoryEfficient:
+      flag = PackedAttentionBackendMask::MemoryEfficient;
+      break;
+    case PackedAttentionBackend::Unfused:
+      flag = PackedAttentionBackendMask::Unfused;
+      break;
+    default:
+      return false;
+  }
+
+  return (static_cast<uint32_t>(mask) & static_cast<uint32_t>(flag)) != 0;
+}
+
 enum class PackedAttentionWorkspaceError {
   None,
   InvalidArgument,
@@ -196,6 +233,16 @@ struct PackedAttentionWorkspaceResult {
   PackedAttentionWorkspaceRecipe recipe;
 };
 
+// AOT routes are mutually exclusive. The attention component is therefore the
+// maximum single-route recipe, while PA's projection is simultaneously live
+// with that component.
+struct PackedAttentionWorkspaceAggregate {
+  PackedAttentionWorkspaceStatus status;
+  size_t projection_bytes = 0;
+  size_t attention_workspace_bytes = 0;
+  size_t total_workspace_bytes = 0;
+};
+
 PackedAttentionWorkspaceStatus CheckedPackedAttentionAdd(size_t left, size_t right, size_t& result) noexcept;
 
 PackedAttentionWorkspaceStatus CheckedPackedAttentionMultiply(size_t left, size_t right,
@@ -217,6 +264,14 @@ PackedAttentionWorkspaceResult GetPackedAttentionWorkspaceRecipe(
 
 PackedAttentionWorkspaceResult GetPackedMultiHeadAttentionWorkspaceRecipe(
     const PackedMultiHeadAttentionProblem& problem) noexcept;
+
+PackedAttentionWorkspaceAggregate GetPackedAttentionWorkspaceAggregate(
+    const PackedAttentionProblem& problem,
+    PackedAttentionBackendMask feasible_backends) noexcept;
+
+PackedAttentionWorkspaceAggregate GetPackedMultiHeadAttentionWorkspaceAggregate(
+    const PackedMultiHeadAttentionProblem& problem,
+    PackedAttentionBackendMask feasible_backends) noexcept;
 
 PackedAttentionWorkspaceStatus ValidatePackedAttentionWorkspaceRecipe(
     const PackedAttentionWorkspaceRecipe& recipe) noexcept;

--- a/onnxruntime/contrib_ops/cuda/bert/packed_attention_workspace_estimate.cc
+++ b/onnxruntime/contrib_ops/cuda/bert/packed_attention_workspace_estimate.cc
@@ -24,6 +24,10 @@ namespace cuda {
 
 namespace {
 
+bool HasExactQkvHiddenSizes(const PackedAttentionWorkspaceEstimateConfig& config) {
+  return config.qkv_hidden_sizes_count == config.qkv_hidden_sizes.size();
+}
+
 bool IsValidConfig(const PackedAttentionWorkspaceEstimateConfig& config) {
   if ((config.element_size != 2 && config.element_size != 4) ||
       config.num_heads <= 0 ||
@@ -46,7 +50,7 @@ bool IsValidConfig(const PackedAttentionWorkspaceEstimateConfig& config) {
       return false;
     }
   }
-  if (config.qkv_hidden_sizes_count == config.qkv_hidden_sizes.size()) {
+  if (HasExactQkvHiddenSizes(config)) {
     const int64_t q = config.qkv_hidden_sizes[0];
     const int64_t k = config.qkv_hidden_sizes[1];
     const int64_t v = config.qkv_hidden_sizes[2];
@@ -60,7 +64,7 @@ bool IsValidConfig(const PackedAttentionWorkspaceEstimateConfig& config) {
 
 bool HasZeroDimension(const PackedAttentionWorkspaceEstimateConfig& config) {
   return config.op == PackedAttentionWorkspaceOperator::PackedAttention &&
-         config.qkv_hidden_sizes_count == config.qkv_hidden_sizes.size() &&
+         HasExactQkvHiddenSizes(config) &&
          std::find(config.qkv_hidden_sizes.begin(), config.qkv_hidden_sizes.end(), int64_t{0}) !=
              config.qkv_hidden_sizes.end();
 }
@@ -121,35 +125,64 @@ bool HasValidPmhaLayoutPresence(gsl::span<const WorkspaceInputShape> input_shape
   return false;
 }
 
-bool IsTrtRoutePossible(const PackedAttentionProblem& problem,
-                        int sm,
-                        const AttentionKernelOptions& kernel_options) {
-  if (problem.sequence_length <= 0) {
+bool IsTrtRouteReachable(int32_t qk_head_size,
+                         int32_t v_head_size,
+                         PackedAttentionHeadSizeDomain head_size_domain,
+                         int32_t sequence_length_bound,
+                         int sm,
+                         const AttentionKernelOptions& kernel_options) {
+  if (sequence_length_bound <= 0) {
     return false;
   }
 
-  return FusedMHARunnerFP16v2::IsSupported(
-             sm, problem.qk_head_size, 1,
-             kernel_options.UseTrtFlashAttention()) ||
-         FusedMHARunnerFP16v2::IsSupported(
-             sm, problem.qk_head_size, problem.sequence_length,
-             kernel_options.UseTrtFlashAttention());
+  const bool enable_flash_attention = kernel_options.UseTrtFlashAttention();
+  if (head_size_domain == PackedAttentionHeadSizeDomain::Exact) {
+    return qk_head_size == v_head_size &&
+           (FusedMHARunnerFP16v2::IsSupported(
+                sm, qk_head_size, 1, enable_flash_attention) ||
+            FusedMHARunnerFP16v2::IsSupported(
+                sm, qk_head_size, sequence_length_bound, enable_flash_attention));
+  }
+
+  const int32_t common_head_size_bound = std::min(qk_head_size, v_head_size);
+  return FusedMHARunnerFP16v2::IsAnySupportedHeadSize(
+             sm, common_head_size_bound, 1, enable_flash_attention) ||
+         FusedMHARunnerFP16v2::IsAnySupportedHeadSize(
+             sm, common_head_size_bound, sequence_length_bound, enable_flash_attention);
 }
 
-bool IsTrtRoutePossible(const PackedMultiHeadAttentionProblem& problem,
-                        int sm,
-                        const AttentionKernelOptions& kernel_options) {
-  if (problem.sequence_length <= 0) {
+#if USE_MEMORY_EFFICIENT_ATTENTION
+bool IsMemoryEfficientRouteReachable(
+    int32_t qk_head_size,
+    int32_t v_head_size,
+    PackedAttentionHeadSizeDomain head_size_domain,
+    int sm,
+    bool is_half) {
+  if (head_size_domain == PackedAttentionHeadSizeDomain::Exact) {
+    return has_memory_efficient_attention(
+        sm, is_half, false, qk_head_size, v_head_size);
+  }
+
+  return has_memory_efficient_attention_for_head_size_bounds(
+      sm, is_half, false, qk_head_size, v_head_size);
+}
+#endif
+
+#if USE_FLASH_ATTENTION
+bool IsFlashRouteReachableForBounds(const PackedMultiHeadAttentionProblem& problem,
+                                    const cudaDeviceProp& device_prop) {
+  const int32_t common_head_size_bound =
+      std::min(problem.qk_head_size, problem.v_head_size);
+  if (common_head_size_bound <= 0) {
     return false;
   }
 
-  return FusedMHARunnerFP16v2::IsSupported(
-             sm, problem.qk_head_size, 1,
-             kernel_options.UseTrtFlashAttention()) ||
-         FusedMHARunnerFP16v2::IsSupported(
-             sm, problem.qk_head_size, problem.sequence_length,
-             kernel_options.UseTrtFlashAttention());
+  return onnxruntime::flash::is_any_supported_head_size<MLFloat16>(
+      device_prop, static_cast<size_t>(common_head_size_bound),
+      static_cast<size_t>(problem.num_heads),
+      static_cast<size_t>(problem.num_heads));
 }
+#endif
 
 std::optional<PackedAttentionWorkspaceAggregate> EstimatePa(
     const PackedAttentionWorkspaceEstimateConfig& config,
@@ -200,8 +233,17 @@ std::optional<PackedAttentionWorkspaceAggregate> EstimatePa(
   }
 
   const auto routes =
-      GetPackedAttentionFeasibleBackends(problem_result.problem, device_prop, kernel_options);
-  const auto aggregate = GetPackedAttentionWorkspaceAggregate(problem_result.problem, routes);
+      GetPackedAttentionReachableBackendsForBounds(
+          problem_result.problem,
+          HasExactQkvHiddenSizes(config)
+              ? PackedAttentionHeadSizeDomain::Exact
+              : PackedAttentionHeadSizeDomain::UpperBound,
+          device_prop, kernel_options);
+  // A reachable route is intentionally evaluated at the original maximum
+  // geometry. Current QKV, projection, and MEA accumulator formulas are
+  // componentwise monotonic even when route eligibility is not.
+  const auto aggregate =
+      GetPackedAttentionWorkspaceAggregateForBounds(problem_result.problem, routes);
   return aggregate.status.IsOK()
              ? std::optional<PackedAttentionWorkspaceAggregate>{aggregate}
              : std::nullopt;
@@ -265,9 +307,12 @@ std::optional<PackedAttentionWorkspaceAggregate> EstimatePmha(
   }
 
   const auto routes =
-      GetPackedMultiHeadAttentionFeasibleBackends(problem_result.problem, device_prop, kernel_options);
+      GetPackedMultiHeadAttentionReachableBackendsForBounds(
+          problem_result.problem, device_prop, kernel_options);
+  // Keep route recipes at the original maximum geometry; only the
+  // reachability probes use smaller supported head witnesses.
   const auto aggregate =
-      GetPackedMultiHeadAttentionWorkspaceAggregate(problem_result.problem, routes);
+      GetPackedMultiHeadAttentionWorkspaceAggregateForBounds(problem_result.problem, routes);
   return aggregate.status.IsOK()
              ? std::optional<PackedAttentionWorkspaceAggregate>{aggregate}
              : std::nullopt;
@@ -325,8 +370,9 @@ std::optional<PackedAttentionWorkspaceEstimateConfig> ConfigFromNode(const Node&
 
 }  // namespace
 
-PackedAttentionBackendMask GetPackedAttentionFeasibleBackends(
+PackedAttentionBackendMask GetPackedAttentionReachableBackendsForBounds(
     const PackedAttentionProblem& problem,
+    PackedAttentionHeadSizeDomain head_size_domain,
     const cudaDeviceProp& device_prop,
     const AttentionKernelOptions& kernel_options) {
   const int sm = device_prop.major * 10 + device_prop.minor;
@@ -335,8 +381,9 @@ PackedAttentionBackendMask GetPackedAttentionFeasibleBackends(
       problem.element_size == 2 &&
       kernel_options.UseTrtFusedAttention() &&
       !problem.has_attention_bias &&
-      problem.qk_head_size == problem.v_head_size &&
-      IsTrtRoutePossible(problem, sm, kernel_options);
+      IsTrtRouteReachable(
+          problem.qk_head_size, problem.v_head_size,
+          head_size_domain, problem.sequence_length, sm, kernel_options);
   if (trt_candidate) {
     routes = routes | PackedAttentionBackendMask::Trt;
   }
@@ -349,8 +396,9 @@ PackedAttentionBackendMask GetPackedAttentionFeasibleBackends(
            ? problem.sequence_length >= static_cast<int32_t>(4 * problem.element_size)
            : true) &&
       problem.element_size == 2 &&
-      has_memory_efficient_attention(
-          sm, true, false, problem.qk_head_size, problem.v_head_size);
+      IsMemoryEfficientRouteReachable(
+          problem.qk_head_size, problem.v_head_size,
+          head_size_domain, sm, true);
 #endif
 
   return mea_feasible
@@ -358,7 +406,7 @@ PackedAttentionBackendMask GetPackedAttentionFeasibleBackends(
              : routes;
 }
 
-PackedAttentionBackendMask GetPackedMultiHeadAttentionFeasibleBackends(
+PackedAttentionBackendMask GetPackedMultiHeadAttentionReachableBackendsForBounds(
     const PackedMultiHeadAttentionProblem& problem,
     const cudaDeviceProp& device_prop,
     const AttentionKernelOptions& kernel_options) {
@@ -372,10 +420,7 @@ PackedAttentionBackendMask GetPackedMultiHeadAttentionFeasibleBackends(
       problem.element_size == 2 &&
       kernel_options.UseFlashAttention() &&
       !problem.has_attention_bias &&
-      problem.qk_head_size == problem.v_head_size &&
-      onnxruntime::flash::is_supported<MLFloat16>(
-          device_prop, static_cast<size_t>(problem.qk_head_size),
-          static_cast<size_t>(problem.num_heads), static_cast<size_t>(problem.num_heads)) &&
+      IsFlashRouteReachableForBounds(problem, device_prop) &&
       (problem.qkv_format != PackedMultiHeadAttentionQkvFormat::Packed ||
        problem.sequence_length >= kernel_options.MinSeqLenForFlashAttentionPackedQkv());
 #endif
@@ -387,8 +432,10 @@ PackedAttentionBackendMask GetPackedMultiHeadAttentionFeasibleBackends(
       problem.element_size == 2 &&
       kernel_options.UseTrtFusedAttention() &&
       !problem.has_attention_bias &&
-      problem.qk_head_size == problem.v_head_size &&
-      IsTrtRoutePossible(problem, sm, kernel_options);
+      IsTrtRouteReachable(
+          problem.qk_head_size, problem.v_head_size,
+          PackedAttentionHeadSizeDomain::UpperBound,
+          problem.sequence_length, sm, kernel_options);
   if (trt_candidate) {
     routes = routes | PackedAttentionBackendMask::Trt;
   }
@@ -402,9 +449,10 @@ PackedAttentionBackendMask GetPackedMultiHeadAttentionFeasibleBackends(
            : true) &&
       (problem.element_size == 2 ||
        problem.sequence_length >= kernel_options.MinSeqLenForEfficientAttentionFp32()) &&
-      has_memory_efficient_attention(
-          sm, problem.element_size == 2, false,
-          problem.qk_head_size, problem.v_head_size);
+      IsMemoryEfficientRouteReachable(
+          problem.qk_head_size, problem.v_head_size,
+          PackedAttentionHeadSizeDomain::UpperBound, sm,
+          problem.element_size == 2);
 #endif
 
   return mea_feasible

--- a/onnxruntime/contrib_ops/cuda/bert/packed_attention_workspace_estimate.cc
+++ b/onnxruntime/contrib_ops/cuda/bert/packed_attention_workspace_estimate.cc
@@ -1,0 +1,487 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#if !defined(DISABLE_CONTRIB_OPS) && !defined(BUILD_CUDA_EP_AS_PLUGIN)
+
+// Must precede the dual-world adapter header so this translation unit gets the
+// shared-provider bridge's Node declaration.
+#include "core/providers/shared_library/provider_api.h"
+
+#include "contrib_ops/cuda/bert/packed_attention_workspace_estimate.h"
+
+#include <algorithm>
+#include <limits>
+#include <string>
+
+#include "core/common/float16.h"
+#include "contrib_ops/cuda/bert/cutlass_fmha/memory_efficient_attention.h"
+#include "contrib_ops/cuda/bert/flash_attention/flash_api.h"
+#include "contrib_ops/cuda/bert/tensorrt_fused_multihead_attention/mha_runner.h"
+
+namespace onnxruntime {
+namespace contrib {
+namespace cuda {
+
+namespace {
+
+bool IsValidConfig(const PackedAttentionWorkspaceEstimateConfig& config) {
+  if ((config.element_size != 2 && config.element_size != 4) ||
+      config.num_heads <= 0 ||
+      config.num_heads > std::numeric_limits<int32_t>::max()) {
+    return false;
+  }
+
+  if (config.op != PackedAttentionWorkspaceOperator::PackedAttention) {
+    return config.qkv_hidden_sizes_count == 0;
+  }
+
+  if (config.qkv_hidden_sizes_count != 0 &&
+      config.qkv_hidden_sizes_count != config.qkv_hidden_sizes.size()) {
+    return false;
+  }
+
+  for (size_t i = 0; i < config.qkv_hidden_sizes_count; ++i) {
+    if (config.qkv_hidden_sizes[i] < 0 ||
+        config.qkv_hidden_sizes[i] > std::numeric_limits<int32_t>::max()) {
+      return false;
+    }
+  }
+  if (config.qkv_hidden_sizes_count == config.qkv_hidden_sizes.size()) {
+    const int64_t q = config.qkv_hidden_sizes[0];
+    const int64_t k = config.qkv_hidden_sizes[1];
+    const int64_t v = config.qkv_hidden_sizes[2];
+    if (q != k || q % config.num_heads != 0 || v % config.num_heads != 0 ||
+        q + k + v > std::numeric_limits<int32_t>::max()) {
+      return false;
+    }
+  }
+  return true;
+}
+
+bool HasZeroDimension(const PackedAttentionWorkspaceEstimateConfig& config) {
+  return config.op == PackedAttentionWorkspaceOperator::PackedAttention &&
+         config.qkv_hidden_sizes_count == config.qkv_hidden_sizes.size() &&
+         std::find(config.qkv_hidden_sizes.begin(), config.qkv_hidden_sizes.end(), int64_t{0}) !=
+             config.qkv_hidden_sizes.end();
+}
+
+bool IsRequiredInputPresent(gsl::span<const WorkspaceInputShape> input_shapes,
+                            size_t input_index) {
+  return GetWorkspaceInputShape(input_shapes, input_index).GetState() !=
+         WorkspaceInputShapeState::Missing;
+}
+
+const TensorShape* GetKnownShape(gsl::span<const WorkspaceInputShape> input_shapes,
+                                 size_t input_index) {
+  return GetWorkspaceInputShape(input_shapes, input_index).GetShape();
+}
+
+PackedAttentionShape ToPackedAttentionShape(const TensorShape& shape) {
+  PackedAttentionShape result;
+  const auto& dimensions = shape.GetDims();
+  result.rank = dimensions.size();
+  const size_t count = std::min(dimensions.size(), result.dimensions.size());
+  for (size_t i = 0; i < count; ++i) {
+    result.dimensions[i] = dimensions[i];
+  }
+  return result;
+}
+
+bool HasZeroDimension(gsl::span<const WorkspaceInputShape> input_shapes) {
+  for (const auto& input_shape : input_shapes) {
+    const TensorShape* shape = input_shape.GetShape();
+    if (shape != nullptr &&
+        std::find(shape->GetDims().begin(), shape->GetDims().end(), int64_t{0}) !=
+            shape->GetDims().end()) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+bool HasValidPmhaLayoutPresence(gsl::span<const WorkspaceInputShape> input_shapes) {
+  const TensorShape* query = GetKnownShape(input_shapes, 0);
+  if (query == nullptr) {
+    return false;
+  }
+
+  const bool has_key = GetWorkspaceInputShape(input_shapes, 1).GetState() !=
+                       WorkspaceInputShapeState::Missing;
+  const bool has_value = GetWorkspaceInputShape(input_shapes, 2).GetState() !=
+                         WorkspaceInputShapeState::Missing;
+  if (query->NumDimensions() == 4) {
+    return !has_key && !has_value;
+  }
+
+  if (query->NumDimensions() == 2) {
+    return has_key && has_value;
+  }
+
+  return false;
+}
+
+bool IsTrtRoutePossible(const PackedAttentionProblem& problem,
+                        int sm,
+                        const AttentionKernelOptions& kernel_options) {
+  if (problem.sequence_length <= 0) {
+    return false;
+  }
+
+  return FusedMHARunnerFP16v2::IsSupported(
+             sm, problem.qk_head_size, 1,
+             kernel_options.UseTrtFlashAttention()) ||
+         FusedMHARunnerFP16v2::IsSupported(
+             sm, problem.qk_head_size, problem.sequence_length,
+             kernel_options.UseTrtFlashAttention());
+}
+
+bool IsTrtRoutePossible(const PackedMultiHeadAttentionProblem& problem,
+                        int sm,
+                        const AttentionKernelOptions& kernel_options) {
+  if (problem.sequence_length <= 0) {
+    return false;
+  }
+
+  return FusedMHARunnerFP16v2::IsSupported(
+             sm, problem.qk_head_size, 1,
+             kernel_options.UseTrtFlashAttention()) ||
+         FusedMHARunnerFP16v2::IsSupported(
+             sm, problem.qk_head_size, problem.sequence_length,
+             kernel_options.UseTrtFlashAttention());
+}
+
+std::optional<PackedAttentionWorkspaceAggregate> EstimatePa(
+    const PackedAttentionWorkspaceEstimateConfig& config,
+    gsl::span<const WorkspaceInputShape> input_shapes,
+    const cudaDeviceProp& device_prop,
+    const AttentionKernelOptions& kernel_options) {
+  for (size_t input_index = 0; input_index < 5; ++input_index) {
+    if (!IsRequiredInputPresent(input_shapes, input_index)) {
+      return std::nullopt;
+    }
+  }
+
+  PackedAttentionInputShapes inputs;
+  const TensorShape* input = GetKnownShape(input_shapes, 0);
+  const TensorShape* weights = GetKnownShape(input_shapes, 1);
+  const TensorShape* bias = GetKnownShape(input_shapes, 2);
+  const TensorShape* token_offset = GetKnownShape(input_shapes, 3);
+  const TensorShape* cumulative_sequence_length = GetKnownShape(input_shapes, 4);
+  if (input == nullptr || weights == nullptr || bias == nullptr ||
+      token_offset == nullptr || cumulative_sequence_length == nullptr) {
+    return std::nullopt;
+  }
+
+  inputs.input = ToPackedAttentionShape(*input);
+  inputs.weights = ToPackedAttentionShape(*weights);
+  inputs.bias = ToPackedAttentionShape(*bias);
+  inputs.token_offset = ToPackedAttentionShape(*token_offset);
+  inputs.cumulative_sequence_length = ToPackedAttentionShape(*cumulative_sequence_length);
+  inputs.element_size = config.element_size;
+  inputs.num_heads = config.num_heads;
+  inputs.qkv_hidden_sizes_count = config.qkv_hidden_sizes_count;
+  inputs.qkv_hidden_sizes = config.qkv_hidden_sizes;
+
+  const auto& attention_bias_shape = GetWorkspaceInputShape(input_shapes, 5);
+  inputs.has_attention_bias =
+      attention_bias_shape.GetState() != WorkspaceInputShapeState::Missing;
+  if (inputs.has_attention_bias) {
+    const TensorShape* shape = attention_bias_shape.GetShape();
+    if (shape == nullptr) {
+      return std::nullopt;
+    }
+    inputs.attention_bias = ToPackedAttentionShape(*shape);
+  }
+
+  const auto problem_result = BuildPackedAttentionProblem(inputs);
+  if (!problem_result.status.IsOK()) {
+    return std::nullopt;
+  }
+
+  const auto routes =
+      GetPackedAttentionFeasibleBackends(problem_result.problem, device_prop, kernel_options);
+  const auto aggregate = GetPackedAttentionWorkspaceAggregate(problem_result.problem, routes);
+  return aggregate.status.IsOK()
+             ? std::optional<PackedAttentionWorkspaceAggregate>{aggregate}
+             : std::nullopt;
+}
+
+std::optional<PackedAttentionWorkspaceAggregate> EstimatePmha(
+    const PackedAttentionWorkspaceEstimateConfig& config,
+    gsl::span<const WorkspaceInputShape> input_shapes,
+    const cudaDeviceProp& device_prop,
+    const AttentionKernelOptions& kernel_options) {
+  for (size_t input_index : {size_t{0}, size_t{4}, size_t{5}}) {
+    if (!IsRequiredInputPresent(input_shapes, input_index)) {
+      return std::nullopt;
+    }
+  }
+
+  if (!HasValidPmhaLayoutPresence(input_shapes)) {
+    return std::nullopt;
+  }
+
+  PackedMultiHeadAttentionInputShapes inputs;
+  const TensorShape* query = GetKnownShape(input_shapes, 0);
+  const TensorShape* token_offset = GetKnownShape(input_shapes, 4);
+  const TensorShape* cumulative_sequence_length = GetKnownShape(input_shapes, 5);
+  if (query == nullptr || token_offset == nullptr || cumulative_sequence_length == nullptr) {
+    return std::nullopt;
+  }
+
+  inputs.query = ToPackedAttentionShape(*query);
+  inputs.token_offset = ToPackedAttentionShape(*token_offset);
+  inputs.cumulative_sequence_length = ToPackedAttentionShape(*cumulative_sequence_length);
+  inputs.element_size = config.element_size;
+  inputs.num_heads = config.num_heads;
+
+  const auto copy_optional_shape =
+      [&input_shapes](size_t input_index, bool& present, PackedAttentionShape& destination) {
+        const auto& input_shape = GetWorkspaceInputShape(input_shapes, input_index);
+        present = input_shape.GetState() != WorkspaceInputShapeState::Missing;
+        if (!present) {
+          return true;
+        }
+
+        const TensorShape* shape = input_shape.GetShape();
+        if (shape == nullptr) {
+          return false;
+        }
+        destination = ToPackedAttentionShape(*shape);
+        return true;
+      };
+
+  if (!copy_optional_shape(1, inputs.has_key, inputs.key) ||
+      !copy_optional_shape(2, inputs.has_value, inputs.value) ||
+      !copy_optional_shape(3, inputs.has_bias, inputs.bias) ||
+      !copy_optional_shape(6, inputs.has_attention_bias, inputs.attention_bias)) {
+    return std::nullopt;
+  }
+
+  const auto problem_result = BuildPackedMultiHeadAttentionProblem(inputs);
+  if (!problem_result.status.IsOK()) {
+    return std::nullopt;
+  }
+
+  const auto routes =
+      GetPackedMultiHeadAttentionFeasibleBackends(problem_result.problem, device_prop, kernel_options);
+  const auto aggregate =
+      GetPackedMultiHeadAttentionWorkspaceAggregate(problem_result.problem, routes);
+  return aggregate.status.IsOK()
+             ? std::optional<PackedAttentionWorkspaceAggregate>{aggregate}
+             : std::nullopt;
+}
+
+std::optional<PackedAttentionWorkspaceEstimateConfig> ConfigFromNode(const Node& node) {
+  PackedAttentionWorkspaceEstimateConfig config;
+  if (node.OpType() == "PackedAttention") {
+    config.op = PackedAttentionWorkspaceOperator::PackedAttention;
+  } else if (node.OpType() == "PackedMultiHeadAttention") {
+    config.op = PackedAttentionWorkspaceOperator::PackedMultiHeadAttention;
+  } else {
+    return std::nullopt;
+  }
+
+  const auto& input_defs = node.InputDefs();
+  if (input_defs.empty() || input_defs[0] == nullptr || !input_defs[0]->Exists()) {
+    return std::nullopt;
+  }
+
+  const auto* type_proto = input_defs[0]->TypeAsProto();
+  if (type_proto == nullptr || !type_proto->has_tensor_type()) {
+    return std::nullopt;
+  }
+
+  switch (type_proto->tensor_type().elem_type()) {
+    case ONNX_NAMESPACE::TensorProto_DataType_FLOAT16:
+      config.element_size = 2;
+      break;
+    case ONNX_NAMESPACE::TensorProto_DataType_FLOAT:
+      config.element_size = 4;
+      break;
+    default:
+      return std::nullopt;
+  }
+
+  bool found_num_heads = false;
+  for (const auto& attr : node.GetAttributes()) {
+    if (attr.first == "num_heads") {
+      config.num_heads = attr.second.i();
+      found_num_heads = true;
+    } else if (attr.first == "qkv_hidden_sizes") {
+      config.qkv_hidden_sizes_count = static_cast<size_t>(attr.second.ints_size());
+      const size_t count = std::min(config.qkv_hidden_sizes_count,
+                                    config.qkv_hidden_sizes.size());
+      for (size_t i = 0; i < count; ++i) {
+        config.qkv_hidden_sizes[i] = attr.second.ints(static_cast<int>(i));
+      }
+    }
+  }
+
+  return found_num_heads ? std::optional<PackedAttentionWorkspaceEstimateConfig>{config}
+                         : std::nullopt;
+}
+
+}  // namespace
+
+PackedAttentionBackendMask GetPackedAttentionFeasibleBackends(
+    const PackedAttentionProblem& problem,
+    const cudaDeviceProp& device_prop,
+    const AttentionKernelOptions& kernel_options) {
+  const int sm = device_prop.major * 10 + device_prop.minor;
+  PackedAttentionBackendMask routes = PackedAttentionBackendMask::Unfused;
+  const bool trt_candidate =
+      problem.element_size == 2 &&
+      kernel_options.UseTrtFusedAttention() &&
+      !problem.has_attention_bias &&
+      problem.qk_head_size == problem.v_head_size &&
+      IsTrtRoutePossible(problem, sm, kernel_options);
+  if (trt_candidate) {
+    routes = routes | PackedAttentionBackendMask::Trt;
+  }
+
+  bool mea_feasible = false;
+#if USE_MEMORY_EFFICIENT_ATTENTION
+  // PackedAttention currently does not consult UseEfficientAttention().
+  mea_feasible =
+      (problem.has_attention_bias
+           ? problem.sequence_length >= static_cast<int32_t>(4 * problem.element_size)
+           : true) &&
+      problem.element_size == 2 &&
+      has_memory_efficient_attention(
+          sm, true, false, problem.qk_head_size, problem.v_head_size);
+#endif
+
+  return mea_feasible
+             ? routes | PackedAttentionBackendMask::MemoryEfficient
+             : routes;
+}
+
+PackedAttentionBackendMask GetPackedMultiHeadAttentionFeasibleBackends(
+    const PackedMultiHeadAttentionProblem& problem,
+    const cudaDeviceProp& device_prop,
+    const AttentionKernelOptions& kernel_options) {
+  const int sm = device_prop.major * 10 + device_prop.minor;
+
+  PackedAttentionBackendMask routes = PackedAttentionBackendMask::Unfused;
+
+  bool flash_feasible = false;
+#if USE_FLASH_ATTENTION
+  flash_feasible =
+      problem.element_size == 2 &&
+      kernel_options.UseFlashAttention() &&
+      !problem.has_attention_bias &&
+      problem.qk_head_size == problem.v_head_size &&
+      onnxruntime::flash::is_supported<MLFloat16>(
+          device_prop, static_cast<size_t>(problem.qk_head_size),
+          static_cast<size_t>(problem.num_heads), static_cast<size_t>(problem.num_heads)) &&
+      (problem.qkv_format != PackedMultiHeadAttentionQkvFormat::Packed ||
+       problem.sequence_length >= kernel_options.MinSeqLenForFlashAttentionPackedQkv());
+#endif
+  if (flash_feasible) {
+    routes = routes | PackedAttentionBackendMask::Flash;
+  }
+
+  const bool trt_candidate =
+      problem.element_size == 2 &&
+      kernel_options.UseTrtFusedAttention() &&
+      !problem.has_attention_bias &&
+      problem.qk_head_size == problem.v_head_size &&
+      IsTrtRoutePossible(problem, sm, kernel_options);
+  if (trt_candidate) {
+    routes = routes | PackedAttentionBackendMask::Trt;
+  }
+
+  bool mea_feasible = false;
+#if USE_MEMORY_EFFICIENT_ATTENTION
+  mea_feasible =
+      kernel_options.UseEfficientAttention() &&
+      (problem.has_attention_bias
+           ? problem.sequence_length >= static_cast<int32_t>(4 * problem.element_size)
+           : true) &&
+      (problem.element_size == 2 ||
+       problem.sequence_length >= kernel_options.MinSeqLenForEfficientAttentionFp32()) &&
+      has_memory_efficient_attention(
+          sm, problem.element_size == 2, false,
+          problem.qk_head_size, problem.v_head_size);
+#endif
+
+  return mea_feasible
+             ? routes | PackedAttentionBackendMask::MemoryEfficient
+             : routes;
+}
+
+std::optional<PackedAttentionWorkspaceAggregate> EstimatePackedAttentionWorkspace(
+    const PackedAttentionWorkspaceEstimateConfig& config,
+    gsl::span<const WorkspaceInputShape> input_shapes,
+    const cudaDeviceProp& device_prop,
+    const AttentionKernelOptions& kernel_options) {
+  if (!IsValidConfig(config)) {
+    return std::nullopt;
+  }
+
+  // WorkspaceInputShape has no provenance: a zero may be an estimation hint,
+  // not proof that runtime output is empty.
+  if (HasZeroDimension(config) || HasZeroDimension(input_shapes)) {
+    return std::nullopt;
+  }
+
+  if (config.op == PackedAttentionWorkspaceOperator::PackedAttention) {
+    return EstimatePa(config, input_shapes, device_prop, kernel_options);
+  }
+
+  if (config.op == PackedAttentionWorkspaceOperator::PackedMultiHeadAttention) {
+    return EstimatePmha(config, input_shapes, device_prop, kernel_options);
+  }
+
+  return std::nullopt;
+}
+
+std::optional<PackedAttentionWorkspaceAggregate> EstimatePackedAttentionWorkspace(
+    const Node& node,
+    gsl::span<const WorkspaceInputShape> input_shapes,
+    const cudaDeviceProp& device_prop,
+    const AttentionKernelOptions& kernel_options) {
+  const auto config = ConfigFromNode(node);
+  if (!config.has_value()) {
+    return std::nullopt;
+  }
+
+  return EstimatePackedAttentionWorkspace(
+      *config, input_shapes, device_prop, kernel_options);
+}
+
+void SetPackedAttentionWorkspaceRequirements(
+    PackedAttentionWorkspaceOperator op,
+    const PackedAttentionWorkspaceAggregate& estimate,
+    InlinedVector<WorkspaceRequirement>& requirements) {
+  requirements.clear();
+  if (!estimate.status.IsOK()) {
+    return;
+  }
+
+  if (op == PackedAttentionWorkspaceOperator::PackedAttention) {
+    if (estimate.projection_bytes != 0) {
+      requirements.push_back(
+          WorkspaceRequirement{estimate.projection_bytes, /*slot_id=*/0, /*alignment_bytes=*/0});
+    }
+    if (estimate.attention_workspace_bytes != 0) {
+      requirements.push_back(
+          WorkspaceRequirement{estimate.attention_workspace_bytes, /*slot_id=*/1, /*alignment_bytes=*/0});
+    }
+    return;
+  }
+
+  if (op == PackedAttentionWorkspaceOperator::PackedMultiHeadAttention &&
+      estimate.attention_workspace_bytes != 0) {
+    requirements.push_back(
+        WorkspaceRequirement{estimate.attention_workspace_bytes, /*slot_id=*/0, /*alignment_bytes=*/0});
+  }
+}
+
+}  // namespace cuda
+}  // namespace contrib
+}  // namespace onnxruntime
+
+#endif  // !defined(DISABLE_CONTRIB_OPS) && !defined(BUILD_CUDA_EP_AS_PLUGIN)

--- a/onnxruntime/contrib_ops/cuda/bert/packed_attention_workspace_estimate.cc
+++ b/onnxruntime/contrib_ops/cuda/bert/packed_attention_workspace_estimate.cc
@@ -453,31 +453,16 @@ std::optional<PackedAttentionWorkspaceAggregate> EstimatePackedAttentionWorkspac
 }
 
 void SetPackedAttentionWorkspaceRequirements(
-    PackedAttentionWorkspaceOperator op,
     const PackedAttentionWorkspaceAggregate& estimate,
     InlinedVector<WorkspaceRequirement>& requirements) {
   requirements.clear();
-  if (!estimate.status.IsOK()) {
+  if (!estimate.status.IsOK() || estimate.total_workspace_bytes == 0) {
     return;
   }
 
-  if (op == PackedAttentionWorkspaceOperator::PackedAttention) {
-    if (estimate.projection_bytes != 0) {
-      requirements.push_back(
-          WorkspaceRequirement{estimate.projection_bytes, /*slot_id=*/0, /*alignment_bytes=*/0});
-    }
-    if (estimate.attention_workspace_bytes != 0) {
-      requirements.push_back(
-          WorkspaceRequirement{estimate.attention_workspace_bytes, /*slot_id=*/1, /*alignment_bytes=*/0});
-    }
-    return;
-  }
-
-  if (op == PackedAttentionWorkspaceOperator::PackedMultiHeadAttention &&
-      estimate.attention_workspace_bytes != 0) {
-    requirements.push_back(
-        WorkspaceRequirement{estimate.attention_workspace_bytes, /*slot_id=*/0, /*alignment_bytes=*/0});
-  }
+  requirements.push_back(
+      WorkspaceRequirement{estimate.total_workspace_bytes, /*slot_id=*/0,
+                           /*alignment_bytes=*/kPackedAttentionWorkspaceAlignment});
 }
 
 }  // namespace cuda

--- a/onnxruntime/contrib_ops/cuda/bert/packed_attention_workspace_estimate.h
+++ b/onnxruntime/contrib_ops/cuda/bert/packed_attention_workspace_estimate.h
@@ -70,10 +70,9 @@ std::optional<PackedAttentionWorkspaceAggregate> EstimatePackedAttentionWorkspac
     const cudaDeviceProp& device_prop,
     const AttentionKernelOptions& kernel_options);
 
-// Converts an available aggregate to the stable Level-2 slot layout. Zero-byte
-// slots are omitted.
+// Converts a successful nonzero aggregate to one explicitly aligned Level-2
+// root requirement. Failed and zero-byte aggregates emit no requirement.
 void SetPackedAttentionWorkspaceRequirements(
-    PackedAttentionWorkspaceOperator op,
     const PackedAttentionWorkspaceAggregate& estimate,
     InlinedVector<WorkspaceRequirement>& requirements);
 

--- a/onnxruntime/contrib_ops/cuda/bert/packed_attention_workspace_estimate.h
+++ b/onnxruntime/contrib_ops/cuda/bert/packed_attention_workspace_estimate.h
@@ -35,25 +35,37 @@ struct PackedAttentionWorkspaceEstimateConfig {
   PackedAttentionWorkspaceOperator op = PackedAttentionWorkspaceOperator::PackedAttention;
   size_t element_size = 0;
   int64_t num_heads = 0;
+  // When present, these immutable node attributes are exact rather than
+  // WorkspaceInputShape bounds.
   size_t qkv_hidden_sizes_count = 0;
   std::array<int64_t, 3> qkv_hidden_sizes{};
 };
 
-// The problem geometry is an upper-bound hint. Returned routes are those that
-// may be reachable at some valid runtime geometry up to that bound.
-PackedAttentionBackendMask GetPackedAttentionFeasibleBackends(
+enum class PackedAttentionHeadSizeDomain {
+  Exact,
+  UpperBound,
+};
+
+// Non-head problem geometry is an upper-bound hint. For UpperBound head
+// geometry, returned routes are those reachable at some valid positive runtime
+// head geometry componentwise no greater than that bound. Exact head geometry
+// retains the runtime backend head-eligibility gates.
+PackedAttentionBackendMask GetPackedAttentionReachableBackendsForBounds(
     const PackedAttentionProblem& problem,
+    PackedAttentionHeadSizeDomain head_size_domain,
     const cudaDeviceProp& device_prop,
     const AttentionKernelOptions& kernel_options);
 
-PackedAttentionBackendMask GetPackedMultiHeadAttentionFeasibleBackends(
+// PMHA head geometry always comes from WorkspaceInputShape, which does not
+// preserve provenance, so head sizes are treated as upper bounds.
+PackedAttentionBackendMask GetPackedMultiHeadAttentionReachableBackendsForBounds(
     const PackedMultiHeadAttentionProblem& problem,
     const cudaDeviceProp& device_prop,
     const AttentionKernelOptions& kernel_options);
 
 // Translates positional framework shapes into the graph-free problem and then
 // aggregates every route potentially reachable up to the supplied geometry.
-// nullopt means required metadata, route feasibility, or checked recipe
+// nullopt means required metadata, route reachability, or checked recipe
 // arithmetic was unavailable.
 std::optional<PackedAttentionWorkspaceAggregate> EstimatePackedAttentionWorkspace(
     const PackedAttentionWorkspaceEstimateConfig& config,

--- a/onnxruntime/contrib_ops/cuda/bert/packed_attention_workspace_estimate.h
+++ b/onnxruntime/contrib_ops/cuda/bert/packed_attention_workspace_estimate.h
@@ -1,0 +1,84 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#if !defined(DISABLE_CONTRIB_OPS) && !defined(BUILD_CUDA_EP_AS_PLUGIN)
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <optional>
+
+#include <cuda_runtime_api.h>
+#include <gsl/span>
+
+#include "core/common/inlined_containers.h"
+#include "core/framework/workspace_input_shape.h"
+#include "core/framework/workspace_requirement.h"
+#include "contrib_ops/cuda/bert/attention_kernel_options.h"
+#include "contrib_ops/cuda/bert/packed_attention_workspace.h"
+
+namespace onnxruntime {
+// Do not forward-declare Node here. This adapter is included from both the
+// in-tree graph world and the shared-provider bridge world, which define Node
+// with different class keys. Each includer must provide its own declaration.
+namespace contrib {
+namespace cuda {
+
+enum class PackedAttentionWorkspaceOperator {
+  PackedAttention,
+  PackedMultiHeadAttention,
+};
+
+struct PackedAttentionWorkspaceEstimateConfig {
+  PackedAttentionWorkspaceOperator op = PackedAttentionWorkspaceOperator::PackedAttention;
+  size_t element_size = 0;
+  int64_t num_heads = 0;
+  size_t qkv_hidden_sizes_count = 0;
+  std::array<int64_t, 3> qkv_hidden_sizes{};
+};
+
+// The problem geometry is an upper-bound hint. Returned routes are those that
+// may be reachable at some valid runtime geometry up to that bound.
+PackedAttentionBackendMask GetPackedAttentionFeasibleBackends(
+    const PackedAttentionProblem& problem,
+    const cudaDeviceProp& device_prop,
+    const AttentionKernelOptions& kernel_options);
+
+PackedAttentionBackendMask GetPackedMultiHeadAttentionFeasibleBackends(
+    const PackedMultiHeadAttentionProblem& problem,
+    const cudaDeviceProp& device_prop,
+    const AttentionKernelOptions& kernel_options);
+
+// Translates positional framework shapes into the graph-free problem and then
+// aggregates every route potentially reachable up to the supplied geometry.
+// nullopt means required metadata, route feasibility, or checked recipe
+// arithmetic was unavailable.
+std::optional<PackedAttentionWorkspaceAggregate> EstimatePackedAttentionWorkspace(
+    const PackedAttentionWorkspaceEstimateConfig& config,
+    gsl::span<const WorkspaceInputShape> input_shapes,
+    const cudaDeviceProp& device_prop,
+    const AttentionKernelOptions& kernel_options);
+
+// Level-1 wrapper. Node provides the operator type, attributes, and input-0
+// dtype. Positional WorkspaceInputShape entries provide optional-input
+// presence and geometry.
+std::optional<PackedAttentionWorkspaceAggregate> EstimatePackedAttentionWorkspace(
+    const Node& node,
+    gsl::span<const WorkspaceInputShape> input_shapes,
+    const cudaDeviceProp& device_prop,
+    const AttentionKernelOptions& kernel_options);
+
+// Converts an available aggregate to the stable Level-2 slot layout. Zero-byte
+// slots are omitted.
+void SetPackedAttentionWorkspaceRequirements(
+    PackedAttentionWorkspaceOperator op,
+    const PackedAttentionWorkspaceAggregate& estimate,
+    InlinedVector<WorkspaceRequirement>& requirements);
+
+}  // namespace cuda
+}  // namespace contrib
+}  // namespace onnxruntime
+
+#endif  // !defined(DISABLE_CONTRIB_OPS) && !defined(BUILD_CUDA_EP_AS_PLUGIN)

--- a/onnxruntime/contrib_ops/cuda/bert/packed_multihead_attention.cc
+++ b/onnxruntime/contrib_ops/cuda/bert/packed_multihead_attention.cc
@@ -121,7 +121,7 @@ Status PackedMultiHeadAttention<T>::DeclareWorkspaceRequirements(
   const auto estimate = EstimatePackedAttentionWorkspace(
       config, input_shapes, this->GetDeviceProp(), *this->kernel_options_);
   if (estimate.has_value()) {
-    SetPackedAttentionWorkspaceRequirements(config.op, *estimate, requirements);
+    SetPackedAttentionWorkspaceRequirements(*estimate, requirements);
   }
   return Status::OK();
 }

--- a/onnxruntime/contrib_ops/cuda/bert/packed_multihead_attention.cc
+++ b/onnxruntime/contrib_ops/cuda/bert/packed_multihead_attention.cc
@@ -11,6 +11,10 @@
 #include "contrib_ops/cuda/bert/cutlass_fmha/memory_efficient_attention.h"
 #include "contrib_ops/cuda/bert/flash_attention/flash_api.h"
 
+#if !defined(DISABLE_CONTRIB_OPS) && !defined(BUILD_CUDA_EP_AS_PLUGIN)
+#include "contrib_ops/cuda/bert/packed_attention_workspace_estimate.h"
+#endif
+
 using namespace onnxruntime::cuda;
 using namespace ::onnxruntime::common;
 using namespace ONNX_NAMESPACE;
@@ -100,6 +104,28 @@ Status PackedMultiHeadAttention<T>::CheckInputs(const TensorShape& query_shape,
 
   return Status::OK();
 }
+
+#if !defined(DISABLE_CONTRIB_OPS) && !defined(BUILD_CUDA_EP_AS_PLUGIN)
+// An unavailable adapter estimate is represented by no Level-2 requirements.
+template <typename T>
+Status PackedMultiHeadAttention<T>::DeclareWorkspaceRequirements(
+    gsl::span<const WorkspaceInputShape> input_shapes,
+    /*out*/ InlinedVector<WorkspaceRequirement>& requirements) const {
+  requirements.clear();
+
+  PackedAttentionWorkspaceEstimateConfig config;
+  config.op = PackedAttentionWorkspaceOperator::PackedMultiHeadAttention;
+  config.element_size = sizeof(T);
+  config.num_heads = num_heads_;
+
+  const auto estimate = EstimatePackedAttentionWorkspace(
+      config, input_shapes, this->GetDeviceProp(), *this->kernel_options_);
+  if (estimate.has_value()) {
+    SetPackedAttentionWorkspaceRequirements(config.op, *estimate, requirements);
+  }
+  return Status::OK();
+}
+#endif
 
 template <typename T>
 Status PackedMultiHeadAttention<T>::ComputeInternal(OpKernelContext* context) const {

--- a/onnxruntime/contrib_ops/cuda/bert/packed_multihead_attention.h
+++ b/onnxruntime/contrib_ops/cuda/bert/packed_multihead_attention.h
@@ -16,6 +16,12 @@ class PackedMultiHeadAttention final : public TrtFusedAttention<T> {
   PackedMultiHeadAttention(const OpKernelInfo& info);
   Status ComputeInternal(OpKernelContext* context) const override;
 
+#if !defined(DISABLE_CONTRIB_OPS) && !defined(BUILD_CUDA_EP_AS_PLUGIN)
+  Status DeclareWorkspaceRequirements(
+      gsl::span<const WorkspaceInputShape> input_shapes,
+      /*out*/ InlinedVector<WorkspaceRequirement>& requirements) const override;
+#endif
+
  private:
   Status CheckInputs(const TensorShape& query_shape,
                      const Tensor* key,

--- a/onnxruntime/contrib_ops/cuda/bert/tensorrt_fused_multihead_attention/mha_runner.cu
+++ b/onnxruntime/contrib_ops/cuda/bert/tensorrt_fused_multihead_attention/mha_runner.cu
@@ -19,6 +19,9 @@
 // Licensed under the MIT License.
 
 #include "contrib_ops/cuda/bert/tensorrt_fused_multihead_attention/mha_runner.h"
+
+#include <algorithm>
+
 #include "contrib_ops/cuda/bert/tensorrt_fused_multihead_attention/fused_multihead_attention_v2.h"
 #include "contrib_ops/cuda/bert/tensorrt_fused_multihead_attention/flash_attention/fmha_flash_attention.h"
 
@@ -206,6 +209,10 @@ bool FusedMHARunnerFP16v2::IsSupported(int sm, int head_size, int sequence_lengt
   ORT_UNUSED_PARAMETER(enable_flash_attention);
   return false;
 #else
+  if (head_size <= 0 || head_size > kFusedMhaMaxHeadSize) {
+    return false;
+  }
+
   bool use_flash = enable_flash_attention && sequence_length >= kMinSequenceLengthFlashAttention;
   if (use_flash && has_flash_attention_kernel(sm, head_size)) {
     return true;
@@ -227,6 +234,20 @@ bool FusedMHARunnerFP16v2::IsSupported(int sm, int head_size, int sequence_lengt
   constexpr int max_sequence_length = 384;
   return sequence_length <= max_sequence_length;
 #endif
+}
+
+bool FusedMHARunnerFP16v2::IsAnySupportedHeadSize(int sm,
+                                                  int max_head_size,
+                                                  int sequence_length,
+                                                  bool enable_flash_attention) {
+  const int search_limit = std::min(max_head_size, kFusedMhaMaxHeadSize);
+  for (int head_size = 1; head_size <= search_limit; ++head_size) {
+    if (IsSupported(sm, head_size, sequence_length, enable_flash_attention)) {
+      return true;
+    }
+  }
+
+  return false;
 }
 
 void FusedMHARunnerFP16v2::Run(int batch_size,

--- a/onnxruntime/contrib_ops/cuda/bert/tensorrt_fused_multihead_attention/mha_runner.h
+++ b/onnxruntime/contrib_ops/cuda/bert/tensorrt_fused_multihead_attention/mha_runner.h
@@ -28,6 +28,7 @@ namespace contrib {
 namespace cuda {
 
 constexpr int kMinSequenceLengthFlashAttention = 385;
+constexpr int kFusedMhaMaxHeadSize = 256;
 
 class MHARunner {
  public:
@@ -67,6 +68,13 @@ class FusedMHARunnerFP16v2 : public MHARunner {
   ~FusedMHARunnerFP16v2() = default;  // for impl_
 
   static bool IsSupported(int sm, int head_size, int sequence_length, bool enable_flash_attention);
+
+  // Uses IsSupported as the authority while bounding the search to the head
+  // sizes for which this runner has kernels.
+  static bool IsAnySupportedHeadSize(int sm,
+                                     int max_head_size,
+                                     int sequence_length,
+                                     bool enable_flash_attention);
 
   static std::unique_ptr<MHARunner> Create(int num_heads,
                                            int head_size,

--- a/onnxruntime/core/providers/cuda/cuda_execution_provider.cc
+++ b/onnxruntime/core/providers/cuda/cuda_execution_provider.cc
@@ -8,6 +8,9 @@
 #include "core/common/inlined_containers.h"
 #include "core/common/parse_string.h"
 #include "core/framework/int4.h"
+#if !defined(USE_CUDA_MINIMAL) && !defined(DISABLE_CONTRIB_OPS) && !defined(BUILD_CUDA_EP_AS_PLUGIN)
+#include "core/framework/node_shape_resolver.h"
+#endif
 #include "core/framework/resource_accountant.h"
 #include "core/platform/env_var_utils.h"
 #include "core/providers/cuda/cuda_execution_provider.h"
@@ -43,6 +46,10 @@
 
 #if !defined(DISABLE_CONTRIB_OPS) && USE_FPA_INTB_GEMM
 #include "contrib_ops/cuda/quantization/matmul_nbits_workspace_estimate.h"
+#endif
+
+#if !defined(USE_CUDA_MINIMAL) && !defined(DISABLE_CONTRIB_OPS) && !defined(BUILD_CUDA_EP_AS_PLUGIN)
+#include "contrib_ops/cuda/bert/packed_attention_workspace_estimate.h"
 #endif
 
 using namespace onnxruntime::common;
@@ -3557,6 +3564,27 @@ CUDAExecutionProvider::GetCapability(const onnxruntime::GraphViewer& graph,
                             : contrib::cuda::EstimateMatMulNBitsWorkspace(*node, GetDeviceProp());
         if (ws.has_value()) {
           LOGS(logger, INFO) << "Level-1 workspace estimate for " << node->Name() << ": " << *ws << " bytes";
+        }
+      }
+#endif
+
+#if !defined(USE_CUDA_MINIMAL) && !defined(DISABLE_CONTRIB_OPS) && !defined(BUILD_CUDA_EP_AS_PLUGIN)
+      // PackedAttention and PackedMultiHeadAttention use the same Level-1
+      // log-only contract as MatMulNBits. Route-aware workspace is not added to
+      // the partition budget until the planner integration is available.
+      if (node != nullptr &&
+          (node->OpType() == "PackedAttention" ||
+           node->OpType() == "PackedMultiHeadAttention") &&
+          node->Domain() == kMSDomain) {
+        const auto input_shapes = ResolveNodeInputShapes(
+            *node, &graph.GetGraph(),
+            resource_accountant->GetMaxShapeInferenceResult());
+        const auto ws = contrib::cuda::EstimatePackedAttentionWorkspace(
+            *node, gsl::make_span(input_shapes), GetDeviceProp(),
+            *GetAttentionKernelOptions());
+        if (ws.has_value()) {
+          LOGS(logger, INFO) << "Level-1 workspace estimate for " << node->Name()
+                             << ": " << ws->total_workspace_bytes << " bytes";
         }
       }
 #endif

--- a/onnxruntime/test/providers/cuda/test_cases/packed_attention_workspace_estimate_test.cc
+++ b/onnxruntime/test/providers/cuda/test_cases/packed_attention_workspace_estimate_test.cc
@@ -261,6 +261,24 @@ void ExpectPmhaAggregateUsesMaximum(
   }
 }
 
+void ExpectAlignedRootLayout(const PackedAttentionWorkspaceAggregate& aggregate) {
+  ASSERT_TRUE(aggregate.status.IsOK()) << aggregate.status.message;
+  EXPECT_EQ(aggregate.attention_workspace_offset_bytes %
+                kPackedAttentionWorkspaceAlignment,
+            0U);
+  ASSERT_GE(aggregate.attention_workspace_offset_bytes,
+            aggregate.projection_bytes);
+  EXPECT_LT(aggregate.attention_workspace_offset_bytes -
+                aggregate.projection_bytes,
+            kPackedAttentionWorkspaceAlignment);
+  EXPECT_EQ(aggregate.total_workspace_bytes,
+            aggregate.attention_workspace_offset_bytes +
+                aggregate.attention_workspace_bytes);
+  EXPECT_GE(aggregate.total_workspace_bytes,
+            aggregate.projection_bytes +
+                aggregate.attention_workspace_bytes);
+}
+
 void ExpectEmptyAggregate(const PackedAttentionWorkspaceAggregate& aggregate) {
   ASSERT_TRUE(aggregate.status.IsOK()) << aggregate.status.message;
   EXPECT_EQ(aggregate.projection_bytes, 0U);
@@ -439,27 +457,21 @@ TEST(PackedAttentionWorkspaceEstimateTest, AggregateUsesMaxOfMutuallyExclusiveRo
   EXPECT_EQ(aggregate.attention_workspace_bytes,
             std::max(mea.recipe.attention_workspace_bytes,
                      unfused.recipe.attention_workspace_bytes));
-  size_t expected_attention_offset = 0;
-  ASSERT_TRUE(contrib::cuda::CheckedPackedAttentionAlign(
-                  aggregate.projection_bytes, kPackedAttentionWorkspaceAlignment,
-                  expected_attention_offset)
-                  .IsOK());
-  EXPECT_EQ(aggregate.attention_workspace_offset_bytes,
-            expected_attention_offset);
-  EXPECT_EQ(aggregate.attention_workspace_offset_bytes %
-                kPackedAttentionWorkspaceAlignment,
-            0U);
-  EXPECT_GT(aggregate.attention_workspace_offset_bytes,
-            aggregate.projection_bytes);
-  EXPECT_LT(aggregate.attention_workspace_offset_bytes -
-                aggregate.projection_bytes,
-            kPackedAttentionWorkspaceAlignment);
-  EXPECT_EQ(aggregate.total_workspace_bytes,
-            aggregate.attention_workspace_offset_bytes +
-                aggregate.attention_workspace_bytes);
+  ExpectAlignedRootLayout(aggregate);
   EXPECT_NE(aggregate.attention_workspace_bytes,
             mea.recipe.attention_workspace_bytes +
                 unfused.recipe.attention_workspace_bytes);
+}
+
+TEST(PackedAttentionWorkspaceEstimateTest, AlignedProjectionStartsAttentionWithoutPadding) {
+  const auto aggregate = GetPackedAttentionWorkspaceAggregate(
+      RoutePaProblem(), PackedAttentionBackendMask::Unfused);
+  ASSERT_TRUE(aggregate.status.IsOK()) << aggregate.status.message;
+  ASSERT_NE(aggregate.projection_bytes, 0U);
+  ASSERT_EQ(aggregate.projection_bytes % kPackedAttentionWorkspaceAlignment, 0U);
+  EXPECT_EQ(aggregate.attention_workspace_offset_bytes,
+            aggregate.projection_bytes);
+  ExpectAlignedRootLayout(aggregate);
 }
 
 TEST(PackedAttentionWorkspaceEstimateTest, Level2AdaptersDeclareOneAlignedRoot) {
@@ -477,17 +489,7 @@ TEST(PackedAttentionWorkspaceEstimateTest, Level2AdaptersDeclareOneAlignedRoot) 
   EXPECT_EQ(requirements[0].size_bytes, estimate->total_workspace_bytes);
   EXPECT_EQ(requirements[0].alignment_bytes,
             kPackedAttentionWorkspaceAlignment);
-  EXPECT_EQ(estimate->attention_workspace_offset_bytes %
-                kPackedAttentionWorkspaceAlignment,
-            0U);
-  EXPECT_EQ(estimate->total_workspace_bytes,
-            estimate->attention_workspace_offset_bytes +
-                estimate->attention_workspace_bytes);
-  EXPECT_GT(estimate->attention_workspace_offset_bytes,
-            estimate->projection_bytes);
-  EXPECT_LT(estimate->attention_workspace_offset_bytes -
-                estimate->projection_bytes,
-            kPackedAttentionWorkspaceAlignment);
+  ExpectAlignedRootLayout(*estimate);
 
   auto graph_problem_inputs = PackedAttentionInputShapes{};
   graph_problem_inputs.input = Shape({6, 6});
@@ -518,6 +520,7 @@ TEST(PackedAttentionWorkspaceEstimateTest, Level2AdaptersDeclareOneAlignedRoot) 
   ASSERT_TRUE(pmha_estimate.has_value());
   EXPECT_EQ(pmha_estimate->projection_bytes, 0U);
   EXPECT_EQ(pmha_estimate->attention_workspace_offset_bytes, 0U);
+  ExpectAlignedRootLayout(*pmha_estimate);
   SetPackedAttentionWorkspaceRequirements(*pmha_estimate, requirements);
   ASSERT_EQ(requirements.size(), 1U);
   EXPECT_EQ(requirements[0].slot_id, 0);

--- a/onnxruntime/test/providers/cuda/test_cases/packed_attention_workspace_estimate_test.cc
+++ b/onnxruntime/test/providers/cuda/test_cases/packed_attention_workspace_estimate_test.cc
@@ -38,6 +38,7 @@ using contrib::cuda::GetPackedAttentionWorkspaceRecipe;
 using contrib::cuda::GetPackedMultiHeadAttentionFeasibleBackends;
 using contrib::cuda::GetPackedMultiHeadAttentionWorkspaceAggregate;
 using contrib::cuda::GetPackedMultiHeadAttentionWorkspaceRecipe;
+using contrib::cuda::kPackedAttentionWorkspaceAlignment;
 using contrib::cuda::PackedAttentionBackend;
 using contrib::cuda::PackedAttentionBackendMask;
 using contrib::cuda::PackedAttentionInputShapes;
@@ -252,11 +253,20 @@ void ExpectPmhaAggregateUsesMaximum(
   }
 
   EXPECT_EQ(aggregate.projection_bytes, 0U);
+  EXPECT_EQ(aggregate.attention_workspace_offset_bytes, 0U);
   EXPECT_EQ(aggregate.attention_workspace_bytes, maximum);
   EXPECT_EQ(aggregate.total_workspace_bytes, maximum);
   if (nonzero_route_count > 1) {
     EXPECT_LT(aggregate.attention_workspace_bytes, sum);
   }
+}
+
+void ExpectEmptyAggregate(const PackedAttentionWorkspaceAggregate& aggregate) {
+  ASSERT_TRUE(aggregate.status.IsOK()) << aggregate.status.message;
+  EXPECT_EQ(aggregate.projection_bytes, 0U);
+  EXPECT_EQ(aggregate.attention_workspace_offset_bytes, 0U);
+  EXPECT_EQ(aggregate.attention_workspace_bytes, 0U);
+  EXPECT_EQ(aggregate.total_workspace_bytes, 0U);
 }
 
 std::optional<PackedAttentionWorkspaceAggregate> EstimateFromNode(
@@ -429,14 +439,30 @@ TEST(PackedAttentionWorkspaceEstimateTest, AggregateUsesMaxOfMutuallyExclusiveRo
   EXPECT_EQ(aggregate.attention_workspace_bytes,
             std::max(mea.recipe.attention_workspace_bytes,
                      unfused.recipe.attention_workspace_bytes));
+  size_t expected_attention_offset = 0;
+  ASSERT_TRUE(contrib::cuda::CheckedPackedAttentionAlign(
+                  aggregate.projection_bytes, kPackedAttentionWorkspaceAlignment,
+                  expected_attention_offset)
+                  .IsOK());
+  EXPECT_EQ(aggregate.attention_workspace_offset_bytes,
+            expected_attention_offset);
+  EXPECT_EQ(aggregate.attention_workspace_offset_bytes %
+                kPackedAttentionWorkspaceAlignment,
+            0U);
+  EXPECT_GT(aggregate.attention_workspace_offset_bytes,
+            aggregate.projection_bytes);
+  EXPECT_LT(aggregate.attention_workspace_offset_bytes -
+                aggregate.projection_bytes,
+            kPackedAttentionWorkspaceAlignment);
   EXPECT_EQ(aggregate.total_workspace_bytes,
-            aggregate.projection_bytes + aggregate.attention_workspace_bytes);
+            aggregate.attention_workspace_offset_bytes +
+                aggregate.attention_workspace_bytes);
   EXPECT_NE(aggregate.attention_workspace_bytes,
             mea.recipe.attention_workspace_bytes +
                 unfused.recipe.attention_workspace_bytes);
 }
 
-TEST(PackedAttentionWorkspaceEstimateTest, StableLevel2SlotLayoutsSumToLevel1Total) {
+TEST(PackedAttentionWorkspaceEstimateTest, Level2AdaptersDeclareOneAlignedRoot) {
   AttentionKernelOptions options;
   options.InitializeOnce(kMath, true);
   const auto shapes = PaShapes();
@@ -445,17 +471,23 @@ TEST(PackedAttentionWorkspaceEstimateTest, StableLevel2SlotLayoutsSumToLevel1Tot
   ASSERT_TRUE(estimate.has_value());
 
   InlinedVector<WorkspaceRequirement> requirements;
-  SetPackedAttentionWorkspaceRequirements(
-      PackedAttentionWorkspaceOperator::PackedAttention, *estimate, requirements);
-  ASSERT_EQ(requirements.size(), 2U);
+  SetPackedAttentionWorkspaceRequirements(*estimate, requirements);
+  ASSERT_EQ(requirements.size(), 1U);
   EXPECT_EQ(requirements[0].slot_id, 0);
-  EXPECT_EQ(requirements[0].size_bytes, estimate->projection_bytes);
-  EXPECT_EQ(requirements[0].alignment_bytes, 0U);
-  EXPECT_EQ(requirements[1].slot_id, 1);
-  EXPECT_EQ(requirements[1].size_bytes, estimate->attention_workspace_bytes);
-  EXPECT_EQ(requirements[1].alignment_bytes, 0U);
-  EXPECT_EQ(requirements[0].size_bytes + requirements[1].size_bytes,
-            estimate->total_workspace_bytes);
+  EXPECT_EQ(requirements[0].size_bytes, estimate->total_workspace_bytes);
+  EXPECT_EQ(requirements[0].alignment_bytes,
+            kPackedAttentionWorkspaceAlignment);
+  EXPECT_EQ(estimate->attention_workspace_offset_bytes %
+                kPackedAttentionWorkspaceAlignment,
+            0U);
+  EXPECT_EQ(estimate->total_workspace_bytes,
+            estimate->attention_workspace_offset_bytes +
+                estimate->attention_workspace_bytes);
+  EXPECT_GT(estimate->attention_workspace_offset_bytes,
+            estimate->projection_bytes);
+  EXPECT_LT(estimate->attention_workspace_offset_bytes -
+                estimate->projection_bytes,
+            kPackedAttentionWorkspaceAlignment);
 
   auto graph_problem_inputs = PackedAttentionInputShapes{};
   graph_problem_inputs.input = Shape({6, 6});
@@ -485,16 +517,16 @@ TEST(PackedAttentionWorkspaceEstimateTest, StableLevel2SlotLayoutsSumToLevel1Tot
       PmhaConfig(), gsl::make_span(PackedPmhaShapes()), Sm80Device(), options);
   ASSERT_TRUE(pmha_estimate.has_value());
   EXPECT_EQ(pmha_estimate->projection_bytes, 0U);
-  SetPackedAttentionWorkspaceRequirements(
-      PackedAttentionWorkspaceOperator::PackedMultiHeadAttention,
-      *pmha_estimate, requirements);
+  EXPECT_EQ(pmha_estimate->attention_workspace_offset_bytes, 0U);
+  SetPackedAttentionWorkspaceRequirements(*pmha_estimate, requirements);
   ASSERT_EQ(requirements.size(), 1U);
   EXPECT_EQ(requirements[0].slot_id, 0);
   EXPECT_EQ(requirements[0].size_bytes, pmha_estimate->total_workspace_bytes);
-  EXPECT_EQ(requirements[0].alignment_bytes, 0U);
+  EXPECT_EQ(requirements[0].alignment_bytes,
+            kPackedAttentionWorkspaceAlignment);
 }
 
-TEST(PackedAttentionWorkspaceEstimateTest, PackedAttentionKernelDeclaresLevel2Slots) {
+TEST(PackedAttentionWorkspaceEstimateTest, PackedAttentionKernelDeclaresOneAlignedRoot) {
   if (!HasCudaDevice()) {
     GTEST_SKIP() << "A CUDA device is required to construct the CUDA kernel.";
   }
@@ -531,12 +563,11 @@ TEST(PackedAttentionWorkspaceEstimateTest, PackedAttentionKernelDeclaresLevel2Sl
   InlinedVector<WorkspaceRequirement> requirements;
   ASSERT_STATUS_OK(kernel->DeclareWorkspaceRequirements(
       gsl::make_span(shapes), requirements));
-  ASSERT_EQ(requirements.size(), 2U);
+  ASSERT_EQ(requirements.size(), 1U);
   EXPECT_EQ(requirements[0].slot_id, 0);
-  EXPECT_EQ(requirements[0].size_bytes, expected->projection_bytes);
-  EXPECT_EQ(requirements[1].slot_id, 1);
-  EXPECT_EQ(requirements[1].size_bytes,
-            expected->attention_workspace_bytes);
+  EXPECT_EQ(requirements[0].size_bytes, expected->total_workspace_bytes);
+  EXPECT_EQ(requirements[0].alignment_bytes,
+            kPackedAttentionWorkspaceAlignment);
 
   auto zero_shapes = shapes;
   zero_shapes[0] = KnownShape({0, 6});
@@ -545,7 +576,7 @@ TEST(PackedAttentionWorkspaceEstimateTest, PackedAttentionKernelDeclaresLevel2Sl
   EXPECT_TRUE(requirements.empty());
 }
 
-TEST(PackedAttentionWorkspaceEstimateTest, PackedMultiHeadAttentionKernelDeclaresLevel2Slot) {
+TEST(PackedAttentionWorkspaceEstimateTest, PackedMultiHeadAttentionKernelDeclaresOneAlignedRoot) {
   if (!HasCudaDevice()) {
     GTEST_SKIP() << "A CUDA device is required to construct the CUDA kernel.";
   }
@@ -584,8 +615,9 @@ TEST(PackedAttentionWorkspaceEstimateTest, PackedMultiHeadAttentionKernelDeclare
       gsl::make_span(shapes), requirements));
   ASSERT_EQ(requirements.size(), 1U);
   EXPECT_EQ(requirements[0].slot_id, 0);
-  EXPECT_EQ(requirements[0].size_bytes,
-            expected->attention_workspace_bytes);
+  EXPECT_EQ(requirements[0].size_bytes, expected->total_workspace_bytes);
+  EXPECT_EQ(requirements[0].alignment_bytes,
+            kPackedAttentionWorkspaceAlignment);
 
   auto zero_shapes = shapes;
   zero_shapes[0] = KnownShape({0, 2, 3, 4});
@@ -673,9 +705,7 @@ TEST(PackedAttentionWorkspaceEstimateTest, ZeroShapeHintsAreUnavailable) {
   ASSERT_TRUE(pa_problem.status.IsOK()) << pa_problem.status.message;
   auto zero_aggregate = GetPackedAttentionWorkspaceAggregate(
       pa_problem.problem, PackedAttentionBackendMask::Unfused);
-  ASSERT_TRUE(zero_aggregate.status.IsOK())
-      << zero_aggregate.status.message;
-  EXPECT_EQ(zero_aggregate.total_workspace_bytes, 0U);
+  ExpectEmptyAggregate(zero_aggregate);
 
   auto zero_v_config = PaConfig();
   zero_v_config.qkv_hidden_sizes = {8, 8, 0};
@@ -693,9 +723,7 @@ TEST(PackedAttentionWorkspaceEstimateTest, ZeroShapeHintsAreUnavailable) {
   ASSERT_TRUE(pa_problem.status.IsOK()) << pa_problem.status.message;
   zero_aggregate = GetPackedAttentionWorkspaceAggregate(
       pa_problem.problem, PackedAttentionBackendMask::Unfused);
-  ASSERT_TRUE(zero_aggregate.status.IsOK())
-      << zero_aggregate.status.message;
-  EXPECT_EQ(zero_aggregate.total_workspace_bytes, 0U);
+  ExpectEmptyAggregate(zero_aggregate);
 
   auto pmha_shapes = PackedPmhaShapes();
   pmha_shapes[0] = KnownShape({0, 2, 3, 4});
@@ -712,9 +740,7 @@ TEST(PackedAttentionWorkspaceEstimateTest, ZeroShapeHintsAreUnavailable) {
   ASSERT_TRUE(pmha_problem.status.IsOK()) << pmha_problem.status.message;
   zero_aggregate = GetPackedMultiHeadAttentionWorkspaceAggregate(
       pmha_problem.problem, PackedAttentionBackendMask::Unfused);
-  ASSERT_TRUE(zero_aggregate.status.IsOK())
-      << zero_aggregate.status.message;
-  EXPECT_EQ(zero_aggregate.total_workspace_bytes, 0U);
+  ExpectEmptyAggregate(zero_aggregate);
 
   pmha_shapes = SeparatePmhaShapes();
   pmha_shapes[0] = KnownShape({0, 8});
@@ -732,9 +758,7 @@ TEST(PackedAttentionWorkspaceEstimateTest, ZeroShapeHintsAreUnavailable) {
   ASSERT_TRUE(pmha_problem.status.IsOK()) << pmha_problem.status.message;
   zero_aggregate = GetPackedMultiHeadAttentionWorkspaceAggregate(
       pmha_problem.problem, PackedAttentionBackendMask::Unfused);
-  ASSERT_TRUE(zero_aggregate.status.IsOK())
-      << zero_aggregate.status.message;
-  EXPECT_EQ(zero_aggregate.total_workspace_bytes, 0U);
+  ExpectEmptyAggregate(zero_aggregate);
 }
 
 TEST(PackedAttentionWorkspaceEstimateTest, RouteSetConservativelyIncludesFallbacks) {
@@ -998,8 +1022,7 @@ TEST(PackedAttentionWorkspaceEstimateTest, InvalidAndEmptyRouteMasksAreDistingui
   nonempty.token_count = 0;
   const auto empty = GetPackedAttentionWorkspaceAggregate(
       nonempty, PackedAttentionBackendMask::None);
-  EXPECT_TRUE(empty.status.IsOK());
-  EXPECT_EQ(empty.total_workspace_bytes, 0U);
+  ExpectEmptyAggregate(empty);
 
   const auto invalid_mask = static_cast<PackedAttentionBackendMask>(1U << 31);
   EXPECT_EQ(GetPackedAttentionWorkspaceAggregate(nonempty, invalid_mask).status.error,
@@ -1017,8 +1040,7 @@ TEST(PackedAttentionWorkspaceEstimateTest, EmptyAggregatesStillValidateProblemGe
   valid_pa.token_count = 0;
   auto aggregate =
       GetPackedAttentionWorkspaceAggregate(valid_pa, PackedAttentionBackendMask::None);
-  ASSERT_TRUE(aggregate.status.IsOK()) << aggregate.status.message;
-  EXPECT_EQ(aggregate.total_workspace_bytes, 0U);
+  ExpectEmptyAggregate(aggregate);
 
   auto malformed_pa = valid_pa;
   malformed_pa.input_hidden_size = -1;
@@ -1038,8 +1060,7 @@ TEST(PackedAttentionWorkspaceEstimateTest, EmptyAggregatesStillValidateProblemGe
   valid_pmha.token_count = 0;
   aggregate = GetPackedMultiHeadAttentionWorkspaceAggregate(
       valid_pmha, PackedAttentionBackendMask::None);
-  ASSERT_TRUE(aggregate.status.IsOK()) << aggregate.status.message;
-  EXPECT_EQ(aggregate.total_workspace_bytes, 0U);
+  ExpectEmptyAggregate(aggregate);
 
   auto malformed_pmha = valid_pmha;
   malformed_pmha.batch_size = -1;
@@ -1088,20 +1109,19 @@ TEST(PackedAttentionWorkspaceEstimateTest, FailedAggregateEmitsNoRequirements) {
   failed.status.error = PackedAttentionWorkspaceError::InvalidArgument;
   failed.status.message = "deliberately failed estimate";
   failed.projection_bytes = 1024;
+  failed.attention_workspace_offset_bytes = 1280;
   failed.attention_workspace_bytes = 2048;
-  failed.total_workspace_bytes = 3072;
+  failed.total_workspace_bytes = 3328;
 
   InlinedVector<WorkspaceRequirement> requirements{
       WorkspaceRequirement{4096, /*slot_id=*/7, /*alignment_bytes=*/0}};
-  SetPackedAttentionWorkspaceRequirements(
-      PackedAttentionWorkspaceOperator::PackedAttention, failed, requirements);
+  SetPackedAttentionWorkspaceRequirements(failed, requirements);
   EXPECT_TRUE(requirements.empty());
 
+  PackedAttentionWorkspaceAggregate empty;
   requirements.push_back(
       WorkspaceRequirement{4096, /*slot_id=*/7, /*alignment_bytes=*/0});
-  SetPackedAttentionWorkspaceRequirements(
-      PackedAttentionWorkspaceOperator::PackedMultiHeadAttention,
-      failed, requirements);
+  SetPackedAttentionWorkspaceRequirements(empty, requirements);
   EXPECT_TRUE(requirements.empty());
 }
 

--- a/onnxruntime/test/providers/cuda/test_cases/packed_attention_workspace_estimate_test.cc
+++ b/onnxruntime/test/providers/cuda/test_cases/packed_attention_workspace_estimate_test.cc
@@ -32,15 +32,16 @@ using contrib::attention::AttentionBackend;
 using contrib::cuda::BuildPackedAttentionProblem;
 using contrib::cuda::BuildPackedMultiHeadAttentionProblem;
 using contrib::cuda::EstimatePackedAttentionWorkspace;
-using contrib::cuda::GetPackedAttentionFeasibleBackends;
-using contrib::cuda::GetPackedAttentionWorkspaceAggregate;
+using contrib::cuda::GetPackedAttentionReachableBackendsForBounds;
+using contrib::cuda::GetPackedAttentionWorkspaceAggregateForBounds;
 using contrib::cuda::GetPackedAttentionWorkspaceRecipe;
-using contrib::cuda::GetPackedMultiHeadAttentionFeasibleBackends;
-using contrib::cuda::GetPackedMultiHeadAttentionWorkspaceAggregate;
+using contrib::cuda::GetPackedMultiHeadAttentionReachableBackendsForBounds;
+using contrib::cuda::GetPackedMultiHeadAttentionWorkspaceAggregateForBounds;
 using contrib::cuda::GetPackedMultiHeadAttentionWorkspaceRecipe;
 using contrib::cuda::kPackedAttentionWorkspaceAlignment;
 using contrib::cuda::PackedAttentionBackend;
 using contrib::cuda::PackedAttentionBackendMask;
+using contrib::cuda::PackedAttentionHeadSizeDomain;
 using contrib::cuda::PackedAttentionInputShapes;
 using contrib::cuda::PackedAttentionProblem;
 using contrib::cuda::PackedAttentionQkvMaterializationIndexWidth;
@@ -180,20 +181,26 @@ PackedAttentionProblem RoutePaProblem(int32_t head_size = 64) {
   return problem;
 }
 
-PackedMultiHeadAttentionProblem RoutePmhaProblem(int32_t head_size = 64) {
+PackedMultiHeadAttentionProblem RoutePmhaProblem(int32_t qk_head_size = 64,
+                                                 int32_t v_head_size = -1) {
+  if (v_head_size < 0) {
+    v_head_size = qk_head_size;
+  }
+
   PackedMultiHeadAttentionProblem problem;
   problem.element_size = 2;
   problem.token_count = 128;
   problem.batch_size = 1;
   problem.sequence_length = 128;
   problem.num_heads = 1;
-  problem.hidden_size = head_size;
-  problem.v_hidden_size = head_size;
-  problem.qk_head_size = head_size;
-  problem.v_head_size = head_size;
+  problem.hidden_size = qk_head_size;
+  problem.v_hidden_size = v_head_size;
+  problem.qk_head_size = qk_head_size;
+  problem.v_head_size = v_head_size;
   problem.qkv_format = PackedMultiHeadAttentionQkvFormat::Separate;
   problem.qkv_materialization_index_width =
-      contrib::cuda::GetPackedAttentionQkvMaterializationIndexWidth(head_size, head_size);
+      contrib::cuda::GetPackedAttentionQkvMaterializationIndexWidth(
+          qk_head_size, v_head_size);
   return problem;
 }
 
@@ -448,7 +455,7 @@ TEST(PackedAttentionWorkspaceEstimateTest, AggregateUsesMaxOfMutuallyExclusiveRo
   const auto unfused = GetPackedAttentionWorkspaceRecipe(unfused_problem);
   ASSERT_TRUE(unfused.status.IsOK()) << unfused.status.message;
 
-  const auto aggregate = GetPackedAttentionWorkspaceAggregate(
+  const auto aggregate = GetPackedAttentionWorkspaceAggregateForBounds(
       pa_problem.problem,
       PackedAttentionBackendMask::MemoryEfficient |
           PackedAttentionBackendMask::Unfused);
@@ -464,7 +471,7 @@ TEST(PackedAttentionWorkspaceEstimateTest, AggregateUsesMaxOfMutuallyExclusiveRo
 }
 
 TEST(PackedAttentionWorkspaceEstimateTest, AlignedProjectionStartsAttentionWithoutPadding) {
-  const auto aggregate = GetPackedAttentionWorkspaceAggregate(
+  const auto aggregate = GetPackedAttentionWorkspaceAggregateForBounds(
       RoutePaProblem(), PackedAttentionBackendMask::Unfused);
   ASSERT_TRUE(aggregate.status.IsOK()) << aggregate.status.message;
   ASSERT_NE(aggregate.projection_bytes, 0U);
@@ -503,7 +510,7 @@ TEST(PackedAttentionWorkspaceEstimateTest, Level2AdaptersDeclareOneAlignedRoot) 
   graph_problem_inputs.qkv_hidden_sizes = {8, 8, 8};
   auto problem = BuildPackedAttentionProblem(graph_problem_inputs);
   ASSERT_TRUE(problem.status.IsOK()) << problem.status.message;
-  const auto graph_free = GetPackedAttentionWorkspaceAggregate(
+  const auto graph_free = GetPackedAttentionWorkspaceAggregateForBounds(
       problem.problem, PackedAttentionBackendMask::Unfused);
   ASSERT_TRUE(graph_free.status.IsOK()) << graph_free.status.message;
   EXPECT_EQ(estimate->total_workspace_bytes, graph_free.total_workspace_bytes);
@@ -706,7 +713,7 @@ TEST(PackedAttentionWorkspaceEstimateTest, ZeroShapeHintsAreUnavailable) {
   pa_inputs.qkv_hidden_sizes = {8, 8, 8};
   auto pa_problem = BuildPackedAttentionProblem(pa_inputs);
   ASSERT_TRUE(pa_problem.status.IsOK()) << pa_problem.status.message;
-  auto zero_aggregate = GetPackedAttentionWorkspaceAggregate(
+  auto zero_aggregate = GetPackedAttentionWorkspaceAggregateForBounds(
       pa_problem.problem, PackedAttentionBackendMask::Unfused);
   ExpectEmptyAggregate(zero_aggregate);
 
@@ -724,7 +731,7 @@ TEST(PackedAttentionWorkspaceEstimateTest, ZeroShapeHintsAreUnavailable) {
   pa_inputs.qkv_hidden_sizes = {8, 8, 0};
   pa_problem = BuildPackedAttentionProblem(pa_inputs);
   ASSERT_TRUE(pa_problem.status.IsOK()) << pa_problem.status.message;
-  zero_aggregate = GetPackedAttentionWorkspaceAggregate(
+  zero_aggregate = GetPackedAttentionWorkspaceAggregateForBounds(
       pa_problem.problem, PackedAttentionBackendMask::Unfused);
   ExpectEmptyAggregate(zero_aggregate);
 
@@ -741,7 +748,7 @@ TEST(PackedAttentionWorkspaceEstimateTest, ZeroShapeHintsAreUnavailable) {
   pmha_inputs.num_heads = 2;
   auto pmha_problem = BuildPackedMultiHeadAttentionProblem(pmha_inputs);
   ASSERT_TRUE(pmha_problem.status.IsOK()) << pmha_problem.status.message;
-  zero_aggregate = GetPackedMultiHeadAttentionWorkspaceAggregate(
+  zero_aggregate = GetPackedMultiHeadAttentionWorkspaceAggregateForBounds(
       pmha_problem.problem, PackedAttentionBackendMask::Unfused);
   ExpectEmptyAggregate(zero_aggregate);
 
@@ -759,7 +766,7 @@ TEST(PackedAttentionWorkspaceEstimateTest, ZeroShapeHintsAreUnavailable) {
   pmha_inputs.has_value = true;
   pmha_problem = BuildPackedMultiHeadAttentionProblem(pmha_inputs);
   ASSERT_TRUE(pmha_problem.status.IsOK()) << pmha_problem.status.message;
-  zero_aggregate = GetPackedMultiHeadAttentionWorkspaceAggregate(
+  zero_aggregate = GetPackedMultiHeadAttentionWorkspaceAggregateForBounds(
       pmha_problem.problem, PackedAttentionBackendMask::Unfused);
   ExpectEmptyAggregate(zero_aggregate);
 }
@@ -770,8 +777,14 @@ TEST(PackedAttentionWorkspaceEstimateTest, RouteSetConservativelyIncludesFallbac
   AttentionKernelOptions all_options;
   all_options.InitializeOnce(kFlash | kMea | kTrt | kTrtFlash | kMath, true);
   const auto pa_routes =
-      GetPackedAttentionFeasibleBackends(RoutePaProblem(), device, all_options);
+      GetPackedAttentionReachableBackendsForBounds(
+          RoutePaProblem(), PackedAttentionHeadSizeDomain::UpperBound,
+          device, all_options);
+#if USE_TRT_FUSED_ATTENTION
   EXPECT_TRUE(HasRoute(pa_routes, PackedAttentionBackend::Trt));
+#else
+  EXPECT_FALSE(HasRoute(pa_routes, PackedAttentionBackend::Trt));
+#endif
 #if USE_MEMORY_EFFICIENT_ATTENTION
   EXPECT_TRUE(HasRoute(pa_routes, PackedAttentionBackend::MemoryEfficient));
 #endif
@@ -779,7 +792,8 @@ TEST(PackedAttentionWorkspaceEstimateTest, RouteSetConservativelyIncludesFallbac
   EXPECT_FALSE(HasRoute(pa_routes, PackedAttentionBackend::Flash));
 
   const auto flash_routes =
-      GetPackedMultiHeadAttentionFeasibleBackends(RoutePmhaProblem(), device, all_options);
+      GetPackedMultiHeadAttentionReachableBackendsForBounds(
+          RoutePmhaProblem(/*qk_head_size=*/128), device, all_options);
 #if USE_FLASH_ATTENTION
   EXPECT_TRUE(HasRoute(flash_routes, PackedAttentionBackend::Flash));
 #else
@@ -790,9 +804,13 @@ TEST(PackedAttentionWorkspaceEstimateTest, RouteSetConservativelyIncludesFallbac
   AttentionKernelOptions trt_mea_options;
   trt_mea_options.InitializeOnce(kMea | kTrt | kTrtFlash | kMath, true);
   const auto trt_fallback_routes =
-      GetPackedMultiHeadAttentionFeasibleBackends(
+      GetPackedMultiHeadAttentionReachableBackendsForBounds(
           RoutePmhaProblem(), device, trt_mea_options);
+#if USE_TRT_FUSED_ATTENTION
   EXPECT_TRUE(HasRoute(trt_fallback_routes, PackedAttentionBackend::Trt));
+#else
+  EXPECT_FALSE(HasRoute(trt_fallback_routes, PackedAttentionBackend::Trt));
+#endif
 #if USE_MEMORY_EFFICIENT_ATTENTION
   EXPECT_TRUE(HasRoute(trt_fallback_routes, PackedAttentionBackend::MemoryEfficient));
 #endif
@@ -801,7 +819,8 @@ TEST(PackedAttentionWorkspaceEstimateTest, RouteSetConservativelyIncludesFallbac
   AttentionKernelOptions mea_options;
   mea_options.InitializeOnce(kMea | kMath, true);
   const auto mea_routes =
-      GetPackedMultiHeadAttentionFeasibleBackends(RoutePmhaProblem(), device, mea_options);
+      GetPackedMultiHeadAttentionReachableBackendsForBounds(
+          RoutePmhaProblem(), device, mea_options);
 #if USE_MEMORY_EFFICIENT_ATTENTION
   EXPECT_TRUE(HasRoute(mea_routes, PackedAttentionBackend::MemoryEfficient));
 #endif
@@ -809,12 +828,302 @@ TEST(PackedAttentionWorkspaceEstimateTest, RouteSetConservativelyIncludesFallbac
 
   AttentionKernelOptions math_options;
   math_options.InitializeOnce(kMath, true);
-  EXPECT_EQ(GetPackedMultiHeadAttentionFeasibleBackends(
+  EXPECT_EQ(GetPackedMultiHeadAttentionReachableBackendsForBounds(
                 RoutePmhaProblem(), device, math_options),
             PackedAttentionBackendMask::Unfused);
-  EXPECT_EQ(GetPackedAttentionFeasibleBackends(
-                RoutePaProblem(7), device, math_options),
+  EXPECT_EQ(GetPackedAttentionReachableBackendsForBounds(
+                RoutePaProblem(7), PackedAttentionHeadSizeDomain::UpperBound,
+                device, math_options),
             PackedAttentionBackendMask::Unfused);
+}
+
+TEST(PackedAttentionWorkspaceEstimateTest, PaTensorHeadBoundAboveMeaLimitSizesReachableSmallerHead) {
+#if USE_MEMORY_EFFICIENT_ATTENTION
+  AttentionKernelOptions options;
+  options.InitializeOnce(kMea | kMath, true);
+
+  auto maximum_problem = RoutePaProblem(/*head_size=*/1032);
+  maximum_problem.token_count = 1;
+  maximum_problem.batch_size = 1;
+  maximum_problem.sequence_length = 1;
+  maximum_problem.input_hidden_size = 1;
+  const auto maximum_routes = GetPackedAttentionReachableBackendsForBounds(
+      maximum_problem, PackedAttentionHeadSizeDomain::UpperBound,
+      Sm80Device(), options);
+  ASSERT_TRUE(HasRoute(maximum_routes, PackedAttentionBackend::MemoryEfficient));
+
+  auto unequal_bounds = maximum_problem;
+  unequal_bounds.v_head_size = 520;
+  unequal_bounds.v_hidden_size = 520;
+  unequal_bounds.qkv_materialization_index_width =
+      contrib::cuda::GetPackedAttentionQkvMaterializationIndexWidth(
+          unequal_bounds.qk_head_size, unequal_bounds.v_head_size);
+  const auto unequal_routes = GetPackedAttentionReachableBackendsForBounds(
+      unequal_bounds, PackedAttentionHeadSizeDomain::UpperBound,
+      Sm80Device(), options);
+  EXPECT_TRUE(HasRoute(unequal_routes, PackedAttentionBackend::MemoryEfficient));
+
+  std::array<WorkspaceInputShape, 6> shapes;
+  shapes[0] = KnownShape({1, 1});
+  shapes[1] = KnownShape({1, 3096});
+  shapes[2] = KnownShape({3096});
+  shapes[3] = KnownShape({1, 1});
+  shapes[4] = KnownShape({2});
+  auto config = PaConfig();
+  config.num_heads = 1;
+  config.qkv_hidden_sizes_count = 0;
+  config.qkv_hidden_sizes = {};
+  const auto estimate = EstimatePackedAttentionWorkspace(
+      config, gsl::make_span(shapes), Sm80Device(), options);
+  ASSERT_TRUE(estimate.has_value());
+  EXPECT_EQ(estimate->total_workspace_bytes, 16720U);
+
+  auto runtime_problem = RoutePaProblem(/*head_size=*/1024);
+  runtime_problem.token_count = 1;
+  runtime_problem.batch_size = 1;
+  runtime_problem.sequence_length = 1;
+  runtime_problem.input_hidden_size = 1;
+  const auto runtime_root = GetPackedAttentionWorkspaceAggregateForBounds(
+      runtime_problem, PackedAttentionBackendMask::MemoryEfficient);
+  ASSERT_TRUE(runtime_root.status.IsOK()) << runtime_root.status.message;
+  EXPECT_EQ(runtime_root.total_workspace_bytes, 16384U);
+  EXPECT_GE(estimate->total_workspace_bytes, runtime_root.total_workspace_bytes);
+#else
+  GTEST_SKIP() << "Memory Efficient Attention is not compiled.";
+#endif
+}
+
+TEST(PackedAttentionWorkspaceEstimateTest, PaExactQkvHiddenSizesDoNotAdmitSmallerHeadRoutes) {
+  AttentionKernelOptions options;
+  options.InitializeOnce(kMea | kTrt | kTrtFlash | kMath, true);
+
+  auto exact_problem = RoutePaProblem(/*head_size=*/1032);
+  exact_problem.token_count = 1;
+  exact_problem.batch_size = 1;
+  exact_problem.sequence_length = 1;
+  exact_problem.input_hidden_size = 1;
+  const auto exact_routes = GetPackedAttentionReachableBackendsForBounds(
+      exact_problem, PackedAttentionHeadSizeDomain::Exact,
+      Sm80Device(), options);
+  EXPECT_FALSE(HasRoute(exact_routes, PackedAttentionBackend::MemoryEfficient));
+  EXPECT_FALSE(HasRoute(exact_routes, PackedAttentionBackend::Trt));
+  EXPECT_EQ(exact_routes, PackedAttentionBackendMask::Unfused);
+
+  std::array<WorkspaceInputShape, 6> shapes;
+  shapes[0] = KnownShape({1, 1});
+  shapes[1] = KnownShape({1, 3096});
+  shapes[2] = KnownShape({3096});
+  shapes[3] = KnownShape({1, 1});
+  shapes[4] = KnownShape({2});
+  auto config = PaConfig();
+  config.num_heads = 1;
+  config.qkv_hidden_sizes = {1032, 1032, 1032};
+  const auto estimate = EstimatePackedAttentionWorkspace(
+      config, gsl::make_span(shapes), Sm80Device(), options);
+  ASSERT_TRUE(estimate.has_value());
+
+  const auto unfused_bound = GetPackedAttentionWorkspaceAggregateForBounds(
+      exact_problem, PackedAttentionBackendMask::Unfused);
+  ASSERT_TRUE(unfused_bound.status.IsOK()) << unfused_bound.status.message;
+  EXPECT_EQ(estimate->total_workspace_bytes,
+            unfused_bound.total_workspace_bytes);
+}
+
+TEST(PackedAttentionWorkspaceEstimateTest, PackedPmhaHeadBoundAboveMeaLimitSizesReachableSmallerHead) {
+#if USE_MEMORY_EFFICIENT_ATTENTION
+  AttentionKernelOptions options;
+  options.InitializeOnce(kMea | kMath, true);
+
+  const auto maximum_problem =
+      BuildPmhaProblem(/*sequence_length=*/1, /*element_size=*/2,
+                       /*packed=*/true, /*has_attention_bias=*/false,
+                       /*head_size=*/1032);
+  const auto maximum_routes = GetPackedMultiHeadAttentionReachableBackendsForBounds(
+      maximum_problem, Sm80Device(), options);
+  ASSERT_TRUE(HasRoute(maximum_routes, PackedAttentionBackend::MemoryEfficient));
+
+  const auto unequal_bounds =
+      RoutePmhaProblem(/*qk_head_size=*/1032, /*v_head_size=*/520);
+  const auto unequal_routes =
+      GetPackedMultiHeadAttentionReachableBackendsForBounds(
+          unequal_bounds, Sm80Device(), options);
+  EXPECT_TRUE(HasRoute(unequal_routes, PackedAttentionBackend::MemoryEfficient));
+
+  const auto shapes = PackedPmhaShapes(/*sequence_length=*/1, /*head_size=*/1032);
+  const auto estimate = EstimatePackedAttentionWorkspace(
+      PmhaConfig(/*element_size=*/2), gsl::make_span(shapes),
+      Sm80Device(), options);
+  ASSERT_TRUE(estimate.has_value());
+  EXPECT_EQ(estimate->total_workspace_bytes, 10320U);
+
+  auto runtime_problem =
+      BuildPmhaProblem(/*sequence_length=*/1, /*element_size=*/2,
+                       /*packed=*/true, /*has_attention_bias=*/false,
+                       /*head_size=*/1024);
+  runtime_problem.backend = PackedAttentionBackend::MemoryEfficient;
+  const auto runtime_recipe =
+      GetPackedMultiHeadAttentionWorkspaceRecipe(runtime_problem);
+  ASSERT_TRUE(runtime_recipe.status.IsOK()) << runtime_recipe.status.message;
+  EXPECT_EQ(runtime_recipe.recipe.attention_workspace_bytes, 10240U);
+  EXPECT_GE(estimate->total_workspace_bytes,
+            runtime_recipe.recipe.attention_workspace_bytes);
+#else
+  GTEST_SKIP() << "Memory Efficient Attention is not compiled.";
+#endif
+}
+
+TEST(PackedAttentionWorkspaceEstimateTest, FlashReachabilityProbesSmallerAndUnequalBoundedHeads) {
+  AttentionKernelOptions options;
+  options.InitializeOnce(kFlash | kMath, true);
+
+  const auto equal_bound_problem = RoutePmhaProblem(/*qk_head_size=*/264);
+  const auto equal_bound_routes =
+      GetPackedMultiHeadAttentionReachableBackendsForBounds(
+          equal_bound_problem, Sm80Device(), options);
+#if USE_FLASH_ATTENTION
+  EXPECT_TRUE(HasRoute(equal_bound_routes, PackedAttentionBackend::Flash));
+#else
+  EXPECT_FALSE(HasRoute(equal_bound_routes, PackedAttentionBackend::Flash));
+#endif
+
+  const auto unequal_bound_problem =
+      RoutePmhaProblem(/*qk_head_size=*/264, /*v_head_size=*/200);
+  const auto unequal_bound_routes =
+      GetPackedMultiHeadAttentionReachableBackendsForBounds(
+          unequal_bound_problem, Sm80Device(), options);
+#if USE_FLASH_ATTENTION
+  ASSERT_TRUE(HasRoute(unequal_bound_routes, PackedAttentionBackend::Flash));
+  const auto aggregate = GetPackedMultiHeadAttentionWorkspaceAggregateForBounds(
+      unequal_bound_problem, PackedAttentionBackendMask::Flash);
+  ASSERT_TRUE(aggregate.status.IsOK()) << aggregate.status.message;
+  EXPECT_EQ(aggregate.total_workspace_bytes, 512U);
+#else
+  EXPECT_FALSE(HasRoute(unequal_bound_routes, PackedAttentionBackend::Flash));
+#endif
+}
+
+TEST(PackedAttentionWorkspaceEstimateTest, TrtReachabilityProbesSmallerAndUnequalBoundedHeads) {
+  AttentionKernelOptions options;
+  options.InitializeOnce(kTrt | kMath, true);
+
+  const auto equal_bound_problem = RoutePmhaProblem(/*qk_head_size=*/72);
+  const auto equal_bound_routes =
+      GetPackedMultiHeadAttentionReachableBackendsForBounds(
+          equal_bound_problem, Sm80Device(), options);
+#if USE_TRT_FUSED_ATTENTION
+  EXPECT_TRUE(HasRoute(equal_bound_routes, PackedAttentionBackend::Trt));
+#else
+  EXPECT_FALSE(HasRoute(equal_bound_routes, PackedAttentionBackend::Trt));
+#endif
+
+  const auto unequal_bound_problem =
+      RoutePmhaProblem(/*qk_head_size=*/72, /*v_head_size=*/80);
+  const auto unequal_bound_routes =
+      GetPackedMultiHeadAttentionReachableBackendsForBounds(
+          unequal_bound_problem, Sm80Device(), options);
+#if USE_TRT_FUSED_ATTENTION
+  ASSERT_TRUE(HasRoute(unequal_bound_routes, PackedAttentionBackend::Trt));
+  const auto aggregate = GetPackedMultiHeadAttentionWorkspaceAggregateForBounds(
+      unequal_bound_problem, PackedAttentionBackendMask::Trt);
+  ASSERT_TRUE(aggregate.status.IsOK()) << aggregate.status.message;
+  EXPECT_EQ(aggregate.total_workspace_bytes, 57344U);
+#else
+  EXPECT_FALSE(HasRoute(unequal_bound_routes, PackedAttentionBackend::Trt));
+#endif
+}
+
+TEST(PackedAttentionWorkspaceEstimateTest, ExactRecipesRejectUnequalHeadsAcceptedByBoundAggregates) {
+  auto pa_problem = RoutePaProblem(/*head_size=*/72);
+  pa_problem.v_head_size = 80;
+  pa_problem.v_hidden_size = 80;
+  pa_problem.qkv_materialization_index_width =
+      contrib::cuda::GetPackedAttentionQkvMaterializationIndexWidth(
+          pa_problem.qk_head_size, pa_problem.v_head_size);
+  pa_problem.backend = PackedAttentionBackend::Trt;
+  pa_problem.trt_runner_available = true;
+  EXPECT_EQ(GetPackedAttentionWorkspaceRecipe(pa_problem).status.error,
+            PackedAttentionWorkspaceError::InvalidArgument);
+
+  const auto pa_bound = GetPackedAttentionWorkspaceAggregateForBounds(
+      pa_problem, PackedAttentionBackendMask::Trt);
+  ASSERT_TRUE(pa_bound.status.IsOK()) << pa_bound.status.message;
+  auto pa_runtime = RoutePaProblem(/*head_size=*/64);
+  pa_runtime.backend = PackedAttentionBackend::Trt;
+  pa_runtime.trt_runner_available = true;
+  const auto pa_runtime_recipe = GetPackedAttentionWorkspaceRecipe(pa_runtime);
+  ASSERT_TRUE(pa_runtime_recipe.status.IsOK()) << pa_runtime_recipe.status.message;
+  EXPECT_GE(pa_bound.projection_bytes,
+            pa_runtime_recipe.recipe.projection_bytes);
+  EXPECT_GE(pa_bound.attention_workspace_bytes,
+            pa_runtime_recipe.recipe.attention_workspace_bytes);
+
+  auto pmha_problem =
+      RoutePmhaProblem(/*qk_head_size=*/136, /*v_head_size=*/160);
+  pmha_problem.backend = PackedAttentionBackend::Trt;
+  pmha_problem.trt_runner_available = true;
+  EXPECT_EQ(GetPackedMultiHeadAttentionWorkspaceRecipe(pmha_problem).status.error,
+            PackedAttentionWorkspaceError::InvalidArgument);
+
+  const auto trt_bound =
+      GetPackedMultiHeadAttentionWorkspaceAggregateForBounds(
+          pmha_problem, PackedAttentionBackendMask::Trt);
+  ASSERT_TRUE(trt_bound.status.IsOK()) << trt_bound.status.message;
+  auto trt_runtime = RoutePmhaProblem(/*qk_head_size=*/64);
+  trt_runtime.backend = PackedAttentionBackend::Trt;
+  trt_runtime.trt_runner_available = true;
+  const auto trt_runtime_recipe =
+      GetPackedMultiHeadAttentionWorkspaceRecipe(trt_runtime);
+  ASSERT_TRUE(trt_runtime_recipe.status.IsOK())
+      << trt_runtime_recipe.status.message;
+  EXPECT_GE(trt_bound.attention_workspace_bytes,
+            trt_runtime_recipe.recipe.attention_workspace_bytes);
+
+  pmha_problem.backend = PackedAttentionBackend::Flash;
+  pmha_problem.trt_runner_available = false;
+  EXPECT_EQ(GetPackedMultiHeadAttentionWorkspaceRecipe(pmha_problem).status.error,
+            PackedAttentionWorkspaceError::InvalidArgument);
+
+  const auto flash_bound =
+      GetPackedMultiHeadAttentionWorkspaceAggregateForBounds(
+          pmha_problem, PackedAttentionBackendMask::Flash);
+  ASSERT_TRUE(flash_bound.status.IsOK()) << flash_bound.status.message;
+  auto flash_runtime = RoutePmhaProblem(/*qk_head_size=*/128);
+  flash_runtime.backend = PackedAttentionBackend::Flash;
+  const auto flash_runtime_recipe =
+      GetPackedMultiHeadAttentionWorkspaceRecipe(flash_runtime);
+  ASSERT_TRUE(flash_runtime_recipe.status.IsOK())
+      << flash_runtime_recipe.status.message;
+  EXPECT_GE(flash_bound.attention_workspace_bytes,
+            flash_runtime_recipe.recipe.attention_workspace_bytes);
+}
+
+TEST(PackedAttentionWorkspaceEstimateTest, HeadBoundsBelowMinimumWitnessesExcludeOptionalRoutes) {
+  AttentionKernelOptions options;
+  options.InitializeOnce(kFlash | kMea | kTrt | kTrtFlash | kMath, true);
+
+  const auto pmha_routes = GetPackedMultiHeadAttentionReachableBackendsForBounds(
+      RoutePmhaProblem(/*qk_head_size=*/7), Sm80Device(), options);
+  EXPECT_FALSE(HasRoute(pmha_routes, PackedAttentionBackend::Flash));
+  EXPECT_FALSE(HasRoute(pmha_routes, PackedAttentionBackend::MemoryEfficient));
+  EXPECT_FALSE(HasRoute(pmha_routes, PackedAttentionBackend::Trt));
+  EXPECT_TRUE(HasRoute(pmha_routes, PackedAttentionBackend::Unfused));
+
+  for (const auto& problem :
+       {RoutePmhaProblem(/*qk_head_size=*/7, /*v_head_size=*/1032),
+        RoutePmhaProblem(/*qk_head_size=*/1032, /*v_head_size=*/7)}) {
+    const auto routes = GetPackedMultiHeadAttentionReachableBackendsForBounds(
+        problem, Sm80Device(), options);
+    EXPECT_FALSE(HasRoute(routes, PackedAttentionBackend::Flash));
+    EXPECT_FALSE(HasRoute(routes, PackedAttentionBackend::MemoryEfficient));
+    EXPECT_FALSE(HasRoute(routes, PackedAttentionBackend::Trt));
+  }
+
+  const auto pa_routes = GetPackedAttentionReachableBackendsForBounds(
+      RoutePaProblem(/*head_size=*/7), PackedAttentionHeadSizeDomain::UpperBound,
+      Sm80Device(), options);
+  EXPECT_FALSE(HasRoute(pa_routes, PackedAttentionBackend::MemoryEfficient));
+  EXPECT_FALSE(HasRoute(pa_routes, PackedAttentionBackend::Trt));
+  EXPECT_TRUE(HasRoute(pa_routes, PackedAttentionBackend::Unfused));
 }
 
 TEST(PackedAttentionWorkspaceEstimateTest, DefaultPackedPmhaCrossesFlashThreshold) {
@@ -826,7 +1135,7 @@ TEST(PackedAttentionWorkspaceEstimateTest, DefaultPackedPmhaCrossesFlashThreshol
       BuildPmhaProblem(/*sequence_length=*/1024, /*element_size=*/2,
                        /*packed=*/true, /*has_attention_bias=*/false,
                        /*head_size=*/128);
-  const auto maximum_routes = GetPackedMultiHeadAttentionFeasibleBackends(
+  const auto maximum_routes = GetPackedMultiHeadAttentionReachableBackendsForBounds(
       maximum_problem, Sm80Device(), options);
   EXPECT_TRUE(HasRoute(maximum_routes, PackedAttentionBackend::Unfused));
 #if USE_FLASH_ATTENTION
@@ -837,7 +1146,7 @@ TEST(PackedAttentionWorkspaceEstimateTest, DefaultPackedPmhaCrossesFlashThreshol
       BuildPmhaProblem(/*sequence_length=*/512, /*element_size=*/2,
                        /*packed=*/true, /*has_attention_bias=*/false,
                        /*head_size=*/128);
-  const auto runtime_bound_routes = GetPackedMultiHeadAttentionFeasibleBackends(
+  const auto runtime_bound_routes = GetPackedMultiHeadAttentionReachableBackendsForBounds(
       runtime_problem, Sm80Device(), options);
   EXPECT_FALSE(HasRoute(runtime_bound_routes, PackedAttentionBackend::Flash));
   EXPECT_TRUE(HasRoute(runtime_bound_routes, PackedAttentionBackend::Unfused));
@@ -859,7 +1168,7 @@ TEST(PackedAttentionWorkspaceEstimateTest, DefaultFp32PmhaCrossesMeaThreshold) {
   const auto maximum_problem =
       BuildPmhaProblem(/*sequence_length=*/512, /*element_size=*/4,
                        /*packed=*/false, /*has_attention_bias=*/true);
-  const auto maximum_routes = GetPackedMultiHeadAttentionFeasibleBackends(
+  const auto maximum_routes = GetPackedMultiHeadAttentionReachableBackendsForBounds(
       maximum_problem, Sm80Device(), options);
   EXPECT_TRUE(HasRoute(maximum_routes, PackedAttentionBackend::Unfused));
 #if USE_MEMORY_EFFICIENT_ATTENTION
@@ -869,7 +1178,7 @@ TEST(PackedAttentionWorkspaceEstimateTest, DefaultFp32PmhaCrossesMeaThreshold) {
   const auto smaller_problem =
       BuildPmhaProblem(/*sequence_length=*/128, /*element_size=*/4,
                        /*packed=*/false, /*has_attention_bias=*/true);
-  const auto smaller_routes = GetPackedMultiHeadAttentionFeasibleBackends(
+  const auto smaller_routes = GetPackedMultiHeadAttentionReachableBackendsForBounds(
       smaller_problem, Sm80Device(), options);
   EXPECT_FALSE(HasRoute(smaller_routes, PackedAttentionBackend::MemoryEfficient));
   EXPECT_TRUE(HasRoute(smaller_routes, PackedAttentionBackend::Unfused));
@@ -890,7 +1199,7 @@ TEST(PackedAttentionWorkspaceEstimateTest, AttentionBiasAlignmentIsPossibleBelow
   const auto too_small_problem =
       BuildPmhaProblem(/*sequence_length=*/7, /*element_size=*/2,
                        /*packed=*/false, /*has_attention_bias=*/true);
-  const auto too_small_routes = GetPackedMultiHeadAttentionFeasibleBackends(
+  const auto too_small_routes = GetPackedMultiHeadAttentionReachableBackendsForBounds(
       too_small_problem, Sm80Device(), options);
   EXPECT_FALSE(HasRoute(too_small_routes, PackedAttentionBackend::MemoryEfficient));
   EXPECT_TRUE(HasRoute(too_small_routes, PackedAttentionBackend::Unfused));
@@ -900,7 +1209,7 @@ TEST(PackedAttentionWorkspaceEstimateTest, AttentionBiasAlignmentIsPossibleBelow
     const auto problem =
         BuildPmhaProblem(maximum_sequence_length, /*element_size=*/2,
                          /*packed=*/false, /*has_attention_bias=*/true);
-    const auto routes = GetPackedMultiHeadAttentionFeasibleBackends(
+    const auto routes = GetPackedMultiHeadAttentionReachableBackendsForBounds(
         problem, Sm80Device(), options);
     EXPECT_TRUE(HasRoute(routes, PackedAttentionBackend::Unfused));
 #if USE_MEMORY_EFFICIENT_ATTENTION
@@ -982,7 +1291,8 @@ TEST(PackedAttentionWorkspaceEstimateTest, AttentionBiasDisablesFlashAndTrtCandi
   problem.broadcast_attn_bias_dim_0 = true;
   problem.broadcast_attn_bias_dim_1 = true;
   const auto routes =
-      GetPackedMultiHeadAttentionFeasibleBackends(problem, Sm80Device(), options);
+      GetPackedMultiHeadAttentionReachableBackendsForBounds(
+          problem, Sm80Device(), options);
   EXPECT_FALSE(HasRoute(routes, PackedAttentionBackend::Flash));
   EXPECT_FALSE(HasRoute(routes, PackedAttentionBackend::Trt));
 #if USE_MEMORY_EFFICIENT_ATTENTION
@@ -1010,30 +1320,30 @@ TEST(PackedAttentionWorkspaceEstimateTest, IncludedRouteOverflowMakesAggregateUn
   const auto single_route = GetPackedMultiHeadAttentionWorkspaceRecipe(problem);
   EXPECT_EQ(single_route.status.error, PackedAttentionWorkspaceError::Overflow);
 
-  const auto aggregate = GetPackedMultiHeadAttentionWorkspaceAggregate(
+  const auto aggregate = GetPackedMultiHeadAttentionWorkspaceAggregateForBounds(
       problem, PackedAttentionBackendMask::MemoryEfficient);
   EXPECT_EQ(aggregate.status.error, PackedAttentionWorkspaceError::Overflow);
 }
 
 TEST(PackedAttentionWorkspaceEstimateTest, InvalidAndEmptyRouteMasksAreDistinguished) {
   auto nonempty = RoutePaProblem();
-  EXPECT_EQ(GetPackedAttentionWorkspaceAggregate(
+  EXPECT_EQ(GetPackedAttentionWorkspaceAggregateForBounds(
                 nonempty, PackedAttentionBackendMask::None)
                 .status.error,
             PackedAttentionWorkspaceError::InvalidArgument);
 
   nonempty.token_count = 0;
-  const auto empty = GetPackedAttentionWorkspaceAggregate(
+  const auto empty = GetPackedAttentionWorkspaceAggregateForBounds(
       nonempty, PackedAttentionBackendMask::None);
   ExpectEmptyAggregate(empty);
 
   const auto invalid_mask = static_cast<PackedAttentionBackendMask>(1U << 31);
-  EXPECT_EQ(GetPackedAttentionWorkspaceAggregate(nonempty, invalid_mask).status.error,
+  EXPECT_EQ(GetPackedAttentionWorkspaceAggregateForBounds(nonempty, invalid_mask).status.error,
             PackedAttentionWorkspaceError::InvalidArgument);
 
   auto empty_pmha = RoutePmhaProblem();
   empty_pmha.token_count = 0;
-  EXPECT_EQ(GetPackedMultiHeadAttentionWorkspaceAggregate(empty_pmha, invalid_mask)
+  EXPECT_EQ(GetPackedMultiHeadAttentionWorkspaceAggregateForBounds(empty_pmha, invalid_mask)
                 .status.error,
             PackedAttentionWorkspaceError::InvalidArgument);
 }
@@ -1042,39 +1352,39 @@ TEST(PackedAttentionWorkspaceEstimateTest, EmptyAggregatesStillValidateProblemGe
   auto valid_pa = RoutePaProblem();
   valid_pa.token_count = 0;
   auto aggregate =
-      GetPackedAttentionWorkspaceAggregate(valid_pa, PackedAttentionBackendMask::None);
+      GetPackedAttentionWorkspaceAggregateForBounds(valid_pa, PackedAttentionBackendMask::None);
   ExpectEmptyAggregate(aggregate);
 
   auto malformed_pa = valid_pa;
   malformed_pa.input_hidden_size = -1;
-  EXPECT_EQ(GetPackedAttentionWorkspaceAggregate(
+  EXPECT_EQ(GetPackedAttentionWorkspaceAggregateForBounds(
                 malformed_pa, PackedAttentionBackendMask::None)
                 .status.error,
             PackedAttentionWorkspaceError::InvalidArgument);
 
   malformed_pa = valid_pa;
   malformed_pa.hidden_size += 1;
-  EXPECT_EQ(GetPackedAttentionWorkspaceAggregate(
+  EXPECT_EQ(GetPackedAttentionWorkspaceAggregateForBounds(
                 malformed_pa, PackedAttentionBackendMask::None)
                 .status.error,
             PackedAttentionWorkspaceError::InvalidArgument);
 
   auto valid_pmha = RoutePmhaProblem();
   valid_pmha.token_count = 0;
-  aggregate = GetPackedMultiHeadAttentionWorkspaceAggregate(
+  aggregate = GetPackedMultiHeadAttentionWorkspaceAggregateForBounds(
       valid_pmha, PackedAttentionBackendMask::None);
   ExpectEmptyAggregate(aggregate);
 
   auto malformed_pmha = valid_pmha;
   malformed_pmha.batch_size = -1;
-  EXPECT_EQ(GetPackedMultiHeadAttentionWorkspaceAggregate(
+  EXPECT_EQ(GetPackedMultiHeadAttentionWorkspaceAggregateForBounds(
                 malformed_pmha, PackedAttentionBackendMask::None)
                 .status.error,
             PackedAttentionWorkspaceError::InvalidArgument);
 
   malformed_pmha = valid_pmha;
   malformed_pmha.hidden_size += 1;
-  EXPECT_EQ(GetPackedMultiHeadAttentionWorkspaceAggregate(
+  EXPECT_EQ(GetPackedMultiHeadAttentionWorkspaceAggregateForBounds(
                 malformed_pmha, PackedAttentionBackendMask::None)
                 .status.error,
             PackedAttentionWorkspaceError::InvalidArgument);
@@ -1082,7 +1392,7 @@ TEST(PackedAttentionWorkspaceEstimateTest, EmptyAggregatesStillValidateProblemGe
   malformed_pmha = valid_pmha;
   malformed_pmha.qkv_format =
       static_cast<PackedMultiHeadAttentionQkvFormat>(-1);
-  EXPECT_EQ(GetPackedMultiHeadAttentionWorkspaceAggregate(
+  EXPECT_EQ(GetPackedMultiHeadAttentionWorkspaceAggregateForBounds(
                 malformed_pmha, PackedAttentionBackendMask::None)
                 .status.error,
             PackedAttentionWorkspaceError::InvalidArgument);

--- a/onnxruntime/test/providers/cuda/test_cases/packed_attention_workspace_estimate_test.cc
+++ b/onnxruntime/test/providers/cuda/test_cases/packed_attention_workspace_estimate_test.cc
@@ -1,0 +1,1111 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "gtest/gtest.h"
+
+#if !defined(USE_CUDA_MINIMAL) && !defined(DISABLE_CONTRIB_OPS) && !defined(BUILD_CUDA_EP_AS_PLUGIN)
+
+#include <algorithm>
+#include <array>
+#include <cstdint>
+#include <limits>
+#include <memory>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "core/framework/op_kernel.h"
+#include "core/framework/session_state.h"
+#include "core/graph/graph.h"
+#include "core/providers/cuda/cuda_execution_provider.h"
+#include "core/providers/cuda/cuda_execution_provider_info.h"
+#include "contrib_ops/cpu/bert/attention_common.h"
+#include "contrib_ops/cuda/bert/packed_attention_workspace_estimate.h"
+#include "test/test_environment.h"
+#include "test/util/include/asserts.h"
+#include "test/util/include/inference_session_wrapper.h"
+
+namespace onnxruntime {
+namespace test {
+
+using contrib::attention::AttentionBackend;
+using contrib::cuda::BuildPackedAttentionProblem;
+using contrib::cuda::BuildPackedMultiHeadAttentionProblem;
+using contrib::cuda::EstimatePackedAttentionWorkspace;
+using contrib::cuda::GetPackedAttentionFeasibleBackends;
+using contrib::cuda::GetPackedAttentionWorkspaceAggregate;
+using contrib::cuda::GetPackedAttentionWorkspaceRecipe;
+using contrib::cuda::GetPackedMultiHeadAttentionFeasibleBackends;
+using contrib::cuda::GetPackedMultiHeadAttentionWorkspaceAggregate;
+using contrib::cuda::GetPackedMultiHeadAttentionWorkspaceRecipe;
+using contrib::cuda::PackedAttentionBackend;
+using contrib::cuda::PackedAttentionBackendMask;
+using contrib::cuda::PackedAttentionInputShapes;
+using contrib::cuda::PackedAttentionProblem;
+using contrib::cuda::PackedAttentionQkvMaterializationIndexWidth;
+using contrib::cuda::PackedAttentionShape;
+using contrib::cuda::PackedAttentionWorkspaceAggregate;
+using contrib::cuda::PackedAttentionWorkspaceError;
+using contrib::cuda::PackedAttentionWorkspaceEstimateConfig;
+using contrib::cuda::PackedAttentionWorkspaceOperator;
+using contrib::cuda::PackedMultiHeadAttentionInputShapes;
+using contrib::cuda::PackedMultiHeadAttentionProblem;
+using contrib::cuda::PackedMultiHeadAttentionQkvFormat;
+using contrib::cuda::SetPackedAttentionWorkspaceRequirements;
+
+namespace {
+
+constexpr int kMath = static_cast<int>(AttentionBackend::MATH);
+constexpr int kFlash = static_cast<int>(AttentionBackend::FLASH_ATTENTION);
+constexpr int kMea = static_cast<int>(AttentionBackend::EFFICIENT_ATTENTION);
+constexpr int kTrt = static_cast<int>(AttentionBackend::TRT_FUSED_ATTENTION);
+constexpr int kTrtFlash = static_cast<int>(AttentionBackend::TRT_FLASH_ATTENTION);
+
+PackedAttentionShape Shape(std::initializer_list<int64_t> dimensions) {
+  PackedAttentionShape shape;
+  shape.rank = dimensions.size();
+  size_t index = 0;
+  for (int64_t dimension : dimensions) {
+    if (index < shape.dimensions.size()) {
+      shape.dimensions[index] = dimension;
+    }
+    ++index;
+  }
+  return shape;
+}
+
+WorkspaceInputShape KnownShape(std::initializer_list<int64_t> dimensions) {
+  return WorkspaceInputShape::PresentWithShape(
+      TensorShape{TensorShapeVector{dimensions}});
+}
+
+std::array<WorkspaceInputShape, 6> PaShapes() {
+  std::array<WorkspaceInputShape, 6> shapes;
+  shapes[0] = KnownShape({6, 6});
+  shapes[1] = KnownShape({6, 24});
+  shapes[2] = KnownShape({24});
+  shapes[3] = KnownShape({2, 4});
+  shapes[4] = KnownShape({3});
+  return shapes;
+}
+
+std::array<WorkspaceInputShape, 7> PackedPmhaShapes() {
+  std::array<WorkspaceInputShape, 7> shapes;
+  shapes[0] = KnownShape({6, 2, 3, 4});
+  shapes[4] = KnownShape({2, 4});
+  shapes[5] = KnownShape({3});
+  return shapes;
+}
+
+std::array<WorkspaceInputShape, 7> SeparatePmhaShapes() {
+  std::array<WorkspaceInputShape, 7> shapes;
+  shapes[0] = KnownShape({6, 8});
+  shapes[1] = KnownShape({6, 8});
+  shapes[2] = KnownShape({6, 8});
+  shapes[4] = KnownShape({2, 4});
+  shapes[5] = KnownShape({3});
+  return shapes;
+}
+
+std::array<WorkspaceInputShape, 7> PackedPmhaShapes(
+    int64_t sequence_length, int64_t head_size = 64) {
+  std::array<WorkspaceInputShape, 7> shapes;
+  shapes[0] = KnownShape({sequence_length, 1, 3, head_size});
+  shapes[4] = KnownShape({1, sequence_length});
+  shapes[5] = KnownShape({2});
+  return shapes;
+}
+
+std::array<WorkspaceInputShape, 7> SeparatePmhaShapes(
+    int64_t sequence_length, bool has_attention_bias, int64_t head_size = 64) {
+  std::array<WorkspaceInputShape, 7> shapes;
+  shapes[0] = KnownShape({sequence_length, head_size});
+  shapes[1] = KnownShape({sequence_length, head_size});
+  shapes[2] = KnownShape({sequence_length, head_size});
+  shapes[4] = KnownShape({1, sequence_length});
+  shapes[5] = KnownShape({2});
+  if (has_attention_bias) {
+    shapes[6] = KnownShape({1, 1, sequence_length, sequence_length});
+  }
+  return shapes;
+}
+
+PackedAttentionWorkspaceEstimateConfig PaConfig() {
+  PackedAttentionWorkspaceEstimateConfig config;
+  config.op = PackedAttentionWorkspaceOperator::PackedAttention;
+  config.element_size = 2;
+  config.num_heads = 2;
+  config.qkv_hidden_sizes_count = 3;
+  config.qkv_hidden_sizes = {8, 8, 8};
+  return config;
+}
+
+PackedAttentionWorkspaceEstimateConfig PmhaConfig() {
+  PackedAttentionWorkspaceEstimateConfig config;
+  config.op = PackedAttentionWorkspaceOperator::PackedMultiHeadAttention;
+  config.element_size = 2;
+  config.num_heads = 2;
+  return config;
+}
+
+PackedAttentionWorkspaceEstimateConfig PmhaConfig(size_t element_size) {
+  auto config = PmhaConfig();
+  config.element_size = element_size;
+  config.num_heads = 1;
+  return config;
+}
+
+cudaDeviceProp Sm80Device() {
+  cudaDeviceProp device_prop{};
+  device_prop.major = 8;
+  device_prop.minor = 0;
+  return device_prop;
+}
+
+PackedAttentionProblem RoutePaProblem(int32_t head_size = 64) {
+  PackedAttentionProblem problem;
+  problem.element_size = 2;
+  problem.token_count = 128;
+  problem.batch_size = 1;
+  problem.sequence_length = 128;
+  problem.num_heads = 1;
+  problem.input_hidden_size = head_size;
+  problem.hidden_size = head_size;
+  problem.v_hidden_size = head_size;
+  problem.qk_head_size = head_size;
+  problem.v_head_size = head_size;
+  problem.qkv_materialization_index_width =
+      contrib::cuda::GetPackedAttentionQkvMaterializationIndexWidth(head_size, head_size);
+  return problem;
+}
+
+PackedMultiHeadAttentionProblem RoutePmhaProblem(int32_t head_size = 64) {
+  PackedMultiHeadAttentionProblem problem;
+  problem.element_size = 2;
+  problem.token_count = 128;
+  problem.batch_size = 1;
+  problem.sequence_length = 128;
+  problem.num_heads = 1;
+  problem.hidden_size = head_size;
+  problem.v_hidden_size = head_size;
+  problem.qk_head_size = head_size;
+  problem.v_head_size = head_size;
+  problem.qkv_format = PackedMultiHeadAttentionQkvFormat::Separate;
+  problem.qkv_materialization_index_width =
+      contrib::cuda::GetPackedAttentionQkvMaterializationIndexWidth(head_size, head_size);
+  return problem;
+}
+
+bool HasRoute(PackedAttentionBackendMask mask, PackedAttentionBackend backend) {
+  return contrib::cuda::HasPackedAttentionBackend(mask, backend);
+}
+
+PackedMultiHeadAttentionProblem BuildPmhaProblem(
+    int32_t sequence_length, size_t element_size, bool packed,
+    bool has_attention_bias = false, int32_t head_size = 64) {
+  PackedMultiHeadAttentionInputShapes inputs;
+  inputs.query = packed
+                     ? Shape({sequence_length, 1, 3, head_size})
+                     : Shape({sequence_length, head_size});
+  inputs.token_offset = Shape({1, sequence_length});
+  inputs.cumulative_sequence_length = Shape({2});
+  inputs.element_size = element_size;
+  inputs.num_heads = 1;
+  if (!packed) {
+    inputs.has_key = true;
+    inputs.has_value = true;
+    inputs.key = Shape({sequence_length, head_size});
+    inputs.value = Shape({sequence_length, head_size});
+  }
+  inputs.has_attention_bias = has_attention_bias;
+  if (has_attention_bias) {
+    inputs.attention_bias = Shape({1, 1, sequence_length, sequence_length});
+  }
+
+  const auto result = BuildPackedMultiHeadAttentionProblem(inputs);
+  EXPECT_TRUE(result.status.IsOK()) << result.status.message;
+  return result.problem;
+}
+
+void ExpectPmhaAggregateUsesMaximum(
+    const PackedMultiHeadAttentionProblem& problem,
+    PackedAttentionBackendMask routes,
+    const PackedAttentionWorkspaceAggregate& aggregate) {
+  size_t maximum = 0;
+  size_t sum = 0;
+  size_t nonzero_route_count = 0;
+  for (PackedAttentionBackend backend :
+       {PackedAttentionBackend::Trt, PackedAttentionBackend::Flash,
+        PackedAttentionBackend::MemoryEfficient, PackedAttentionBackend::Unfused}) {
+    if (!HasRoute(routes, backend)) {
+      continue;
+    }
+
+    auto route_problem = problem;
+    route_problem.backend = backend;
+    route_problem.trt_runner_available = backend == PackedAttentionBackend::Trt;
+    const auto route = GetPackedMultiHeadAttentionWorkspaceRecipe(route_problem);
+    ASSERT_TRUE(route.status.IsOK()) << route.status.message;
+    maximum = std::max(maximum, route.recipe.attention_workspace_bytes);
+    sum += route.recipe.attention_workspace_bytes;
+    nonzero_route_count += route.recipe.attention_workspace_bytes != 0 ? 1U : 0U;
+  }
+
+  EXPECT_EQ(aggregate.projection_bytes, 0U);
+  EXPECT_EQ(aggregate.attention_workspace_bytes, maximum);
+  EXPECT_EQ(aggregate.total_workspace_bytes, maximum);
+  if (nonzero_route_count > 1) {
+    EXPECT_LT(aggregate.attention_workspace_bytes, sum);
+  }
+}
+
+std::optional<PackedAttentionWorkspaceAggregate> EstimateFromNode(
+    const char* op_type,
+    int32_t element_type,
+    std::optional<int64_t> num_heads,
+    std::optional<std::vector<int64_t>> qkv_hidden_sizes,
+    gsl::span<const WorkspaceInputShape> input_shapes,
+    const AttentionKernelOptions& options) {
+  ONNX_NAMESPACE::TypeProto input_type;
+  input_type.mutable_tensor_type()->set_elem_type(element_type);
+  NodeArg input{"input", &input_type};
+
+  NodeAttributes attributes;
+  if (num_heads.has_value()) {
+    ONNX_NAMESPACE::AttributeProto attribute;
+    attribute.set_name("num_heads");
+    attribute.set_type(ONNX_NAMESPACE::AttributeProto_AttributeType_INT);
+    attribute.set_i(*num_heads);
+    attributes.emplace("num_heads", std::move(attribute));
+  }
+  if (qkv_hidden_sizes.has_value()) {
+    ONNX_NAMESPACE::AttributeProto attribute;
+    attribute.set_name("qkv_hidden_sizes");
+    attribute.set_type(ONNX_NAMESPACE::AttributeProto_AttributeType_INTS);
+    for (int64_t value : *qkv_hidden_sizes) {
+      attribute.add_ints(value);
+    }
+    attributes.emplace("qkv_hidden_sizes", std::move(attribute));
+  }
+
+  const std::vector<NodeArg*> inputs{&input};
+  const std::vector<NodeArg*> outputs;
+  Node node{"packed_attention", op_type, "", inputs, outputs, &attributes, kMSDomain};
+  return EstimatePackedAttentionWorkspace(
+      node, input_shapes, Sm80Device(), options);
+}
+
+void SetValueInfo(ONNX_NAMESPACE::ValueInfoProto& value_info,
+                  const char* name,
+                  int32_t element_type,
+                  std::initializer_list<int64_t> dimensions) {
+  value_info.set_name(name);
+  auto* tensor_type = value_info.mutable_type()->mutable_tensor_type();
+  tensor_type->set_elem_type(element_type);
+  auto* shape = tensor_type->mutable_shape();
+  for (int64_t dimension : dimensions) {
+    shape->add_dim()->set_dim_value(dimension);
+  }
+}
+
+std::string BuildPackedAttentionKernelModel(
+    PackedAttentionWorkspaceOperator op) {
+  ONNX_NAMESPACE::ModelProto model;
+  model.set_ir_version(ONNX_NAMESPACE::IR_VERSION);
+  auto* onnx_opset = model.add_opset_import();
+  onnx_opset->set_domain("");
+  onnx_opset->set_version(17);
+  auto* ms_opset = model.add_opset_import();
+  ms_opset->set_domain(kMSDomain);
+  ms_opset->set_version(1);
+
+  auto* graph = model.mutable_graph();
+  graph->set_name("packed_attention_workspace_level2");
+  auto* node = graph->add_node();
+  node->set_domain(kMSDomain);
+  node->set_name("packed_attention");
+
+  auto* num_heads = node->add_attribute();
+  num_heads->set_name("num_heads");
+  num_heads->set_type(ONNX_NAMESPACE::AttributeProto_AttributeType_INT);
+  num_heads->set_i(2);
+
+  constexpr int32_t kFloat16 =
+      ONNX_NAMESPACE::TensorProto_DataType_FLOAT16;
+  constexpr int32_t kInt32 =
+      ONNX_NAMESPACE::TensorProto_DataType_INT32;
+  if (op == PackedAttentionWorkspaceOperator::PackedAttention) {
+    node->set_op_type("PackedAttention");
+    for (const char* input_name :
+         {"input", "weights", "bias", "token_offset",
+          "cumulative_sequence_length"}) {
+      node->add_input(input_name);
+    }
+    node->add_output("output");
+
+    auto* qkv_hidden_sizes = node->add_attribute();
+    qkv_hidden_sizes->set_name("qkv_hidden_sizes");
+    qkv_hidden_sizes->set_type(
+        ONNX_NAMESPACE::AttributeProto_AttributeType_INTS);
+    qkv_hidden_sizes->add_ints(8);
+    qkv_hidden_sizes->add_ints(8);
+    qkv_hidden_sizes->add_ints(8);
+
+    SetValueInfo(*graph->add_input(), "input", kFloat16, {6, 6});
+    SetValueInfo(*graph->add_input(), "weights", kFloat16, {6, 24});
+    SetValueInfo(*graph->add_input(), "bias", kFloat16, {24});
+    SetValueInfo(*graph->add_input(), "token_offset", kInt32, {2, 4});
+    SetValueInfo(*graph->add_input(), "cumulative_sequence_length",
+                 kInt32, {3});
+    SetValueInfo(*graph->add_output(), "output", kFloat16, {6, 8});
+  } else {
+    node->set_op_type("PackedMultiHeadAttention");
+    node->add_input("query");
+    node->add_input("");
+    node->add_input("");
+    node->add_input("");
+    node->add_input("token_offset");
+    node->add_input("cumulative_sequence_length");
+    node->add_output("output");
+
+    SetValueInfo(*graph->add_input(), "query", kFloat16, {6, 2, 3, 4});
+    SetValueInfo(*graph->add_input(), "token_offset", kInt32, {2, 4});
+    SetValueInfo(*graph->add_input(), "cumulative_sequence_length",
+                 kInt32, {3});
+    SetValueInfo(*graph->add_output(), "output", kFloat16, {6, 8});
+  }
+
+  std::string bytes;
+  model.SerializeToString(&bytes);
+  return bytes;
+}
+
+const Node* FindNodeByOpType(const Graph& graph, const char* op_type) {
+  for (const auto& node : graph.Nodes()) {
+    if (node.OpType() == op_type) {
+      return &node;
+    }
+  }
+  return nullptr;
+}
+
+bool HasCudaDevice() {
+  int device_count = 0;
+  return cudaGetDeviceCount(&device_count) == cudaSuccess &&
+         device_count > 0;
+}
+
+}  // namespace
+
+TEST(PackedAttentionWorkspaceEstimateTest, AggregateUsesMaxOfMutuallyExclusiveRoutes) {
+  PackedAttentionInputShapes pa_inputs;
+  pa_inputs.input = Shape({6, 6});
+  pa_inputs.weights = Shape({6, 24});
+  pa_inputs.bias = Shape({24});
+  pa_inputs.token_offset = Shape({2, 4});
+  pa_inputs.cumulative_sequence_length = Shape({3});
+  pa_inputs.element_size = 2;
+  pa_inputs.num_heads = 2;
+  pa_inputs.qkv_hidden_sizes_count = 3;
+  pa_inputs.qkv_hidden_sizes = {8, 8, 8};
+  auto pa_problem = BuildPackedAttentionProblem(pa_inputs);
+  ASSERT_TRUE(pa_problem.status.IsOK()) << pa_problem.status.message;
+
+  auto mea_problem = pa_problem.problem;
+  mea_problem.backend = PackedAttentionBackend::MemoryEfficient;
+  const auto mea = GetPackedAttentionWorkspaceRecipe(mea_problem);
+  ASSERT_TRUE(mea.status.IsOK()) << mea.status.message;
+  auto unfused_problem = pa_problem.problem;
+  unfused_problem.backend = PackedAttentionBackend::Unfused;
+  const auto unfused = GetPackedAttentionWorkspaceRecipe(unfused_problem);
+  ASSERT_TRUE(unfused.status.IsOK()) << unfused.status.message;
+
+  const auto aggregate = GetPackedAttentionWorkspaceAggregate(
+      pa_problem.problem,
+      PackedAttentionBackendMask::MemoryEfficient |
+          PackedAttentionBackendMask::Unfused);
+  ASSERT_TRUE(aggregate.status.IsOK()) << aggregate.status.message;
+  EXPECT_EQ(aggregate.projection_bytes, mea.recipe.projection_bytes);
+  EXPECT_EQ(aggregate.attention_workspace_bytes,
+            std::max(mea.recipe.attention_workspace_bytes,
+                     unfused.recipe.attention_workspace_bytes));
+  EXPECT_EQ(aggregate.total_workspace_bytes,
+            aggregate.projection_bytes + aggregate.attention_workspace_bytes);
+  EXPECT_NE(aggregate.attention_workspace_bytes,
+            mea.recipe.attention_workspace_bytes +
+                unfused.recipe.attention_workspace_bytes);
+}
+
+TEST(PackedAttentionWorkspaceEstimateTest, StableLevel2SlotLayoutsSumToLevel1Total) {
+  AttentionKernelOptions options;
+  options.InitializeOnce(kMath, true);
+  const auto shapes = PaShapes();
+  const auto estimate = EstimatePackedAttentionWorkspace(
+      PaConfig(), gsl::make_span(shapes), Sm80Device(), options);
+  ASSERT_TRUE(estimate.has_value());
+
+  InlinedVector<WorkspaceRequirement> requirements;
+  SetPackedAttentionWorkspaceRequirements(
+      PackedAttentionWorkspaceOperator::PackedAttention, *estimate, requirements);
+  ASSERT_EQ(requirements.size(), 2U);
+  EXPECT_EQ(requirements[0].slot_id, 0);
+  EXPECT_EQ(requirements[0].size_bytes, estimate->projection_bytes);
+  EXPECT_EQ(requirements[0].alignment_bytes, 0U);
+  EXPECT_EQ(requirements[1].slot_id, 1);
+  EXPECT_EQ(requirements[1].size_bytes, estimate->attention_workspace_bytes);
+  EXPECT_EQ(requirements[1].alignment_bytes, 0U);
+  EXPECT_EQ(requirements[0].size_bytes + requirements[1].size_bytes,
+            estimate->total_workspace_bytes);
+
+  auto graph_problem_inputs = PackedAttentionInputShapes{};
+  graph_problem_inputs.input = Shape({6, 6});
+  graph_problem_inputs.weights = Shape({6, 24});
+  graph_problem_inputs.bias = Shape({24});
+  graph_problem_inputs.token_offset = Shape({2, 4});
+  graph_problem_inputs.cumulative_sequence_length = Shape({3});
+  graph_problem_inputs.element_size = 2;
+  graph_problem_inputs.num_heads = 2;
+  graph_problem_inputs.qkv_hidden_sizes_count = 3;
+  graph_problem_inputs.qkv_hidden_sizes = {8, 8, 8};
+  auto problem = BuildPackedAttentionProblem(graph_problem_inputs);
+  ASSERT_TRUE(problem.status.IsOK()) << problem.status.message;
+  const auto graph_free = GetPackedAttentionWorkspaceAggregate(
+      problem.problem, PackedAttentionBackendMask::Unfused);
+  ASSERT_TRUE(graph_free.status.IsOK()) << graph_free.status.message;
+  EXPECT_EQ(estimate->total_workspace_bytes, graph_free.total_workspace_bytes);
+
+  problem.problem.backend = PackedAttentionBackend::Unfused;
+  const auto runtime_recipe = GetPackedAttentionWorkspaceRecipe(problem.problem);
+  ASSERT_TRUE(runtime_recipe.status.IsOK()) << runtime_recipe.status.message;
+  EXPECT_EQ(estimate->projection_bytes, runtime_recipe.recipe.projection_bytes);
+  EXPECT_EQ(estimate->attention_workspace_bytes,
+            runtime_recipe.recipe.attention_workspace_bytes);
+
+  const auto pmha_estimate = EstimatePackedAttentionWorkspace(
+      PmhaConfig(), gsl::make_span(PackedPmhaShapes()), Sm80Device(), options);
+  ASSERT_TRUE(pmha_estimate.has_value());
+  EXPECT_EQ(pmha_estimate->projection_bytes, 0U);
+  SetPackedAttentionWorkspaceRequirements(
+      PackedAttentionWorkspaceOperator::PackedMultiHeadAttention,
+      *pmha_estimate, requirements);
+  ASSERT_EQ(requirements.size(), 1U);
+  EXPECT_EQ(requirements[0].slot_id, 0);
+  EXPECT_EQ(requirements[0].size_bytes, pmha_estimate->total_workspace_bytes);
+  EXPECT_EQ(requirements[0].alignment_bytes, 0U);
+}
+
+TEST(PackedAttentionWorkspaceEstimateTest, PackedAttentionKernelDeclaresLevel2Slots) {
+  if (!HasCudaDevice()) {
+    GTEST_SKIP() << "A CUDA device is required to construct the CUDA kernel.";
+  }
+
+  SessionOptions session_options;
+  session_options.graph_optimization_level = TransformerLevel::Default;
+  session_options.session_logid = "PackedAttentionWorkspaceLevel2";
+  InferenceSessionWrapper session(session_options, GetEnvironment());
+
+  CUDAExecutionProviderInfo provider_info;
+  provider_info.sdpa_kernel = kMath;
+  auto cuda_ep = std::make_shared<CUDAExecutionProvider>(provider_info);
+  ASSERT_STATUS_OK(session.RegisterExecutionProvider(cuda_ep));
+  const std::string model_bytes = BuildPackedAttentionKernelModel(
+      PackedAttentionWorkspaceOperator::PackedAttention);
+  ASSERT_STATUS_OK(
+      session.Load(model_bytes.data(), static_cast<int>(model_bytes.size())));
+  ASSERT_STATUS_OK(session.Initialize());
+
+  const Graph& graph = session.GetGraph();
+  const Node* node = FindNodeByOpType(graph, "PackedAttention");
+  ASSERT_NE(node, nullptr);
+  ASSERT_EQ(node->GetExecutionProviderType(), kCudaExecutionProvider);
+  const OpKernel* kernel =
+      session.GetSessionState().GetKernel(node->Index());
+  ASSERT_NE(kernel, nullptr);
+
+  const auto shapes = PaShapes();
+  const auto expected = EstimatePackedAttentionWorkspace(
+      PaConfig(), gsl::make_span(shapes), cuda_ep->GetDeviceProp(),
+      *cuda_ep->GetAttentionKernelOptions());
+  ASSERT_TRUE(expected.has_value());
+
+  InlinedVector<WorkspaceRequirement> requirements;
+  ASSERT_STATUS_OK(kernel->DeclareWorkspaceRequirements(
+      gsl::make_span(shapes), requirements));
+  ASSERT_EQ(requirements.size(), 2U);
+  EXPECT_EQ(requirements[0].slot_id, 0);
+  EXPECT_EQ(requirements[0].size_bytes, expected->projection_bytes);
+  EXPECT_EQ(requirements[1].slot_id, 1);
+  EXPECT_EQ(requirements[1].size_bytes,
+            expected->attention_workspace_bytes);
+
+  auto zero_shapes = shapes;
+  zero_shapes[0] = KnownShape({0, 6});
+  ASSERT_STATUS_OK(kernel->DeclareWorkspaceRequirements(
+      gsl::make_span(zero_shapes), requirements));
+  EXPECT_TRUE(requirements.empty());
+}
+
+TEST(PackedAttentionWorkspaceEstimateTest, PackedMultiHeadAttentionKernelDeclaresLevel2Slot) {
+  if (!HasCudaDevice()) {
+    GTEST_SKIP() << "A CUDA device is required to construct the CUDA kernel.";
+  }
+
+  SessionOptions session_options;
+  session_options.graph_optimization_level = TransformerLevel::Default;
+  session_options.session_logid = "PackedMultiHeadAttentionWorkspaceLevel2";
+  InferenceSessionWrapper session(session_options, GetEnvironment());
+
+  CUDAExecutionProviderInfo provider_info;
+  provider_info.sdpa_kernel = kMath;
+  auto cuda_ep = std::make_shared<CUDAExecutionProvider>(provider_info);
+  ASSERT_STATUS_OK(session.RegisterExecutionProvider(cuda_ep));
+  const std::string model_bytes = BuildPackedAttentionKernelModel(
+      PackedAttentionWorkspaceOperator::PackedMultiHeadAttention);
+  ASSERT_STATUS_OK(
+      session.Load(model_bytes.data(), static_cast<int>(model_bytes.size())));
+  ASSERT_STATUS_OK(session.Initialize());
+
+  const Graph& graph = session.GetGraph();
+  const Node* node = FindNodeByOpType(graph, "PackedMultiHeadAttention");
+  ASSERT_NE(node, nullptr);
+  ASSERT_EQ(node->GetExecutionProviderType(), kCudaExecutionProvider);
+  const OpKernel* kernel =
+      session.GetSessionState().GetKernel(node->Index());
+  ASSERT_NE(kernel, nullptr);
+
+  const auto shapes = PackedPmhaShapes();
+  const auto expected = EstimatePackedAttentionWorkspace(
+      PmhaConfig(), gsl::make_span(shapes), cuda_ep->GetDeviceProp(),
+      *cuda_ep->GetAttentionKernelOptions());
+  ASSERT_TRUE(expected.has_value());
+
+  InlinedVector<WorkspaceRequirement> requirements;
+  ASSERT_STATUS_OK(kernel->DeclareWorkspaceRequirements(
+      gsl::make_span(shapes), requirements));
+  ASSERT_EQ(requirements.size(), 1U);
+  EXPECT_EQ(requirements[0].slot_id, 0);
+  EXPECT_EQ(requirements[0].size_bytes,
+            expected->attention_workspace_bytes);
+
+  auto zero_shapes = shapes;
+  zero_shapes[0] = KnownShape({0, 2, 3, 4});
+  ASSERT_STATUS_OK(kernel->DeclareWorkspaceRequirements(
+      gsl::make_span(zero_shapes), requirements));
+  EXPECT_TRUE(requirements.empty());
+}
+
+TEST(PackedAttentionWorkspaceEstimateTest, PositionalShapesHandlePmhaHolesAndLayouts) {
+  AttentionKernelOptions options;
+  options.InitializeOnce(kMath, true);
+
+  const auto packed = EstimatePackedAttentionWorkspace(
+      PmhaConfig(), gsl::make_span(PackedPmhaShapes()), Sm80Device(), options);
+  ASSERT_TRUE(packed.has_value());
+  EXPECT_GT(packed->attention_workspace_bytes, 0U);
+
+  auto separate_shapes = SeparatePmhaShapes();
+  const auto separate = EstimatePackedAttentionWorkspace(
+      PmhaConfig(), gsl::make_span(separate_shapes), Sm80Device(), options);
+  ASSERT_TRUE(separate.has_value());
+  EXPECT_GT(separate->attention_workspace_bytes, 0U);
+
+  separate_shapes[3] = KnownShape({24});
+  const auto with_bias = EstimatePackedAttentionWorkspace(
+      PmhaConfig(), gsl::make_span(separate_shapes), Sm80Device(), options);
+  ASSERT_TRUE(with_bias.has_value());
+}
+
+TEST(PackedAttentionWorkspaceEstimateTest, UnknownAndMissingRequiredShapesAreUnavailable) {
+  AttentionKernelOptions options;
+  options.InitializeOnce(kMath, true);
+
+  auto pa_shapes = PaShapes();
+  pa_shapes[1] = KnownShape({-1, 24});
+  EXPECT_FALSE(EstimatePackedAttentionWorkspace(
+                   PaConfig(), gsl::make_span(pa_shapes), Sm80Device(), options)
+                   .has_value());
+
+  pa_shapes = PaShapes();
+  pa_shapes[3] = WorkspaceInputShape::PresentWithoutShape();
+  EXPECT_FALSE(EstimatePackedAttentionWorkspace(
+                   PaConfig(), gsl::make_span(pa_shapes), Sm80Device(), options)
+                   .has_value());
+
+  pa_shapes = PaShapes();
+  pa_shapes[4] = WorkspaceInputShape{};
+  EXPECT_FALSE(EstimatePackedAttentionWorkspace(
+                   PaConfig(), gsl::make_span(pa_shapes), Sm80Device(), options)
+                   .has_value());
+
+  auto pmha_shapes = SeparatePmhaShapes();
+  pmha_shapes[2] = WorkspaceInputShape::PresentWithoutShape();
+  EXPECT_FALSE(EstimatePackedAttentionWorkspace(
+                   PmhaConfig(), gsl::make_span(pmha_shapes), Sm80Device(), options)
+                   .has_value());
+
+  pmha_shapes = SeparatePmhaShapes();
+  pmha_shapes[6] = WorkspaceInputShape::PresentWithoutShape();
+  EXPECT_FALSE(EstimatePackedAttentionWorkspace(
+                   PmhaConfig(), gsl::make_span(pmha_shapes), Sm80Device(), options)
+                   .has_value());
+}
+
+TEST(PackedAttentionWorkspaceEstimateTest, ZeroShapeHintsAreUnavailable) {
+  AttentionKernelOptions options;
+  options.InitializeOnce(kMath, true);
+
+  auto pa_shapes = PaShapes();
+  pa_shapes[0] = KnownShape({0, 6});
+  EXPECT_FALSE(EstimatePackedAttentionWorkspace(
+                   PaConfig(), gsl::make_span(pa_shapes), Sm80Device(), options)
+                   .has_value());
+  PackedAttentionInputShapes pa_inputs;
+  pa_inputs.input = Shape({0, 6});
+  pa_inputs.weights = Shape({6, 24});
+  pa_inputs.bias = Shape({24});
+  pa_inputs.token_offset = Shape({2, 4});
+  pa_inputs.cumulative_sequence_length = Shape({3});
+  pa_inputs.element_size = 2;
+  pa_inputs.num_heads = 2;
+  pa_inputs.qkv_hidden_sizes_count = 3;
+  pa_inputs.qkv_hidden_sizes = {8, 8, 8};
+  auto pa_problem = BuildPackedAttentionProblem(pa_inputs);
+  ASSERT_TRUE(pa_problem.status.IsOK()) << pa_problem.status.message;
+  auto zero_aggregate = GetPackedAttentionWorkspaceAggregate(
+      pa_problem.problem, PackedAttentionBackendMask::Unfused);
+  ASSERT_TRUE(zero_aggregate.status.IsOK())
+      << zero_aggregate.status.message;
+  EXPECT_EQ(zero_aggregate.total_workspace_bytes, 0U);
+
+  auto zero_v_config = PaConfig();
+  zero_v_config.qkv_hidden_sizes = {8, 8, 0};
+  pa_shapes = PaShapes();
+  pa_shapes[1] = KnownShape({6, 16});
+  pa_shapes[2] = KnownShape({16});
+  EXPECT_FALSE(EstimatePackedAttentionWorkspace(
+                   zero_v_config, gsl::make_span(pa_shapes), Sm80Device(), options)
+                   .has_value());
+  pa_inputs.input = Shape({6, 6});
+  pa_inputs.weights = Shape({6, 16});
+  pa_inputs.bias = Shape({16});
+  pa_inputs.qkv_hidden_sizes = {8, 8, 0};
+  pa_problem = BuildPackedAttentionProblem(pa_inputs);
+  ASSERT_TRUE(pa_problem.status.IsOK()) << pa_problem.status.message;
+  zero_aggregate = GetPackedAttentionWorkspaceAggregate(
+      pa_problem.problem, PackedAttentionBackendMask::Unfused);
+  ASSERT_TRUE(zero_aggregate.status.IsOK())
+      << zero_aggregate.status.message;
+  EXPECT_EQ(zero_aggregate.total_workspace_bytes, 0U);
+
+  auto pmha_shapes = PackedPmhaShapes();
+  pmha_shapes[0] = KnownShape({0, 2, 3, 4});
+  EXPECT_FALSE(EstimatePackedAttentionWorkspace(
+                   PmhaConfig(), gsl::make_span(pmha_shapes), Sm80Device(), options)
+                   .has_value());
+  PackedMultiHeadAttentionInputShapes pmha_inputs;
+  pmha_inputs.query = Shape({0, 2, 3, 4});
+  pmha_inputs.token_offset = Shape({2, 4});
+  pmha_inputs.cumulative_sequence_length = Shape({3});
+  pmha_inputs.element_size = 2;
+  pmha_inputs.num_heads = 2;
+  auto pmha_problem = BuildPackedMultiHeadAttentionProblem(pmha_inputs);
+  ASSERT_TRUE(pmha_problem.status.IsOK()) << pmha_problem.status.message;
+  zero_aggregate = GetPackedMultiHeadAttentionWorkspaceAggregate(
+      pmha_problem.problem, PackedAttentionBackendMask::Unfused);
+  ASSERT_TRUE(zero_aggregate.status.IsOK())
+      << zero_aggregate.status.message;
+  EXPECT_EQ(zero_aggregate.total_workspace_bytes, 0U);
+
+  pmha_shapes = SeparatePmhaShapes();
+  pmha_shapes[0] = KnownShape({0, 8});
+  pmha_shapes[1] = KnownShape({0, 8});
+  pmha_shapes[2] = KnownShape({0, 8});
+  EXPECT_FALSE(EstimatePackedAttentionWorkspace(
+                   PmhaConfig(), gsl::make_span(pmha_shapes), Sm80Device(), options)
+                   .has_value());
+  pmha_inputs.query = Shape({0, 8});
+  pmha_inputs.key = Shape({0, 8});
+  pmha_inputs.value = Shape({0, 8});
+  pmha_inputs.has_key = true;
+  pmha_inputs.has_value = true;
+  pmha_problem = BuildPackedMultiHeadAttentionProblem(pmha_inputs);
+  ASSERT_TRUE(pmha_problem.status.IsOK()) << pmha_problem.status.message;
+  zero_aggregate = GetPackedMultiHeadAttentionWorkspaceAggregate(
+      pmha_problem.problem, PackedAttentionBackendMask::Unfused);
+  ASSERT_TRUE(zero_aggregate.status.IsOK())
+      << zero_aggregate.status.message;
+  EXPECT_EQ(zero_aggregate.total_workspace_bytes, 0U);
+}
+
+TEST(PackedAttentionWorkspaceEstimateTest, RouteSetConservativelyIncludesFallbacks) {
+  const auto device = Sm80Device();
+
+  AttentionKernelOptions all_options;
+  all_options.InitializeOnce(kFlash | kMea | kTrt | kTrtFlash | kMath, true);
+  const auto pa_routes =
+      GetPackedAttentionFeasibleBackends(RoutePaProblem(), device, all_options);
+  EXPECT_TRUE(HasRoute(pa_routes, PackedAttentionBackend::Trt));
+#if USE_MEMORY_EFFICIENT_ATTENTION
+  EXPECT_TRUE(HasRoute(pa_routes, PackedAttentionBackend::MemoryEfficient));
+#endif
+  EXPECT_TRUE(HasRoute(pa_routes, PackedAttentionBackend::Unfused));
+  EXPECT_FALSE(HasRoute(pa_routes, PackedAttentionBackend::Flash));
+
+  const auto flash_routes =
+      GetPackedMultiHeadAttentionFeasibleBackends(RoutePmhaProblem(), device, all_options);
+#if USE_FLASH_ATTENTION
+  EXPECT_TRUE(HasRoute(flash_routes, PackedAttentionBackend::Flash));
+#else
+  EXPECT_FALSE(HasRoute(flash_routes, PackedAttentionBackend::Flash));
+#endif
+  EXPECT_TRUE(HasRoute(flash_routes, PackedAttentionBackend::Unfused));
+
+  AttentionKernelOptions trt_mea_options;
+  trt_mea_options.InitializeOnce(kMea | kTrt | kTrtFlash | kMath, true);
+  const auto trt_fallback_routes =
+      GetPackedMultiHeadAttentionFeasibleBackends(
+          RoutePmhaProblem(), device, trt_mea_options);
+  EXPECT_TRUE(HasRoute(trt_fallback_routes, PackedAttentionBackend::Trt));
+#if USE_MEMORY_EFFICIENT_ATTENTION
+  EXPECT_TRUE(HasRoute(trt_fallback_routes, PackedAttentionBackend::MemoryEfficient));
+#endif
+  EXPECT_TRUE(HasRoute(trt_fallback_routes, PackedAttentionBackend::Unfused));
+
+  AttentionKernelOptions mea_options;
+  mea_options.InitializeOnce(kMea | kMath, true);
+  const auto mea_routes =
+      GetPackedMultiHeadAttentionFeasibleBackends(RoutePmhaProblem(), device, mea_options);
+#if USE_MEMORY_EFFICIENT_ATTENTION
+  EXPECT_TRUE(HasRoute(mea_routes, PackedAttentionBackend::MemoryEfficient));
+#endif
+  EXPECT_TRUE(HasRoute(mea_routes, PackedAttentionBackend::Unfused));
+
+  AttentionKernelOptions math_options;
+  math_options.InitializeOnce(kMath, true);
+  EXPECT_EQ(GetPackedMultiHeadAttentionFeasibleBackends(
+                RoutePmhaProblem(), device, math_options),
+            PackedAttentionBackendMask::Unfused);
+  EXPECT_EQ(GetPackedAttentionFeasibleBackends(
+                RoutePaProblem(7), device, math_options),
+            PackedAttentionBackendMask::Unfused);
+}
+
+TEST(PackedAttentionWorkspaceEstimateTest, DefaultPackedPmhaCrossesFlashThreshold) {
+  AttentionKernelOptions options;
+  options.InitializeOnce(0, true);
+  EXPECT_EQ(options.MinSeqLenForFlashAttentionPackedQkv(), 513);
+
+  const auto maximum_problem =
+      BuildPmhaProblem(/*sequence_length=*/1024, /*element_size=*/2,
+                       /*packed=*/true, /*has_attention_bias=*/false,
+                       /*head_size=*/128);
+  const auto maximum_routes = GetPackedMultiHeadAttentionFeasibleBackends(
+      maximum_problem, Sm80Device(), options);
+  EXPECT_TRUE(HasRoute(maximum_routes, PackedAttentionBackend::Unfused));
+#if USE_FLASH_ATTENTION
+  EXPECT_TRUE(HasRoute(maximum_routes, PackedAttentionBackend::Flash));
+#endif
+
+  const auto runtime_problem =
+      BuildPmhaProblem(/*sequence_length=*/512, /*element_size=*/2,
+                       /*packed=*/true, /*has_attention_bias=*/false,
+                       /*head_size=*/128);
+  const auto runtime_bound_routes = GetPackedMultiHeadAttentionFeasibleBackends(
+      runtime_problem, Sm80Device(), options);
+  EXPECT_FALSE(HasRoute(runtime_bound_routes, PackedAttentionBackend::Flash));
+  EXPECT_TRUE(HasRoute(runtime_bound_routes, PackedAttentionBackend::Unfused));
+
+  const auto shapes = PackedPmhaShapes(/*sequence_length=*/1024,
+                                       /*head_size=*/128);
+  const auto estimate = EstimatePackedAttentionWorkspace(
+      PmhaConfig(/*element_size=*/2), gsl::make_span(shapes),
+      Sm80Device(), options);
+  ASSERT_TRUE(estimate.has_value());
+  ExpectPmhaAggregateUsesMaximum(maximum_problem, maximum_routes, *estimate);
+}
+
+TEST(PackedAttentionWorkspaceEstimateTest, DefaultFp32PmhaCrossesMeaThreshold) {
+  AttentionKernelOptions options;
+  options.InitializeOnce(0, true);
+  EXPECT_EQ(options.MinSeqLenForEfficientAttentionFp32(), 256);
+
+  const auto maximum_problem =
+      BuildPmhaProblem(/*sequence_length=*/512, /*element_size=*/4,
+                       /*packed=*/false, /*has_attention_bias=*/true);
+  const auto maximum_routes = GetPackedMultiHeadAttentionFeasibleBackends(
+      maximum_problem, Sm80Device(), options);
+  EXPECT_TRUE(HasRoute(maximum_routes, PackedAttentionBackend::Unfused));
+#if USE_MEMORY_EFFICIENT_ATTENTION
+  EXPECT_TRUE(HasRoute(maximum_routes, PackedAttentionBackend::MemoryEfficient));
+#endif
+
+  const auto smaller_problem =
+      BuildPmhaProblem(/*sequence_length=*/128, /*element_size=*/4,
+                       /*packed=*/false, /*has_attention_bias=*/true);
+  const auto smaller_routes = GetPackedMultiHeadAttentionFeasibleBackends(
+      smaller_problem, Sm80Device(), options);
+  EXPECT_FALSE(HasRoute(smaller_routes, PackedAttentionBackend::MemoryEfficient));
+  EXPECT_TRUE(HasRoute(smaller_routes, PackedAttentionBackend::Unfused));
+
+  const auto shapes = SeparatePmhaShapes(
+      /*sequence_length=*/512, /*has_attention_bias=*/true);
+  const auto estimate = EstimatePackedAttentionWorkspace(
+      PmhaConfig(/*element_size=*/4), gsl::make_span(shapes),
+      Sm80Device(), options);
+  ASSERT_TRUE(estimate.has_value());
+  ExpectPmhaAggregateUsesMaximum(maximum_problem, maximum_routes, *estimate);
+}
+
+TEST(PackedAttentionWorkspaceEstimateTest, AttentionBiasAlignmentIsPossibleBelowMaximum) {
+  AttentionKernelOptions options;
+  options.InitializeOnce(0, true);
+
+  const auto too_small_problem =
+      BuildPmhaProblem(/*sequence_length=*/7, /*element_size=*/2,
+                       /*packed=*/false, /*has_attention_bias=*/true);
+  const auto too_small_routes = GetPackedMultiHeadAttentionFeasibleBackends(
+      too_small_problem, Sm80Device(), options);
+  EXPECT_FALSE(HasRoute(too_small_routes, PackedAttentionBackend::MemoryEfficient));
+  EXPECT_TRUE(HasRoute(too_small_routes, PackedAttentionBackend::Unfused));
+
+  for (int32_t maximum_sequence_length : {10, 16}) {
+    SCOPED_TRACE(maximum_sequence_length);
+    const auto problem =
+        BuildPmhaProblem(maximum_sequence_length, /*element_size=*/2,
+                         /*packed=*/false, /*has_attention_bias=*/true);
+    const auto routes = GetPackedMultiHeadAttentionFeasibleBackends(
+        problem, Sm80Device(), options);
+    EXPECT_TRUE(HasRoute(routes, PackedAttentionBackend::Unfused));
+#if USE_MEMORY_EFFICIENT_ATTENTION
+    EXPECT_TRUE(HasRoute(routes, PackedAttentionBackend::MemoryEfficient));
+#endif
+
+    const auto shapes = SeparatePmhaShapes(
+        maximum_sequence_length, /*has_attention_bias=*/true);
+    const auto estimate = EstimatePackedAttentionWorkspace(
+        PmhaConfig(/*element_size=*/2), gsl::make_span(shapes),
+        Sm80Device(), options);
+    ASSERT_TRUE(estimate.has_value());
+    ExpectPmhaAggregateUsesMaximum(problem, routes, *estimate);
+  }
+}
+
+TEST(PackedAttentionWorkspaceEstimateTest, NodeOverloadParsesAttributesDtypeAndShapes) {
+  AttentionKernelOptions options;
+  options.InitializeOnce(kMath, true);
+
+  const auto pa_shapes = PaShapes();
+  const auto pa = EstimateFromNode(
+      "PackedAttention", ONNX_NAMESPACE::TensorProto_DataType_FLOAT16,
+      /*num_heads=*/2, std::vector<int64_t>{8, 8, 8},
+      gsl::make_span(pa_shapes), options);
+  ASSERT_TRUE(pa.has_value());
+  EXPECT_GT(pa->total_workspace_bytes, 0U);
+
+  const auto pmha_shapes = PackedPmhaShapes();
+  const auto pmha = EstimateFromNode(
+      "PackedMultiHeadAttention", ONNX_NAMESPACE::TensorProto_DataType_FLOAT16,
+      /*num_heads=*/2, std::nullopt, gsl::make_span(pmha_shapes), options);
+  ASSERT_TRUE(pmha.has_value());
+  EXPECT_GT(pmha->total_workspace_bytes, 0U);
+  EXPECT_EQ(pmha->projection_bytes, 0U);
+
+  EXPECT_FALSE(EstimateFromNode(
+                   "PackedAttention", ONNX_NAMESPACE::TensorProto_DataType_FLOAT16,
+                   std::nullopt, std::vector<int64_t>{8, 8, 8},
+                   gsl::make_span(pa_shapes), options)
+                   .has_value());
+  EXPECT_FALSE(EstimateFromNode(
+                   "PackedAttention", ONNX_NAMESPACE::TensorProto_DataType_FLOAT16,
+                   /*num_heads=*/0, std::vector<int64_t>{8, 8, 8},
+                   gsl::make_span(pa_shapes), options)
+                   .has_value());
+  EXPECT_FALSE(EstimateFromNode(
+                   "PackedAttention", ONNX_NAMESPACE::TensorProto_DataType_INT32,
+                   /*num_heads=*/2, std::vector<int64_t>{8, 8, 8},
+                   gsl::make_span(pa_shapes), options)
+                   .has_value());
+  EXPECT_FALSE(EstimateFromNode(
+                   "PackedAttention", ONNX_NAMESPACE::TensorProto_DataType_FLOAT16,
+                   /*num_heads=*/2, std::vector<int64_t>{8, 8},
+                   gsl::make_span(pa_shapes), options)
+                   .has_value());
+  EXPECT_FALSE(EstimateFromNode(
+                   "PackedAttention", ONNX_NAMESPACE::TensorProto_DataType_FLOAT16,
+                   /*num_heads=*/2, std::vector<int64_t>{8, -8, 8},
+                   gsl::make_span(pa_shapes), options)
+                   .has_value());
+  EXPECT_FALSE(EstimateFromNode(
+                   "PackedAttention", ONNX_NAMESPACE::TensorProto_DataType_FLOAT16,
+                   /*num_heads=*/2, std::vector<int64_t>{7, 7, 8},
+                   gsl::make_span(pa_shapes), options)
+                   .has_value());
+  EXPECT_FALSE(EstimateFromNode(
+                   "PackedMultiHeadAttention", ONNX_NAMESPACE::TensorProto_DataType_FLOAT16,
+                   /*num_heads=*/2, std::vector<int64_t>{8, 8, 8},
+                   gsl::make_span(pmha_shapes), options)
+                   .has_value());
+}
+
+TEST(PackedAttentionWorkspaceEstimateTest, AttentionBiasDisablesFlashAndTrtCandidates) {
+  AttentionKernelOptions options;
+  options.InitializeOnce(kFlash | kMea | kTrt | kTrtFlash | kMath, true);
+  auto problem = RoutePmhaProblem();
+  problem.has_attention_bias = true;
+  problem.broadcast_attn_bias_dim_0 = true;
+  problem.broadcast_attn_bias_dim_1 = true;
+  const auto routes =
+      GetPackedMultiHeadAttentionFeasibleBackends(problem, Sm80Device(), options);
+  EXPECT_FALSE(HasRoute(routes, PackedAttentionBackend::Flash));
+  EXPECT_FALSE(HasRoute(routes, PackedAttentionBackend::Trt));
+#if USE_MEMORY_EFFICIENT_ATTENTION
+  EXPECT_TRUE(HasRoute(routes, PackedAttentionBackend::MemoryEfficient));
+#endif
+  EXPECT_TRUE(HasRoute(routes, PackedAttentionBackend::Unfused));
+}
+
+TEST(PackedAttentionWorkspaceEstimateTest, IncludedRouteOverflowMakesAggregateUnavailable) {
+  PackedMultiHeadAttentionProblem problem;
+  problem.element_size = 2;
+  problem.token_count = 1;
+  problem.batch_size = 65535;
+  problem.sequence_length = 65535;
+  problem.num_heads = 65535;
+  problem.qk_head_size = 32768;
+  problem.v_head_size = 32768;
+  problem.hidden_size = 65535 * 32768;
+  problem.v_hidden_size = problem.hidden_size;
+  problem.qkv_format = PackedMultiHeadAttentionQkvFormat::Separate;
+  problem.qkv_materialization_index_width =
+      PackedAttentionQkvMaterializationIndexWidth::Vector4;
+
+  problem.backend = PackedAttentionBackend::MemoryEfficient;
+  const auto single_route = GetPackedMultiHeadAttentionWorkspaceRecipe(problem);
+  EXPECT_EQ(single_route.status.error, PackedAttentionWorkspaceError::Overflow);
+
+  const auto aggregate = GetPackedMultiHeadAttentionWorkspaceAggregate(
+      problem, PackedAttentionBackendMask::MemoryEfficient);
+  EXPECT_EQ(aggregate.status.error, PackedAttentionWorkspaceError::Overflow);
+}
+
+TEST(PackedAttentionWorkspaceEstimateTest, InvalidAndEmptyRouteMasksAreDistinguished) {
+  auto nonempty = RoutePaProblem();
+  EXPECT_EQ(GetPackedAttentionWorkspaceAggregate(
+                nonempty, PackedAttentionBackendMask::None)
+                .status.error,
+            PackedAttentionWorkspaceError::InvalidArgument);
+
+  nonempty.token_count = 0;
+  const auto empty = GetPackedAttentionWorkspaceAggregate(
+      nonempty, PackedAttentionBackendMask::None);
+  EXPECT_TRUE(empty.status.IsOK());
+  EXPECT_EQ(empty.total_workspace_bytes, 0U);
+
+  const auto invalid_mask = static_cast<PackedAttentionBackendMask>(1U << 31);
+  EXPECT_EQ(GetPackedAttentionWorkspaceAggregate(nonempty, invalid_mask).status.error,
+            PackedAttentionWorkspaceError::InvalidArgument);
+
+  auto empty_pmha = RoutePmhaProblem();
+  empty_pmha.token_count = 0;
+  EXPECT_EQ(GetPackedMultiHeadAttentionWorkspaceAggregate(empty_pmha, invalid_mask)
+                .status.error,
+            PackedAttentionWorkspaceError::InvalidArgument);
+}
+
+TEST(PackedAttentionWorkspaceEstimateTest, EmptyAggregatesStillValidateProblemGeometry) {
+  auto valid_pa = RoutePaProblem();
+  valid_pa.token_count = 0;
+  auto aggregate =
+      GetPackedAttentionWorkspaceAggregate(valid_pa, PackedAttentionBackendMask::None);
+  ASSERT_TRUE(aggregate.status.IsOK()) << aggregate.status.message;
+  EXPECT_EQ(aggregate.total_workspace_bytes, 0U);
+
+  auto malformed_pa = valid_pa;
+  malformed_pa.input_hidden_size = -1;
+  EXPECT_EQ(GetPackedAttentionWorkspaceAggregate(
+                malformed_pa, PackedAttentionBackendMask::None)
+                .status.error,
+            PackedAttentionWorkspaceError::InvalidArgument);
+
+  malformed_pa = valid_pa;
+  malformed_pa.hidden_size += 1;
+  EXPECT_EQ(GetPackedAttentionWorkspaceAggregate(
+                malformed_pa, PackedAttentionBackendMask::None)
+                .status.error,
+            PackedAttentionWorkspaceError::InvalidArgument);
+
+  auto valid_pmha = RoutePmhaProblem();
+  valid_pmha.token_count = 0;
+  aggregate = GetPackedMultiHeadAttentionWorkspaceAggregate(
+      valid_pmha, PackedAttentionBackendMask::None);
+  ASSERT_TRUE(aggregate.status.IsOK()) << aggregate.status.message;
+  EXPECT_EQ(aggregate.total_workspace_bytes, 0U);
+
+  auto malformed_pmha = valid_pmha;
+  malformed_pmha.batch_size = -1;
+  EXPECT_EQ(GetPackedMultiHeadAttentionWorkspaceAggregate(
+                malformed_pmha, PackedAttentionBackendMask::None)
+                .status.error,
+            PackedAttentionWorkspaceError::InvalidArgument);
+
+  malformed_pmha = valid_pmha;
+  malformed_pmha.hidden_size += 1;
+  EXPECT_EQ(GetPackedMultiHeadAttentionWorkspaceAggregate(
+                malformed_pmha, PackedAttentionBackendMask::None)
+                .status.error,
+            PackedAttentionWorkspaceError::InvalidArgument);
+
+  malformed_pmha = valid_pmha;
+  malformed_pmha.qkv_format =
+      static_cast<PackedMultiHeadAttentionQkvFormat>(-1);
+  EXPECT_EQ(GetPackedMultiHeadAttentionWorkspaceAggregate(
+                malformed_pmha, PackedAttentionBackendMask::None)
+                .status.error,
+            PackedAttentionWorkspaceError::InvalidArgument);
+
+  PackedMultiHeadAttentionInputShapes malformed_presence;
+  malformed_presence.query = Shape({0, 64});
+  malformed_presence.token_offset = Shape({1, 1});
+  malformed_presence.cumulative_sequence_length = Shape({2});
+  malformed_presence.element_size = 2;
+  malformed_presence.num_heads = 1;
+  malformed_presence.has_key = true;
+  malformed_presence.key = Shape({0, 64});
+  EXPECT_EQ(BuildPackedMultiHeadAttentionProblem(malformed_presence)
+                .status.error,
+            PackedAttentionWorkspaceError::InvalidArgument);
+
+  malformed_presence.query = Shape({0, 1, 3, 64});
+  malformed_presence.has_value = true;
+  malformed_presence.value = Shape({0, 64});
+  EXPECT_EQ(BuildPackedMultiHeadAttentionProblem(malformed_presence)
+                .status.error,
+            PackedAttentionWorkspaceError::InvalidArgument);
+}
+
+TEST(PackedAttentionWorkspaceEstimateTest, FailedAggregateEmitsNoRequirements) {
+  PackedAttentionWorkspaceAggregate failed;
+  failed.status.error = PackedAttentionWorkspaceError::InvalidArgument;
+  failed.status.message = "deliberately failed estimate";
+  failed.projection_bytes = 1024;
+  failed.attention_workspace_bytes = 2048;
+  failed.total_workspace_bytes = 3072;
+
+  InlinedVector<WorkspaceRequirement> requirements{
+      WorkspaceRequirement{4096, /*slot_id=*/7, /*alignment_bytes=*/0}};
+  SetPackedAttentionWorkspaceRequirements(
+      PackedAttentionWorkspaceOperator::PackedAttention, failed, requirements);
+  EXPECT_TRUE(requirements.empty());
+
+  requirements.push_back(
+      WorkspaceRequirement{4096, /*slot_id=*/7, /*alignment_bytes=*/0});
+  SetPackedAttentionWorkspaceRequirements(
+      PackedAttentionWorkspaceOperator::PackedMultiHeadAttention,
+      failed, requirements);
+  EXPECT_TRUE(requirements.empty());
+}
+
+}  // namespace test
+}  // namespace onnxruntime
+
+#endif  // !defined(DISABLE_CONTRIB_OPS) && !defined(BUILD_CUDA_EP_AS_PLUGIN)


### PR DESCRIPTION
## Summary

Add MatMulNBits-equivalent operator-side workspace estimation for CUDA
`PackedAttention` and `PackedMultiHeadAttention`:

- Level 1 derives a conservative estimate from the node, resolved input shapes,
  CUDA device properties, and the EP's resolved attention options.
- Level 2 declares the same estimate from positional `WorkspaceInputShape`
  metadata and constructed kernel state.
- Existing graph-free runtime recipes remain the single source of truth for
  workspace bytes and layouts.
- PackedAttention declares one 256-byte-aligned root in slot 0, with internal
  projection and attention regions.
- PackedMultiHeadAttention declares one 256-byte-aligned attention root in slot 0.

Level 1 is log-only, matching the current MatMulNBits pilot. This PR does not
add #32071-specific planner APIs or change runtime `GetScratchBuffer()` behavior.

## Route aggregation

Runtime routes are mutually exclusive, so the estimate uses:

```text
PackedAttention:
  align_up(projection_bytes, 256) + max(feasible TRT, MEA, unfused recipes)

PackedMultiHeadAttention:
  max(feasible Flash, TRT, MEA, unfused recipes)
```

Route reachability is evaluated conservatively for every runtime shape up to
the supplied maximum geometry. This is necessary because Flash/MEA thresholds
and attention-bias alignment gates are not monotonic when moving from a maximum
shape to a smaller runtime shape. Unfused fallback is always retained, and a
failure to size any included route makes the estimate unavailable rather than
silently underestimating.

## Shape and zero semantics

- Missing mandatory inputs, shapeless required inputs, unknown dimensions,
  malformed geometry, and checked-arithmetic overflow produce no estimate.
- `WorkspaceInputShape` does not carry max-shape provenance, so zero-shaped
  framework hints are conservatively treated as unavailable.
- Exact zero behavior remains supported by the graph-free runtime recipes.
- At the current Level-2 boundary, both unavailable and zero are represented by
  an empty requirements list.

## Planner integration

- Both operators fit #32071's current one-slot pilot. Generic framework
  multi-slot support remains unchanged.
- A declaration alone is not planner opt-in. `SupportsPreallocatedWorkspace()`,
  slot-0 retrieval, and PA root slicing must land atomically in the planner
  integration.
- Until then, PA retains its two dynamic allocations and PMHA retains its one
  dynamic allocation.

## Build boundaries

The framework adapters and kernel overrides are excluded from:

- CUDA minimal builds
- `DISABLE_CONTRIB_OPS` builds
- CUDA plugin EP builds

The graph-free workspace recipes remain available to the shared BERT attention
infrastructure where required.

## Validation

- 18/18 PA/PMHA workspace estimator tests
  - includes direct production-kernel Level-2 declaration tests
  - route-threshold, max-not-sum, aligned-root padding/no-padding,
    optional-hole, zero, overflow, and malformed geometry coverage
- 23/23 existing packed-attention workspace recipe tests
- 20/20 existing hand-calculated runtime parity cases
- 26/26 PackedAttention/PackedMultiHeadAttention runtime operator tests
- CUDA provider-test build
- 145 CUDA internal tests executed: 143 passed, 2 unrelated LeanAttention skips
- `DISABLE_CONTRIB_OPS` and CUDA-minimal compile-guard probes
- C++ formatting and diff checks

## Dependency

This is a stacked follow-up to #32312. The base should change to `main` after
#32312 merges.

Tracking: #29775
