### PR TITLE
Limit function call depth and fix lint issues

### DIFF
--- a/onnxruntime/core/graph/graph.cc
+++ b/onnxruntime/core/graph/graph.cc
@@ -31,6 +31,9 @@
 #include "core/graph/graph_viewer.h"
 #include "core/graph/indexed_sub_graph.h"
 #include "core/graph/model.h"
+#if !defined(ORT_MINIMAL_BUILD)
+#include "core/graph/model_helpers.h"
+#endif
 #include "core/graph/graph_utils.h"
 #include "core/graph/model_editor_api_types.h"
 #include "core/graph/model_load_utils.h"
@@ -3803,6 +3806,10 @@ Status Graph::Resolve(const ResolveOptions& options) {
   if (!GraphResolveNeeded() && !subgraphs_need_resolve) {
     return Status::OK();
   }
+
+#if !defined(ORT_MINIMAL_BUILD)
+  ORT_RETURN_IF_ERROR(owning_model_.ValidateLocalFunctionCallDepth(ToGraphProto()));
+#endif
 
   // init all graph/subgraphs. non-recursive so call via ForThisAndAllSubgraphs.
   auto init_func = [](Graph& graph) { return graph.InitInputsInitializersOutputs(); };

--- a/onnxruntime/core/graph/graph.cc
+++ b/onnxruntime/core/graph/graph.cc
@@ -3808,7 +3808,10 @@ Status Graph::Resolve(const ResolveOptions& options) {
   }
 
 #if !defined(ORT_MINIMAL_BUILD)
-  ORT_RETURN_IF_ERROR(owning_model_.ValidateLocalFunctionCallDepth(ToGraphProto()));
+  const bool graph_proto_sync_needed = GraphProtoSyncNeeded();
+  const auto depth_status = owning_model_.ValidateLocalFunctionCallDepth(ToGraphProto());
+  GraphProtoSyncNeeded(graph_proto_sync_needed);
+  ORT_RETURN_IF_ERROR(depth_status);
 #endif
 
   // init all graph/subgraphs. non-recursive so call via ForThisAndAllSubgraphs.

--- a/onnxruntime/core/graph/graph.cc
+++ b/onnxruntime/core/graph/graph.cc
@@ -3808,10 +3808,7 @@ Status Graph::Resolve(const ResolveOptions& options) {
   }
 
 #if !defined(ORT_MINIMAL_BUILD)
-  const bool graph_proto_sync_needed = GraphProtoSyncNeeded();
-  const auto depth_status = owning_model_.ValidateLocalFunctionCallDepth(ToGraphProto());
-  GraphProtoSyncNeeded(graph_proto_sync_needed);
-  ORT_RETURN_IF_ERROR(depth_status);
+  ORT_RETURN_IF_ERROR(owning_model_.ValidateLocalFunctionCallDepth(*this));
 #endif
 
   // init all graph/subgraphs. non-recursive so call via ForThisAndAllSubgraphs.

--- a/onnxruntime/core/graph/model.cc
+++ b/onnxruntime/core/graph/model.cc
@@ -301,6 +301,10 @@ const NodeHashMap<std::string, std::unique_ptr<FunctionTemplate>>& Model::GetMod
   return model_local_function_templates_maps_;
 }
 
+Status Model::ValidateLocalFunctionCallDepth(const ONNX_NAMESPACE::GraphProto& graph_proto) const {
+  return ValidateModelLocalFunctionCallDepth(model_local_functions_, graph_proto);
+}
+
 Version Model::IrVersion() const {
   if (utils::HasIrVersion(model_proto_)) {
     return model_proto_.ir_version();

--- a/onnxruntime/core/graph/model.cc
+++ b/onnxruntime/core/graph/model.cc
@@ -301,8 +301,8 @@ const NodeHashMap<std::string, std::unique_ptr<FunctionTemplate>>& Model::GetMod
   return model_local_function_templates_maps_;
 }
 
-Status Model::ValidateLocalFunctionCallDepth(const ONNX_NAMESPACE::GraphProto& graph_proto) const {
-  return ValidateModelLocalFunctionCallDepth(model_local_functions_, graph_proto);
+Status Model::ValidateLocalFunctionCallDepth(const Graph& graph) const {
+  return ValidateModelLocalFunctionCallDepth(model_local_functions_, graph);
 }
 
 Version Model::IrVersion() const {

--- a/onnxruntime/core/graph/model.h
+++ b/onnxruntime/core/graph/model.h
@@ -157,6 +157,8 @@ class Model {
 
   const NodeHashMap<std::string, std::unique_ptr<FunctionTemplate>>& GetModelLocalFunctionTemplates() const;
 
+  common::Status ValidateLocalFunctionCallDepth(const ONNX_NAMESPACE::GraphProto& graph_proto) const;
+
 #else
   // Get model's IR version.
   // Return <kNoVersion> if not specified.

--- a/onnxruntime/core/graph/model.h
+++ b/onnxruntime/core/graph/model.h
@@ -157,7 +157,7 @@ class Model {
 
   const NodeHashMap<std::string, std::unique_ptr<FunctionTemplate>>& GetModelLocalFunctionTemplates() const;
 
-  common::Status ValidateLocalFunctionCallDepth(const ONNX_NAMESPACE::GraphProto& graph_proto) const;
+  common::Status ValidateLocalFunctionCallDepth(const Graph& graph) const;
 
 #else
   // Get model's IR version.

--- a/onnxruntime/core/graph/model_helpers.cc
+++ b/onnxruntime/core/graph/model_helpers.cc
@@ -5,6 +5,7 @@
 
 #include "core/graph/model_helpers.h"
 
+#include <algorithm>
 #include <string>
 #include <string_view>
 #include <unordered_map>
@@ -177,11 +178,87 @@ Status ValidateCallGraphAcyclic(const LocalFunctionCallGraph& call_graph) {
   return Status::OK();
 }
 
+Status ValidateCallGraphDepth(const LocalFunctionCallGraph& call_graph,
+                              gsl::span<const std::string_view> roots) {
+  InlinedHashMap<std::string_view, size_t> call_depths;
+  call_depths.reserve(call_graph.size());
+  InlinedHashSet<std::string_view> visited;
+  InlinedVector<std::string_view> postorder;
+
+  struct DfsFrame {
+    std::string_view function_id;
+    size_t next_callee_index;
+  };
+  InlinedVector<DfsFrame> dfs_stack;
+
+  for (const auto root_id : roots) {
+    if (call_graph.find(root_id) == call_graph.end()) {
+      continue;
+    }
+    if (!visited.insert(root_id).second) {
+      continue;
+    }
+
+    dfs_stack.push_back({root_id, 0});
+    while (!dfs_stack.empty()) {
+      auto& frame = dfs_stack.back();
+      const auto function_it = call_graph.find(frame.function_id);
+      if (function_it == call_graph.end() || frame.next_callee_index >= function_it->second.size()) {
+        postorder.push_back(frame.function_id);
+        dfs_stack.pop_back();
+        continue;
+      }
+
+      const auto callee_id = function_it->second[frame.next_callee_index++];
+      if (call_graph.find(callee_id) != call_graph.end() && visited.insert(callee_id).second) {
+        dfs_stack.push_back({callee_id, 0});
+      }
+    }
+  }
+
+  for (const auto function_id : postorder) {
+    size_t call_depth = 1;
+    const auto function_it = call_graph.find(function_id);
+    ORT_ENFORCE(function_it != call_graph.end());
+    for (const auto callee_id : function_it->second) {
+      const auto callee_depth_it = call_depths.find(callee_id);
+      if (callee_depth_it != call_depths.end()) {
+        call_depth = std::max(call_depth, callee_depth_it->second + 1);
+      }
+    }
+
+    call_depths.emplace(function_id, call_depth);
+  }
+
+  for (const auto root_id : roots) {
+    const auto depth_it = call_depths.find(root_id);
+    if (depth_it != call_depths.end() && depth_it->second > kMaxModelLocalFunctionCallDepth) {
+      return ORT_MAKE_STATUS(
+          ONNXRUNTIME, NOT_IMPLEMENTED,
+          "Model local function call depth ", depth_it->second,
+          " exceeds the maximum supported depth of ", kMaxModelLocalFunctionCallDepth, ".");
+    }
+  }
+
+  return Status::OK();
+}
+
 Status ValidateModelLocalFunctionAcyclic(
     const std::unordered_map<std::string, const ONNX_NAMESPACE::FunctionProto*>& model_local_functions) {
   LocalFunctionCallGraph call_graph;
   ORT_RETURN_IF_ERROR(BuildLocalFunctionCallGraph(model_local_functions, call_graph));
   return ValidateCallGraphAcyclic(call_graph);
+}
+
+Status ValidateModelLocalFunctionCallDepth(
+    const std::unordered_map<std::string, const ONNX_NAMESPACE::FunctionProto*>& model_local_functions,
+    const ONNX_NAMESPACE::GraphProto& main_graph) {
+  LocalFunctionCallGraph call_graph;
+  ORT_RETURN_IF_ERROR(BuildLocalFunctionCallGraph(model_local_functions, call_graph));
+  InlinedHashSet<std::string_view> seen_calls;
+  InlinedVector<std::string_view> root_calls;
+  CollectLocalFunctionCalls(main_graph.node(), model_local_functions, seen_calls, root_calls);
+  return ValidateCallGraphDepth(call_graph, root_calls);
 }
 
 }  // namespace onnxruntime

--- a/onnxruntime/core/graph/model_helpers.cc
+++ b/onnxruntime/core/graph/model_helpers.cc
@@ -93,8 +93,8 @@ void CollectLocalFunctionCalls(
             CollectLocalFunctionCalls(attr.g().node(), model_local_functions, seen_calls, called_functions);
           }
         }
-        for (const auto& graph : attr.graphs()) {
-          CollectLocalFunctionCalls(graph.node(), model_local_functions, seen_calls, called_functions);
+        for (const auto& attribute_graph : attr.graphs()) {
+          CollectLocalFunctionCalls(attribute_graph.node(), model_local_functions, seen_calls, called_functions);
         }
       }
     }

--- a/onnxruntime/core/graph/model_helpers.cc
+++ b/onnxruntime/core/graph/model_helpers.cc
@@ -13,6 +13,7 @@
 #include <vector>
 
 #include "core/graph/function_utils.h"
+#include "core/graph/graph.h"
 #include "core/graph/onnx_protobuf.h"
 
 namespace onnxruntime {
@@ -60,6 +61,43 @@ void CollectLocalFunctionCalls(
     const auto* graph = pending_graphs.back();
     pending_graphs.pop_back();
     process_nodes(graph->node());
+  }
+}
+
+void CollectLocalFunctionCalls(
+    const Graph& main_graph,
+    const std::unordered_map<std::string, const ONNX_NAMESPACE::FunctionProto*>& model_local_functions,
+    InlinedHashSet<std::string_view>& seen_calls,
+    InlinedVector<std::string_view>& called_functions) {
+  InlinedVector<const Graph*> pending_graphs{&main_graph};
+
+  while (!pending_graphs.empty()) {
+    const auto* graph = pending_graphs.back();
+    pending_graphs.pop_back();
+    for (const auto& node : graph->Nodes()) {
+      const auto function_id = function_utils::GetFunctionIdentifier(
+          node.Domain(), node.OpType(), node.Overload());
+      auto function_it = model_local_functions.find(function_id);
+      if (function_it != model_local_functions.end()) {
+        std::string_view key_view = function_it->first;
+        if (seen_calls.insert(key_view).second) {
+          called_functions.push_back(key_view);
+        }
+      }
+
+      for (const auto& [attr_name, attr] : node.GetAttributes()) {
+        if (attr.type() == ONNX_NAMESPACE::AttributeProto_AttributeType_GRAPH || attr.has_g()) {
+          if (const auto* subgraph = node.GetGraphAttribute(attr_name); subgraph != nullptr) {
+            pending_graphs.push_back(subgraph);
+          } else if (attr.has_g()) {
+            CollectLocalFunctionCalls(attr.g().node(), model_local_functions, seen_calls, called_functions);
+          }
+        }
+        for (const auto& graph : attr.graphs()) {
+          CollectLocalFunctionCalls(graph.node(), model_local_functions, seen_calls, called_functions);
+        }
+      }
+    }
   }
 }
 
@@ -252,12 +290,16 @@ Status ValidateModelLocalFunctionAcyclic(
 
 Status ValidateModelLocalFunctionCallDepth(
     const std::unordered_map<std::string, const ONNX_NAMESPACE::FunctionProto*>& model_local_functions,
-    const ONNX_NAMESPACE::GraphProto& main_graph) {
+    const Graph& main_graph) {
+  if (model_local_functions.empty()) {
+    return Status::OK();
+  }
+
   LocalFunctionCallGraph call_graph;
   ORT_RETURN_IF_ERROR(BuildLocalFunctionCallGraph(model_local_functions, call_graph));
   InlinedHashSet<std::string_view> seen_calls;
   InlinedVector<std::string_view> root_calls;
-  CollectLocalFunctionCalls(main_graph.node(), model_local_functions, seen_calls, root_calls);
+  CollectLocalFunctionCalls(main_graph, model_local_functions, seen_calls, root_calls);
   return ValidateCallGraphDepth(call_graph, root_calls);
 }
 

--- a/onnxruntime/core/graph/model_helpers.h
+++ b/onnxruntime/core/graph/model_helpers.h
@@ -15,7 +15,7 @@
 namespace ONNX_NAMESPACE {
 class FunctionProto;
 class GraphProto;
-}
+}  // namespace ONNX_NAMESPACE
 
 namespace onnxruntime {
 

--- a/onnxruntime/core/graph/model_helpers.h
+++ b/onnxruntime/core/graph/model_helpers.h
@@ -14,6 +14,7 @@
 
 namespace ONNX_NAMESPACE {
 class FunctionProto;
+class GraphProto;
 }
 
 namespace onnxruntime {
@@ -21,6 +22,8 @@ namespace onnxruntime {
 /// Adjacency list representation of a local function call graph.
 /// Keys and values are string_views into stable storage (e.g. map keys that outlive this structure).
 using LocalFunctionCallGraph = InlinedHashMap<std::string_view, InlinedVector<std::string_view>>;
+
+constexpr size_t kMaxModelLocalFunctionCallDepth = 100;
 
 /// Build a call graph adjacency list from model local functions.
 /// String views in the returned graph point into the keys of @p model_local_functions.
@@ -32,9 +35,18 @@ Status BuildLocalFunctionCallGraph(
 /// Returns an error with the cycle path if a cycle is detected.
 Status ValidateCallGraphAcyclic(const LocalFunctionCallGraph& call_graph);
 
-/// Convenience: build the call graph from model local functions and validate acyclicity.
+/// Enforce the depth limit for calls reachable from @p roots in an acyclic call graph.
+Status ValidateCallGraphDepth(const LocalFunctionCallGraph& call_graph,
+                              gsl::span<const std::string_view> roots);
+
+/// Build the call graph from model local functions and validate acyclicity.
 Status ValidateModelLocalFunctionAcyclic(
     const std::unordered_map<std::string, const ONNX_NAMESPACE::FunctionProto*>& model_local_functions);
+
+/// Enforce the local function depth limit for calls reachable from @p main_graph.
+Status ValidateModelLocalFunctionCallDepth(
+    const std::unordered_map<std::string, const ONNX_NAMESPACE::FunctionProto*>& model_local_functions,
+    const ONNX_NAMESPACE::GraphProto& main_graph);
 
 }  // namespace onnxruntime
 

--- a/onnxruntime/core/graph/model_helpers.h
+++ b/onnxruntime/core/graph/model_helpers.h
@@ -9,6 +9,8 @@
 #include <string_view>
 #include <unordered_map>
 
+#include <gsl/gsl>
+
 #include "core/common/common.h"
 #include "core/common/inlined_containers.h"
 

--- a/onnxruntime/core/graph/model_helpers.h
+++ b/onnxruntime/core/graph/model_helpers.h
@@ -16,10 +16,11 @@
 
 namespace ONNX_NAMESPACE {
 class FunctionProto;
-class GraphProto;
 }  // namespace ONNX_NAMESPACE
 
 namespace onnxruntime {
+
+class Graph;
 
 /// Adjacency list representation of a local function call graph.
 /// Keys and values are string_views into stable storage (e.g. map keys that outlive this structure).
@@ -48,7 +49,7 @@ Status ValidateModelLocalFunctionAcyclic(
 /// Enforce the local function depth limit for calls reachable from @p main_graph.
 Status ValidateModelLocalFunctionCallDepth(
     const std::unordered_map<std::string, const ONNX_NAMESPACE::FunctionProto*>& model_local_functions,
-    const ONNX_NAMESPACE::GraphProto& main_graph);
+    const Graph& main_graph);
 
 }  // namespace onnxruntime
 

--- a/onnxruntime/test/framework/function_test.cc
+++ b/onnxruntime/test/framework/function_test.cc
@@ -4,6 +4,7 @@
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
+#include <array>
 #include <sstream>
 
 #include "core/graph/onnx_protobuf.h"
@@ -539,6 +540,134 @@ TEST(FunctionTest, CallGraphAcyclic_SharedCallsDiamondNoCycle) {
   call_graph[c] = {d};
   call_graph[d] = {};
   ASSERT_STATUS_OK(onnxruntime::ValidateCallGraphAcyclic(call_graph));
+}
+
+TEST(FunctionTest, CallGraphDepth_MaximumDepthAccepted) {
+  std::vector<std::string> function_ids;
+  function_ids.reserve(onnxruntime::kMaxModelLocalFunctionCallDepth);
+  for (size_t i = 0; i < onnxruntime::kMaxModelLocalFunctionCallDepth; ++i) {
+    function_ids.push_back("function_" + std::to_string(i));
+  }
+
+  onnxruntime::LocalFunctionCallGraph call_graph;
+  for (size_t i = 0; i < function_ids.size(); ++i) {
+    auto& callees = call_graph[function_ids[i]];
+    if (i + 1 < function_ids.size()) {
+      callees.push_back(function_ids[i + 1]);
+    }
+  }
+
+  const std::array<std::string_view, 1> roots{function_ids[0]};
+  ASSERT_STATUS_OK(onnxruntime::ValidateCallGraphAcyclic(call_graph));
+  ASSERT_STATUS_OK(onnxruntime::ValidateCallGraphDepth(call_graph, roots));
+}
+
+TEST(FunctionTest, CallGraphDepth_UnreachableExcessiveDepthAccepted) {
+  std::vector<std::string> function_ids;
+  function_ids.reserve(onnxruntime::kMaxModelLocalFunctionCallDepth + 2);
+  for (size_t i = 0; i < onnxruntime::kMaxModelLocalFunctionCallDepth + 2; ++i) {
+    function_ids.push_back("function_" + std::to_string(i));
+  }
+
+  onnxruntime::LocalFunctionCallGraph call_graph;
+  call_graph[function_ids[0]] = {};
+  for (size_t i = 1; i < function_ids.size(); ++i) {
+    auto& callees = call_graph[function_ids[i]];
+    if (i + 1 < function_ids.size()) {
+      callees.push_back(function_ids[i + 1]);
+    }
+  }
+
+  const std::array<std::string_view, 1> roots{function_ids[0]};
+  ASSERT_STATUS_OK(onnxruntime::ValidateCallGraphAcyclic(call_graph));
+  ASSERT_STATUS_OK(onnxruntime::ValidateCallGraphDepth(call_graph, roots));
+}
+
+TEST(FunctionTest, CallGraphDepth_ExcessiveSharedTailRejected) {
+  std::vector<std::string> function_ids;
+  function_ids.reserve(onnxruntime::kMaxModelLocalFunctionCallDepth + 2);
+  for (size_t i = 0; i < onnxruntime::kMaxModelLocalFunctionCallDepth + 2; ++i) {
+    function_ids.push_back("function_" + std::to_string(i));
+  }
+
+  onnxruntime::LocalFunctionCallGraph call_graph;
+  call_graph[function_ids[0]] = {function_ids[2]};
+  call_graph[function_ids[1]] = {function_ids[0], function_ids[2]};
+  for (size_t i = 2; i < function_ids.size(); ++i) {
+    auto& callees = call_graph[function_ids[i]];
+    if (i + 1 < function_ids.size()) {
+      callees.push_back(function_ids[i + 1]);
+    }
+  }
+
+  ASSERT_STATUS_OK(onnxruntime::ValidateCallGraphAcyclic(call_graph));
+  const std::array<std::string_view, 1> roots{function_ids[1]};
+  const auto status = onnxruntime::ValidateCallGraphDepth(call_graph, roots);
+  ASSERT_FALSE(status.IsOK());
+  EXPECT_THAT(status.ErrorMessage(), testing::HasSubstr("exceeds the maximum supported depth"));
+}
+
+static ONNX_NAMESPACE::ModelProto CreateLocalFunctionChainModel(size_t call_depth) {
+  ONNX_NAMESPACE::ModelProto model_proto;
+  model_proto.set_ir_version(ONNX_NAMESPACE::Version::IR_VERSION);
+  auto* onnx_opset = model_proto.add_opset_import();
+  onnx_opset->set_domain(onnxruntime::kOnnxDomain);
+  onnx_opset->set_version(16);
+  auto* local_opset = model_proto.add_opset_import();
+  local_opset->set_domain("local");
+  local_opset->set_version(1);
+
+  auto* graph = model_proto.mutable_graph();
+  graph->set_name("local_function_chain");
+  auto* graph_input = graph->add_input();
+  graph_input->set_name("x");
+  graph_input->mutable_type()->mutable_tensor_type()->set_elem_type(ONNX_NAMESPACE::TensorProto_DataType_FLOAT);
+  auto* graph_output = graph->add_output();
+  graph_output->set_name("y");
+  graph_output->mutable_type()->mutable_tensor_type()->set_elem_type(ONNX_NAMESPACE::TensorProto_DataType_FLOAT);
+  auto* graph_node = graph->add_node();
+  graph_node->set_domain("local");
+  graph_node->set_op_type("function_0");
+  graph_node->add_input("x");
+  graph_node->add_output("y");
+
+  for (size_t i = 0; i < call_depth; ++i) {
+    auto* function = model_proto.add_functions();
+    function->set_domain("local");
+    function->set_name("function_" + std::to_string(i));
+    function->add_input("x");
+    function->add_output("y");
+    auto* function_onnx_opset = function->add_opset_import();
+    function_onnx_opset->set_domain(onnxruntime::kOnnxDomain);
+    function_onnx_opset->set_version(16);
+    auto* function_local_opset = function->add_opset_import();
+    function_local_opset->set_domain("local");
+    function_local_opset->set_version(1);
+
+    auto* node = function->add_node();
+    node->set_op_type(i + 1 < call_depth ? "function_" + std::to_string(i + 1) : "Identity");
+    if (i + 1 < call_depth) {
+      node->set_domain("local");
+    }
+    node->add_input("x");
+    node->add_output("y");
+  }
+
+  return model_proto;
+}
+
+TEST(FunctionTest, LoadFromBytes_ExcessiveLocalFunctionDepthReturnsStatus) {
+  auto model_proto = CreateLocalFunctionChainModel(onnxruntime::kMaxModelLocalFunctionCallDepth + 1);
+  std::string serialized_model;
+  ASSERT_TRUE(model_proto.SerializeToString(&serialized_model));
+
+  auto& logger = DefaultLoggingManager().DefaultLogger();
+  std::shared_ptr<Model> model;
+  const auto status = Model::LoadFromBytes(static_cast<int>(serialized_model.size()), serialized_model.data(),
+                                           model, nullptr, logger);
+  ASSERT_FALSE(status.IsOK());
+  EXPECT_EQ(status.Code(), common::NOT_IMPLEMENTED);
+  EXPECT_THAT(status.ErrorMessage(), testing::HasSubstr("exceeds the maximum supported depth"));
 }
 
 // --- Model-level integration tests ---

--- a/onnxruntime/test/framework/function_test.cc
+++ b/onnxruntime/test/framework/function_test.cc
@@ -670,6 +670,31 @@ TEST(FunctionTest, LoadFromBytes_ExcessiveLocalFunctionDepthReturnsStatus) {
   EXPECT_THAT(status.ErrorMessage(), testing::HasSubstr("exceeds the maximum supported depth"));
 }
 
+TEST(FunctionTest, LocalFunctionDepthValidationPreservesGraphProtoSyncFlag) {
+  auto model_proto = CreateLocalFunctionChainModel(1);
+  auto& logger = DefaultLoggingManager().DefaultLogger();
+  std::shared_ptr<Model> model;
+  ASSERT_STATUS_OK(Model::Load(std::move(model_proto), model, nullptr, logger));
+
+  auto& graph = model->MainGraph();
+  graph.SetGraphResolveNeeded().SetGraphProtoSyncNeeded();
+  ASSERT_STATUS_OK(graph.Resolve());
+  EXPECT_TRUE(graph.GraphProtoSyncNeeded());
+}
+
+TEST(FunctionTest, FailedLocalFunctionDepthValidationPreservesGraphProtoSyncFlag) {
+  auto model_proto = CreateLocalFunctionChainModel(onnxruntime::kMaxModelLocalFunctionCallDepth + 1);
+  auto& logger = DefaultLoggingManager().DefaultLogger();
+  Model model(std::move(model_proto), nullptr, logger);
+
+  auto& graph = model.MainGraph();
+  graph.SetGraphResolveNeeded().SetGraphProtoSyncNeeded();
+  const auto status = graph.Resolve();
+  ASSERT_FALSE(status.IsOK());
+  EXPECT_EQ(status.Code(), common::NOT_IMPLEMENTED);
+  EXPECT_TRUE(graph.GraphProtoSyncNeeded());
+}
+
 // --- Model-level integration tests ---
 
 TEST(FunctionTest, RejectsLongerCycle) {

--- a/onnxruntime/test/framework/function_test.cc
+++ b/onnxruntime/test/framework/function_test.cc
@@ -695,6 +695,45 @@ TEST(FunctionTest, FailedLocalFunctionDepthValidationPreservesGraphProtoSyncFlag
   EXPECT_TRUE(graph.GraphProtoSyncNeeded());
 }
 
+TEST(FunctionTest, ExcessiveLocalFunctionDepthInGraphsAttributeReturnsStatus) {
+  auto model_proto = CreateLocalFunctionChainModel(onnxruntime::kMaxModelLocalFunctionCallDepth + 1);
+  auto* root_node = model_proto.mutable_graph()->mutable_node(0);
+  root_node->set_domain(onnxruntime::kOnnxDomain);
+  root_node->set_op_type("Identity");
+  auto* graphs_attr = root_node->add_attribute();
+  graphs_attr->set_name("graphs");
+  graphs_attr->set_type(ONNX_NAMESPACE::AttributeProto_AttributeType_GRAPHS);
+  auto* function_call = graphs_attr->add_graphs()->add_node();
+  function_call->set_domain("local");
+  function_call->set_op_type("function_0");
+
+  auto& logger = DefaultLoggingManager().DefaultLogger();
+  Model model(std::move(model_proto), nullptr, logger);
+  const auto status = model.MainGraph().Resolve();
+  ASSERT_FALSE(status.IsOK());
+  EXPECT_EQ(status.Code(), common::NOT_IMPLEMENTED);
+  EXPECT_THAT(status.ErrorMessage(), testing::HasSubstr("exceeds the maximum supported depth"));
+}
+
+TEST(FunctionTest, ExcessiveLocalFunctionDepthInUntypedGraphAttributeReturnsStatus) {
+  auto model_proto = CreateLocalFunctionChainModel(onnxruntime::kMaxModelLocalFunctionCallDepth + 1);
+  auto* root_node = model_proto.mutable_graph()->mutable_node(0);
+  root_node->set_domain(onnxruntime::kOnnxDomain);
+  root_node->set_op_type("Identity");
+  auto* graph_attr = root_node->add_attribute();
+  graph_attr->set_name("graph");
+  auto* function_call = graph_attr->mutable_g()->add_node();
+  function_call->set_domain("local");
+  function_call->set_op_type("function_0");
+
+  auto& logger = DefaultLoggingManager().DefaultLogger();
+  Model model(std::move(model_proto), nullptr, logger);
+  const auto status = model.MainGraph().Resolve();
+  ASSERT_FALSE(status.IsOK());
+  EXPECT_EQ(status.Code(), common::NOT_IMPLEMENTED);
+  EXPECT_THAT(status.ErrorMessage(), testing::HasSubstr("exceeds the maximum supported depth"));
+}
+
 // --- Model-level integration tests ---
 
 TEST(FunctionTest, RejectsLongerCycle) {


### PR DESCRIPTION
This pull request adds validation to enforce a maximum call depth for model local functions in ONNX Runtime, helping to prevent excessively deep or recursive function chains that could cause stack overflows or performance issues. The validation is implemented in the core graph logic and is covered by new unit tests.

**Core runtime changes:**

* Added a constant `kMaxModelLocalFunctionCallDepth` (set to 100) and implemented logic to validate that model local function call graphs do not exceed this maximum depth. This includes the new functions `ValidateCallGraphDepth` and `ValidateModelLocalFunctionCallDepth` in `model_helpers.cc`/`.h`. [[1]](diffhunk://#diff-a53ff461ebc52d6d228c126597a017c9d757b899f3244a795ab2118e41f29444L17-R27) [[2]](diffhunk://#diff-e1f6b61449afbbdbd824e4eef1019d66b329a821db67db46b9f06e011369a8deR181-R263) [[3]](diffhunk://#diff-a53ff461ebc52d6d228c126597a017c9d757b899f3244a795ab2118e41f29444L35-R50)
* Integrated the call depth validation into the model loading and graph resolution process by calling `owning_model_.ValidateLocalFunctionCallDepth` in `Graph::Resolve` (guarded by `!defined(ORT_MINIMAL_BUILD)`). [[1]](diffhunk://#diff-e231a92b40d89409cc8e82436be0a15bc87ef95c93b303b9feaeab6e50c8835cR3810-R3813) [[2]](diffhunk://#diff-27dfc51b4b723d56e08b54409b60a5d7a689f3908c2208385449435ad3db9641R304-R307) [[3]](diffhunk://#diff-fe6678da94ab081bad3fc9d2a999be576ba067eeca41cb5d0f474408da2a832bR160-R161)

**Testing:**

* Added comprehensive unit tests for the new call depth validation logic, including tests for maximum accepted depth, unreachable excessive depth, excessive shared tail, and integration with model loading.

**Other:**

* Minor includes and code organization for new logic and tests. [[1]](diffhunk://#diff-e1f6b61449afbbdbd824e4eef1019d66b329a821db67db46b9f06e011369a8deR8) [[2]](diffhunk://#diff-c78e822207193cf3dbd4c9b5630ed0da508286c156454770d8c8b74d3047d317R7) [[3]](diffhunk://#diff-e231a92b40d89409cc8e82436be0a15bc87ef95c93b303b9feaeab6e50c8835cR34-R36)

These changes improve the robustness of ONNX Runtime by preventing models with excessively deep local function call chains from being loaded or executed.