### PR TITLE
[WebGPU] Allow Split-K for Relu- and SiLU-fused MatMul

### DIFF
--- a/.github/workflows/windows_webgpu.yml
+++ b/.github/workflows/windows_webgpu.yml
@@ -160,10 +160,11 @@ jobs:
               -not (Select-String -Path $dump -Pattern 'MatMul_Split_K_Reduce' -SimpleMatch -Quiet)) {
             throw "MatMul_Split_K_Reduce never dispatched, so the tests did not exercise Split-K."
           }
-          # The activation tests pass whichever path they take, so assert a fused activation reached
-          # the reduction rather than the convolutions falling back to the non-Split-K path.
-          if (-not (Select-String -Path $dump -Pattern 'MatMul_Split_K_Reduce\[[^\]]*ActivationKind: [1-9]' -Quiet)) {
-            throw "No fused activation reached the Split-K reduction."
+          # Relu is 1 and QuickGelu is 7. Assert both reached the reduction, not just one.
+          foreach ($kind in 1, 7) {
+            if (-not (Select-String -Path $dump -Pattern "MatMul_Split_K_Reduce\[[^\]]*ActivationKind: $kind;" -Quiet)) {
+              throw "ActivationKind $kind never reached the Split-K reduction."
+            }
           }
 
       - name: Validate C# native delegates

--- a/.github/workflows/windows_webgpu.yml
+++ b/.github/workflows/windows_webgpu.yml
@@ -138,6 +138,29 @@ jobs:
           }
           Remove-Item "${{ github.workspace }}\RelWithDebInfo" -Include "*.obj" -Recurse
 
+      # SplitKConfig only enables Split-K on Intel adapters, so the run above takes the non-Split-K
+      # path on this pool. Rerun the Split-K tests with the override on, and confirm from the shader
+      # dump that the reduction dispatched: the tests pass either way, so running them is not by
+      # itself evidence that they exercised Split-K.
+      - name: Run Split-K tests with the path forced on
+        shell: pwsh
+        working-directory: ${{ github.workspace }}\RelWithDebInfo\RelWithDebInfo
+        env:
+          ORT_WEBGPU_SPLIT_K: "on"
+        run: |
+          $dump = Join-Path $PWD "splitk_shader_dump.log"
+          # The dump is opened in append mode, so a stale file would be a false positive.
+          Remove-Item $dump -ErrorAction SilentlyContinue
+          $env:ORT_WEBGPU_EP_SHADER_DUMP_FILE = $dump
+          .\onnxruntime_provider_test.exe "--gtest_filter=MatMul_SplitK.*:Gemm_SplitK.*"
+          if ($LASTEXITCODE -ne 0) {
+            throw "Split-K tests failed with exit code $LASTEXITCODE."
+          }
+          if (-not (Test-Path $dump) -or
+              -not (Select-String -Path $dump -Pattern 'MatMul_Split_K_Reduce' -SimpleMatch -Quiet)) {
+            throw "MatMul_Split_K_Reduce never dispatched, so the tests did not exercise Split-K."
+          }
+
       - name: Validate C# native delegates
         run: python tools\ValidateNativeDelegateAttributes.py
         shell: cmd

--- a/.github/workflows/windows_webgpu.yml
+++ b/.github/workflows/windows_webgpu.yml
@@ -160,6 +160,11 @@ jobs:
               -not (Select-String -Path $dump -Pattern 'MatMul_Split_K_Reduce' -SimpleMatch -Quiet)) {
             throw "MatMul_Split_K_Reduce never dispatched, so the tests did not exercise Split-K."
           }
+          # The activation tests pass whichever path they take, so assert a fused activation reached
+          # the reduction rather than the convolutions falling back to the non-Split-K path.
+          if (-not (Select-String -Path $dump -Pattern 'MatMul_Split_K_Reduce\[[^\]]*ActivationKind: [1-9]' -Quiet)) {
+            throw "No fused activation reached the Split-K reduction."
+          }
 
       - name: Validate C# native delegates
         run: python tools\ValidateNativeDelegateAttributes.py

--- a/onnxruntime/core/providers/webgpu/math/gemm_packed.cc
+++ b/onnxruntime/core/providers/webgpu/math/gemm_packed.cc
@@ -3,6 +3,8 @@
 
 #include "core/providers/webgpu/math/gemm_packed.h"
 
+#include <limits>
+
 #include "core/providers/webgpu/webgpu_utils.h"
 
 #include "core/providers/webgpu/math/matmul.h"
@@ -14,12 +16,7 @@ namespace webgpu {
 
 Status GemmProgram::GenerateShaderCode(ShaderHelper& shader) const {
   const bool need_split_k = NeedSplitK();
-  ShaderUsage output_usage = ShaderUsage::UseUniform | ShaderUsage::UseIndicesTypeAlias | ShaderUsage::UseValueTypeAlias | ShaderUsage::UseElementTypeAlias;
-  if (need_split_k) {
-    // When Split-K is enabled, we will declare output as `atomic<i32>` to call atomic built-in
-    // functions on it, so we need below information to correctly compute the index on the output.
-    output_usage |= ShaderUsage::UseIndicesToOffset | ShaderUsage::UseShapeAndStride;
-  }
+  const ShaderUsage output_usage = ShaderUsage::UseUniform | ShaderUsage::UseIndicesTypeAlias | ShaderUsage::UseValueTypeAlias | ShaderUsage::UseElementTypeAlias;
   const ShaderVariableHelper& output = shader.AddOutput("output", output_usage);
 
   // Each thread compute 4*4 elements
@@ -45,8 +42,9 @@ Status GemmProgram::GenerateShaderCode(ShaderHelper& shader) const {
   }
 
   if (need_split_k) {
-    const ProgramVariableDataType output_var_type = this->Outputs()[0].var_type;
-    MatMulWriteFnSourceWithSplitK(shader, output, /*is_gemm = */ true, output_var_type);
+    // `beta * C` is applied by `MatMulSplitKReduceProgram` after the partials are summed, so the bias
+    // input is deliberately left unbound here.
+    MatMulWriteFnSourceWithSplitK(shader, output, /*is_gemm = */ true);
   } else {
     MatMulWriteFnSourceForGemm(shader, output, c, c_is_scalar_);
   }
@@ -107,40 +105,44 @@ Status ApplyGemmPacked(const Tensor* a,
   ProgramOutput output(y, ProgramTensorMetadataDependency::TypeAndRank, output_components);
   uint32_t dispatch_z = 1;
   uint32_t split_dim_inner = 1;
+  uint32_t splits = 1;
 
-  // Current Split-K implementation relies on atomic operations, which are not deterministic.
-  if (!context.KernelContext().GetUseDeterministicCompute()) {
-    const SplitKConfig& split_k_config = context.GetSplitKConfig();
-    // Currently we require the components for Y must also be a multiple of 4 when Split-K is used.
-    const bool output_is_vec4 = output_components == 4;
-    // We need to use `true` as `is_channels_last` to meet the requirement in `UseSplitK`.
-    const bool need_split_k = split_k_config.UseSplitK(is_vec4 && output_is_vec4, ActivationKind::None, /*batch_size*/ 1, M, N, K);
-    if (need_split_k) {
-      const Tensor* bias = nullptr;
-      uint32_t output_components_in_fill_bias_program = 4;
-      if (need_handle_bias) {
-        bias = c;
-        output_components_in_fill_bias_program = c_components;
-      }
-      const TensorShape output_shape = TensorShape{M, N / output_components_in_fill_bias_program};
+  // Split-K partial sums. Empty unless Split-K is used; `partials` must outlive both dispatches.
+  Tensor partials;
 
-      auto fill_bias_program = CreateMatMulFillBiasOrZeroBeforeSplitKProgram(
-          bias, y, /*is_gemm*/ true, beta, output_components_in_fill_bias_program, output_shape);
-      ORT_RETURN_IF_ERROR(context.RunProgram(fill_bias_program));
+  const SplitKConfig& split_k_config = context.GetSplitKConfig();
+  // Currently we require the components for Y must also be a multiple of 4 when Split-K is used.
+  const bool output_is_vec4 = output_components == 4;
+  // We need to use `true` as `is_channels_last` to meet the requirement in `UseSplitK`.
+  const bool need_split_k = split_k_config.UseSplitK(is_vec4 && output_is_vec4, ActivationKind::None, /*batch_size*/ 1, M, N, K);
+  if (need_split_k) {
+    ORT_RETURN_IF_NOT(N % 4 == 0, "Split-K GEMM requires N to be a multiple of 4.");
 
-      // When Split-K is used, `bias` will be handled in `MatMulFillBiasOrZeroBeforeSplitKProgram`
-      // instead of here.
-      need_handle_bias = false;
+    // With Split-K, `dim_inner` will be split into multiple parts and `dispatch_z` will be the
+    // number of splits along `dim_inner`.
+    split_dim_inner = split_k_config.GetSplitDimInner();
+    splits = (K + split_dim_inner - 1) / split_dim_inner;
+    dispatch_z = splits;
 
-      // With Split-K, `dim_inner` will be split into multiple parts and `dispatch_z` will be the
-      // number of splits along `dim_inner`.
-      split_dim_inner = split_k_config.GetSplitDimInner();
-      dispatch_z = (K + split_dim_inner - 1) / split_dim_inner;
+    // Each split writes to its own slot of `partials` instead of accumulating into the shared output,
+    // so the summation order is fixed by index in the reduction below. `beta * C` is applied there.
+    const uint64_t out_elems = static_cast<uint64_t>(M) * (N / output_components);
+    const uint64_t scratch_elems = static_cast<uint64_t>(splits) * out_elems;
+    const uint64_t scratch_scalars = scratch_elems * output_components;
+    ORT_RETURN_IF_NOT(scratch_scalars <= static_cast<uint64_t>(std::numeric_limits<int64_t>::max()),
+                      "Split-K scratch size exceeds int64_t range: ", scratch_scalars);
+    partials = context.CreateGPUTensor(y->DataType(),
+                                       TensorShape{static_cast<int64_t>(scratch_scalars)});
 
-      // The output should be declared in atomic types in `MatMulProgram` for the use of atomic
-      // built-in functions.
-      output.is_atomic = true;
-    }
+    // Pass 1 writes whole vec4 elements at a flat offset, so bind the scratch as rank 1.
+    output = ProgramOutput(&partials, ProgramTensorMetadataDependency::TypeAndRank,
+                           TensorShape{static_cast<int64_t>(scratch_elems)}, output_components);
+  }
+
+  // `beta * C` is applied by the Split-K reduction rather than by `GemmProgram`.
+  const bool reduce_handles_bias = need_split_k && need_handle_bias;
+  if (need_split_k) {
+    need_handle_bias = false;
   }
 
   GemmProgram program{transA, transB, alpha, need_handle_bias, need_handle_matmul, c_is_scalar, output_components, is_vec4, split_dim_inner};
@@ -172,7 +174,18 @@ Status ApplyGemmPacked(const Tensor* a,
                             {dispatch_z}} /* logical_dispatch_z */
       );
 
-  return context.RunProgram(program);
+  ORT_RETURN_IF_ERROR(context.RunProgram(program));
+
+  if (!need_split_k) {
+    return Status::OK();
+  }
+
+  // Pass 2: sum the per-split partials in a fixed index order, apply `beta * C`, and write Y.
+  const TensorShape reduce_output_shape = TensorShape{M, N / output_components};
+  auto reduce_program = CreateMatMulSplitKReduceProgram(
+      partials, reduce_handles_bias ? c : nullptr, y, /*is_gemm*/ true, Activation{}, beta,
+      narrow<uint32_t>(output_components), narrow<uint32_t>(c_components), reduce_output_shape, splits);
+  return context.RunProgram(reduce_program);
 }
 
 }  // namespace webgpu

--- a/onnxruntime/core/providers/webgpu/math/gemm_packed.cc
+++ b/onnxruntime/core/providers/webgpu/math/gemm_packed.cc
@@ -114,7 +114,8 @@ Status ApplyGemmPacked(const Tensor* a,
   // Currently we require the components for Y must also be a multiple of 4 when Split-K is used.
   const bool output_is_vec4 = output_components == 4;
   // We need to use `true` as `is_channels_last` to meet the requirement in `UseSplitK`.
-  const bool need_split_k = split_k_config.UseSplitK(is_vec4 && output_is_vec4, ActivationKind::None, /*batch_size*/ 1, M, N, K);
+  // Gemm fuses no activation.
+  const bool need_split_k = split_k_config.UseSplitK(is_vec4 && output_is_vec4, Activation{}, /*batch_size*/ 1, M, N, K);
   if (need_split_k) {
     ORT_RETURN_IF_NOT(N % 4 == 0, "Split-K GEMM requires N to be a multiple of 4.");
 

--- a/onnxruntime/core/providers/webgpu/math/gemm_utils.cc
+++ b/onnxruntime/core/providers/webgpu/math/gemm_utils.cc
@@ -51,58 +51,21 @@ void HandleMaybeBiasForMatMul(ShaderHelper& shader,
                                     << "    " << output.SetByIndices("coords", "value") << "\n";
 }
 
-void HandleMatMulWithSplitK(
-    ShaderHelper& shader,
-    bool is_gemm,
-    const ShaderVariableHelper& output,
-    ProgramVariableDataType output_variable_type) {
-  if (is_gemm) {
-    shader.AdditionalImplementation() << "    let coords = vec2(u32(row), u32(colIn));";
-  } else {
-    shader.AdditionalImplementation() << "    let coords = vec3(u32(batch), u32(row), u32(colIn));\n";
-  }
+void HandleMatMulWriteToSplitKPartials(ShaderHelper& shader,
+                                       bool is_gemm,
+                                       const ShaderVariableHelper& output) {
+  // Split-K pass 1. Laid out split-major so a split's writes stay contiguous in `colIn` and the
+  // reduction's reads stay coalesced within each split.
+  const std::string batch_size = is_gemm
+                                     ? std::string{"1"}
+                                     : std::string{"i32(uniforms.logical_dispatch_z / uniforms.splits_per_batch)"};
 
-  // With Split-K, the final output will be the sum of the sub-outputs from multiple workgroups,
-  // so we must add them with atomic built-in functions. Because currently WebGPU doesn't support
-  // atomic built-in functions on `f32` or `f16`, we implement the `atomicAdd` on `f32` and `f16`
-  // with `atomicLoad` and `atomicCompareExchangeWeak`:
-  // 1. Get `old_output_i32` from `output[offset]` with `atomicLoad`.
-  // 2. Convert `old_output_i32` into `f32` (`old_output_f32`) or `vec2h` (`old_output_vec2h`).
-  // 3. Add incoming `value` into `old_output_f32` or `old_output_vec2h`.
-  // 4. Convert the result of step 3 into `i32` values.
-  // 5. Try assigning the result of step 4 into `output[offset]` with `atomicCompareExchangeWeak`
-  //    and `old_output_i32`. The assignment will fail if at this time `output[offset]` is not
-  //    equal to `old_output_i32` (it is updated in another invocation). If the assignment fails
-  //    we have to go to step 1 and repeat all the above steps.
-  switch (output_variable_type) {
-    case ProgramVariableDataType::Float32x4: {
-      shader.AdditionalImplementation() << R"(
-    let offset0 = i2o_output(coords) * 4u;
-    for (var i = 0u; i < 4u; i++) {
-        let offset = offset0 + i;
-)";
-      shader.AdditionalImplementation() << GenerateAtomicAddNonIntegerCode(output, "offset", "f32", "value[i]") << R"(
-    }
-)";
-      break;
-    }
-    case ProgramVariableDataType::Float16x4: {
-      shader.AdditionalImplementation() << R"(
-    let offset0 = i2o_output(coords) * 2u;
-    var vec2h_values : array<vec2h, 2>;
-    vec2h_values[0] = value.xy;
-    vec2h_values[1] = value.zw;
-    for (var i = 0u; i < 2u; i++) {
-        let offset = offset0 + i;
-)";
-      shader.AdditionalImplementation() << GenerateAtomicAddNonIntegerCode(output, "offset", "vec2h", "vec2h_values[i]") << R"(
-    }
-)";
-      break;
-    }
-    default:
-      break;
-  }
+  shader.AdditionalImplementation()
+      << "    let dim_b_outer_vec = i32(uniforms.dim_b_outer) / " << output.NumComponents() << ";\n"
+      << "    let split_k_out_elems = " << batch_size << " * i32(uniforms.dim_a_outer) * dim_b_outer_vec;\n"
+      << "    let split_k_offset = splitIndex * split_k_out_elems + "
+      << "(batch * i32(uniforms.dim_a_outer) + row) * dim_b_outer_vec + colIn;\n"
+      << "    " << output.SetByOffset("u32(split_k_offset)", "value") << "\n";
 }
 
 // Compute `logical_workgroup_id` and `logical_global_id` because the dispatch workgroup size in
@@ -119,10 +82,13 @@ void InitializeLogicalWorkgroupIDAndGlobalID(ShaderHelper& shader) {
       << "  let logical_global_id = logical_workgroup_id * workgroupSize + local_id;\n";
 }
 
-void EmitMatMulWriteFnHeader(ShaderHelper& shader, const ShaderVariableHelper& output) {
+void EmitMatMulWriteFnHeader(ShaderHelper& shader, const ShaderVariableHelper& output,
+                             bool with_split_index = false) {
   const int output_components = output.NumComponents();
   shader.AdditionalImplementation()
-      << "fn mm_write(batch: i32, row: i32, colIn: i32, valueIn: output_value_t) {\n";
+      << "fn mm_write(batch: i32, row: i32, colIn: i32, "
+      << (with_split_index ? "splitIndex: i32, " : "")
+      << "valueIn: output_value_t) {\n";
 
   shader.AdditionalImplementation() << "  let col = colIn * " << output_components << ";\n";
 
@@ -210,10 +176,9 @@ void MatMulWriteFnSourceForGemm(ShaderHelper& shader,
 
 void MatMulWriteFnSourceWithSplitK(ShaderHelper& shader,
                                    const ShaderVariableHelper& output,
-                                   bool is_gemm,
-                                   ProgramVariableDataType output_variable_type) {
-  EmitMatMulWriteFnHeader(shader, output);
-  HandleMatMulWithSplitK(shader, is_gemm, output, output_variable_type);
+                                   bool is_gemm) {
+  EmitMatMulWriteFnHeader(shader, output, /*with_split_index = */ true);
+  HandleMatMulWriteToSplitKPartials(shader, is_gemm, output);
   EmitMatMulWriteFnFooter(shader);
 }
 
@@ -263,6 +228,14 @@ Status MakeMatMulPackedVec4Source(ShaderHelper& shader,
                            workgroup_size_y, ". elements_per_thread_x: ", elements_per_thread_x, " must be 4.");
   }
 
+  // The Split-K partial store writes whole `output_components`-wide elements and indexes the scratch
+  // buffer in those units, so it requires the vec4 output path. `SplitKConfig::UseSplitK` already gates
+  // on `is_vec4`; this catches a caller that enables Split-K without honouring it.
+  if (split_k && output_components != 4) {
+    return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
+                           "Split-K requires a vec4 output, but output_components is ", output_components, ".");
+  }
+
   shader.AdditionalImplementation()
       << "var<workgroup> mm_Asub: array<array<vec" << inner_elements_size << "<" << data_type << ">, " << tile_a_width / inner_elements_size << ">, " << tile_a_height << ">;\n"
       << "var<workgroup> mm_Bsub: array<array<vec4<" << data_type << ">, " << tile_b_outer / elements_per_thread_x << ">, " << tile_inner << ">;\n"
@@ -298,15 +271,16 @@ Status MakeMatMulPackedVec4Source(ShaderHelper& shader,
     //                                                     [c2 c2]]
     //
     //  With Split-K:
-    //  1. Initialize output Y with B in `MatMulFillBiasOrZeroBeforeSplitKProgram`:  Y = [[d1, d2]
-    //                                                                                   [d1, d2]]
-    //  2. Split the original 1 workgroup into 3 workgroups (now `dispatch_z = 3` in API side)
+    //  1. Split the original 1 workgroup into 3 workgroups (now `dispatch_z = 3` in API side)
     //     Workgroup1: compute (A1 * A2)  Workgroup2: compute (B1 * B2)
     //     Workgroup3: compute (C1 * C2)
     //     In each workgroup:
     //     - `num_tiles` is computed with `kSplitK`, and `kStart` is computed with `logical_global_id.z`
-    //     - When the computation in each workgroup is completed, add the result to Y with several
-    //       atomic built-in functions in `HandleMatMulWithSplitK()`.
+    //     - When the computation in each workgroup is completed, the result is stored to that split's
+    //       own slot of the scratch buffer in `HandleMatMulWriteToSplitKPartials()`.
+    //  2. `MatMulSplitKReduceProgram` sums the per-split slots in a fixed index order, adds bias (B)
+    //     and any activation, and writes Y. Because the order is fixed by index rather than by the
+    //     order in which workgroups retire, the result is bit-reproducible.
     shader.MainFunctionBody()
         << "const kSplitK = " << split_dim_inner << ";\n"
         << "  let num_tiles = (kSplitK - 1) / tileInner + 1;\n";
@@ -326,7 +300,8 @@ Status MakeMatMulPackedVec4Source(ShaderHelper& shader,
     } else {
       // With Split-K without batch (in Gemm), `logical_global_id.z` is exactly the Split-K index.
       shader.MainFunctionBody()
-          << "  var kStart = kSplitK * i32(logical_global_id.z);\n"
+          << "  let split_index = i32(logical_global_id.z);\n"
+          << "  var kStart = kSplitK * split_index;\n"
           << "  let batch = 0;\n"
           << "  let batchIndices = 0u;\n";
     }
@@ -457,6 +432,8 @@ Status MakeMatMulPackedVec4Source(ShaderHelper& shader,
     shader.MainFunctionBody() << " for (var i = 0; i < innerElementSize; i = i + 1) {\n"
                               << "    mm_write(batch, globalRow + innerRow, globalCol * innerElementSize + i, acc[innerRow][i]);\n"
                               << "  }\n";
+  } else if (split_k) {
+    shader.MainFunctionBody() << "    mm_write(batch, globalRow + innerRow, globalCol, split_index, acc[innerRow]);\n";
   } else {
     shader.MainFunctionBody() << "    mm_write(batch, globalRow + innerRow, globalCol, acc[innerRow]);\n";
   }

--- a/onnxruntime/core/providers/webgpu/math/gemm_utils.h
+++ b/onnxruntime/core/providers/webgpu/math/gemm_utils.h
@@ -26,10 +26,11 @@ void MatMulWriteFnSourceForGemm(ShaderHelper& shader,
                                 const ShaderVariableHelper* bias,
                                 bool c_is_scalar);
 
+// Emits `mm_write` for Split-K pass 1: stores this split's partial tile to its own slot of the
+// `partials` scratch buffer. The generated function takes an extra `splitIndex` argument.
 void MatMulWriteFnSourceWithSplitK(ShaderHelper& shader,
                                    const ShaderVariableHelper& output,
-                                   bool is_gemm,
-                                   ProgramVariableDataType output_variable_type);
+                                   bool is_gemm);
 
 // The two following functions are used to generate shader code for vec4 and scalar.
 // It is used in GEMM, Matmul, and Conv.

--- a/onnxruntime/core/providers/webgpu/math/matmul.cc
+++ b/onnxruntime/core/providers/webgpu/math/matmul.cc
@@ -272,38 +272,38 @@ Status ComputeMatMul(ComputeContext* context,
   uint32_t split_dim_inner = 1;
   uint32_t splits_per_batch = 1;
 
-  // Current Split-K implementation relies on atomic operations, which are not deterministic.
-  if (!context->KernelContext().GetUseDeterministicCompute()) {
-    const SplitKConfig& split_k_config = context->GetSplitKConfig();
-    const bool need_split_k = split_k_config.UseSplitK(is_vec4, activation.activation_kind_, batch_size, dim_a_outer, dim_b_outer, dim_inner, is_channels_last);
-    if (need_split_k) {
-      ORT_ENFORCE(is_vec4, "Split-K MatMul requires vec4 packing.");
+  // Split-K partial sums. Empty unless Split-K is used; `partials` must outlive both dispatches.
+  Tensor partials;
 
-      if (has_bias) {
-        ORT_ENFORCE(is_channels_last, "Split-K MatMul only supports channels-last format.");
-      }
+  const SplitKConfig& split_k_config = context->GetSplitKConfig();
+  const bool need_split_k = split_k_config.UseSplitK(is_vec4, activation.activation_kind_, batch_size, dim_a_outer, dim_b_outer, dim_inner, is_channels_last);
+  if (need_split_k) {
+    ORT_RETURN_IF_NOT(is_vec4, "Split-K MatMul requires vec4 packing.");
+    ORT_RETURN_IF_NOT(dim_b_outer % 4 == 0, "Split-K MatMul requires dim_b_outer to be a multiple of 4.");
+    ORT_RETURN_IF_NOT(!has_bias || is_channels_last, "Split-K MatMul with bias requires channels-last.");
 
-      // Initialize `output_tensor` with 0 or bias before MatMulProgram with Split-K enabled.
-      const auto fill_bias_program = CreateMatMulFillBiasOrZeroBeforeSplitKProgram(bias, output_tensor, /*is_gemm*/ false, /*beta*/ 1.0f, /*bias_components*/ 4, output_shape_temp, narrow<uint32_t>(batch_size));
-      ORT_RETURN_IF_ERROR(context->RunProgram(fill_bias_program));
+    split_dim_inner = split_k_config.GetSplitDimInner();
+    splits_per_batch = (dim_inner + split_dim_inner - 1) / split_dim_inner;
+    // One dispatch per (batch, split) pair; the shader recovers both from `logical_global_id.z`.
+    const uint64_t dispatch_z_u64 = static_cast<uint64_t>(batch_size) * static_cast<uint64_t>(splits_per_batch);
+    ORT_RETURN_IF_NOT(dispatch_z_u64 <= static_cast<uint64_t>(std::numeric_limits<uint32_t>::max()),
+                      "dispatch_z exceeds uint32_t range: ", dispatch_z_u64);
+    dispatch_z = narrow<uint32_t>(dispatch_z_u64);
 
-      // `bias` has been handled in the execution of `fill_bias_program` so we don't need to set
-      // `bias` again in `MatMulProgram`.
-      use_bias_in_matmul = false;
+    // Bias is applied by the reduction, once, after the partials are summed.
+    use_bias_in_matmul = false;
 
-      // With Split-K, `dim_inner` will be split into multiple parts. `dispatch_z` encodes
-      // both the split-k index and the batch index: dispatch_z = splits_per_batch * batch_size.
-      split_dim_inner = split_k_config.GetSplitDimInner();
-      splits_per_batch = (dim_inner + split_dim_inner - 1) / split_dim_inner;
-      const uint64_t dispatch_z_u64 = static_cast<uint64_t>(batch_size) * static_cast<uint64_t>(splits_per_batch);
-      ORT_ENFORCE(dispatch_z_u64 <= static_cast<uint64_t>(std::numeric_limits<uint32_t>::max()),
-                  "dispatch_z exceeds uint32_t range: ", dispatch_z_u64);
-      dispatch_z = narrow<uint32_t>(dispatch_z_u64);
+    const uint64_t out_elems = static_cast<uint64_t>(batch_size) * dim_a_outer * (dim_b_outer / components);
+    const uint64_t scratch_elems = splits_per_batch * out_elems;
+    const uint64_t scratch_scalars = scratch_elems * components;
+    ORT_RETURN_IF_NOT(scratch_scalars <= static_cast<uint64_t>(std::numeric_limits<int64_t>::max()),
+                      "Split-K scratch size exceeds int64_t range: ", scratch_scalars);
+    partials = context->CreateGPUTensor(output_tensor->DataType(),
+                                        TensorShape{static_cast<int64_t>(scratch_scalars)});
 
-      // The output should be declared in atomic types in `MatMulProgram` for the use of atomic
-      // built-in functions.
-      output.is_atomic = true;
-    }
+    // Pass 1 writes whole vec4 elements at a flat offset, so bind the scratch as rank 1.
+    output = ProgramOutput(&partials, ProgramTensorMetadataDependency::TypeAndRank,
+                           TensorShape{static_cast<int64_t>(scratch_elems)}, components);
   }
 
   MatMulProgram matmul_program{activation, use_bias_in_matmul, is_vec4, elements_per_thread, is_channels_last, split_dim_inner};
@@ -325,43 +325,66 @@ Status ComputeMatMul(ComputeContext* context,
     matmul_program.AddInput({bias, ProgramTensorMetadataDependency::Rank, reduced_bias_shape, bias_components});
   }
 
-  return context->RunProgram(matmul_program);
+  ORT_RETURN_IF_ERROR(context->RunProgram(matmul_program));
+
+  if (!need_split_k) {
+    return Status::OK();
+  }
+
+  // Pass 2: sum the per-split partials in a fixed index order, apply bias, and write the output.
+  auto reduce_program = CreateMatMulSplitKReduceProgram(
+      partials, bias, output_tensor, /*is_gemm*/ false, activation, /*beta*/ 1.0f,
+      /*output_components*/ narrow<uint32_t>(components), /*bias_components*/ narrow<uint32_t>(components),
+      output_shape_temp, splits_per_batch, narrow<uint32_t>(batch_size));
+  return context->RunProgram(reduce_program);
 }
 
-MatMulFillBiasOrZeroBeforeSplitKProgram CreateMatMulFillBiasOrZeroBeforeSplitKProgram(
+MatMulSplitKReduceProgram CreateMatMulSplitKReduceProgram(
+    const Tensor& partials,
     const Tensor* bias,
     Tensor* output,
     bool is_gemm,
+    const Activation& activation,
     float beta,
     uint32_t output_components,
+    uint32_t bias_components,
     const TensorShape& output_shape,
+    uint32_t splits,
     uint32_t batch_size) {
   const bool has_bias = bias != nullptr;
   const bool bias_is_scalar = has_bias ? bias->Shape().Size() == 1 : false;
 
-  MatMulFillBiasOrZeroBeforeSplitKProgram program(is_gemm, has_bias, output_components, bias_is_scalar);
+  MatMulSplitKReduceProgram program(is_gemm, has_bias, output_components, bias_is_scalar, activation);
 
   const uint32_t dim_a_outer = narrow<uint32_t>(output_shape[output_shape.NumDimensions() - 2]);
-  const uint32_t dim_b_outer = narrow<uint32_t>(output_shape[output_shape.NumDimensions() - 1]);
+  // `output_shape` carries the last dimension in components; the shader expects elements.
+  const uint32_t dim_b_outer = narrow<uint32_t>(output_shape[output_shape.NumDimensions() - 1]) * output_components;
 
-  // Fill one value per invocation across all batches.
+  // One invocation per output element, so the dispatch covers them a workgroup at a time.
   const uint64_t total_outputs = static_cast<uint64_t>(batch_size) *
                                  static_cast<uint64_t>(dim_a_outer) *
-                                 static_cast<uint64_t>(dim_b_outer);
+                                 static_cast<uint64_t>(dim_b_outer / output_components);
   const uint64_t dispatch_x_u64 = CeilDiv(total_outputs, static_cast<uint64_t>(WORKGROUP_SIZE));
   ORT_ENFORCE(dispatch_x_u64 <= static_cast<uint64_t>(std::numeric_limits<uint32_t>::max()),
               "dispatch_x exceeds uint32_t range: ", dispatch_x_u64);
   const uint32_t dispatch_x = narrow<uint32_t>(dispatch_x_u64);
 
-  const uint32_t dim_b_outer_components = narrow<uint32_t>(dim_b_outer * output_components);
-  program.CacheHint(is_gemm, has_bias, output_components, bias_is_scalar)
-      .AddOutput({output, ProgramTensorMetadataDependency::TypeAndRank, output_shape, static_cast<int32_t>(output_components)})
-      .AddUniformVariables({{dim_a_outer}, {dim_b_outer_components}, {beta}, {batch_size}})
+  const TensorShape partials_shape = TensorShape{static_cast<int64_t>(total_outputs * splits)};
+
+  program.CacheHint(is_gemm, has_bias, output_components, bias_is_scalar, activation.CacheKey())
+      .AddInput({&partials, ProgramTensorMetadataDependency::TypeAndRank, partials_shape,
+                 static_cast<int32_t>(output_components)})
+      .AddOutput({output, ProgramTensorMetadataDependency::TypeAndRank, output_shape,
+                  static_cast<int32_t>(output_components)})
+      .AddUniformVariables({{dim_a_outer}, {dim_b_outer}, {beta}, {batch_size}, {splits}})
       .SetDispatchGroupSize(dispatch_x);
+  // Must stay last among uniform appends: definitions pair with values by index, not by name.
+  AppendActivationUniformsData(activation, program);
 
   if (has_bias) {
-    const TensorShape reduced_bias_shape = ReduceShapeByComponents(bias->Shape(), output_components);
-    program.AddInput({bias, ProgramTensorMetadataDependency::TypeAndRank, reduced_bias_shape, static_cast<int32_t>(output_components)});
+    const TensorShape reduced_bias_shape = ReduceShapeByComponents(bias->Shape(), bias_components);
+    program.AddInput({bias, ProgramTensorMetadataDependency::TypeAndRank, reduced_bias_shape,
+                      static_cast<int32_t>(bias_components)});
   }
 
   return program;

--- a/onnxruntime/core/providers/webgpu/math/matmul.cc
+++ b/onnxruntime/core/providers/webgpu/math/matmul.cc
@@ -276,7 +276,7 @@ Status ComputeMatMul(ComputeContext* context,
   Tensor partials;
 
   const SplitKConfig& split_k_config = context->GetSplitKConfig();
-  const bool need_split_k = split_k_config.UseSplitK(is_vec4, activation.activation_kind_, batch_size, dim_a_outer, dim_b_outer, dim_inner, is_channels_last);
+  const bool need_split_k = split_k_config.UseSplitK(is_vec4, activation, batch_size, dim_a_outer, dim_b_outer, dim_inner, is_channels_last);
   if (need_split_k) {
     ORT_RETURN_IF_NOT(is_vec4, "Split-K MatMul requires vec4 packing.");
     ORT_RETURN_IF_NOT(dim_b_outer % 4 == 0, "Split-K MatMul requires dim_b_outer to be a multiple of 4.");
@@ -306,9 +306,13 @@ Status ComputeMatMul(ComputeContext* context,
                            TensorShape{static_cast<int64_t>(scratch_elems)}, components);
   }
 
-  MatMulProgram matmul_program{activation, use_bias_in_matmul, is_vec4, elements_per_thread, is_channels_last, split_dim_inner};
+  // Pass 1 writes partial sums and never applies the activation, so clearing it keeps the pipeline
+  // cache key from splitting on an activation the shader does not emit.
+  const Activation matmul_activation = need_split_k ? Activation{} : activation;
+
+  MatMulProgram matmul_program{matmul_activation, use_bias_in_matmul, is_vec4, elements_per_thread, is_channels_last, split_dim_inner};
   matmul_program
-      .CacheHint(activation.CacheKey(), absl::StrJoin(elements_per_thread, "-"), std::to_string(is_vec4), components, is_channels_last, split_dim_inner)
+      .CacheHint(matmul_activation.CacheKey(), absl::StrJoin(elements_per_thread, "-"), std::to_string(is_vec4), components, is_channels_last, split_dim_inner)
       .AddInputs({{a, ProgramTensorMetadataDependency::TypeAndRank, a_shape_temp, components},
                   {b, ProgramTensorMetadataDependency::TypeAndRank, b_shape_temp, components}})
       .AddUniformVariables({{dim_a_outer}, {dim_b_outer}, {dim_inner}, {dispatch_x}, {dispatch_y}, {dispatch_z}, {splits_per_batch}})
@@ -317,7 +321,7 @@ Status ComputeMatMul(ComputeContext* context,
       .SetWorkgroupSize(MatMul::MATMUL_PACKED_WORKGROUP_SIZE_X, MatMul::MATMUL_PACKED_WORKGROUP_SIZE_Y, MatMul::MATMUL_PACKED_WORKGROUP_SIZE_Z)
       .AddOutput(std::move(output));
   // Activation uniforms must remain last because definitions and values are matched by index.
-  AppendActivationUniformsData(activation, matmul_program);
+  AppendActivationUniformsData(matmul_activation, matmul_program);
 
   if (use_bias_in_matmul) {
     auto bias_components = is_channels_last ? components : 1;

--- a/onnxruntime/core/providers/webgpu/math/matmul.h
+++ b/onnxruntime/core/providers/webgpu/math/matmul.h
@@ -21,13 +21,19 @@ Status ComputeMatMul(ComputeContext* context, const Activation& activation, std:
                      const TensorShape& input_a_reshape = TensorShape(),
                      const TensorShape& input_b_reshape = TensorShape());
 
-MatMulFillBiasOrZeroBeforeSplitKProgram CreateMatMulFillBiasOrZeroBeforeSplitKProgram(
+// Builds the pass-2 reduction program. `output_shape` is the intermediate output shape, whose last
+// dimension is expressed in components rather than elements.
+MatMulSplitKReduceProgram CreateMatMulSplitKReduceProgram(
+    const Tensor& partials,
     const Tensor* bias,
     Tensor* output,
     bool is_gemm,
+    const Activation& activation,
     float beta,
     uint32_t output_components,
+    uint32_t bias_components,
     const TensorShape& output_shape,
+    uint32_t splits,
     uint32_t batch_size = 1);
 
 class MatMul final : public WebGpuKernel {

--- a/onnxruntime/core/providers/webgpu/math/matmul_packed.cc
+++ b/onnxruntime/core/providers/webgpu/math/matmul_packed.cc
@@ -16,12 +16,7 @@ Status MatMulProgram::GenerateShaderCode(ShaderHelper& shader) const {
   const auto& b = shader.AddInput("b", ShaderUsage::UseUniform | ShaderUsage::UseIndicesTypeAlias | ShaderUsage::UseValueTypeAlias);
 
   const bool need_split_k = NeedSplitK();
-  ShaderUsage output_usage = ShaderUsage::UseUniform | ShaderUsage::UseIndicesTypeAlias | ShaderUsage::UseValueTypeAlias | ShaderUsage::UseElementTypeAlias;
-  if (need_split_k) {
-    // When Split-K is enabled, we will declare output as `atomic<i32>` to call atomic built-in
-    // functions on it, so we need below information to correctly compute the index on the output.
-    output_usage |= ShaderUsage::UseIndicesToOffset | ShaderUsage::UseShapeAndStride;
-  }
+  const ShaderUsage output_usage = ShaderUsage::UseUniform | ShaderUsage::UseIndicesTypeAlias | ShaderUsage::UseValueTypeAlias | ShaderUsage::UseElementTypeAlias;
   const auto& output = shader.AddOutput("output", output_usage);
 
   const auto& batch_dims = shader.AddIndices("batch_dims", ShaderUsage::UseUniform | ShaderUsage::UseIndicesTypeAlias);
@@ -33,11 +28,12 @@ Status MatMulProgram::GenerateShaderCode(ShaderHelper& shader) const {
   std::string apply_activation = GetActivationSnippet(activation_, "output_value_t", "output_element_t");
   // Emit activation helpers before the write function uses them.
   shader.AdditionalImplementation() << GetActivationDeclaration(activation_, "output_value_t", "output_element_t");
-  ProgramVariableDataType output_var_type = this->Outputs()[0].var_type;
   // declare the read and write functions
   MatMulReadFnSource(shader, a, b, &batch_dims, /*transA = */ false, /*transB = */ false);
   if (need_split_k) {
-    MatMulWriteFnSourceWithSplitK(shader, output, /*is_gemm = */ false, output_var_type);
+    // Bias and activation are applied by `MatMulSplitKReduceProgram` after the partials are summed,
+    // so `bias` is deliberately not bound here.
+    MatMulWriteFnSourceWithSplitK(shader, output, /*is_gemm = */ false);
   } else {
     MatMulWriteFnSourceForMatMul(shader, output, bias, apply_activation, is_channels_last_);
   }
@@ -58,7 +54,8 @@ bool MatMulProgram::NeedSplitK() const {
   return split_dim_inner_ > 1;
 }
 
-Status MatMulFillBiasOrZeroBeforeSplitKProgram::GenerateShaderCode(ShaderHelper& shader) const {
+Status MatMulSplitKReduceProgram::GenerateShaderCode(ShaderHelper& shader) const {
+  const auto& partials = shader.AddInput("partials", ShaderUsage::UseUniform);
   const auto& output = shader.AddOutput("output", ShaderUsage::UseUniform | ShaderUsage::UseIndicesTypeAlias | ShaderUsage::UseValueTypeAlias | ShaderUsage::UseElementTypeAlias);
 
   const ShaderVariableHelper* bias = nullptr;
@@ -66,12 +63,15 @@ Status MatMulFillBiasOrZeroBeforeSplitKProgram::GenerateShaderCode(ShaderHelper&
     bias = &shader.AddInput("bias", ShaderUsage::UseUniform);
   }
 
-  // Handle bias with `MatMulWriteFnSourceForGemm() or MatMulWriteFnSourceForMatMul()`.
+  const std::string apply_activation = GetActivationSnippet(activation_, "output_value_t", "output_element_t");
+  // Emit activation helpers before the write function uses them.
+  shader.AdditionalImplementation() << GetActivationDeclaration(activation_, "output_value_t", "output_element_t");
   if (is_gemm_) {
+    // GEMM has no fused activation.
     MatMulWriteFnSourceForGemm(shader, output, bias, bias_is_scalar_);
   } else {
-    // Currently we only support `is_channels_last` to be true and no activation.
-    MatMulWriteFnSourceForMatMul(shader, output, bias, /*activation_snippet*/ "", /*is_channels_last*/ true);
+    // `UseSplitK` only admits `is_channels_last`.
+    MatMulWriteFnSourceForMatMul(shader, output, bias, apply_activation, /*is_channels_last*/ true);
   }
 
   shader.MainFunctionBody() << "  let output_components = " << output_components_ << ";\n";
@@ -82,7 +82,8 @@ Status MatMulFillBiasOrZeroBeforeSplitKProgram::GenerateShaderCode(ShaderHelper&
   let dim_a_outer = i32(uniforms.dim_a_outer);
   let dim_b_outer = i32(uniforms.dim_b_outer) / output_components;
   let elements_per_batch = dim_a_outer * dim_b_outer;
-  if (output_id >= batch_size * elements_per_batch) {
+  let out_elems = batch_size * elements_per_batch;
+  if (output_id >= out_elems) {
     return;
   }
 
@@ -90,9 +91,16 @@ Status MatMulFillBiasOrZeroBeforeSplitKProgram::GenerateShaderCode(ShaderHelper&
   let remaining = output_id % elements_per_batch;
   let output_row = remaining / dim_b_outer;
   let output_col = remaining % dim_b_outer;
-  let output_value = output_value_t();
-  mm_write(output_batch, output_row, output_col, output_value);
 )";
+
+  // Accumulating in f32 for f16 output avoids rounding the running sum at every step.
+  const std::string acc_type = MakeScalarOrVectorType(static_cast<int>(output_components_), "f32");
+  shader.MainFunctionBody()
+      << "  var acc = " << acc_type << "(0.0);\n"
+      << "  for (var s = 0; s < i32(uniforms.splits); s++) {\n"
+      << "    acc += " << acc_type << "(" << partials.GetByOffset("u32(s * out_elems + output_id)") << ");\n"
+      << "  }\n"
+      << "  mm_write(output_batch, output_row, output_col, output_value_t(acc));\n";
 
   return Status::OK();
 }

--- a/onnxruntime/core/providers/webgpu/math/matmul_packed.h
+++ b/onnxruntime/core/providers/webgpu/math/matmul_packed.h
@@ -42,18 +42,26 @@ class MatMulProgram final : public Program<MatMulProgram> {
   uint32_t split_dim_inner_ = 1;
 };
 
-// The program to initialize the output with 0 or bias before doing MatMul with Split-K. In Split-K,
-// we set the output values with `atomicLoad` and `atomicCompareExchangeWeak` instead of a direct
-// assignment (see the function `HandleMatMulWithSplitK()` in `gemm_utils.cc`), so we must initialize
-// the output with 0 or bias first to make sure `atomicLoad` won't return garbage data.
-class MatMulFillBiasOrZeroBeforeSplitKProgram final : public Program<MatMulFillBiasOrZeroBeforeSplitKProgram> {
+// Pass 2 of the deterministic two-pass Split-K reduction. Pass 1 leaves each split's partial sum in
+// its own slot of a scratch buffer laid out split-major:
+//
+//   partials[split_index * out_elems + output_id],  out_elems = batch_size * dim_a_outer * dim_b_outer_vec
+//
+// One invocation per output element sums those slots in a fixed index order, applies bias (or
+// `beta * C` for GEMM), and writes the output. Fixing the order by index rather than by the order
+// pass-1 workgroups retire is what makes the result reproducible.
+//
+// `splits` is a uniform rather than a shader constant so one pipeline serves every split count.
+class MatMulSplitKReduceProgram final : public Program<MatMulSplitKReduceProgram> {
  public:
-  MatMulFillBiasOrZeroBeforeSplitKProgram(bool is_gemm, bool has_bias, uint32_t output_components, bool bias_is_scalar)
-      : Program{"MatMul_Fill_Bias_Or_Zero_Before_Split_K"},
+  MatMulSplitKReduceProgram(bool is_gemm, bool has_bias, uint32_t output_components, bool bias_is_scalar,
+                            const Activation& activation)
+      : Program{"MatMul_Split_K_Reduce"},
         is_gemm_(is_gemm),
         has_bias_(has_bias),
         output_components_(output_components),
-        bias_is_scalar_(bias_is_scalar) {
+        bias_is_scalar_(bias_is_scalar),
+        activation_(activation) {
   }
 
   Status GenerateShaderCode(ShaderHelper& sh) const override;
@@ -61,13 +69,16 @@ class MatMulFillBiasOrZeroBeforeSplitKProgram final : public Program<MatMulFillB
   WEBGPU_PROGRAM_DEFINE_UNIFORM_VARIABLES({"dim_a_outer", ProgramUniformVariableDataType::Uint32},
                                           {"dim_b_outer", ProgramUniformVariableDataType::Uint32},
                                           {"beta", ProgramUniformVariableDataType::Float32},
-                                          {"batch_size", ProgramUniformVariableDataType::Uint32});
+                                          {"batch_size", ProgramUniformVariableDataType::Uint32},
+                                          {"splits", ProgramUniformVariableDataType::Uint32},
+                                          WEBGPU_PROGRAM_ACTIVATION_UNIFORM_VARIABLES);
 
  private:
-  bool is_gemm_ = false;
-  bool has_bias_ = false;
-  uint32_t output_components_ = 0;
-  bool bias_is_scalar_ = false;
+  const bool is_gemm_;
+  const bool has_bias_;
+  const uint32_t output_components_;
+  const bool bias_is_scalar_;
+  const Activation activation_;
 };
 
 }  // namespace webgpu

--- a/onnxruntime/core/providers/webgpu/webgpu_utils.cc
+++ b/onnxruntime/core/providers/webgpu/webgpu_utils.cc
@@ -30,6 +30,15 @@ SplitKOverride ReadSplitKOverride() {
   return SplitKOverride::Default;
 }
 
+// Activations the Split-K reduction has been measured with. Relu and unit-alpha QuickGelu, which is
+// SiLU, cover the fused convolutions in ResNet and EfficientNet. Other kinds are excluded pending
+// measurement, since each one changes which dispatches take the Split-K path.
+bool IsActivationSupportedBySplitK(const Activation& activation) {
+  return activation.activation_kind_ == ActivationKind::None ||
+         activation.activation_kind_ == ActivationKind::Relu ||
+         activation.HasUnitQuickGeluAlpha();
+}
+
 }  // namespace
 
 TensorShape ReduceShapeByComponents(const TensorShape& shape, int64_t components) {
@@ -131,7 +140,7 @@ uint32_t SplitKConfig::GetMaxDimInnerWithSplitK() const {
 
 bool SplitKConfig::UseSplitK(
     bool is_vec4,
-    ActivationKind activation_kind,
+    const Activation& activation,
     uint64_t batch_size,
     uint32_t dim_a_outer,
     uint32_t dim_b_outer,
@@ -143,8 +152,8 @@ bool SplitKConfig::UseSplitK(
 
   bool use_split_k = true;
 
-  // TODO: support the cases below.
-  use_split_k &= activation_kind == ActivationKind::None;
+  use_split_k &= IsActivationSupportedBySplitK(activation);
+  // TODO: support the scalar (non-vec4) path.
   use_split_k &= is_vec4;
 
   // Larger batches increase parallelism on their own, so we temporarily set a batch size threshold

--- a/onnxruntime/core/providers/webgpu/webgpu_utils.cc
+++ b/onnxruntime/core/providers/webgpu/webgpu_utils.cc
@@ -30,9 +30,8 @@ SplitKOverride ReadSplitKOverride() {
   return SplitKOverride::Default;
 }
 
-// Activations the Split-K reduction has been measured with. Relu and unit-alpha QuickGelu, which is
-// SiLU, cover the fused convolutions in ResNet and EfficientNet. Other kinds are excluded pending
-// measurement, since each one changes which dispatches take the Split-K path.
+// Relu and unit-alpha QuickGelu, which is SiLU, are the kinds the Split-K reduction has been
+// measured with. Others are excluded pending measurement.
 bool IsActivationSupportedBySplitK(const Activation& activation) {
   return activation.activation_kind_ == ActivationKind::None ||
          activation.activation_kind_ == ActivationKind::Relu ||

--- a/onnxruntime/core/providers/webgpu/webgpu_utils.cc
+++ b/onnxruntime/core/providers/webgpu/webgpu_utils.cc
@@ -2,11 +2,35 @@
 // Licensed under the MIT License.
 #include "core/providers/webgpu/webgpu_utils.h"
 
-#include <sstream>
-#include "core/providers/webgpu/shader_variable.h"
+#include <string>
+#include "core/platform/env_var.h"
 
 namespace onnxruntime {
 namespace webgpu {
+
+namespace {
+
+// Test/measurement override for Split-K gating, read from `ORT_WEBGPU_SPLIT_K`. `on` and `off` let a
+// single binary produce both arms of an A/B comparison, and let tests exercise the Split-K path on
+// adapters whose vendor table leaves it disabled.
+enum class SplitKOverride {
+  Default,
+  ForceOff,
+  ForceOn,
+};
+
+SplitKOverride ReadSplitKOverride() {
+  const std::string value = onnxruntime::detail::GetEnvironmentVar("ORT_WEBGPU_SPLIT_K");
+  if (value == "off" || value == "0") {
+    return SplitKOverride::ForceOff;
+  }
+  if (value == "on" || value == "1") {
+    return SplitKOverride::ForceOn;
+  }
+  return SplitKOverride::Default;
+}
+
+}  // namespace
 
 TensorShape ReduceShapeByComponents(const TensorShape& shape, int64_t components) {
   // Reduce the last dimensions by components creating a new tensor shape.
@@ -26,6 +50,12 @@ TensorShape ReduceShapeByComponents(const TensorShape& shape, int64_t components
 }
 
 SplitKConfig::SplitKConfig(const wgpu::AdapterInfo& adapter_info) {
+  const SplitKOverride override_mode = ReadSplitKOverride();
+  if (override_mode == SplitKOverride::ForceOff) {
+    // `enable_split_k_` defaults to false, and `UseSplitK` short-circuits on it.
+    return;
+  }
+
   if (adapter_info.vendor == std::string_view{"intel"}) {
     // Disable Split-K on old Intel GPUs.
     if (adapter_info.architecture == std::string_view{"gen-7"} ||
@@ -74,6 +104,21 @@ SplitKConfig::SplitKConfig(const wgpu::AdapterInfo& adapter_info) {
       configs_per_dim_inner_range_.emplace_back(4096, 6.0);
     }
   }
+
+  if (override_mode == SplitKOverride::ForceOn && !enable_split_k_) {
+    // The override must produce a usable config on an adapter the vendor table left disabled, so it
+    // carries its own thresholds.
+    enable_split_k_ = true;
+
+    max_batch_size_ = 8;
+    split_dim_inner_ = 256;
+    min_dim_inner_with_split_k_ = split_dim_inner_ * 2;
+
+    configs_per_dim_inner_range_.emplace_back(768, 52.0);
+    configs_per_dim_inner_range_.emplace_back(2304, 35.0);
+    configs_per_dim_inner_range_.emplace_back(3072, 21.5);
+    configs_per_dim_inner_range_.emplace_back(4096, 16.0);
+  }
 }
 
 SplitKConfig::ConfigAtRange::ConfigAtRange(uint32_t max_dim_inner, double rate)
@@ -110,7 +155,7 @@ bool SplitKConfig::UseSplitK(
   // MatMul/Conv|MatMul path. For GEMM and for MatMul or Conv|MatMul without bias, we need to
   // use `true` as `is_channels_last` to make `UseSplitK` ignore `is_channels_last`.
   // When `is_channels_last` has a valid value here, it is required to be true because we only
-  // generate `vec4` shaders in `MatMulFillBiasOrZeroBeforeSplitKProgram`.
+  // generate `vec4` shaders in `MatMulSplitKReduceProgram`, which is where bias is applied.
   use_split_k &= is_channels_last;
 
   // Split-K works best when `dim_inner` is relatively large compared with `dim_a_outer` and
@@ -134,24 +179,6 @@ bool SplitKConfig::UseSplitK(
 
 uint32_t SplitKConfig::GetSplitDimInner() const {
   return split_dim_inner_;
-}
-
-std::string GenerateAtomicAddNonIntegerCode(const ShaderVariableHelper& output, const std::string& offset, const std::string& output_type, const std::string& add_value) {
-  std::ostringstream ss;
-
-  std::string get_output_by_offset = output.GetByOffset(offset);
-  ss << "while (true) {\n"
-     << "  let old_output_i32 = atomicLoad(&" << get_output_by_offset << ");\n"
-     << "  let old_output_" << output_type << " = bitcast<" << output_type << ">(old_output_i32);\n"
-     << "  let new_output_" << output_type << " = old_output_" << output_type << " + " << add_value << ";\n"
-     << "  let new_output_i32 = bitcast<i32>(new_output_" << output_type << ");\n"
-     << "  let output_compare_exchange = atomicCompareExchangeWeak(&" << get_output_by_offset << ", old_output_i32, new_output_i32);\n"
-     << "  if (output_compare_exchange.old_value == old_output_i32) {\n"
-     << "    break;\n"
-     << "  }\n"
-     << "}\n";
-
-  return ss.str();
 }
 
 }  // namespace webgpu

--- a/onnxruntime/core/providers/webgpu/webgpu_utils.h
+++ b/onnxruntime/core/providers/webgpu/webgpu_utils.h
@@ -13,8 +13,6 @@
 namespace onnxruntime {
 namespace webgpu {
 
-class ShaderVariableHelper;
-
 template <typename T>
 inline T CeilDiv(T numerator, T denominator) {
   return (numerator + denominator - 1) / denominator;
@@ -126,22 +124,6 @@ class SplitKConfig {
   };
   std::vector<ConfigAtRange> configs_per_dim_inner_range_;
 };
-
-/**
- * Generates WGSL (WebGPU Shading Language) code for performing an atomic add operation
- * on a non-integer value (e.g., floating-point) in a shader.
- *
- * Since WGSL natively supports atomic operations only on integer types, this function
- * generates code that emulates atomic addition for non-integer types using a compare-and-swap loop.
- *
- * @param output        A reference to the ShaderVariableHelper representing the atomic variable
- *                      to be updated. This encapsulates the variable's name and access logic.
- * @param offset        The offset or index within the atomic variable where the operation is applied.
- * @param output_type   The WGSL type of the value being added (e.g., "f32").
- * @param add_value     The expression or variable representing the value to add.
- * @return              A string containing the generated WGSL code for the atomic add operation.
- */
-std::string GenerateAtomicAddNonIntegerCode(const ShaderVariableHelper& output, const std::string& offset, const std::string& output_type, const std::string& add_value);
 
 }  // namespace webgpu
 }  // namespace onnxruntime

--- a/onnxruntime/core/providers/webgpu/webgpu_utils.h
+++ b/onnxruntime/core/providers/webgpu/webgpu_utils.h
@@ -104,7 +104,7 @@ class SplitKConfig {
   explicit SplitKConfig(const wgpu::AdapterInfo& adapter_info);
 
   bool UseSplitK(
-      bool is_vec4, ActivationKind activation_kind, uint64_t batch_size,
+      bool is_vec4, const Activation& activation, uint64_t batch_size,
       uint32_t dim_a_outer, uint32_t dim_b_outer, uint32_t dim_inner, bool is_channels_last = true) const;
 
   uint32_t GetSplitDimInner() const;

--- a/onnxruntime/test/providers/webgpu/matmul_split_k_test.cc
+++ b/onnxruntime/test/providers/webgpu/matmul_split_k_test.cc
@@ -7,6 +7,7 @@
 // path on an adapter that would otherwise leave it disabled, or `off` to force it off. The value is
 // read when the WebGPU context is created, so it must be set before the process starts.
 
+#include <algorithm>
 #include <cmath>
 #include <cstdint>
 #include <cstring>
@@ -183,6 +184,8 @@ void RunFusedConvAgainstReference(const char* activation_name,
 
   constexpr int64_t kIn = 1024;
   constexpr int64_t kOut = 16;
+  constexpr int64_t kSplitDimInner = 256;  // SplitKConfig's split width
+  static_assert(kIn % kSplitDimInner == 0, "kIn must divide evenly into splits");
   const std::vector<int64_t> x_dims{1, kIn, 1, 1};
   const std::vector<int64_t> w_dims{kOut, kIn, 1, 1};
 
@@ -191,13 +194,25 @@ void RunFusedConvAgainstReference(const char* activation_name,
   std::vector<float> w_vals(random.Gaussian<float>(AsSpan(w_dims), 0.0f, 0.25f));
 
   std::vector<float> expected(kOut);
+  float max_gap = 0.0f;
   for (int64_t o = 0; o < kOut; ++o) {
     float acc = 0.0f;
-    for (int64_t c = 0; c < kIn; ++c) {
-      acc += x_vals[static_cast<size_t>(c)] * w_vals[static_cast<size_t>(o * kIn + c)];
+    float per_split = 0.0f;
+    for (int64_t base = 0; base < kIn; base += kSplitDimInner) {
+      float partial = 0.0f;
+      for (int64_t c = base; c < base + kSplitDimInner; ++c) {
+        partial += x_vals[static_cast<size_t>(c)] * w_vals[static_cast<size_t>(o * kIn + c)];
+      }
+      acc += partial;
+      per_split += apply(partial);
     }
     expected[static_cast<size_t>(o)] = apply(acc);
+    max_gap = std::max(max_gap, std::fabs(per_split - apply(acc)));
   }
+
+  // Applying the activation per split rather than once to the total would produce `per_split`, so
+  // assert the inputs separate the two.
+  ASSERT_GT(max_gap, 1e-2f);
 
   OpTester test("FusedConv", 1, kMSDomain);
   test.AddAttribute("activation", activation_name);
@@ -215,8 +230,7 @@ void RunFusedConvAgainstReference(const char* activation_name,
 
 }  // namespace
 
-// The activation must be applied to the completed sum, not per split. That is only distinguishable
-// when some partial sums differ in sign from the total, which the Gaussian inputs provide.
+// The activation must be applied to the completed sum, not per split.
 TEST(MatMul_SplitK, FusedConvReluAppliedAfterReduction) {
   RunFusedConvAgainstReference("Relu", {}, [](float v) { return v > 0.0f ? v : 0.0f; });
 }
@@ -260,8 +274,7 @@ TEST(MatMul_SplitK, GemvClassifierShapeFloat16) {
 }
 
 // The reduction's `has_bias && !is_gemm` branch is only reachable through Conv, since ONNX MatMul has
-// no bias input. Conv's 1x1 fast path forwards its bias into `ComputeMatMul`. With an activation the
-// reduction must compute `act(sum + b)`; the two are distinguishable because Relu is not additive.
+// no bias input. Conv's 1x1 fast path forwards its bias into `ComputeMatMul`.
 void RunConv1x1BiasAgainstReference(const char* activation_name,
                                     const std::function<float(float)>& apply) {
   auto webgpu_ep = DefaultWebGpuExecutionProvider();
@@ -289,17 +302,26 @@ void RunConv1x1BiasAgainstReference(const char* activation_name,
 
   // A 1x1 convolution is a matmul over the channel axis, plus the bias once per output channel.
   std::vector<float> expected(static_cast<size_t>(kOutChannels * kSpatial));
+  float max_gap = 0.0f;
   for (int64_t m = 0; m < kOutChannels; ++m) {
     for (int64_t p = 0; p < kSpatial; ++p) {
       float sum = 0.0f;
       for (int64_t c = 0; c < kInChannels; ++c) {
         sum += w_vals[static_cast<size_t>(m * kInChannels + c)] * x_vals[static_cast<size_t>(c * kSpatial + p)];
       }
-      expected[static_cast<size_t>(m * kSpatial + p)] = apply(sum + b_vals[static_cast<size_t>(m)]);
+      const float bias = b_vals[static_cast<size_t>(m)];
+      expected[static_cast<size_t>(m * kSpatial + p)] = apply(sum + bias);
+      max_gap = std::max(max_gap, std::fabs((apply(sum) + bias) - apply(sum + bias)));
     }
   }
 
   const bool fused = activation_name != nullptr;
+
+  // `act(sum) + b` is the plausible wrong order, so assert the inputs separate it from `act(sum + b)`.
+  if (fused) {
+    ASSERT_GT(max_gap, 1e-2f);
+  }
+
   OpTester test(fused ? "FusedConv" : "Conv", fused ? 1 : 11, fused ? kMSDomain : kOnnxDomain);
   if (fused) {
     test.AddAttribute("activation", activation_name);
@@ -321,8 +343,7 @@ TEST(MatMul_SplitK, Conv1x1BiasAppliedOnceByReduction) {
   RunConv1x1BiasAgainstReference(nullptr, [](float v) { return v; });
 }
 
-// Bias and activation together. `act(sum + b)` and `act(sum) + b` differ, and only the first is
-// correct, so this guards the order the reduction applies them in.
+// Bias and activation together. The reduction must compute `act(sum + b)`, not `act(sum) + b`.
 TEST(MatMul_SplitK, Conv1x1BiasThenActivation) {
   RunConv1x1BiasAgainstReference("Relu", [](float v) { return v > 0.0f ? v : 0.0f; });
 }

--- a/onnxruntime/test/providers/webgpu/matmul_split_k_test.cc
+++ b/onnxruntime/test/providers/webgpu/matmul_split_k_test.cc
@@ -1,0 +1,378 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+// Tests for the deterministic two-pass Split-K MatMul/Gemm path in the WebGPU EP.
+//
+// `SplitKConfig` gates Split-K on the adapter vendor. Set `ORT_WEBGPU_SPLIT_K=on` to exercise the
+// path on an adapter that would otherwise leave it disabled, or `off` to force it off. The value is
+// read when the WebGPU context is created, so it must be set before the process starts.
+
+#include <cstdint>
+#include <cstring>
+#include <string>
+#include <type_traits>
+#include <vector>
+
+#include "gtest/gtest.h"
+
+#include "core/framework/tensor.h"
+#include "test/providers/provider_test_utils.h"
+#include "test/common/tensor_op_test_utils.h"
+#include "default_providers.h"
+
+namespace onnxruntime {
+namespace test {
+
+namespace {
+
+// Reference 2-D/batched matmul. `batch` slices of [M,K] x [K,N].
+void ComputeExpectedMatMul(const std::vector<float>& a_vals, const std::vector<float>& b_vals,
+                           int64_t batch, int64_t M, int64_t K, int64_t N,
+                           bool b_is_batched, std::vector<float>& out_vals) {
+  out_vals.assign(static_cast<size_t>(batch * M * N), 0.0f);
+  for (int64_t bi = 0; bi < batch; ++bi) {
+    const float* a = a_vals.data() + bi * M * K;
+    const float* b = b_vals.data() + (b_is_batched ? bi * K * N : 0);
+    float* out = out_vals.data() + bi * M * N;
+    for (int64_t m = 0; m < M; ++m) {
+      for (int64_t n = 0; n < N; ++n) {
+        float sum = 0.0f;
+        for (int64_t k = 0; k < K; ++k) {
+          sum += a[m * K + k] * b[k * N + n];
+        }
+        out[m * N + n] = sum;
+      }
+    }
+  }
+}
+
+// Compares two buffers by raw bit pattern. Deliberately not an error metric: `-0.0` and `+0.0`, and
+// NaNs with different payloads, must not compare equal here.
+::testing::AssertionResult BytesIdentical(const std::vector<uint8_t>& lhs, const std::vector<uint8_t>& rhs) {
+  if (lhs.size() != rhs.size()) {
+    return ::testing::AssertionFailure() << "size mismatch: " << lhs.size() << " vs " << rhs.size();
+  }
+  for (size_t i = 0; i < lhs.size(); ++i) {
+    if (lhs[i] != rhs[i]) {
+      return ::testing::AssertionFailure()
+             << "first differing byte at offset " << i << ": 0x" << std::hex << static_cast<int>(lhs[i])
+             << " vs 0x" << static_cast<int>(rhs[i]);
+    }
+  }
+  return ::testing::AssertionSuccess();
+}
+
+// Runs one MatMul on the WebGPU EP and returns the raw bytes of the output tensor. A fresh OpTester
+// (and therefore a fresh session) is used per call so that a difference between two calls reflects the
+// kernel, not retained state.
+std::vector<uint8_t> RunMatMulCaptureBytes(const std::vector<int64_t>& a_dims,
+                                           const std::vector<int64_t>& b_dims,
+                                           const std::vector<int64_t>& y_dims,
+                                           const std::vector<float>& a_vals,
+                                           const std::vector<float>& b_vals) {
+  std::vector<uint8_t> bytes;
+
+  auto webgpu_ep = DefaultWebGpuExecutionProvider();
+  if (!webgpu_ep) {
+    return bytes;
+  }
+
+  OpTester test("MatMul", 13);
+  test.AddInput<float>("A", a_dims, a_vals);
+  test.AddInput<float>("B", b_dims, b_vals);
+
+  int64_t y_size = 1;
+  for (int64_t d : y_dims) {
+    y_size *= d;
+  }
+  // Placeholder: the custom verifier below replaces the default comparison.
+  test.AddOutput<float>("Y", y_dims, std::vector<float>(static_cast<size_t>(y_size), 0.0f));
+
+  test.SetCustomOutputVerifier([&bytes](const std::vector<OrtValue>& fetches, const std::string&) {
+    ASSERT_EQ(fetches.size(), static_cast<size_t>(1));
+    const Tensor& tensor = fetches[0].Get<Tensor>();
+    const auto* data = static_cast<const uint8_t*>(tensor.DataRaw());
+    bytes.assign(data, data + tensor.SizeInBytes());
+  });
+
+  test.ConfigEp(std::move(webgpu_ep)).RunWithConfig();
+  return bytes;
+}
+
+std::string ShapeToString(const std::vector<int64_t>& dims) {
+  std::string s = "[";
+  for (size_t i = 0; i < dims.size(); ++i) {
+    if (i > 0) {
+      s += ",";
+    }
+    s += std::to_string(dims[i]);
+  }
+  return s + "]";
+}
+
+// A is [M,K] or [batch,M,K]; B is [K,N] or [batch,K,N]. The logical dimensions are derived from the
+// shapes rather than passed in, so the reference cannot be computed for a different shape than the one
+// the EP is given.
+template <typename T>
+void RunMatMulAgainstReferenceTyped(const std::vector<int64_t>& a_dims, const std::vector<int64_t>& b_dims,
+                                    const std::vector<int64_t>& y_dims) {
+  static_assert(std::is_same_v<T, float> || std::is_same_v<T, MLFloat16>, "unexpected type for T");
+
+  auto webgpu_ep = DefaultWebGpuExecutionProvider();
+  if (!webgpu_ep) {
+    GTEST_SKIP() << "WebGPU execution provider is not available.";
+  }
+
+  SCOPED_TRACE("A=" + ShapeToString(a_dims) + " B=" + ShapeToString(b_dims));
+  ASSERT_GE(a_dims.size(), static_cast<size_t>(2));
+  ASSERT_GE(b_dims.size(), static_cast<size_t>(2));
+
+  const int64_t K = a_dims.back();
+  const int64_t M = a_dims[a_dims.size() - 2];
+  const int64_t N = b_dims.back();
+  const int64_t batch = a_dims.size() > 2 ? a_dims[0] : 1;
+  const bool b_is_batched = b_dims.size() > 2;
+  ASSERT_EQ(b_dims[b_dims.size() - 2], K) << "B's inner dimension must match A's.";
+
+  RandomValueGenerator random{1234};
+  std::vector<float> a_vals(random.Gaussian<float>(AsSpan(a_dims), 0.0f, 0.25f));
+  std::vector<float> b_vals(random.Gaussian<float>(AsSpan(b_dims), 0.0f, 0.25f));
+
+  std::vector<float> expected;
+  ComputeExpectedMatMul(a_vals, b_vals, batch, M, K, N, b_is_batched, expected);
+
+  OpTester test("MatMul", 13);
+  if constexpr (std::is_same_v<T, float>) {
+    test.AddInput<T>("A", a_dims, a_vals);
+    test.AddInput<T>("B", b_dims, b_vals);
+    test.AddOutput<T>("Y", y_dims, expected);
+    // K here is up to a few thousand, so a fused-multiply-add on the GPU legitimately differs from the
+    // sequential CPU reference by more than the default tolerance.
+    test.SetOutputAbsErr("Y", 1e-3f);
+    test.SetOutputRelErr("Y", 1e-3f);
+  } else {
+    test.AddInput<T>("A", a_dims, FloatsToMLFloat16s(a_vals));
+    test.AddInput<T>("B", b_dims, FloatsToMLFloat16s(b_vals));
+    test.AddOutput<T>("Y", y_dims, FloatsToMLFloat16s(expected));
+    // Inputs and partials are f16 while the reference sums in f32, so the tolerance is set by the
+    // input rounding rather than by the reduction.
+    test.SetOutputAbsErr("Y", 0.055f);
+    test.SetOutputRelErr("Y", 0.02f);
+  }
+  test.ConfigEp(std::move(webgpu_ep)).RunWithConfig();
+}
+
+void RunMatMulAgainstReference(const std::vector<int64_t>& a_dims, const std::vector<int64_t>& b_dims,
+                               const std::vector<int64_t>& y_dims) {
+  RunMatMulAgainstReferenceTyped<float>(a_dims, b_dims, y_dims);
+}
+
+}  // namespace
+
+// EfficientNet-B0's classifier shape: M = 1, N = 1000, K = 1280. `dim_inner / split_dim_inner` is
+// exactly 5, so every split covers a full 256-wide slice.
+TEST(MatMul_SplitK, GemvClassifierShape) {
+  RunMatMulAgainstReference({1, 1280}, {1280, 1000}, {1, 1000});
+}
+
+// Squeeze-and-excite shapes: M = 1 after a global average pool, small N.
+TEST(MatMul_SplitK, GemvSqueezeExciteShapes) {
+  RunMatMulAgainstReference({1, 512}, {512, 20}, {1, 20});
+  RunMatMulAgainstReference({1, 1024}, {1024, 64}, {1, 64});
+}
+
+// `dim_inner` not a multiple of `split_dim_inner` (256): the last split runs past `dim_inner` and its
+// out-of-range reads must contribute exactly zero.
+TEST(MatMul_SplitK, InnerDimNotDivisibleBySplit) {
+  RunMatMulAgainstReference({1, 1000}, {1000, 64}, {1, 64});
+  RunMatMulAgainstReference({4, 516}, {516, 32}, {4, 32});
+}
+
+// Batched B, so `dispatch_z` encodes both the batch index and the split index and the scratch buffer
+// is indexed across both. A non-batched B would be folded into M instead.
+TEST(MatMul_SplitK, BatchedB) {
+  RunMatMulAgainstReference({2, 4, 512}, {2, 512, 64}, {2, 4, 64});
+  RunMatMulAgainstReference({3, 2, 768}, {3, 768, 128}, {3, 2, 128});
+}
+
+// Pass 1 stores `vec4<f16>` partials and pass 2 accumulates them in f32 before a single narrowing
+// write, so f16 takes a different path through the reduction than f32.
+TEST(MatMul_SplitK, GemvClassifierShapeFloat16) {
+  RunMatMulAgainstReferenceTyped<MLFloat16>({1, 1280}, {1280, 1000}, {1, 1000});
+}
+
+// The reduction's `has_bias && !is_gemm` branch is only reachable through Conv, since ONNX MatMul has
+// no bias input. Conv's 1x1 fast path forwards its bias into `ComputeMatMul`.
+TEST(MatMul_SplitK, Conv1x1BiasAppliedOnceByReduction) {
+  auto webgpu_ep = DefaultWebGpuExecutionProvider();
+  if (!webgpu_ep) {
+    GTEST_SKIP() << "WebGPU execution provider is not available.";
+  }
+
+  constexpr int64_t kInChannels = 512;  // dim_inner
+  constexpr int64_t kOutChannels = 64;  // dim_b_outer
+  constexpr int64_t kHeight = 4;
+  constexpr int64_t kWidth = 4;  // dim_a_outer = kHeight * kWidth
+  constexpr int64_t kSpatial = kHeight * kWidth;
+
+  const std::vector<int64_t> x_dims{1, kInChannels, kHeight, kWidth};
+  const std::vector<int64_t> w_dims{kOutChannels, kInChannels, 1, 1};
+  const std::vector<int64_t> b_dims{kOutChannels};
+  const std::vector<int64_t> y_dims{1, kOutChannels, kHeight, kWidth};
+
+  RandomValueGenerator random{7};
+  std::vector<float> x_vals(random.Gaussian<float>(AsSpan(x_dims), 0.0f, 0.25f));
+  std::vector<float> w_vals(random.Gaussian<float>(AsSpan(w_dims), 0.0f, 0.25f));
+  std::vector<float> b_vals(random.Gaussian<float>(AsSpan(b_dims), 0.0f, 0.25f));
+
+  // A 1x1 convolution is a matmul over the channel axis, plus the bias once per output channel.
+  std::vector<float> expected(static_cast<size_t>(kOutChannels * kSpatial));
+  for (int64_t m = 0; m < kOutChannels; ++m) {
+    for (int64_t p = 0; p < kSpatial; ++p) {
+      float sum = 0.0f;
+      for (int64_t c = 0; c < kInChannels; ++c) {
+        sum += w_vals[static_cast<size_t>(m * kInChannels + c)] * x_vals[static_cast<size_t>(c * kSpatial + p)];
+      }
+      expected[static_cast<size_t>(m * kSpatial + p)] = sum + b_vals[static_cast<size_t>(m)];
+    }
+  }
+
+  OpTester test("Conv", 11);
+  test.AddAttribute("group", static_cast<int64_t>(1));
+  test.AddAttribute("kernel_shape", std::vector<int64_t>{1, 1});
+  test.AddAttribute("pads", std::vector<int64_t>{0, 0, 0, 0});
+  test.AddAttribute("strides", std::vector<int64_t>{1, 1});
+  test.AddInput<float>("X", x_dims, x_vals);
+  test.AddInput<float>("W", w_dims, w_vals);
+  test.AddInput<float>("B", b_dims, b_vals);
+  test.AddOutput<float>("Y", y_dims, expected);
+  test.SetOutputAbsErr("Y", 1e-3f);
+  test.SetOutputRelErr("Y", 1e-3f);
+  test.ConfigEp(std::move(webgpu_ep)).RunWithConfig();
+}
+
+// Identical input must produce identical output bytes. Compared as raw bit patterns rather than with
+// a tolerance, because a reordered floating-point sum can differ in the last bit only.
+TEST(MatMul_SplitK, BitReproducibleAcrossRuns) {
+  if (!DefaultWebGpuExecutionProvider()) {
+    GTEST_SKIP() << "WebGPU execution provider is not available.";
+  }
+
+  const std::vector<int64_t> a_dims{1, 1280};
+  const std::vector<int64_t> b_dims{1280, 1000};
+  const std::vector<int64_t> y_dims{1, 1000};
+
+  RandomValueGenerator random{4321};
+  std::vector<float> a_vals(random.Gaussian<float>(AsSpan(a_dims), 0.0f, 0.25f));
+  std::vector<float> b_vals(random.Gaussian<float>(AsSpan(b_dims), 0.0f, 0.25f));
+
+  const std::vector<uint8_t> first = RunMatMulCaptureBytes(a_dims, b_dims, y_dims, a_vals, b_vals);
+  ASSERT_FALSE(first.empty()) << "No output captured from the first run.";
+
+  constexpr int kRepeats = 4;
+  for (int i = 1; i <= kRepeats; ++i) {
+    const std::vector<uint8_t> again = RunMatMulCaptureBytes(a_dims, b_dims, y_dims, a_vals, b_vals);
+    ASSERT_FALSE(again.empty()) << "No output captured from run " << i << ".";
+    EXPECT_TRUE(BytesIdentical(first, again)) << "Run " << i << " is not bit-identical to run 0.";
+  }
+}
+
+// Guards the comparator itself: `BytesIdentical` must reject a flipped mantissa bit, and must treat
+// `-0.0` and differing NaN payloads as distinct rather than equal.
+TEST(MatMul_SplitK, BitComparisonRejectsSingleBitDifference) {
+  std::vector<uint8_t> lhs(64, 0);
+  std::vector<uint8_t> rhs(64, 0);
+  EXPECT_TRUE(BytesIdentical(lhs, rhs));
+
+  rhs[17] ^= 0x01;
+  EXPECT_FALSE(BytesIdentical(lhs, rhs));
+
+  // Positive and negative zero share every bit but the sign, and must not compare equal.
+  const float pos_zero = 0.0f;
+  const float neg_zero = -0.0f;
+  std::vector<uint8_t> pos(sizeof(float));
+  std::vector<uint8_t> neg(sizeof(float));
+  std::memcpy(pos.data(), &pos_zero, sizeof(float));
+  std::memcpy(neg.data(), &neg_zero, sizeof(float));
+  EXPECT_FALSE(BytesIdentical(pos, neg));
+
+  // NaNs with different payloads must not compare equal either.
+  const uint32_t nan_a = 0x7FC00000u;
+  const uint32_t nan_b = 0x7FC00001u;
+  std::vector<uint8_t> a(sizeof(uint32_t));
+  std::vector<uint8_t> b(sizeof(uint32_t));
+  std::memcpy(a.data(), &nan_a, sizeof(uint32_t));
+  std::memcpy(b.data(), &nan_b, sizeof(uint32_t));
+  EXPECT_FALSE(BytesIdentical(a, b));
+}
+
+// Gemm reaches Split-K through `ApplyGemmPacked`, which uses a separate program with its own uniform
+// set and no batch dimension. `beta * C` is applied by the reduction.
+TEST(Gemm_SplitK, WithAndWithoutBias) {
+  auto make_ep = []() { return DefaultWebGpuExecutionProvider(); };
+  if (!make_ep()) {
+    GTEST_SKIP() << "WebGPU execution provider is not available.";
+  }
+
+  constexpr int64_t M = 4;
+  constexpr int64_t K = 1024;
+  constexpr int64_t N = 64;
+
+  const std::vector<int64_t> a_dims{M, K};
+  const std::vector<int64_t> b_dims{K, N};
+  const std::vector<int64_t> y_dims{M, N};
+
+  RandomValueGenerator random{99};
+  std::vector<float> a_vals(random.Gaussian<float>(AsSpan(a_dims), 0.0f, 0.25f));
+  std::vector<float> b_vals(random.Gaussian<float>(AsSpan(b_dims), 0.0f, 0.25f));
+
+  std::vector<float> matmul_only;
+  ComputeExpectedMatMul(a_vals, b_vals, /*batch*/ 1, M, K, N, /*b_is_batched*/ false, matmul_only);
+
+  // No bias.
+  {
+    OpTester test("Gemm", 13);
+    test.AddInput<float>("A", a_dims, a_vals);
+    test.AddInput<float>("B", b_dims, b_vals);
+    test.AddOutput<float>("Y", y_dims, matmul_only);
+    test.SetOutputAbsErr("Y", 1e-3f);
+    test.SetOutputRelErr("Y", 1e-3f);
+    test.ConfigEp(make_ep()).RunWithConfig();
+  }
+
+  // C's shape selects one of three branches in the reduction's write function: read per column for
+  // [N], as a scalar for [1], and per row for [M,1]. `beta` is a uniform on the same path, so a case
+  // with beta != 1 is what separates applying it from ignoring it.
+  const auto run_with_bias = [&](const std::vector<int64_t>& c_dims, float beta) {
+    SCOPED_TRACE("C=" + ShapeToString(c_dims) + " beta=" + std::to_string(beta));
+    std::vector<float> c_vals(random.Gaussian<float>(AsSpan(c_dims), 0.0f, 0.25f));
+
+    std::vector<float> expected(matmul_only);
+    for (int64_t m = 0; m < M; ++m) {
+      for (int64_t n = 0; n < N; ++n) {
+        const float c = c_vals.size() == 1
+                            ? c_vals[0]
+                            : c_vals[static_cast<size_t>(c_dims.back() == 1 ? m : n)];
+        expected[static_cast<size_t>(m * N + n)] += beta * c;
+      }
+    }
+
+    OpTester test("Gemm", 13);
+    test.AddAttribute("beta", beta);
+    test.AddInput<float>("A", a_dims, a_vals);
+    test.AddInput<float>("B", b_dims, b_vals);
+    test.AddInput<float>("C", c_dims, c_vals);
+    test.AddOutput<float>("Y", y_dims, expected);
+    test.SetOutputAbsErr("Y", 1e-3f);
+    test.SetOutputRelErr("Y", 1e-3f);
+    test.ConfigEp(make_ep()).RunWithConfig();
+  };
+
+  run_with_bias({N}, 1.0f);
+  run_with_bias({N}, 0.5f);
+  run_with_bias({1}, 1.0f);
+  run_with_bias({M, 1}, 1.0f);
+}
+
+}  // namespace test
+}  // namespace onnxruntime

--- a/onnxruntime/test/providers/webgpu/matmul_split_k_test.cc
+++ b/onnxruntime/test/providers/webgpu/matmul_split_k_test.cc
@@ -7,8 +7,10 @@
 // path on an adapter that would otherwise leave it disabled, or `off` to force it off. The value is
 // read when the WebGPU context is created, so it must be set before the process starts.
 
+#include <cmath>
 #include <cstdint>
 #include <cstring>
+#include <functional>
 #include <string>
 #include <type_traits>
 #include <vector>
@@ -16,6 +18,7 @@
 #include "gtest/gtest.h"
 
 #include "core/framework/tensor.h"
+#include "core/graph/constants.h"
 #include "test/providers/provider_test_utils.h"
 #include "test/common/tensor_op_test_utils.h"
 #include "default_providers.h"
@@ -167,7 +170,62 @@ void RunMatMulAgainstReference(const std::vector<int64_t>& a_dims, const std::ve
   RunMatMulAgainstReferenceTyped<float>(a_dims, b_dims, y_dims);
 }
 
+// A fused activation reaches ComputeMatMul only through Conv's 1x1 path, so the activation gate is
+// exercised through FusedConv rather than a bare MatMul. Squeeze-and-excite shape: many channels in,
+// few out, which is what the rate gate selects for.
+void RunFusedConvAgainstReference(const char* activation_name,
+                                  const std::vector<float>& activation_params,
+                                  const std::function<float(float)>& apply) {
+  auto webgpu_ep = DefaultWebGpuExecutionProvider();
+  if (!webgpu_ep) {
+    GTEST_SKIP() << "WebGPU execution provider is not available.";
+  }
+
+  constexpr int64_t kIn = 1024;
+  constexpr int64_t kOut = 16;
+  const std::vector<int64_t> x_dims{1, kIn, 1, 1};
+  const std::vector<int64_t> w_dims{kOut, kIn, 1, 1};
+
+  RandomValueGenerator random{1234};
+  std::vector<float> x_vals(random.Gaussian<float>(AsSpan(x_dims), 0.0f, 0.25f));
+  std::vector<float> w_vals(random.Gaussian<float>(AsSpan(w_dims), 0.0f, 0.25f));
+
+  std::vector<float> expected(kOut);
+  for (int64_t o = 0; o < kOut; ++o) {
+    float acc = 0.0f;
+    for (int64_t c = 0; c < kIn; ++c) {
+      acc += x_vals[static_cast<size_t>(c)] * w_vals[static_cast<size_t>(o * kIn + c)];
+    }
+    expected[static_cast<size_t>(o)] = apply(acc);
+  }
+
+  OpTester test("FusedConv", 1, kMSDomain);
+  test.AddAttribute("activation", activation_name);
+  test.AddAttribute("kernel_shape", std::vector<int64_t>{1, 1});
+  if (!activation_params.empty()) {
+    test.AddAttribute("activation_params", activation_params);
+  }
+  test.AddInput<float>("X", x_dims, x_vals);
+  test.AddInput<float>("W", w_dims, w_vals);
+  test.AddOutput<float>("Y", {1, kOut, 1, 1}, expected);
+  test.SetOutputAbsErr("Y", 1e-3f);
+  test.SetOutputRelErr("Y", 1e-3f);
+  test.ConfigEp(std::move(webgpu_ep)).RunWithConfig();
+}
+
 }  // namespace
+
+// The activation must be applied to the completed sum, not per split. That is only distinguishable
+// when some partial sums differ in sign from the total, which the Gaussian inputs provide.
+TEST(MatMul_SplitK, FusedConvReluAppliedAfterReduction) {
+  RunFusedConvAgainstReference("Relu", {}, [](float v) { return v > 0.0f ? v : 0.0f; });
+}
+
+// Alpha 1 is SiLU, the only QuickGelu the gate admits.
+TEST(MatMul_SplitK, FusedConvSiluAppliedAfterReduction) {
+  RunFusedConvAgainstReference("QuickGelu", {1.0f},
+                               [](float v) { return v / (1.0f + std::exp(-v)); });
+}
 
 // EfficientNet-B0's classifier shape: M = 1, N = 1000, K = 1280. `dim_inner / split_dim_inner` is
 // exactly 5, so every split covers a full 256-wide slice.
@@ -202,12 +260,16 @@ TEST(MatMul_SplitK, GemvClassifierShapeFloat16) {
 }
 
 // The reduction's `has_bias && !is_gemm` branch is only reachable through Conv, since ONNX MatMul has
-// no bias input. Conv's 1x1 fast path forwards its bias into `ComputeMatMul`.
-TEST(MatMul_SplitK, Conv1x1BiasAppliedOnceByReduction) {
+// no bias input. Conv's 1x1 fast path forwards its bias into `ComputeMatMul`. With an activation the
+// reduction must compute `act(sum + b)`; the two are distinguishable because Relu is not additive.
+void RunConv1x1BiasAgainstReference(const char* activation_name,
+                                    const std::function<float(float)>& apply) {
   auto webgpu_ep = DefaultWebGpuExecutionProvider();
   if (!webgpu_ep) {
     GTEST_SKIP() << "WebGPU execution provider is not available.";
   }
+
+  SCOPED_TRACE(activation_name == nullptr ? "no activation" : activation_name);
 
   constexpr int64_t kInChannels = 512;  // dim_inner
   constexpr int64_t kOutChannels = 64;  // dim_b_outer
@@ -233,11 +295,15 @@ TEST(MatMul_SplitK, Conv1x1BiasAppliedOnceByReduction) {
       for (int64_t c = 0; c < kInChannels; ++c) {
         sum += w_vals[static_cast<size_t>(m * kInChannels + c)] * x_vals[static_cast<size_t>(c * kSpatial + p)];
       }
-      expected[static_cast<size_t>(m * kSpatial + p)] = sum + b_vals[static_cast<size_t>(m)];
+      expected[static_cast<size_t>(m * kSpatial + p)] = apply(sum + b_vals[static_cast<size_t>(m)]);
     }
   }
 
-  OpTester test("Conv", 11);
+  const bool fused = activation_name != nullptr;
+  OpTester test(fused ? "FusedConv" : "Conv", fused ? 1 : 11, fused ? kMSDomain : kOnnxDomain);
+  if (fused) {
+    test.AddAttribute("activation", activation_name);
+  }
   test.AddAttribute("group", static_cast<int64_t>(1));
   test.AddAttribute("kernel_shape", std::vector<int64_t>{1, 1});
   test.AddAttribute("pads", std::vector<int64_t>{0, 0, 0, 0});
@@ -249,6 +315,16 @@ TEST(MatMul_SplitK, Conv1x1BiasAppliedOnceByReduction) {
   test.SetOutputAbsErr("Y", 1e-3f);
   test.SetOutputRelErr("Y", 1e-3f);
   test.ConfigEp(std::move(webgpu_ep)).RunWithConfig();
+}
+
+TEST(MatMul_SplitK, Conv1x1BiasAppliedOnceByReduction) {
+  RunConv1x1BiasAgainstReference(nullptr, [](float v) { return v; });
+}
+
+// Bias and activation together. `act(sum + b)` and `act(sum) + b` differ, and only the first is
+// correct, so this guards the order the reduction applies them in.
+TEST(MatMul_SplitK, Conv1x1BiasThenActivation) {
+  RunConv1x1BiasAgainstReference("Relu", [](float v) { return v > 0.0f ? v : 0.0f; });
 }
 
 // Identical input must produce identical output bytes. Compared as raw bit patterns rather than with


### PR DESCRIPTION
### Description

*This depends on #32318, which is the first of the two commits here. Only the second commit belongs to this PR, and by itself it is 5 files, +82/-9. I will rebase once #32318 merges. I could not set the base branch to it because that branch only exists on my fork.*

Split-K splits one matmul's reduction across several dispatches. Until now it refused to run at all if the convolution had an activation fused into it.

That restriction was necessary with the old atomic version. The work was spread across dispatches and none of them held the finished sum, so applying something like Relu there would have applied it to a partial result, once per split.

The two-pass reduction removed the problem. The second pass does hold the finished sum, and it already applies the bias, so running the activation there costs no extra dispatch. This PR lifts the restriction for Relu and for QuickGelu at alpha 1, which is SiLU.

The other activation kinds stay out for now. Some of them need helper code that the reduction does not emit, and admitting any kind changes which dispatches take the Split-K path, so each one should be measured before it is allowed in.

### Motivation and Context

A fused activation reaches ComputeMatMul only through Conv's 1x1 path, which is where
squeeze-and-excite convolutions land: many channels in, few out, so K is large while M * N stays
small. That is the shape the rate gate selects for, and it is most of the Split-K opportunity in
EfficientNet-B0.

Covered by two FusedConv tests in matmul_split_k_test.cc, one per admitted kind, checked against a
CPU reference.