### PR TITLE
[Superseded by #32346] [JS Node] Output buffer reuse and Electron-safe buffers

### DIFF
--- a/js/node/src/inference_session_wrap.cc
+++ b/js/node/src/inference_session_wrap.cc
@@ -195,6 +195,7 @@ Napi::Value InferenceSessionWrap::Run(const Napi::CallbackInfo& info) {
   std::vector<const char*> outputNames_cstr;
   std::vector<Ort::Value> outputValues;
   std::vector<bool> reuseOutput;
+  std::vector<Napi::Value> outputJsValues;
   size_t inputIndex = 0;
   size_t outputIndex = 0;
   Ort::MemoryInfo cpuMemoryInfo = Ort::MemoryInfo::CreateCpu(OrtDeviceAllocator, OrtMemTypeDefault);
@@ -215,6 +216,7 @@ Napi::Value InferenceSessionWrap::Run(const Napi::CallbackInfo& info) {
         outputNames_cstr.push_back(name.c_str());
         auto value = fetch.Get(name);
         reuseOutput.push_back(!value.IsNull());
+        outputJsValues.push_back(value);
         outputValues.emplace_back(value.IsNull() ? Ort::Value{nullptr} : NapiValueToOrtValue(env, value, cpuMemoryInfo, gpuBufferMemoryInfo));
       }
     }
@@ -233,7 +235,8 @@ Napi::Value InferenceSessionWrap::Run(const Napi::CallbackInfo& info) {
       Napi::Object result = Napi::Object::New(env);
 
       for (size_t i = 0; i < outputIndex; i++) {
-        result.Set(outputNames_cstr[i], OrtValueToNapiValue(env, std::move(outputValues[i])));
+        result.Set(outputNames_cstr[i], reuseOutput[i] ? outputJsValues[i]
+                                                       : OrtValueToNapiValue(env, std::move(outputValues[i])));
       }
       return scope.Escape(result);
     } else {
@@ -245,9 +248,9 @@ Napi::Value InferenceSessionWrap::Run(const Napi::CallbackInfo& info) {
         ioBinding_->BindInput(inputNames_cstr[i], inputValues[i]);
       }
       for (size_t i = 0; i < outputIndex; i++) {
-        // TODO: support preallocated output tensor (outputValues[i])
-
-        if (preferredOutputLocations_[i] == DATA_LOCATION_GPU_BUFFER) {
+        if (reuseOutput[i]) {
+          ioBinding_->BindOutput(outputNames_cstr[i], outputValues[i]);
+        } else if (preferredOutputLocations_[i] == DATA_LOCATION_GPU_BUFFER) {
           ioBinding_->BindOutput(outputNames_cstr[i], gpuBufferMemoryInfo);
         } else {
           ioBinding_->BindOutput(outputNames_cstr[i], cpuMemoryInfo);
@@ -261,7 +264,8 @@ Napi::Value InferenceSessionWrap::Run(const Napi::CallbackInfo& info) {
 
       Napi::Object result = Napi::Object::New(env);
       for (size_t i = 0; i < outputIndex; i++) {
-        result.Set(outputNames_cstr[i], OrtValueToNapiValue(env, std::move(outputs[i])));
+        result.Set(outputNames_cstr[i], reuseOutput[i] ? outputJsValues[i]
+                                                       : OrtValueToNapiValue(env, std::move(outputs[i])));
       }
       return scope.Escape(result);
     }

--- a/js/node/src/ort_instance_data.cc
+++ b/js/node/src/ort_instance_data.cc
@@ -6,6 +6,18 @@
 #include "ort_singleton_data.h"
 #include "onnxruntime_cxx_api.h"
 
+namespace {
+bool IsElectronRuntime(Napi::Env env) {
+  const auto process = env.Global().Get("process");
+  if (!process.IsObject()) {
+    return false;
+  }
+
+  const auto versions = process.As<Napi::Object>().Get("versions");
+  return versions.IsObject() && versions.As<Napi::Object>().Get("electron").IsString();
+}
+}  // namespace
+
 OrtInstanceData::OrtInstanceData() {
 }
 
@@ -13,6 +25,7 @@ void OrtInstanceData::Create(Napi::Env env, Napi::Function inferenceSessionWrapp
   ORT_NAPI_THROW_ERROR_IF(env.GetInstanceData<void>() != nullptr, env, "OrtInstanceData already created.");
   auto data = new OrtInstanceData{};
   data->wrappedSessionConstructor = Napi::Persistent(inferenceSessionWrapperFunction);
+  data->isElectron_ = IsElectronRuntime(env);
   env.SetInstanceData(data);
 }
 
@@ -32,4 +45,9 @@ const Napi::FunctionReference& OrtInstanceData::TensorConstructor(Napi::Env env)
   ORT_NAPI_THROW_ERROR_IF(data == nullptr, env, "OrtInstanceData not created.");
 
   return data->ortTensorConstructor;
+}
+
+bool OrtInstanceData::IsElectron(Napi::Env env) {
+  auto data = env.GetInstanceData<OrtInstanceData>();
+  return data != nullptr && data->isElectron_;
 }

--- a/js/node/src/ort_instance_data.h
+++ b/js/node/src/ort_instance_data.h
@@ -22,6 +22,8 @@ struct OrtInstanceData {
   static void InitOrt(Napi::Env env, int log_level, Napi::Function tensorConstructor, bool is_main_thread);
   // Get the Tensor constructor reference for the Napi::Env
   static const Napi::FunctionReference& TensorConstructor(Napi::Env env);
+  // Return whether this Napi::Env belongs to an Electron runtime.
+  static bool IsElectron(Napi::Env env);
 
  private:
   OrtInstanceData();
@@ -29,4 +31,5 @@ struct OrtInstanceData {
   // per env persistent constructors
   Napi::FunctionReference wrappedSessionConstructor;
   Napi::FunctionReference ortTensorConstructor;
+  bool isElectron_{false};
 };

--- a/js/node/src/tensor_helper.cc
+++ b/js/node/src/tensor_helper.cc
@@ -325,10 +325,10 @@ Napi::Value OrtValueToNapiValue(Napi::Env env, Ort::Value&& value) {
 
       return scope.Escape(tensorFromGpuBuffer.Call({Napi::External<OrtValue>::New(env, underlyingOrtValue), options}));
     } else {
-      // Let the JS ArrayBuffer own the OrtValue so the output buffer is not copied.
       const size_t byteLength = value.GetTensorSizeInBytes();
       Napi::ArrayBuffer arrayBuffer;
-      if (byteLength > 0) {
+      if (byteLength > 0 && !OrtInstanceData::IsElectron(env)) {
+        // Let the JS ArrayBuffer own the OrtValue so the output buffer is not copied.
         OrtValue* underlyingValue = value;
         arrayBuffer = Napi::ArrayBuffer::New(
             env, value.GetTensorMutableRawData(), byteLength,
@@ -341,7 +341,11 @@ Napi::Value OrtValueToNapiValue(Napi::Env env, Ort::Value&& value) {
             underlyingValue);
         value.release();
       } else {
-        arrayBuffer = Napi::ArrayBuffer::New(env, 0);
+        // Electron's V8 Memory Cage rejects external ArrayBuffers. Copy into V8-owned memory there.
+        arrayBuffer = Napi::ArrayBuffer::New(env, byteLength);
+        if (byteLength > 0) {
+          memcpy(arrayBuffer.Data(), value.GetTensorRawData(), byteLength);
+        }
       }
       napi_value typedArrayData;
       napi_status status =

--- a/js/node/src/tensor_helper.cc
+++ b/js/node/src/tensor_helper.cc
@@ -8,6 +8,7 @@
 
 #include "common.h"
 #include "ort_instance_data.h"
+#include "ort_singleton_data.h"
 #include "tensor_helper.h"
 #include "inference_session_wrap.h"
 
@@ -324,10 +325,23 @@ Napi::Value OrtValueToNapiValue(Napi::Env env, Ort::Value&& value) {
 
       return scope.Escape(tensorFromGpuBuffer.Call({Napi::External<OrtValue>::New(env, underlyingOrtValue), options}));
     } else {
-      // TODO: optimize memory
-      auto arrayBuffer = Napi::ArrayBuffer::New(env, size * DATA_TYPE_ELEMENT_SIZE_MAP[elemType]);
-      if (size > 0) {
-        memcpy(arrayBuffer.Data(), value.GetTensorRawData(), size * DATA_TYPE_ELEMENT_SIZE_MAP[elemType]);
+      // Let the JS ArrayBuffer own the OrtValue so the output buffer is not copied.
+      const size_t byteLength = value.GetTensorSizeInBytes();
+      Napi::ArrayBuffer arrayBuffer;
+      if (byteLength > 0) {
+        OrtValue* underlyingValue = value;
+        arrayBuffer = Napi::ArrayBuffer::New(
+            env, value.GetTensorMutableRawData(), byteLength,
+            [](Napi::Env, void*, OrtValue* value) {
+              // The environment cleanup hook may run before N-API finalizers during process shutdown.
+              if (OrtSingletonData::GetOrtObjects()) {
+                Ort::GetApi().ReleaseValue(value);
+              }
+            },
+            underlyingValue);
+        value.release();
+      } else {
+        arrayBuffer = Napi::ArrayBuffer::New(env, 0);
       }
       napi_value typedArrayData;
       napi_status status =

--- a/js/node/test/unittests/lib/inference-session.ts
+++ b/js/node/test/unittests/lib/inference-session.ts
@@ -177,8 +177,7 @@ describe('UnitTests - InferenceSession.run()', () => {
     const result = await session!.run({ data_0: input0 }, { softmaxout_1: null });
     assertTensorEqual(result.softmaxout_1, expectedOutput0);
   });
-  // TODO: enable after buffer reuse is implemented
-  it.skip('run() - fetches object (pre-allocated)', async () => {
+  it('run() - fetches object (pre-allocated)', async () => {
     const preAllocatedOutputBuffer = new Float32Array(expectedOutput0.size);
     const result = await session!.run(
       { data_0: input0 },


### PR DESCRIPTION
> Superseded by #32346. The output buffer reuse and Electron-safe ArrayBuffer changes have been integrated into that pull request so the async inference and ownership changes can be reviewed together.

Original scope:
- reuse preallocated output tensors for Session.Run and IoBinding
- return the original JavaScript tensor for preallocated outputs
- avoid CPU output copies with external ArrayBuffers
- use V8-owned ArrayBuffers in Electron