### PR TITLE
Accept comma-separated disabled optimizer lists

### DIFF
--- a/include/onnxruntime/core/session/onnxruntime_session_options_config_keys.h
+++ b/include/onnxruntime/core/session/onnxruntime_session_options_config_keys.h
@@ -115,7 +115,7 @@ static const char* const kOrtSessionOptionsMemoryOptimizerApplyConfig = "optimiz
 static const char* const kOrtSessionOptionsMemoryOptimizerProbeConfig = "optimization.enable_memory_probe_recompute_config";
 #endif
 
-// This setting if set should contain a comma separated list of optimizers names that should be disabled.
+// This setting if set should contain a comma- or semicolon-separated list of optimizer names that should be disabled.
 // Optimizers may take time to execute and affect model loading time. If you feel that a specific optimizer
 // does not provider runtime benefits, but affects your model loading time you may disable it using this config
 // entry. This option is not enabled in ORT_MINIMAL_BUILD build.

--- a/onnxruntime/core/session/inference_session.cc
+++ b/onnxruntime/core/session/inference_session.cc
@@ -145,6 +145,26 @@ PathString GetExternalInitializersFolderModelPath(const ConfigOptions& config_op
 }
 #endif  // !defined(ORT_MINIMAL_BUILD)
 
+#if !defined(ORT_MINIMAL_BUILD) || defined(ORT_EXTENDED_MINIMAL_BUILD)
+InlinedHashSet<std::string> ParseDisabledOptimizersConfig(std::string_view disabled_string) {
+  std::string normalized{disabled_string};
+  std::replace(normalized.begin(), normalized.end(), ';', ',');
+
+  const auto disabled_list = utils::SplitString(normalized, ",");
+  InlinedHashSet<std::string> disabled_rules_and_transformers;
+  disabled_rules_and_transformers.reserve(disabled_list.size());
+
+  for (const auto disabled_rule_or_transformer : disabled_list) {
+    std::string trimmed_name = utils::TrimString(disabled_rule_or_transformer);
+    if (!trimmed_name.empty()) {
+      disabled_rules_and_transformers.insert(std::move(trimmed_name));
+    }
+  }
+
+  return disabled_rules_and_transformers;
+}
+#endif  // !defined(ORT_MINIMAL_BUILD) || defined(ORT_EXTENDED_MINIMAL_BUILD)
+
 // Parse a spin backoff max config value (exponential-backoff cap). Defaults to
 // 1 (no backoff, one SpinPause() per iteration). Values >= 2 enable backoff.
 unsigned int ParseSpinBackoffMax(std::string_view str, const char* config_key,
@@ -500,11 +520,7 @@ void InferenceSession::ConstructorCommon(const SessionOptions& session_options,
     auto disabled_string = session_options_.config_options.GetConfigOrDefault(
         kOrtSessionOptionsDisableSpecifiedOptimizers, "");
     if (!disabled_string.empty()) {
-      const auto disabled_list = utils::SplitString(disabled_string, ";");
-      InlinedHashSet<std::string> disabled_rules_and_transformers;
-      disabled_rules_and_transformers.reserve(disabled_list.size());
-      disabled_rules_and_transformers.insert(disabled_list.cbegin(), disabled_list.cend());
-      ORT_THROW_IF_ERROR(FilterEnabledOptimizers(std::move(disabled_rules_and_transformers)));
+      ORT_THROW_IF_ERROR(FilterEnabledOptimizers(ParseDisabledOptimizersConfig(disabled_string)));
     }
   }
 #endif

--- a/onnxruntime/test/optimizer/graph_transform_test.cc
+++ b/onnxruntime/test/optimizer/graph_transform_test.cc
@@ -10471,6 +10471,34 @@ TEST_F(GraphTransformationTests, FilterEnabledOptimizersViaSessionOptions) {
   ASSERT_TRUE(op_to_count["Add"] == 1);
 }
 
+TEST_F(GraphTransformationTests, FilterEnabledOptimizersViaSessionOptionsAcceptsCommaSeparatedList) {
+  constexpr const ORTCHAR_T* model_uri = MODEL_FOLDER "fusion/constant_folding_with_scalar_shape_to_initializer.onnx";
+
+  SessionOptions so;
+  so.session_logid = "GraphTransformationTests.FilterEnabledOptimizersViaSessionOptionsAcceptsCommaSeparatedList";
+  ASSERT_STATUS_OK(
+      so.config_options.AddConfigEntry(kOrtSessionOptionsDisableSpecifiedOptimizers, "EliminateIdentity,ConstantFolding"));
+
+  InferenceSessionWrapper session_object{so, GetEnvironment()};
+
+  ASSERT_STATUS_OK(session_object.Load(model_uri));
+
+  const auto& graph = session_object.GetGraph();
+
+  // check the ops that should go away if the constant folding transformer runs
+  std::map<std::string, int> op_to_count = CountOpsInGraph(graph);
+  ASSERT_TRUE(op_to_count["Shape"] == 1);
+  ASSERT_TRUE(op_to_count["ConstantOfShape"] == 1);
+  ASSERT_TRUE(op_to_count["Add"] == 1);
+
+  ASSERT_STATUS_OK(session_object.Initialize());  // Initialize runs the transformers
+
+  op_to_count = CountOpsInGraph(graph);
+  ASSERT_TRUE(op_to_count["Shape"] == 1);
+  ASSERT_TRUE(op_to_count["ConstantOfShape"] == 1);
+  ASSERT_TRUE(op_to_count["Add"] == 1);
+}
+
 TEST_F(GraphTransformationTests, PropagateCastOpsTests) {
   using Strategy = GraphTransformerConfiguration::PropagateCastOpsConfiguration::Strategy;
   struct PropagateCastOpsTestSpecs {


### PR DESCRIPTION
## Summary
- accept comma-separated values for `optimization.disable_specified_optimizers`
- keep semicolon-separated values working for backward compatibility
- add a regression test covering a comma-separated optimizer list passed through session options

## Testing
- `lintrunner -a onnxruntime/core/session/inference_session.cc include/onnxruntime/core/session/onnxruntime_session_options_config_keys.h onnxruntime/test/optimizer/graph_transform_test.cc`
- `python tools/ci_build/build.py --config Release --build_dir build_wave4_pb33 --update --build --parallel --skip_submodule_sync --skip_tests --target onnxruntime_test_all --cmake_extra_defines CMAKE_DISABLE_FIND_PACKAGE_Protobuf=TRUE CMAKE_DISABLE_FIND_PACKAGE_protobuf=TRUE onnxruntime_USE_KLEIDIAI=OFF onnxruntime_USE_TELEMETRY=OFF`
- `(cd build_wave4_pb33/Release && ./onnxruntime_test_all --gtest_filter='GraphTransformationTests.FilterEnabledOptimizersViaSessionOptions*')`
- `python tools/ci_build/build.py --config Release --build_dir build_wave4_extended_minimal --update --build --parallel --skip_submodule_sync --skip_tests --minimal_build extended --target onnxruntime_session --cmake_extra_defines CMAKE_DISABLE_FIND_PACKAGE_Protobuf=TRUE CMAKE_DISABLE_FIND_PACKAGE_protobuf=TRUE onnxruntime_USE_KLEIDIAI=OFF onnxruntime_USE_TELEMETRY=OFF`

Fixes #32211.
