### PR TITLE
[CUDA] Refine fpA-intB GEMV support checks

### DIFF
--- a/onnxruntime/contrib_ops/cuda/llm/fpA_intB_gemv/fpA_intB_gemv.cu
+++ b/onnxruntime/contrib_ops/cuda/llm/fpA_intB_gemv/fpA_intB_gemv.cu
@@ -27,7 +27,7 @@ namespace onnxruntime::llm {
 namespace kernels {
 namespace fpA_intB_gemv {
 
-void kernel_launcher(int arch, Params& params, cudaStream_t s) {
+void kernel_launcher(int kernel_arch, Params& params, cudaStream_t s) {
 #define EXEC(KType, A, B, Layout, ConverterInterleave)                                                       \
   if (params.type == KType) {                                                                                \
     select_gs<kernel_type_traits<KType>::isGroupwise, KernelDetails<A, B, Layout, ConverterInterleave, 64>>( \
@@ -43,16 +43,20 @@ void kernel_launcher(int arch, Params& params, cudaStream_t s) {
     return;                                                                                                   \
   }
 
-  ORT_ENFORCE(arch >= 75, "Unsupported CUDA architecture: ", arch);
+  ORT_ENFORCE(kernel_arch >= 75, "Unsupported CUDA kernel architecture: ", kernel_arch);
 #if USE_COMPACT_FPA_INTB_GEMM
+  ORT_ENFORCE(kernel_arch < 90 || kernel_arch >= 100,
+              "The compact fpA_intB GEMV does not support the SM90 weight layout");
+  ORT_ENFORCE(params.type == KernelType::FP16Int8Groupwise || params.type == KernelType::FP16Int4Groupwise,
+              "The compact fpA_intB GEMV supports only FP16 groupwise kernels");
   EXEC(KernelType::FP16Int8Groupwise, FP16DetailsA, Int8DetailsW, ColumnMajorInterleaved, true);
   EXEC(KernelType::FP16Int4Groupwise, FP16DetailsA, Int4DetailsW, ColumnMajorInterleaved, true);
 #else
-  if (arch < 80) {
+  if (kernel_arch < 80) {
     EXEC(KernelType::FP16Int8Groupwise, FP16DetailsA, Int8DetailsW, ColumnMajorInterleaved, true);
     EXEC(KernelType::FP16Int4Groupwise, FP16DetailsA, Int4DetailsW, ColumnMajorInterleaved, true);
 #ifndef EXCLUDE_SM_90
-  } else if (arch >= 90 && arch < 100) {
+  } else if (kernel_arch >= 90 && kernel_arch < 100) {
     // Dispatchers for W4A8 groupwise
     // EXEC_W4A8(KernelType::FP16Int4Groupwise, FP16DetailsA, Int4DetailsW, ColumnMajorInterleavedForHopper, true);
     // EXEC_W4A8(KernelType::BF16Int4Groupwise, BF16DetailsA, Int4DetailsW, ColumnMajorInterleavedForHopper, true);
@@ -80,32 +84,34 @@ void kernel_launcher(int arch, Params& params, cudaStream_t s) {
 #undef EXEC
 }
 
-bool is_supported(int arch, KernelType kernel_type) {
-#if USE_COMPACT_FPA_INTB_GEMM
-  return arch >= 75 &&
-         (kernel_type == KernelType::FP16Int8Groupwise || kernel_type == KernelType::FP16Int4Groupwise);
-#else
-#define SUPPORT(Type)      \
-  if (kernel_type == Type) \
-    return true;
+bool is_supported(int device_arch, int kernel_arch, KernelType kernel_type) {
+  if (device_arch < 75 || kernel_arch < 75) {
+    return false;
+  }
 
-  if (arch >= 75 && arch < 80) {
-    SUPPORT(KernelType::FP16Int8Groupwise);
-    SUPPORT(KernelType::FP16Int4Groupwise);
-  } else if (arch >= 80) {
-#ifdef EXCLUDE_SM_90
-    if (arch >= 90 && arch < 100) {
+  const bool is_fp16 = kernel_type == KernelType::FP16Int8Groupwise ||
+                       kernel_type == KernelType::FP16Int4Groupwise;
+#if USE_COMPACT_FPA_INTB_GEMM
+  const bool is_sm90_layout = kernel_arch >= 90 && kernel_arch < 100;
+  return is_fp16 && !is_sm90_layout;
+#else
+  const bool is_bf16 = kernel_type == KernelType::BF16Int8Groupwise ||
+                       kernel_type == KernelType::BF16Int4Groupwise;
+  if (!is_fp16 && !is_bf16) {
+    return false;
+  }
+  if ((device_arch < 80 || kernel_arch < 80) && is_bf16) {
+    return false;
+  }
+  if (kernel_arch >= 90 && kernel_arch < 100) {
+    if (device_arch < 90 || device_arch >= 100) {
       return false;
     }
+#ifdef EXCLUDE_SM_90
+    return false;
 #endif
-    SUPPORT(KernelType::FP16Int8Groupwise);
-    SUPPORT(KernelType::FP16Int4Groupwise);
-
-    SUPPORT(KernelType::BF16Int8Groupwise);
-    SUPPORT(KernelType::BF16Int4Groupwise);
   }
-  return false;
-#undef SUPPORT
+  return true;
 #endif
 }
 

--- a/onnxruntime/contrib_ops/cuda/llm/fpA_intB_gemv/fpA_intB_gemv.h
+++ b/onnxruntime/contrib_ops/cuda/llm/fpA_intB_gemv/fpA_intB_gemv.h
@@ -70,9 +70,9 @@ struct Params {
   }
 };
 
-void kernel_launcher(int arch, Params& params, cudaStream_t s);
+void kernel_launcher(int kernel_arch, Params& params, cudaStream_t s);
 
-bool is_supported(int arch, KernelType kernel_type);
+bool is_supported(int device_arch, int kernel_arch, KernelType kernel_type);
 
 }  // namespace fpA_intB_gemv
 }  // namespace kernels

--- a/onnxruntime/contrib_ops/cuda/quantization/matmul_nbits.h
+++ b/onnxruntime/contrib_ops/cuda/quantization/matmul_nbits.h
@@ -196,7 +196,8 @@ class MatMulNBits final : public CudaKernel {
         } else if constexpr (std::is_same<T, BFloat16>::value) {
           cuda_kernel_type = (nbits_ == 8) ? KernelType::BF16Int8Groupwise : KernelType::BF16Int4Groupwise;
         }
-        if (onnxruntime::llm::kernels::fpA_intB_gemv::is_supported(FpAIntBPackingSmForKernel(), cuda_kernel_type)) {
+        if (onnxruntime::llm::kernels::fpA_intB_gemv::is_supported(
+                sm_, FpAIntBPackingSmForKernel(), cuda_kernel_type)) {
           has_fpA_intB_gemv_ = true;
         }
 

--- a/onnxruntime/test/contrib_ops/cuda_kernels/fpA_intB_gemm_kernel_test.cc
+++ b/onnxruntime/test/contrib_ops/cuda_kernels/fpA_intB_gemm_kernel_test.cc
@@ -415,9 +415,14 @@ class KernelTestFixture : public ::testing::Test {
     if (m_ < 16) {
       cuda_time_ms = measure_kernel_time(
           [&]() {
-            int arch = onnxruntime::llm::common::getSMVersion();
-            ORT_ENFORCE(wo::is_supported(arch, params.type));
-            wo::kernel_launcher(arch, params, s_);
+            const int device_arch = onnxruntime::llm::common::getSMVersion();
+#if USE_COMPACT_FPA_INTB_GEMM
+            constexpr int kernel_arch = 80;
+#else
+            const int kernel_arch = device_arch;
+#endif
+            ORT_ENFORCE(wo::is_supported(device_arch, kernel_arch, params.type));
+            wo::kernel_launcher(kernel_arch, params, s_);
           },
           warmup_, repeats_, s_);
       d_out_->to_cpu(h_out1_.data());
@@ -595,6 +600,28 @@ using Fp16Int4GroupwiseTest = KernelTestFixture<wo::KernelType::FP16Int4Groupwis
 using Bf16Int8GroupwiseTest = KernelTestFixture<wo::KernelType::BF16Int8Groupwise>;
 using Bf16Int4GroupwiseTest = KernelTestFixture<wo::KernelType::BF16Int4Groupwise>;
 #endif
+
+TEST(FpAIntBGemvTest, SupportUsesDeviceAndKernelArchitectures) {
+  EXPECT_FALSE(wo::is_supported(74, 80, wo::KernelType::FP16Int4Groupwise));
+  EXPECT_TRUE(wo::is_supported(75, 80, wo::KernelType::FP16Int4Groupwise));
+  EXPECT_FALSE(wo::is_supported(75, 80, wo::KernelType::BF16Int4Groupwise));
+  EXPECT_FALSE(wo::is_supported(90, 80, wo::KernelType::FP16Int4PerChannel));
+
+#if USE_COMPACT_FPA_INTB_GEMM
+  EXPECT_TRUE(wo::is_supported(90, 80, wo::KernelType::FP16Int4Groupwise));
+  EXPECT_FALSE(wo::is_supported(90, 80, wo::KernelType::BF16Int4Groupwise));
+  EXPECT_FALSE(wo::is_supported(90, 90, wo::KernelType::FP16Int4Groupwise));
+#else
+  EXPECT_TRUE(wo::is_supported(80, 80, wo::KernelType::BF16Int4Groupwise));
+  EXPECT_TRUE(wo::is_supported(90, 80, wo::KernelType::BF16Int4Groupwise));
+  EXPECT_FALSE(wo::is_supported(80, 90, wo::KernelType::FP16Int4Groupwise));
+#ifdef EXCLUDE_SM_90
+  EXPECT_FALSE(wo::is_supported(90, 90, wo::KernelType::FP16Int4Groupwise));
+#else
+  EXPECT_TRUE(wo::is_supported(90, 90, wo::KernelType::FP16Int4Groupwise));
+#endif
+#endif
+}
 
 TEST_F(Fp16Int8GroupwiseTest, Fp16_Int8_Gemm_CudaKernel) {
   int const arch = onnxruntime::llm::common::getSMVersion();

--- a/onnxruntime/test/python/quantization/test_op_matmulnbits_prepacked_cuda.py
+++ b/onnxruntime/test/python/quantization/test_op_matmulnbits_prepacked_cuda.py
@@ -285,7 +285,7 @@ class TestFpAIntBConfigKeys(unittest.TestCase):
         sess = ort.InferenceSession(model.SerializeToString(), so, providers=["CUDAExecutionProvider"])
         return sess.run(None, {"A": a})[0]
 
-    def _make_int4_case(self, m=32, k=256, n=512, block_size=64):
+    def _make_int4_case(self, m=32, k=256, n=512, block_size=32):
         rng = np.random.default_rng(2024)
         a = rng.normal(0.0, 0.25, size=(m, k)).astype(np.float16)
         weight = rng.normal(0.0, 0.25, size=(k, n)).astype(np.float16)


### PR DESCRIPTION
## Description

Refine fpA-intB GEMV support checks and test coverage for the compact kernel configuration introduced by PR #32324. The support query now evaluates the physical device architecture separately from the selected kernel/layout architecture, while compact mode remains limited to FP16 groupwise kernels using the non-SM90 layout.

## Summary of Changes

### GEMV support and dispatch

| File | Change |
|------|--------|
| `onnxruntime/contrib_ops/cuda/llm/fpA_intB_gemv/fpA_intB_gemv.h` | Update the support-query declaration to accept both device and kernel architectures. |
| `onnxruntime/contrib_ops/cuda/llm/fpA_intB_gemv/fpA_intB_gemv.cu` | Apply compact/full build checks using separate device and kernel architecture inputs, including SM90-layout and BF16 constraints. |
| `onnxruntime/contrib_ops/cuda/quantization/matmul_nbits.h` | Pass the physical device architecture and selected packing architecture to the support query. |

### Tests

| File | Change |
|------|--------|
| `onnxruntime/test/contrib_ops/cuda_kernels/fpA_intB_gemm_kernel_test.cc` | Add support-matrix coverage for combinations of device architecture, kernel/layout architecture, and kernel type. |
| `onnxruntime/test/python/quantization/test_op_matmulnbits_prepacked_cuda.py` | Use compact-compatible `block_size=32` in the configuration-key fixture so the test exercises fpA-intB instead of falling back. |

## Testing

- CUDA internal tests passed: 123 tests, including `FpAIntBGemvTest.SupportUsesDeviceAndKernelArchitectures`.
- Four Python configuration-key tests passed against a fresh native build.
- Both modified translation units compiled successfully with compact mode disabled/full-mode settings.
- `git show --check` passed with no whitespace errors.
- `lintrunner -a` was attempted; the Ruff, Ruff-format, and ClangFormat adapters failed without reporting violations in the changed files.

## Motivation and Context

A Hopper device can use either the SM80-compatible packing/layout or the native SM90 layout. Treating the selected layout architecture as the device architecture incorrectly rejected valid compatibility-layout dispatch, while ignoring the layout allowed compact mode to select unsupported kernels. Keeping these inputs separate makes the support matrix reflect both hardware capability and the compiled kernel path.

## Checklist

- [x] Tests added/updated
- [x] No breaking changes
- [x] Documentation updated (not applicable)
