### PR TITLE
[Node.js] Float16Array input reports zero ByteLength with Node 24+ after #27327

### DIFF
--- a/js/node/src/tensor_helper.cc
+++ b/js/node/src/tensor_helper.cc
@@ -200,7 +200,6 @@ Ort::Value NapiValueToOrtValue(Napi::Env env, Napi::Value value, OrtMemoryInfo* 
       ORT_NAPI_THROW_TYPEERROR_IF(!tensorDataValue.IsTypedArray(), env,
                                   "Tensor.data must be a typed array for numeric tensor.");
 
-      auto tensorDataTypedArray = tensorDataValue.As<Napi::TypedArray>();
       std::underlying_type_t<napi_typedarray_type> typedArrayType = tensorDataValue.As<Napi::TypedArray>().TypedArrayType();
 
       // For float16 tensors, accept both Uint16Array and Float16Array.
@@ -217,10 +216,15 @@ Ort::Value NapiValueToOrtValue(Napi::Env env, Napi::Value value, OrtMemoryInfo* 
                                   elemType == ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT16 ? " or Float16Array" : "",
                                   ") for ", tensorTypeString, " tensors, but got typed array (", typedArrayType, ").");
 
-      char* buffer = reinterpret_cast<char*>(tensorDataTypedArray.ArrayBuffer().Data());
-      size_t bufferByteOffset = tensorDataTypedArray.ByteOffset();
-      size_t bufferByteLength = tensorDataTypedArray.ByteLength();
-      return Ort::Value::CreateTensor(cpu_memory_info, buffer + bufferByteOffset, bufferByteLength,
+      size_t typedArrayElementCount = 0;
+      void* typedArrayData = nullptr;
+      NAPI_THROW_IF_FAILED(
+        env,
+        napi_get_typedarray_info(env, tensorDataValue, nullptr, &typedArrayElementCount, &typedArrayData,
+                                 nullptr, nullptr),
+        Ort::Value());
+      const size_t bufferByteLength = typedArrayElementCount * DATA_TYPE_ELEMENT_SIZE_MAP[elemType];
+      return Ort::Value::CreateTensor(cpu_memory_info, typedArrayData, bufferByteLength,
                                       dims.empty() ? nullptr : &dims[0], dims.size(), elemType);
     } else {
       ORT_NAPI_THROW_TYPEERROR_IF(tensorLocation != DATA_LOCATION_GPU_BUFFER, env, "Tensor.location must be 'gpu-buffer' for IO binding.");

--- a/js/node/test/api/simple-api-tests.ts
+++ b/js/node/test/api/simple-api-tests.ts
@@ -111,3 +111,35 @@ describe('API Tests - simple API tests', () => {
     });
   });
 });
+
+describe('API Tests - float16 tensor input', () => {
+  const MODEL = path.join(TEST_DATA_ROOT, 'test_types_float16.onnx');
+  const INPUT_BITS = [0x3c00];
+  const Float16ArrayCtor = (globalThis as { Float16Array?: new (length: number) => object }).Float16Array;
+
+  function assertFloat16Output(output: Tensor): void {
+    assert.strictEqual(output.type, 'float16');
+    const view = output.data as unknown as Uint16Array;
+    assert.deepStrictEqual(Array.from(new Uint16Array(view.buffer, view.byteOffset, view.length)), INPUT_BITS);
+  }
+
+  it('test_types_float16.onnx accepts Uint16Array input data', async () => {
+    const data = Uint16Array.from([0x7fff, INPUT_BITS[0]]).subarray(1);
+    const output = await (
+      await InferenceSession.create(MODEL)
+    ).run({ input: new Tensor('float16', data, [1, 1, 1, 1]) });
+    assertFloat16Output(output.output);
+  });
+
+  it('test_types_float16.onnx accepts Float16Array input data', async function () {
+    if (!Float16ArrayCtor) {
+      this.skip();
+    }
+    const data = new Float16ArrayCtor(1) as unknown as Uint16Array;
+    new Uint16Array(data.buffer)[0] = INPUT_BITS[0];
+    const output = await (await InferenceSession.create(MODEL)).run({
+      input: new Tensor('float16', data, [1, 1, 1, 1]),
+    });
+    assertFloat16Output(output.output);
+  });
+});


### PR DESCRIPTION
# [Node.js] Float16Array input reports zero ByteLength with Node 24+ after #27327

## Description

PR #27327 made the Node.js binding accept both `Uint16Array` and `Float16Array` as data for
`float16` tensors. However, the CPU input path still obtains the byte length via node-addon-api's
`Napi::TypedArray::ByteLength()`, which derives the byte size from an element-size table that
predates `napi_float16_array`. As a result, on runtimes where `globalThis.Float16Array` exists
(Node.js 23+), every `float16` tensor input reaches the binding as a `Float16Array` and reports a
byte length of 0, so `Ort::Value::CreateTensor()` rejects the input with:

```
not enough space: expected 8, got 0
```

This makes `float16` inference unusable on affected runtimes (e.g. Electron 43, which embeds
Node.js 24.18, and Node.js 26). This change fixes the data path so that both `Uint16Array` and
`Float16Array` inputs work on all runtimes.

## Root cause

`onnxruntime-common` maps the `float16` tensor type to `Float16Array` when the runtime provides it
(`js/common/lib/tensor-impl-type-mapping.ts`), and additionally converts a `Uint16Array` passed as
`float16` tensor data into a `Float16Array` view (`js/common/lib/tensor-impl.ts`). Consequently, on
Node.js 23+ the binding always receives a `Float16Array`.

The binding's type check added by #27327 correctly accepts it
(`js/node/src/tensor_helper.cc`, `NapiValueToOrtValue`). The failure happens one step later:

```cpp
char* buffer = reinterpret_cast<char*>(tensorDataTypedArray.ArrayBuffer().Data());
size_t bufferByteOffset = tensorDataTypedArray.ByteOffset();
size_t bufferByteLength = tensorDataTypedArray.ByteLength();  // 0 for Float16Array
```

`node-addon-api` 6.x's `TypedArray::ByteLength()` computes `element_count * element_size` using an
element-size `switch` that has no case for `napi_float16_array` (the type was added to Node-API
after node-addon-api 6.x was released), so it returns 0 for any `Float16Array`, even though the
object itself is valid (`data.length` and `data.byteLength` are correct in JS).

Minimal reproduction (fails on Node.js 23+ with the current binding):

```js
const ort = require('onnxruntime-node');
const data = new Float16Array([1.5, 2.5, 3.5, 4.5]);
const session = await ort.InferenceSession.create('./identity_fp16.onnx'); // Identity, float16 [1,4]
const output = await session.run({ x: new ort.Tensor('float16', data, [1, 4]) });
// Error: not enough space: expected 8, got 0
```

The same failure occurs when passing a plain `Uint16Array`, because the wrapper converts it into a
`Float16Array` view before the binding sees it.

## Fix

Replace the `node-addon-api` accessors with the raw Node-API in the CPU input path of
`NapiValueToOrtValue()`:

```cpp
size_t typedArrayElementCount = 0;
void* typedArrayData = nullptr;
NAPI_THROW_IF_FAILED(
  env,
  napi_get_typedarray_info(env, tensorDataValue, nullptr, &typedArrayElementCount, &typedArrayData,
                           nullptr, nullptr),
  Ort::Value());
const size_t bufferByteLength = typedArrayElementCount * DATA_TYPE_ELEMENT_SIZE_MAP[elemType];
return Ort::Value::CreateTensor(cpu_memory_info, typedArrayData, bufferByteLength,
                                dims.empty() ? nullptr : &dims[0], dims.size(), elemType);
```

`napi_get_typedarray_info()` reports neither the view's type nor its element count incorrectly for
`Float16Array`, and returns the address of the view's first element, so `buffer + byteOffset` is no
longer needed. The byte length is computed from the authoritative `DATA_TYPE_ELEMENT_SIZE_MAP`,
which is consistent with the existing `gpu-buffer` path in the same function
(`DATA_TYPE_ELEMENT_SIZE_MAP[elemType] * elementSize`). `Uint16Array` inputs keep working unchanged.

## Testing

* Added two API test cases to `js/node/test/api/simple-api-tests.ts`, named after the existing
  `test/testdata/test_types_float16.onnx` model (identity over `[1,1,1,1]`), asserting the
  bit-exact round trip of a float16 input:
  * `test_types_float16.onnx accepts Uint16Array input data` — reproduces the failure on Node.js
    23+ before this change (the wrapper converts it to `Float16Array`), passes after.
  * `test_types_float16.onnx accepts Float16Array input data` — new coverage for #27327's
    feature; skipped on runtimes without `Float16Array`.
* Validated on Windows x64 (Node.js 24.18.0 embedded in Electron 43.1.1, and Node.js 26.7.0) with
  a binding rebuilt from this branch:
  * before the change: both cases fail with `not enough space: expected 2, got 0`
  * after the change: both cases pass, with output bits identical to the input bit patterns
* A `float32` Identity model shows no behavioral change on the float32 path.