### PR TITLE
Fix int32 overflow in softmax_warp_forward offset arithmetic

### DIFF
--- a/onnxruntime/core/providers/cuda/math/softmax_warpwise_impl.cuh
+++ b/onnxruntime/core/providers/cuda/math/softmax_warpwise_impl.cuh
@@ -91,8 +91,13 @@ __global__ void softmax_warp_forward(output_t* dst, const input_t* src, int batc
   // there might be multiple batches per warp. compute the index within the batch
   int local_idx = threadIdx.x;
 
-  src += first_batch * stride + local_idx;
-  dst += first_batch * stride + local_idx;
+  // first_batch and stride are both int32_t; on large inputs their product can
+  // exceed INT32_MAX and silently wrap before it's added to src/dst, causing
+  // out-of-bounds reads/writes. Cast to int64_t before multiplying so the
+  // arithmetic happens in 64-bit.
+  const int64_t thread_offset = static_cast<int64_t>(first_batch) * stride + local_idx;
+  src += thread_offset;
+  dst += thread_offset;
 
   // The nested loops over WARP_BATCH and then WARP_ITERATIONS can be simplified to one loop,
   // but I think doing so would obfuscate the logic of the algorithm, thus I chose to keep
@@ -174,8 +179,14 @@ __global__ void softmax_warp_forward_resource_efficient(output_t* dst, const inp
   constexpr int WARP_ITERATIONS = next_power_of_two / WARP_SIZE;
 
   int local_idx = threadIdx.x;
-  src += blockIdx.x * stride + local_idx;
-  dst += blockIdx.x * stride + local_idx;
+  // blockIdx.x and stride are both int32; on large inputs their product can
+  // exceed INT32_MAX and silently wrap before it's added to src/dst, causing
+  // out-of-bounds reads/writes. Cast to int64_t before multiplying so the
+  // arithmetic happens in 64-bit.
+  const int64_t block_offset = static_cast<int64_t>(blockIdx.x) * stride + local_idx;
+  src += block_offset;
+  dst += block_offset;
+
   extern __shared__ unsigned char smem[];
   input_t(&elements)[WARP_ITERATIONS][WARP_SIZE] = *reinterpret_cast<input_t(*)[WARP_ITERATIONS][WARP_SIZE]>(smem);
 #pragma unroll


### PR DESCRIPTION
first_batch and stride/blockIdx.x are int32; their product can exceed INT32_MAX for large batch counts, silently wrapping before being added to src/dst. This causes out-of-bounds reads/writes, observed as an illegal memory access, silently unwritten output, or occasionally a hang, depending on allocator layout.

Fixes both softmax_warp_forward and softmax_warp_forward_resource_efficient, which have the identical pattern. Widened the offset computation to int64_t at the multiply site rather than changing first_batch/stride's types, since those are used elsewhere in signed-subtraction bounds checks that assume int.

Verified with a standalone repro: an isolated arithmetic test showing the exact expression wraps to a negative offset, and a full GPU kernel test (~4GB fp16 tensor, ~2.1M rows) showing the unfixed kernel faults with an illegal memory access at the exact predicted boundary row, and the fixed kernel produces correct output across the boundary.

Addresses #32299

Good — this is close, but it looks like the template's section headers (`### Description`, `### Motivation and Context`) got left as empty placeholders below your actual content instead of your content going *into* them. Let's restructure it properly and fold in the test output as evidence. Here's the full corrected PR body:

---

### Description

Widens the offset computation in `softmax_warp_forward` and `softmax_warp_forward_resource_efficient` (`onnxruntime/core/providers/cuda/math/softmax_warpwise_impl.cuh`) from `int32` to `int64_t` at the multiply site.

`first_batch` and `stride` (and `blockIdx.x`/`stride` in the resource-efficient variant) are both `int32`. Their product can exceed `INT32_MAX` for large batch counts, silently wrapping before being added to `src`/`dst`. This causes out-of-bounds reads/writes — observed as an illegal memory access, silently unwritten output, or occasionally a hang, depending on allocator layout.

Kept `first_batch`/`stride`/`batch_size` as `int` rather than widening their declared types, since `local_batches = batch_size - first_batch` relies on signed subtraction elsewhere in the function and widening those types risked an unrelated regression for no benefit — only the multiplication result needed widening.

### Motivation and Context

Addresses #32299.

A tensor large enough to trigger this (`batch_size × stride > 2^31`) requires several GB of host memory to construct through the standard `OpTester` float-vector interface, which isn't practical to add as a CI unit test. Instead, I verified the fix two ways:

**1. Isolated arithmetic test (no GPU):** confirms `first_batch * stride` computed in `int32` produces a wrapped/negative result for representative large inputs, and that the `int64_t`-cast version produces the correct value.

**2. Standalone GPU repro:** a minimal extraction of the kernel's offset logic and warp-reduction structure, run against a ~4GB fp16 tensor (~2.1M rows × 1024 elements) straddling the exact overflow boundary (predicted boundary row: 2,097,152, where `first_batch × stride` first exceeds `INT32_MAX`).

Before the fix, the kernel faults deterministically at the predicted boundary:
```
❯ ./gpu_repro buggy
Mode: BUGGY (int32 offset)
batch_size=2101248 stride=1024 total_elements=2151677952 (4.01 GiB)
overflow boundary row (int32 math): 2097152
Fill complete.
*** Kernel execution FAILED: an illegal memory access was encountered ***
```

After the fix, the same tensor — including the rows immediately straddling the boundary — produces correct output:
```
❯ ./gpu_repro fixed
Mode: FIXED (int64_t offset)
batch_size=2101248 stride=1024 total_elements=2151677952 (4.01 GiB)
overflow boundary row (int32 math): 2097152
Fill complete.
Kernel completed without a fault -- checking output correctness...

-- Sanity check (well below overflow boundary) --
row            0 | expected peak col  1023 | actual peak col  1023 | PASS
row            5 | expected peak col     0 | actual peak col     0 | PASS
row         1000 | expected peak col  1023 | actual peak col  1023 | PASS
row       500000 | expected peak col  1023 | actual peak col  1023 | PASS

-- Boundary check (around row 2097152) --
row      2097150 | expected peak col  1023 | actual peak col  1023 | PASS
row      2097151 | expected peak col     0 | actual peak col     0 | PASS
row      2097152 | expected peak col  1023 | actual peak col  1023 | PASS
row      2097153 | expected peak col     0 | actual peak col     0 | PASS
row      2097154 | expected peak col  1023 | actual peak col  1023 | PASS

Sanity rows:  ALL PASS
Boundary rows: ALL PASS
```

Existing `Softmax` op tests (`softmax_test.cc`) are unaffected by this change — it only touches the offset computation, not the reduction/arithmetic logic.

**Note on Erf**

The linked issue also reports Erf as silently producing wrong output above the same 2³¹-element boundary. I traced Erf's standalone CUDA path end-to-end, unary_elementwise_ops.cc::ComputeInternal (passes Tensor::Shape().Size(), which is int64_t) → Impl_Erf → UnaryElementWiseImpl → the templated _UnaryElementWise kernel in unary_elementwise_impl.cuh — and didn't find the same bug. The kernel's per-thread index is computed as static_cast<int64_t>(NumElementsPerThread) * NumThreadsPerBlock * blockIdx.x + threadIdx.x, which widens to int64_t before any multiplication happens, and the host-side grid-size calculation is already guarded with ORT_ENFORCE(blocksPerGridSize <= INT32_MAX, ...). This path appears correct as-is on main.

This PR only fixes the Softmax case (softmax_warp_forward / softmax_warp_forward_resource_efficient). I don't have a repro for the Erf case described in the issue, it's possible it goes through a fused path (e.g. GELU) or is specific to the ROCm backend (the issue's hardware trace is from ROCm/MI300A) rather than the standalone CUDA unary-elementwise dispatch I checked. Flagging this rather than guessing at a fix for code I couldn't confirm is broken, happy to dig further if a maintainer can point me at the right path, or if the issue author can confirm which path they hit.


