### PR TITLE
Limit nested model graph depth

### DIFF
--- a/onnxruntime/core/graph/model.cc
+++ b/onnxruntime/core/graph/model.cc
@@ -136,6 +136,7 @@ Model::Model(const std::string& graph_name,
                                             func_ptr);
   }
 
+  ORT_THROW_IF_ERROR(ValidateModelSubgraphDepth(model_proto_));
   ORT_THROW_IF_ERROR(ValidateModelLocalFunctionAcyclic(model_local_functions_));
 
   model_local_function_templates_maps_.reserve(model_proto_.functions().size());
@@ -270,6 +271,7 @@ Model::Model(ModelProto&& model_proto, const PathString& model_path,
     model_local_functions_.insert_or_assign(function_utils::GetFunctionIdentifier(func.domain(), func.name(), func.overload()), &func);
   }
 
+  ORT_THROW_IF_ERROR(ValidateModelSubgraphDepth(model_proto_));
   ORT_THROW_IF_ERROR(ValidateModelLocalFunctionAcyclic(model_local_functions_));
 
   model_local_function_templates_maps_.reserve(model_proto_.functions().size());

--- a/onnxruntime/core/graph/model.cc
+++ b/onnxruntime/core/graph/model.cc
@@ -80,6 +80,11 @@ void Model::RemoveLocalFunctionsProtos(const InlinedHashSet<std::string>& retain
 
 static constexpr int DEFAULT_PROTOBUF_BLOCK_SIZE = 4 * 1024 * 1024;
 
+static ModelProto ValidateAndCopyModelProto(const ModelProto& model_proto) {
+  ORT_THROW_IF_ERROR(ValidateModelSubgraphDepth(model_proto));
+  return model_proto;
+}
+
 Model::Model(const std::string& graph_name,
              bool is_onnx_domain_only,
              const ModelMetaData& model_metadata,
@@ -128,6 +133,10 @@ Model::Model(const std::string& graph_name,
     opset_id_proto->set_version(version);
   }
 
+  for (const auto& func : model_local_functions) {
+    ORT_THROW_IF_ERROR(ValidateFunctionSubgraphDepth(func));
+  }
+
   model_local_functions_.reserve(model_local_functions.size());
   for (auto& func : model_local_functions) {
     auto func_ptr = model_proto_.add_functions();
@@ -167,7 +176,7 @@ Model::Model(const std::string& graph_name,
 Model::Model(const ModelProto& model_proto, const PathString& model_path,
              const IOnnxRuntimeOpSchemaRegistryList* local_registries, const logging::Logger& logger,
              const ModelOptions& options)
-    : Model(ModelProto(model_proto), model_path, local_registries, logger, options) {
+    : Model(ValidateAndCopyModelProto(model_proto), model_path, local_registries, logger, options) {
 }
 
 Model::Model(ModelProto&& model_proto, const PathString& model_path,

--- a/onnxruntime/core/graph/model_helpers.cc
+++ b/onnxruntime/core/graph/model_helpers.cc
@@ -64,6 +64,38 @@ void CollectLocalFunctionCalls(
 
 }  // namespace
 
+Status ValidateModelSubgraphDepth(const ONNX_NAMESPACE::ModelProto& model_proto) {
+  using NodeRange = const google::protobuf::RepeatedPtrField<ONNX_NAMESPACE::NodeProto>*;
+  InlinedVector<std::pair<NodeRange, size_t>> pending{{&model_proto.graph().node(), 0}};
+  for (const auto& function : model_proto.functions()) {
+    pending.push_back({&function.node(), 0});
+  }
+
+  while (!pending.empty()) {
+    const auto [nodes, depth] = pending.back();
+    pending.pop_back();
+    for (const auto& node : *nodes) {
+      for (const auto& attr : node.attribute()) {
+        const size_t subgraph_depth = depth + 1;
+        if ((attr.has_g() || !attr.graphs().empty()) && subgraph_depth > kMaxModelSubgraphDepth) {
+          return ORT_MAKE_STATUS(
+              ONNXRUNTIME, NOT_IMPLEMENTED,
+              "Model subgraph depth ", subgraph_depth,
+              " exceeds the maximum supported depth of ", kMaxModelSubgraphDepth, ".");
+        }
+        if (attr.has_g()) {
+          pending.push_back({&attr.g().node(), subgraph_depth});
+        }
+        for (const auto& graph : attr.graphs()) {
+          pending.push_back({&graph.node(), subgraph_depth});
+        }
+      }
+    }
+  }
+
+  return Status::OK();
+}
+
 Status BuildLocalFunctionCallGraph(
     const std::unordered_map<std::string, const ONNX_NAMESPACE::FunctionProto*>& model_local_functions,
     LocalFunctionCallGraph& call_graph) {

--- a/onnxruntime/core/graph/model_helpers.cc
+++ b/onnxruntime/core/graph/model_helpers.cc
@@ -18,6 +18,52 @@ namespace onnxruntime {
 
 namespace {
 
+using NodeRange = const google::protobuf::RepeatedPtrField<ONNX_NAMESPACE::NodeProto>*;
+using PendingNodeRanges = InlinedVector<std::pair<NodeRange, size_t>>;
+
+Status AddAttributeSubgraphs(const ONNX_NAMESPACE::AttributeProto& attr,
+                             size_t subgraph_depth,
+                             PendingNodeRanges& pending) {
+  if ((attr.has_g() || !attr.graphs().empty()) && subgraph_depth > kMaxModelSubgraphDepth) {
+    return ORT_MAKE_STATUS(
+        ONNXRUNTIME, NOT_IMPLEMENTED,
+        "Model subgraph depth ", subgraph_depth,
+        " exceeds the maximum supported depth of ", kMaxModelSubgraphDepth, ".");
+  }
+
+  if (attr.has_g()) {
+    pending.push_back({&attr.g().node(), subgraph_depth});
+  }
+  for (const auto& graph : attr.graphs()) {
+    pending.push_back({&graph.node(), subgraph_depth});
+  }
+
+  return Status::OK();
+}
+
+Status ValidateSubgraphDepth(
+    const google::protobuf::RepeatedPtrField<ONNX_NAMESPACE::NodeProto>& root_nodes,
+    const google::protobuf::RepeatedPtrField<ONNX_NAMESPACE::AttributeProto>* root_attributes = nullptr) {
+  PendingNodeRanges pending{{&root_nodes, 0}};
+  if (root_attributes != nullptr) {
+    for (const auto& attr : *root_attributes) {
+      ORT_RETURN_IF_ERROR(AddAttributeSubgraphs(attr, 1, pending));
+    }
+  }
+
+  while (!pending.empty()) {
+    const auto [nodes, depth] = pending.back();
+    pending.pop_back();
+    for (const auto& node : *nodes) {
+      for (const auto& attr : node.attribute()) {
+        ORT_RETURN_IF_ERROR(AddAttributeSubgraphs(attr, depth + 1, pending));
+      }
+    }
+  }
+
+  return Status::OK();
+}
+
 // Iterative collection of local function calls from a sequence of nodes,
 // including nodes inside nested subgraph attributes. Avoids recursion to
 // prevent stack overflow from maliciously deep subgraph nesting.
@@ -65,35 +111,16 @@ void CollectLocalFunctionCalls(
 }  // namespace
 
 Status ValidateModelSubgraphDepth(const ONNX_NAMESPACE::ModelProto& model_proto) {
-  using NodeRange = const google::protobuf::RepeatedPtrField<ONNX_NAMESPACE::NodeProto>*;
-  InlinedVector<std::pair<NodeRange, size_t>> pending{{&model_proto.graph().node(), 0}};
+  ORT_RETURN_IF_ERROR(ValidateSubgraphDepth(model_proto.graph().node()));
   for (const auto& function : model_proto.functions()) {
-    pending.push_back({&function.node(), 0});
-  }
-
-  while (!pending.empty()) {
-    const auto [nodes, depth] = pending.back();
-    pending.pop_back();
-    for (const auto& node : *nodes) {
-      for (const auto& attr : node.attribute()) {
-        const size_t subgraph_depth = depth + 1;
-        if ((attr.has_g() || !attr.graphs().empty()) && subgraph_depth > kMaxModelSubgraphDepth) {
-          return ORT_MAKE_STATUS(
-              ONNXRUNTIME, NOT_IMPLEMENTED,
-              "Model subgraph depth ", subgraph_depth,
-              " exceeds the maximum supported depth of ", kMaxModelSubgraphDepth, ".");
-        }
-        if (attr.has_g()) {
-          pending.push_back({&attr.g().node(), subgraph_depth});
-        }
-        for (const auto& graph : attr.graphs()) {
-          pending.push_back({&graph.node(), subgraph_depth});
-        }
-      }
-    }
+    ORT_RETURN_IF_ERROR(ValidateFunctionSubgraphDepth(function));
   }
 
   return Status::OK();
+}
+
+Status ValidateFunctionSubgraphDepth(const ONNX_NAMESPACE::FunctionProto& function_proto) {
+  return ValidateSubgraphDepth(function_proto.node(), &function_proto.attribute_proto());
 }
 
 Status BuildLocalFunctionCallGraph(

--- a/onnxruntime/core/graph/model_helpers.h
+++ b/onnxruntime/core/graph/model_helpers.h
@@ -14,6 +14,7 @@
 
 namespace ONNX_NAMESPACE {
 class FunctionProto;
+class ModelProto;
 }
 
 namespace onnxruntime {
@@ -21,6 +22,10 @@ namespace onnxruntime {
 /// Adjacency list representation of a local function call graph.
 /// Keys and values are string_views into stable storage (e.g. map keys that outlive this structure).
 using LocalFunctionCallGraph = InlinedHashMap<std::string_view, InlinedVector<std::string_view>>;
+
+constexpr size_t kMaxModelSubgraphDepth = 32;
+
+Status ValidateModelSubgraphDepth(const ONNX_NAMESPACE::ModelProto& model_proto);
 
 /// Build a call graph adjacency list from model local functions.
 /// String views in the returned graph point into the keys of @p model_local_functions.

--- a/onnxruntime/core/graph/model_helpers.h
+++ b/onnxruntime/core/graph/model_helpers.h
@@ -15,7 +15,7 @@
 namespace ONNX_NAMESPACE {
 class FunctionProto;
 class ModelProto;
-}
+}  // namespace ONNX_NAMESPACE
 
 namespace onnxruntime {
 

--- a/onnxruntime/core/graph/model_helpers.h
+++ b/onnxruntime/core/graph/model_helpers.h
@@ -26,6 +26,7 @@ using LocalFunctionCallGraph = InlinedHashMap<std::string_view, InlinedVector<st
 constexpr size_t kMaxModelSubgraphDepth = 32;
 
 Status ValidateModelSubgraphDepth(const ONNX_NAMESPACE::ModelProto& model_proto);
+Status ValidateFunctionSubgraphDepth(const ONNX_NAMESPACE::FunctionProto& function_proto);
 
 /// Build a call graph adjacency list from model local functions.
 /// String views in the returned graph point into the keys of @p model_local_functions.

--- a/onnxruntime/test/framework/function_test.cc
+++ b/onnxruntime/test/framework/function_test.cc
@@ -444,6 +444,35 @@ TEST(FunctionTest, RejectsRecursionThroughSubgraph) {
 // --- Synthetic adjacency-list tests for ValidateCallGraphAcyclic ---
 // These test the cycle detection algorithm directly without constructing ONNX models.
 
+static ONNX_NAMESPACE::ModelProto CreateNestedLocalFunctionModel(size_t depth, bool use_graphs_attribute) {
+  ONNX_NAMESPACE::ModelProto model_proto;
+  auto* nodes = model_proto.add_functions()->mutable_node();
+  for (size_t i = 0; i < depth; ++i) {
+    auto* node = nodes->Add();
+    auto* attr = node->add_attribute();
+    if (use_graphs_attribute) {
+      nodes = attr->add_graphs()->mutable_node();
+    } else {
+      nodes = attr->mutable_g()->mutable_node();
+    }
+  }
+
+  return model_proto;
+}
+
+TEST(FunctionTest, LocalFunctionSubgraphDepthValidated) {
+  EXPECT_STATUS_OK(ValidateModelSubgraphDepth(
+      CreateNestedLocalFunctionModel(kMaxModelSubgraphDepth, false)));
+  EXPECT_EQ(ValidateModelSubgraphDepth(
+                CreateNestedLocalFunctionModel(kMaxModelSubgraphDepth + 1, false))
+                .Code(),
+            common::NOT_IMPLEMENTED);
+  EXPECT_EQ(ValidateModelSubgraphDepth(
+                CreateNestedLocalFunctionModel(kMaxModelSubgraphDepth + 1, true))
+                .Code(),
+            common::NOT_IMPLEMENTED);
+}
+
 TEST(FunctionTest, CallGraphAcyclic_EmptyGraph) {
   onnxruntime::LocalFunctionCallGraph call_graph;
   ASSERT_STATUS_OK(onnxruntime::ValidateCallGraphAcyclic(call_graph));

--- a/onnxruntime/test/framework/function_test.cc
+++ b/onnxruntime/test/framework/function_test.cc
@@ -460,6 +460,21 @@ static ONNX_NAMESPACE::ModelProto CreateNestedLocalFunctionModel(size_t depth, b
   return model_proto;
 }
 
+static ONNX_NAMESPACE::ModelProto CreateNestedLocalFunctionDefaultAttributeModel(
+    size_t depth, bool use_graphs_attribute) {
+  ONNX_NAMESPACE::ModelProto model_proto;
+  auto* function = model_proto.add_functions();
+  auto* attr = function->add_attribute_proto();
+  auto* graph = use_graphs_attribute ? attr->add_graphs() : attr->mutable_g();
+  for (size_t i = 1; i < depth; ++i) {
+    auto* node = graph->add_node();
+    attr = node->add_attribute();
+    graph = attr->mutable_g();
+  }
+
+  return model_proto;
+}
+
 TEST(FunctionTest, LocalFunctionSubgraphDepthValidated) {
   EXPECT_STATUS_OK(ValidateModelSubgraphDepth(
       CreateNestedLocalFunctionModel(kMaxModelSubgraphDepth, false)));
@@ -469,6 +484,19 @@ TEST(FunctionTest, LocalFunctionSubgraphDepthValidated) {
             common::NOT_IMPLEMENTED);
   EXPECT_EQ(ValidateModelSubgraphDepth(
                 CreateNestedLocalFunctionModel(kMaxModelSubgraphDepth + 1, true))
+                .Code(),
+            common::NOT_IMPLEMENTED);
+}
+
+TEST(FunctionTest, LocalFunctionDefaultAttributeSubgraphDepthValidated) {
+  EXPECT_STATUS_OK(ValidateModelSubgraphDepth(
+      CreateNestedLocalFunctionDefaultAttributeModel(kMaxModelSubgraphDepth, false)));
+  EXPECT_EQ(ValidateModelSubgraphDepth(
+                CreateNestedLocalFunctionDefaultAttributeModel(kMaxModelSubgraphDepth + 1, false))
+                .Code(),
+            common::NOT_IMPLEMENTED);
+  EXPECT_EQ(ValidateModelSubgraphDepth(
+                CreateNestedLocalFunctionDefaultAttributeModel(kMaxModelSubgraphDepth + 1, true))
                 .Code(),
             common::NOT_IMPLEMENTED);
 }

--- a/onnxruntime/test/ir/graph_test.cc
+++ b/onnxruntime/test/ir/graph_test.cc
@@ -13,6 +13,7 @@
 #include "core/graph/graph_viewer.h"
 #include "core/graph/graph_utils.h"
 #include "core/graph/model.h"
+#include "core/graph/model_helpers.h"
 #include "core/graph/op.h"
 #include "core/graph/ort_format_load_options.h"
 #include "core/session/inference_session.h"
@@ -3874,6 +3875,32 @@ TEST_F(GraphTest, DeeplyNestedLoopSubgraphsResolveInReasonableTime) {
   EXPECT_LT(elapsed_seconds, 60) << "Loading the 30-level nested Loop model took " << elapsed_seconds
                                  << "s, which suggests the subgraph type/shape inferencing recursion "
                                     "regression has returned.";
+}
+
+static ModelProto CreateNestedSubgraphModel(size_t depth) {
+  ModelProto model_proto;
+  model_proto.set_ir_version(ONNX_NAMESPACE::Version::IR_VERSION);
+  auto* opset = model_proto.add_opset_import();
+  opset->set_domain(kOnnxDomain);
+  opset->set_version(21);
+
+  auto* graph = model_proto.mutable_graph();
+  for (size_t i = 0; i < depth; ++i) {
+    auto* node = graph->add_node();
+    auto* attr = node->add_attribute();
+    graph = attr->mutable_g();
+  }
+
+  return model_proto;
+}
+
+TEST_F(GraphTest, ExcessiveSubgraphDepthRejected) {
+  auto model_proto = CreateNestedSubgraphModel(kMaxModelSubgraphDepth + 1);
+  std::shared_ptr<Model> model;
+  const auto status = Model::Load(std::move(model_proto), model, nullptr, *logger_);
+  ASSERT_FALSE(status.IsOK());
+  EXPECT_EQ(status.Code(), common::NOT_IMPLEMENTED);
+  EXPECT_THAT(status.ErrorMessage(), testing::HasSubstr("exceeds the maximum supported depth"));
 }
 
 }  // namespace test

--- a/onnxruntime/test/ir/graph_test.cc
+++ b/onnxruntime/test/ir/graph_test.cc
@@ -3903,5 +3903,14 @@ TEST_F(GraphTest, ExcessiveSubgraphDepthRejected) {
   EXPECT_THAT(status.ErrorMessage(), testing::HasSubstr("exceeds the maximum supported depth"));
 }
 
+TEST_F(GraphTest, ExcessiveSubgraphDepthRejectedFromLvalueProto) {
+  const auto model_proto = CreateNestedSubgraphModel(kMaxModelSubgraphDepth + 1);
+  std::shared_ptr<Model> model;
+  const auto status = Model::Load(model_proto, model, nullptr, *logger_);
+  ASSERT_FALSE(status.IsOK());
+  EXPECT_EQ(status.Code(), common::NOT_IMPLEMENTED);
+  EXPECT_THAT(status.ErrorMessage(), testing::HasSubstr("exceeds the maximum supported depth"));
+}
+
 }  // namespace test
 }  // namespace onnxruntime


### PR DESCRIPTION
This pull request introduces a validation step to limit the maximum allowed subgraph nesting depth in ONNX models to 32. This prevents excessively deep or recursive subgraph structures that could cause stack overflows or performance issues. The change is enforced during model loading and is covered by new unit tests.

**Model validation enhancements:**

* Added a new function `ValidateModelSubgraphDepth` that checks the nesting depth of subgraphs in a model and returns an error if the depth exceeds `kMaxModelSubgraphDepth` (32). [[1]](diffhunk://#diff-e1f6b61449afbbdbd824e4eef1019d66b329a821db67db46b9f06e011369a8deR67-R98) [[2]](diffhunk://#diff-a53ff461ebc52d6d228c126597a017c9d757b899f3244a795ab2118e41f29444R26-R29)
* Integrated `ValidateModelSubgraphDepth` into the `Model` constructor to enforce subgraph depth checks during model loading. [[1]](diffhunk://#diff-27dfc51b4b723d56e08b54409b60a5d7a689f3908c2208385449435ad3db9641R139) [[2]](diffhunk://#diff-27dfc51b4b723d56e08b54409b60a5d7a689f3908c2208385449435ad3db9641R274)

**Testing improvements:**

* Added unit tests to verify that models with excessive subgraph depth are correctly rejected, and that the depth limit is enforced for both regular subgraphs and those in local functions. [[1]](diffhunk://#diff-c78e822207193cf3dbd4c9b5630ed0da508286c156454770d8c8b74d3047d317R447-R475) [[2]](diffhunk://#diff-1d3978c99d95a56af0f2603bdd0b10cf02bdc1cecbd4fe5db353a8c8388696efR3880-R3905)
* Included necessary header for `model_helpers.h` in test files to support new validation logic.

**API and constant definition:**

* Introduced the constant `kMaxModelSubgraphDepth` in `model_helpers.h` to define the supported subgraph depth limit.
* Declared the new validation function in the header for use across the codebase. [[1]](diffhunk://#diff-a53ff461ebc52d6d228c126597a017c9d757b899f3244a795ab2118e41f29444R26-R29) [[2]](diffhunk://#diff-a53ff461ebc52d6d228c126597a017c9d757b899f3244a795ab2118e41f29444R17)