### PR TITLE
Validate recurrent input rank before access

### DIFF
--- a/onnxruntime/core/providers/cpu/rnn/deep_cpu_gru.cc
+++ b/onnxruntime/core/providers/cpu/rnn/deep_cpu_gru.cc
@@ -371,6 +371,10 @@ Status DeepCpuGruOp::ComputeImpl(OpKernelContext& context) const {
   const auto* initial_h = context.Input<Tensor>(5);      // initial hidden. [num_directions, batch_size, hidden_size]
 
   auto& X_shape = X.Shape();
+  const auto& W_shape = (W != nullptr) ? W->Shape() : pre_packed_input_weights_.shape_;
+  const auto& R_shape = (R != nullptr) ? R->Shape() : pre_packed_recurrent_ZR_.shape_;  // original shape saved
+  ORT_RETURN_IF_ERROR(ValidateCommonRnnInputs(X, W_shape, R_shape, B, 3, sequence_lens, initial_h,
+                                              num_directions_, hidden_size_));
 
   int seq_length = narrow<int>(X_shape[0]);
   int batch_size = narrow<int>(X_shape[1]);
@@ -379,11 +383,6 @@ Status DeepCpuGruOp::ComputeImpl(OpKernelContext& context) const {
   // #ifdef _DEBUG
   //   std::cout << "GRU: seq_len: " << seq_length << " batch_size: " << batch_size << " input_size: " << input_size << std::endl;
   // #endif
-
-  const auto& W_shape = (W != nullptr) ? W->Shape() : pre_packed_input_weights_.shape_;
-  const auto& R_shape = (R != nullptr) ? R->Shape() : pre_packed_recurrent_ZR_.shape_;  // original shape saved
-  auto status = ValidateCommonRnnInputs(X, W_shape, R_shape, B, 3, sequence_lens, initial_h, num_directions_, hidden_size_);
-  ORT_RETURN_IF_ERROR(status);
 
   // GRU outputs are optional but must be in the same order
   TensorShape Y_dims{seq_length, num_directions_, batch_size, hidden_size_};
@@ -403,7 +402,7 @@ Status DeepCpuGruOp::ComputeImpl(OpKernelContext& context) const {
   }
 
   AllocatorPtr alloc;
-  status = context.GetTempSpaceAllocator(&alloc);
+  auto status = context.GetTempSpaceAllocator(&alloc);
   ORT_RETURN_IF_ERROR(status);
   const auto* input_weights = (W != nullptr) ? W->Data<T>() : nullptr;
   const auto recurrent_weights = (R != nullptr) ? R->DataAsSpan<T>() : gsl::span<const T>();

--- a/onnxruntime/core/providers/cpu/rnn/rnn.cc
+++ b/onnxruntime/core/providers/cpu/rnn/rnn.cc
@@ -159,13 +159,12 @@ Status RNN<float>::Compute(OpKernelContext* ctx) const {
   const auto* initial_h = ctx->Input<Tensor>(5);
 
   int64_t num_directions = direction_ == "bidirectional" ? 2 : 1;
+  ORT_RETURN_IF_ERROR(rnn::detail::ValidateCommonRnnInputs(X, W.Shape(), R.Shape(), B, 1, sequence_lens, initial_h,
+                                                           num_directions, hidden_size_));
+
   int64_t seq_length = X.Shape()[0];
   int64_t batch_size = X.Shape()[1];
   int64_t input_size = X.Shape()[2];
-
-  auto status = rnn::detail::ValidateCommonRnnInputs(X, W.Shape(), R.Shape(), B, 1, sequence_lens, initial_h,
-                                                     num_directions, hidden_size_);
-  ORT_RETURN_IF_ERROR(status);
 
   // RNN outputs are optional
   std::vector<int64_t> Y_dims({seq_length, num_directions, batch_size, hidden_size_});

--- a/onnxruntime/core/providers/cpu/rnn/rnn_helpers.cc
+++ b/onnxruntime/core/providers/cpu/rnn/rnn_helpers.cc
@@ -39,12 +39,12 @@ Status ValidateCommonRnnInputs(const Tensor& X,
                                bool weights_transposed) {
   auto& X_shape = X.Shape();
 
+  if (X_shape.NumDimensions() != 3)
+    return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT, "Input X must have 3 dimensions only. Actual:", X_shape);
+
   int64_t seq_length = X_shape[0];
   int64_t batch_size = X_shape[1];
   int64_t input_size = X_shape[2];
-
-  if (X_shape.NumDimensions() != 3)
-    return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT, "Input X must have 3 dimensions only. Actual:", X_shape);
 
   // The gate dimension (mult * hidden_size) and the input/hidden dimension are on dims 1 and 2
   // respectively for the standard layout, and swapped for the transposed (quantized) layout.

--- a/onnxruntime/test/providers/cpu/rnn/deep_cpu_gru_op_test.cc
+++ b/onnxruntime/test/providers/cpu/rnn/deep_cpu_gru_op_test.cc
@@ -19,6 +19,22 @@ using namespace std;
 namespace onnxruntime {
 namespace test {
 
+TEST(GRUTest, RuntimeScalarInputRejected) {
+  OpTester test("GRU", 14);
+  test.AddShapeToTensorData(false);
+  test.AddAttribute("hidden_size", int64_t{1});
+  test.AddInput<float>("X", {}, {1.0f});
+  test.AddInput<float>("W", {1, 3, 1}, {1.0f, 1.0f, 1.0f});
+  test.AddInput<float>("R", {1, 3, 1}, {1.0f, 1.0f, 1.0f});
+  test.AddOptionalOutputEdge<float>();
+  test.AddOptionalOutputEdge<float>();
+
+  std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
+  execution_providers.push_back(DefaultCpuExecutionProvider());
+  test.Run(OpTester::ExpectResult::kExpectFailure, "Input X must have 3 dimensions only", {}, nullptr,
+           &execution_providers);
+}
+
 #ifndef ORT_NO_EXCEPTIONS
 TEST(GRUTest, CalculateBufferElementCountThrowsOnOverflow) {
   EXPECT_THROW((void)onnxruntime::rnn::detail::CalculateBufferElementCount({std::numeric_limits<int>::max(), std::numeric_limits<int>::max(), 5}),

--- a/onnxruntime/test/providers/cpu/rnn/deep_cpu_gru_op_test.cc
+++ b/onnxruntime/test/providers/cpu/rnn/deep_cpu_gru_op_test.cc
@@ -26,7 +26,7 @@ TEST(GRUTest, RuntimeScalarInputRejected) {
   test.AddInput<float>("X", {}, {1.0f});
   test.AddInput<float>("W", {1, 3, 1}, {1.0f, 1.0f, 1.0f});
   test.AddInput<float>("R", {1, 3, 1}, {1.0f, 1.0f, 1.0f});
-  test.AddOptionalOutputEdge<float>();
+  test.AddOutput<float>("Y", {1, 1, 1, 1}, {0.0f});
   test.AddOptionalOutputEdge<float>();
 
   std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;

--- a/onnxruntime/test/providers/cpu/rnn/rnn_op_test.cc
+++ b/onnxruntime/test/providers/cpu/rnn/rnn_op_test.cc
@@ -11,6 +11,22 @@ using namespace std;
 namespace onnxruntime {
 namespace test {
 
+TEST(RNNTest, RuntimeScalarInputRejected) {
+  OpTester test("RNN", 14);
+  test.AddShapeToTensorData(false);
+  test.AddAttribute("hidden_size", int64_t{1});
+  test.AddInput<float>("X", {}, {1.0f});
+  test.AddInput<float>("W", {1, 1, 1}, {1.0f});
+  test.AddInput<float>("R", {1, 1, 1}, {1.0f});
+  test.AddOptionalOutputEdge<float>();
+  test.AddOptionalOutputEdge<float>();
+
+  std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
+  execution_providers.push_back(DefaultCpuExecutionProvider());
+  test.Run(OpTester::ExpectResult::kExpectFailure, "Input X must have 3 dimensions only", {}, nullptr,
+           &execution_providers);
+}
+
 // test input data is generated from CNTK with shape of [batch_size, seq_length, input_size]
 // onnxruntime takes input of shape [seq_length, batch_size, input_size)
 template <typename T>

--- a/onnxruntime/test/providers/cpu/rnn/rnn_op_test.cc
+++ b/onnxruntime/test/providers/cpu/rnn/rnn_op_test.cc
@@ -18,7 +18,7 @@ TEST(RNNTest, RuntimeScalarInputRejected) {
   test.AddInput<float>("X", {}, {1.0f});
   test.AddInput<float>("W", {1, 1, 1}, {1.0f});
   test.AddInput<float>("R", {1, 1, 1}, {1.0f});
-  test.AddOptionalOutputEdge<float>();
+  test.AddOutput<float>("Y", {1, 1, 1, 1}, {0.0f});
   test.AddOptionalOutputEdge<float>();
 
   std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;


### PR DESCRIPTION
This pull request improves input validation for RNN and GRU operators in ONNX Runtime by ensuring that the input tensor `X` has exactly three dimensions, and adds corresponding unit tests to verify this behavior. The changes also simplify and clarify the validation logic in the operator implementations.

**Input validation improvements:**

* Added an explicit check in `ValidateCommonRnnInputs` to ensure the input tensor `X` has exactly three dimensions, returning a clear error message if not.
* Updated `DeepCpuGruOp::ComputeImpl` and `RNN<float>::Compute` to directly call `ValidateCommonRnnInputs` and immediately return on failure, simplifying the code and ensuring consistent validation. [[1]](diffhunk://#diff-922aca6b1d7d35d367a101411376915b905420a310f6b1dfb1f2ab0fb088abcfR374-R377) [[2]](diffhunk://#diff-eb4d6d9c063b4f9cb51a5db0863aaeb67c3e58c2f05787b16450ba99a886e13bR162-L169)

**Testing enhancements:**

* Added new unit tests `RuntimeScalarInputRejected` for both GRU and RNN operators to verify that scalar (non-3D) inputs are correctly rejected at runtime, with the expected error message. [[1]](diffhunk://#diff-b30c5b41c9bae493629916e041f6f6629094e5ba3d5a94da62bf6a45255fc9f3R22-R37) [[2]](diffhunk://#diff-5d71c039a353c95cc1309175e97ac4aa337520d28eb03ab2b7b0eb5b945286f8R14-R29)

**Code cleanup:**

* Removed redundant code and improved variable initialization in operator implementations for clarity and maintainability. [[1]](diffhunk://#diff-922aca6b1d7d35d367a101411376915b905420a310f6b1dfb1f2ab0fb088abcfL383-L387) [[2]](diffhunk://#diff-922aca6b1d7d35d367a101411376915b905420a310f6b1dfb1f2ab0fb088abcfL406-R405)