### PR TITLE
[CUDA] Fix malformed GatedDeltaNet test output verification

### DIFF
--- a/onnxruntime/test/contrib_ops/gated_delta_net_op_test.cc
+++ b/onnxruntime/test/contrib_ops/gated_delta_net_op_test.cc
@@ -960,7 +960,7 @@ TEST(GatedDeltaNetTest, MalformedCuSeqlensIsClamped) {
        {std::vector<int32_t>{0, -8, 64},       // negative
         std::vector<int32_t>{0, 48, 16},       // decreasing
         std::vector<int32_t>{0, 32, 4096}}) {  // end beyond total_tokens
-    OpTester test("GatedDeltaNet", 1, onnxruntime::kMSDomain);
+    OpTester test("GatedDeltaNet", 1, onnxruntime::kMSDomain, /*verify_output=*/false);
     Options o;
     AddCommonAttrs(test, o);
     test.AddInput<MLFloat16>("query", {g.total_tokens, g.hq, g.dk}, ToFloat16(in.q));


### PR DESCRIPTION
### Description

Disable output value verification in `GatedDeltaNetTest.MalformedCuSeqlensIsClamped`. The test validates that malformed device-provided offsets are clamped safely and do not fault; output values are intentionally unspecified.

For decreasing offsets such as `{0, 48, 16}`, tokens 48-63 are not written. A CUDA allocator may return memory containing NaNs, and `EXPECT_NEAR` rejects NaN regardless of the configured tolerance. `verify_output=false` still runs the session and fetches all outputs while skipping the invalid element-wise comparison.

### Testing

- `ninja -C build/cu130/Release onnxruntime_provider_test`
- `build/cu130/Release/onnxruntime_provider_test --gtest_filter=GatedDeltaNetTest.MalformedCuSeqlensIsClamped`
- `clang-format --dry-run --Werror onnxruntime/test/contrib_ops/gated_delta_net_op_test.cc`