### PR TITLE
Fix pkgconfig issues in the official binary releases

### DIFF
--- a/tools/ci_build/github/linux/copy_strip_binary.sh
+++ b/tools/ci_build/github/linux/copy_strip_binary.sh
@@ -48,6 +48,8 @@ fi
 # Change includedir and prefix to match the header and libdir move done above
 sed -i.bak 's|^includedir=.*|includedir=${prefix}/include|' "$ARTIFACT_NAME/lib/pkgconfig/libonnxruntime.pc"
 sed -i.bak 's|^libdir=.*|libdir=${prefix}/lib|' "$ARTIFACT_NAME/lib/pkgconfig/libonnxruntime.pc"
+# Make the pc file relocatable
+sed -i.bak 's|^prefix=.*|prefix=${pcfiledir}/../..|' "$ARTIFACT_NAME/lib/pkgconfig/libonnxruntime.pc"
 rm "$ARTIFACT_NAME/lib/pkgconfig/libonnxruntime.pc.bak"
 
 # copy the README, licence and TPN

--- a/tools/ci_build/github/linux/copy_strip_binary.sh
+++ b/tools/ci_build/github/linux/copy_strip_binary.sh
@@ -45,6 +45,11 @@ else
    mv $ARTIFACT_NAME/lib64 $ARTIFACT_NAME/lib
 fi
 
+# Change includedir and prefix to match the header and libdir move done above
+sed -i.bak 's|^includedir=.*|includedir=${prefix}/include|' "$ARTIFACT_NAME/lib/pkgconfig/libonnxruntime.pc"
+sed -i.bak 's|^libdir=.*|libdir=${prefix}/lib|' "$ARTIFACT_NAME/lib/pkgconfig/libonnxruntime.pc"
+rm "$ARTIFACT_NAME/lib/pkgconfig/libonnxruntime.pc.bak"
+
 # copy the README, licence and TPN
 cp $SOURCE_DIR/README.md $BINARY_DIR/$ARTIFACT_NAME/README.md
 cp $SOURCE_DIR/docs/Privacy.md $BINARY_DIR/$ARTIFACT_NAME/Privacy.md


### PR DESCRIPTION
### Description

`includedir` and `prefix` needed changing in the `libonnxruntime.pc` file when included in the official binary release. The commit messages describe the two changes that were needed.

### Motivation and Context

You cannot consume the official binary releases using pkgconfig, since the include dir was wrong and the prefix was hard-coded.