### PR TITLE
Pin Ruby for Objective-C API docs

### DIFF
--- a/.github/workflows/publish-objectivec-apidocs.yml
+++ b/.github/workflows/publish-objectivec-apidocs.yml
@@ -39,6 +39,11 @@ jobs:
         add-cmake-to-path: 'true'
         disable-terrapin: 'true'
 
+    - name: Setup Ruby
+      uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1.321.0
+      with:
+        ruby-version: '3.2'
+
     - name: Install Jazzy
       run: |
         sudo gem install jazzy --version 0.14.3


### PR DESCRIPTION
## Summary
- pin the Objective-C API docs workflow to Ruby 3.2
- keep Jazzy 0.14.3 while avoiding its Ruby 3.4 incompatibility

## Validation
- parsed the workflow YAML successfully
- git diff --check