### PR TITLE
Validate GatherND indices rank before access

### DIFF
--- a/onnxruntime/core/providers/cpu/tensor/gather_nd.cc
+++ b/onnxruntime/core/providers/cpu/tensor/gather_nd.cc
@@ -155,6 +155,10 @@ Status GatherND::Compute(OpKernelContext* context) const {
   const auto& input_shape = input_tensor->Shape();
   const auto& indices_shape = indices_tensor->Shape();
 
+  if (indices_shape.NumDimensions() == 0) {
+    return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT, "indices tensor must has rank larger than 0");
+  }
+
   int64_t last_indices_dimension = batch_dims_ + indices_shape[indices_shape.NumDimensions() - 1];
   if (last_indices_dimension > static_cast<int64_t>(input_shape.NumDimensions())) {
     return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,

--- a/onnxruntime/test/providers/cpu/tensor/gather_nd_op_test.cc
+++ b/onnxruntime/test/providers/cpu/tensor/gather_nd_op_test.cc
@@ -396,5 +396,19 @@ TEST(GatherNDOpTest, GatherND_zero_dim_error) {
            &cpu_only_ep);
 }
 
+TEST(GatherNDOpTest, GatherND_runtime_scalar_indices_error) {
+  OpTester test("GatherND", 12, kOnnxDomain);
+  test.AddShapeToTensorData(false);
+  test.AddInput<float>("data", {2}, {1.f, 2.f});
+  test.AddInput<int64_t>("indices", {}, {0LL});
+  test.AddOutput<float>("output", {}, {0.f});
+
+  std::vector<std::unique_ptr<onnxruntime::IExecutionProvider>> cpu_only_ep;
+  cpu_only_ep.push_back(DefaultCpuExecutionProvider());
+  test.Run(OpTester::ExpectResult::kExpectFailure,
+           "indices tensor must has rank larger than 0",
+           {}, nullptr, &cpu_only_ep);
+}
+
 }  // namespace test
 }  // namespace onnxruntime


### PR DESCRIPTION
This pull request introduces a validation check in the `GatherND` operator to ensure that the `indices` tensor is not scalar (i.e., has rank greater than 0), and adds a corresponding unit test to verify the new error handling. This prevents invalid inputs from proceeding and improves the robustness of the operator.

Input validation improvements:

* Added a check in `gather_nd.cc` to return an error if the `indices` tensor has zero dimensions, with a clear error message.

Testing enhancements:

* Added a unit test `GatherND_runtime_scalar_indices_error` in `gather_nd_op_test.cc` to verify that passing a scalar `indices` tensor triggers the expected error.