### PR TITLE
Validate ScatterND indexed dimensions

### DIFF
--- a/onnxruntime/core/providers/cpu/tensor/scatter_nd.h
+++ b/onnxruntime/core/providers/cpu/tensor/scatter_nd.h
@@ -36,6 +36,15 @@ inline Status ValidateShapes(const TensorShape& input_shape,
                            "last dimension of indices must not be larger than rank of input tensor");
   }
 
+  if (indice_shape.SizeToDimension(indice_rank - 1) > 0) {
+    for (int64_t i = 0; i < last_indice_dimension; ++i) {
+      if (input_shape[onnxruntime::narrow<size_t>(i)] == 0) {
+        return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
+                               "indices must be empty when an indexed data dimension has size 0");
+      }
+    }
+  }
+
   bool is_update_shape_invalid = [&]() {
     if (update_rank != (input_rank + indice_rank - 1 - static_cast<ptrdiff_t>(last_indice_dimension))) {
       return true;

--- a/onnxruntime/test/providers/cpu/tensor/scatter_nd_op_test.cc
+++ b/onnxruntime/test/providers/cpu/tensor/scatter_nd_op_test.cc
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 #include "gtest/gtest.h"
+#include "core/providers/cpu/tensor/scatter_nd.h"
 #include "test/providers/provider_test_utils.h"
 
 namespace onnxruntime {
@@ -298,6 +299,14 @@ TEST(ScatterNDOpTest, ScatterND_zero_index_depth_empty_data) {
   test.AddOutput<float>("output", {0, 3}, {});
   test.Run(OpTester::ExpectResult::kExpectSuccess, "",
            {kTensorrtExecutionProvider, kWebGpuExecutionProvider});
+}
+
+TEST(ScatterNDOpTest, ScatterND_nonempty_indices_reject_indexed_zero_dimension) {
+  const auto status = scatter_nd_internal::ValidateShapes(
+      TensorShape{1, 0, 2}, TensorShape{1, 2}, TensorShape{1, 2});
+  ASSERT_FALSE(status.IsOK());
+  EXPECT_THAT(status.ErrorMessage(), testing::HasSubstr(
+                                         "indices must be empty when an indexed data dimension has size 0"));
 }
 
 }  // namespace test


### PR DESCRIPTION
This pull request improves validation in the `ScatterND` operator to ensure that indices are empty when any indexed data dimension has size zero, and adds a corresponding unit test to verify this behavior.

Validation logic improvements:

* Updated `ValidateShapes` in `scatter_nd.h` to return an error if indices are non-empty and any indexed input data dimension is zero, preventing invalid scatter operations.

Testing:

* Added a new test (`ScatterND_nonempty_indices_reject_indexed_zero_dimension`) in `scatter_nd_op_test.cc` to assert that the validation correctly rejects non-empty indices when an indexed data dimension is zero.
* Included the necessary header for `scatter_nd.h` in the test file to support the new test.