### PR TITLE
[WebGPU] Fix 1D-dispatch shader fast path

### DIFF
--- a/onnxruntime/core/providers/webgpu/program_cache_key.cc
+++ b/onnxruntime/core/providers/webgpu/program_cache_key.cc
@@ -52,17 +52,15 @@ void AppendTensorInfo(OStringStream& ss,
 
 std::string CalculateProgramCacheKey(const ProgramBase& program,
                                      std::span<uint32_t> inputs_segments,
-                                     std::span<uint32_t> outputs_segments,
-                                     bool is_1d_dispatch) {
+                                     std::span<uint32_t> outputs_segments) {
   SS(ss, kStringInitialSizeCacheKey);
 
   // final key format:
-  // <KEY>=<PROGRAM_NAME>[<CUSTOM_CACHE_HINT>]:<WORKGROUP_SIZE>:<SUBGROUP_SIZE>:<DISPATCH_FLAG>:<UNIFORMS>:<INPUTS_INFO>
+  // <KEY>=<PROGRAM_NAME>[<CUSTOM_CACHE_HINT>]:<WORKGROUP_SIZE>:<SUBGROUP_SIZE>:<UNIFORMS>:<INPUTS_INFO>
   //
   // <CUSTOM_CACHE_HINT> = <HINT_0>|<HINT_1>|...
   // <WORKGROUP_SIZE>    = <X_IF_OVERRIDDEN>,<Y_IF_OVERRIDDEN>,<Z_IF_OVERRIDDEN>
   // <SUBGROUP_SIZE>     = <SUBGROUP_SIZE_IF_OVERRIDDEN>
-  // <DISPATCH_FLAG>     = <!IS_1D_DISPATCH>
   // <UNIFORMS>          = <UNIFORMS_INFO_0>|<UNIFORMS_INFO_1>|...
   // <UNIFORMS_INFO_i>   = <UNIFORM_LENGTH>
   // <INPUTS_INFO>       = <INPUTS_INFO_0>|<INPUTS_INFO_1>|...
@@ -97,7 +95,6 @@ std::string CalculateProgramCacheKey(const ProgramBase& program,
     ss << ":" D("SubgroupSize=") << subgroup_size;
   }
 
-  ss << ":" D("DispatchDim=") << (is_1d_dispatch ? "1" : "3");
   ss << ":" D("UniformSizes=");
   bool first = true;
   for (const auto& uniform : program.UniformVariables()) {

--- a/onnxruntime/core/providers/webgpu/program_cache_key.h
+++ b/onnxruntime/core/providers/webgpu/program_cache_key.h
@@ -13,8 +13,7 @@ namespace webgpu {
 
 std::string CalculateProgramCacheKey(const ProgramBase& program,
                                      std::span<uint32_t> inputs_segments,
-                                     std::span<uint32_t> outputs_segments,
-                                     bool is_1d_dispatch);
+                                     std::span<uint32_t> outputs_segments);
 
 }  // namespace webgpu
 }  // namespace onnxruntime

--- a/onnxruntime/core/providers/webgpu/shader_helper.cc
+++ b/onnxruntime/core/providers/webgpu/shader_helper.cc
@@ -73,7 +73,6 @@ Status ShaderHelper::Init() {
   }
 
   // init body string stream
-  bool is_1d_dispatch = dispatch_group_size_y_ == 1 && dispatch_group_size_z_ == 1;
   bool use_indirect_dispatch = program_.IndirectDispatchTensor() != nullptr;
 
   // append header for main function so it is ready for user to append main function body
@@ -103,10 +102,6 @@ Status ShaderHelper::Init() {
                 "  let num_workgroups_y = indirect_buffer[1];\n"
                 "  let workgroup_idx = workgroup_id.z * num_workgroups_x * num_workgroups_y + workgroup_id.y * num_workgroups_x + workgroup_id.x;\n"
                 "  let global_idx = workgroup_idx * (workgroup_size_x * workgroup_size_y * workgroup_size_z) + local_idx;\n";
-  } else if (is_1d_dispatch) {
-    body_ss_ << ") {\n";
-    body_ss_ << "  let global_idx = global_id.x;\n"
-                "  let workgroup_idx = workgroup_id.x;\n";
   } else {
     body_ss_ << ",\n"
                 "        @builtin(num_workgroups) num_workgroups : vec3<u32>) {\n";

--- a/onnxruntime/core/providers/webgpu/webgpu_context.cc
+++ b/onnxruntime/core/providers/webgpu/webgpu_context.cc
@@ -474,9 +474,7 @@ Status WebGpuContext::Run(ComputeContextBase& context, const ProgramBase& progra
                 "Only one of SetIndirectDispatchTensor and SetDispatchGroupSize should be called for program", program.Name());
   }
 
-  bool is_1d_dispatch = (y == 1 && z == 1);
-
-  auto key = CalculateProgramCacheKey(program, inputs_segments, outputs_segments, is_1d_dispatch);
+  auto key = CalculateProgramCacheKey(program, inputs_segments, outputs_segments);
 
   LOGS(context.Logger(), INFO) << "Starting program \"" << key << "\" (" << x << ", " << y << ", " << z << ")";
   // The program cache prevents duplicate builds across encoded windows.


### PR DESCRIPTION
### Description
ShaderHelper::Init() special-cased shaders whose dispatch grid has a single row of workgroups (dispatch_group_size_y_ == 1 && dispatch_group_size_z_ == 1) by computing global_idx directly from `@builtin(global_invocation_id).x` and workgroup_idx from `@builtin(workgroup_id).x`.

This is only correct when the workgroup itself is also 1D (workgroup_size_y == 1 && workgroup_size_z == 1). For a program dispatched as a single row of 2D/3D workgroups (e.g. workgroup_size = (8, 8, 1)), global_id.x omits the contribution of local_invocation_id.y/z that local_invocation_index folds in, so global_idx (and workgroup_idx-derived offsets) come out wrong and the shader reads/writes incorrect elements.

Remove the special-cased fast path so every non-indirect dispatch uses the general num_workgroups-based formula, which is correct regardless of workgroup or dispatch shape. Also drop the now-unnecessary is_1d_dispatch distinction from the program cache key (program_cache_key.h/.cc, webgpu_context.cc), since generated shader source no longer varies with dispatch dimensionality.


### Motivation and Context
See above.

