### PR TITLE
Fix XNNPACK Resize with empty scales

### DIFF
--- a/onnxruntime/core/providers/xnnpack/tensor/resize.cc
+++ b/onnxruntime/core/providers/xnnpack/tensor/resize.cc
@@ -36,9 +36,11 @@ bool Resize::IsOnnxNodeSupported(const NodeUnit& node_unit,
     const auto* x_shape = x_arg.Shape();
 
     // 'bilinear' == 2-D input or 4-D input with outermost 2 scales as 1 (NCHW) can be supported.
-    // we only support 4-d tensor for now, and the channel must be known.
+    // we only support 4-d tensors for now. The channel and spatial dimensions must be known
+    // because the kernel caches the output H and W during construction.
     // we assume the input in NCHW for this test.
-    if (!x_shape || x_shape->dim_size() != 4 || x_shape->dim(1).dim_value() <= 0) {
+    if (!x_shape || x_shape->dim_size() != 4 || x_shape->dim(1).dim_value() <= 0 ||
+        x_shape->dim(2).dim_value() <= 0 || x_shape->dim(3).dim_value() <= 0) {
       break;
     }
 
@@ -96,15 +98,15 @@ bool Resize::IsOnnxNodeSupported(const NodeUnit& node_unit,
     if (size_tensor) {
       const Initializer size_val(graph_viewer.GetGraph(), *size_tensor, node_unit.ModelPath());
       const auto sizes = size_val.DataAsSpan<int64_t>();
-      if (!sizes.empty()) {
-        if (sizes.size() != 4) {
-          break;
-        }
+      // ORT treats an empty scales tensor as unused when sizes supplies the geometry, but it
+      // does not treat an empty sizes tensor as unused when scales is present.
+      if (sizes.size() != 4) {
+        break;
+      }
 
-        has_sizes_data = true;
-        if (sizes[1] != x_shape->dim(1).dim_value()) {
-          break;
-        }
+      has_sizes_data = true;
+      if (sizes[1] != x_shape->dim(1).dim_value()) {
+        break;
       }
     }
 

--- a/onnxruntime/core/providers/xnnpack/tensor/resize.cc
+++ b/onnxruntime/core/providers/xnnpack/tensor/resize.cc
@@ -57,46 +57,67 @@ bool Resize::IsOnnxNodeSupported(const NodeUnit& node_unit,
                                   ? graph_viewer.GetConstantInitializer(inputs[size_idx].node_arg.Name(), true)
                                   : nullptr;
 
-    // if both scales and sizes are nullptr the one that was provided was not a constant initializer
-    if (!scale_tensor && !size_tensor) {
-      break;
-    }
-
     // check the scale for the second dim is 1 or the size of the second dim matches the input shape.
     // if not, it is not the C dim as a Resize will not change the number of channels.
+    bool has_scales_data = false;
     if (scale_tensor) {
       const Initializer scale_val(graph_viewer.GetGraph(), *scale_tensor, node_unit.ModelPath());
       const auto scales = scale_val.DataAsSpan<float>();
-      if (scales[1] != 1.0F) {
-        break;
-      }
-
-      // downsampling output seems to require the output size to be a factor of the input to match ONNX
-      if (scales[2] < 1.0f || scales[3] < 1.0f) {
-        // we also require input_shape to be known to check
-        int64_t h_in = x_shape->dim(2).dim_value();
-        int64_t w_in = x_shape->dim(3).dim_value();
-        if (h_in < 0 || w_in < 0) {
+      if (!scales.empty()) {
+        if (scales.size() != 4) {
           break;
         }
 
-        float scale_h = scales[2];
-        float scale_w = scales[3];
-        if (!utils::ReciprocalIsAFactorOfN(h_in, scale_h) ||
-            !utils::ReciprocalIsAFactorOfN(w_in, scale_w)) {
+        has_scales_data = true;
+        if (scales[1] != 1.0F) {
+          break;
+        }
+
+        // downsampling output seems to require the output size to be a factor of the input to match ONNX
+        if (scales[2] < 1.0f || scales[3] < 1.0f) {
+          // we also require input_shape to be known to check
+          int64_t h_in = x_shape->dim(2).dim_value();
+          int64_t w_in = x_shape->dim(3).dim_value();
+          if (h_in < 0 || w_in < 0) {
+            break;
+          }
+
+          float scale_h = scales[2];
+          float scale_w = scales[3];
+          if (!utils::ReciprocalIsAFactorOfN(h_in, scale_h) ||
+              !utils::ReciprocalIsAFactorOfN(w_in, scale_w)) {
+            break;
+          }
+        }
+      }
+    }
+
+    bool has_sizes_data = false;
+    if (size_tensor) {
+      const Initializer size_val(graph_viewer.GetGraph(), *size_tensor, node_unit.ModelPath());
+      const auto sizes = size_val.DataAsSpan<int64_t>();
+      if (!sizes.empty()) {
+        if (sizes.size() != 4) {
+          break;
+        }
+
+        has_sizes_data = true;
+        if (sizes[1] != x_shape->dim(1).dim_value()) {
           break;
         }
       }
     }
 
-    if (size_tensor) {
-      const Initializer size_val(graph_viewer.GetGraph(), *size_tensor, node_unit.ModelPath());
-      if (size_val.DataAsSpan<int64_t>()[1] != x_shape->dim(1).dim_value()) {
-        break;
-      }
+    // Exactly one input must provide the output geometry. A zero-element tensor represents an unused input.
+    if (has_scales_data == has_sizes_data) {
+      break;
     }
 
     const auto* output_shape = node_unit.Outputs()[0].node_arg.Shape();
+    if (!output_shape || output_shape->dim_size() != 4) {
+      break;
+    }
+
     bool length_resized_compatible_pytorch_half_pixel = true;
     // when length_resized > 1, there is no difference between pytorch_half_pixel and half_pixel
     // according onnx spec.

--- a/onnxruntime/test/providers/xnnpack/xnnpack_basic_test.cc
+++ b/onnxruntime/test/providers/xnnpack/xnnpack_basic_test.cc
@@ -521,6 +521,26 @@ TEST(XnnpackEP, Resize) {
   RunModelTestWithPath(ort_model_path, "test_resize", nullptr);
 }
 
+TEST(XnnpackEP, TestResizeEmptyScalesUsesSizes) {
+  auto model_builder = [](ModelTestBuilder& builder) {
+    auto* input = builder.MakeInput<float>({1, 3, 8, 8}, -1.0f, 1.0f);
+    auto* roi = builder.MakeInitializer<float>({0}, {});
+    auto* scales = builder.MakeInitializer<float>({0}, {});
+    auto* sizes = builder.MakeInitializer<int64_t>({4}, {1, 3, 16, 16});
+    auto* output = builder.MakeOutput();
+
+    auto& resize = builder.AddNode("Resize", {input, roi, scales, sizes}, {output});
+    resize.AddAttribute("mode", "linear");
+    resize.AddAttribute("coordinate_transformation_mode", "half_pixel");
+  };
+
+  RunModelTest(model_builder, "xnnpack_test_resize_empty_scales",
+               {
+                   ExpectedEPNodeAssignment::Some,
+                   1e-4f /* fp32_abs_err */,
+               });
+}
+
 TEST(XnnpackEP, DISABLED_TestResize_u8_and_s8_NCWH_asymmetric_no_node_assiged) {  // [ONNXRuntimeError] : 9 : NOT_IMPLEMENTED : Could not find an implementation for Resize(19) node with name 'node_token_5'
   // NCHW
   RunModelTest(BuildQDQResizeTestCase({1, 3, 64, 64} /* input_shape */,

--- a/onnxruntime/test/providers/xnnpack/xnnpack_basic_test.cc
+++ b/onnxruntime/test/providers/xnnpack/xnnpack_basic_test.cc
@@ -541,6 +541,34 @@ TEST(XnnpackEP, TestResizeEmptyScalesUsesSizes) {
                });
 }
 
+TEST(XnnpackEP, TestResizeDynamicSpatialDimensionsFallBack) {
+  const std::vector<int64_t> input_shape = {1, 3, 8, 8};
+  auto model_builder = [&](ModelTestBuilder& builder) {
+    auto* input = builder.MakeSymbolicInput<float>(
+        {int64_t{1}, int64_t{3}, std::string("height"), std::string("width")});
+    auto* roi = builder.MakeInitializer<float>({0}, {});
+    auto* scales = builder.MakeInitializer<float>({0}, {});
+    auto* sizes = builder.MakeInitializer<int64_t>({4}, {1, 3, 16, 16});
+    auto* output = builder.MakeOutput();
+
+    auto& resize = builder.AddNode("Resize", {input, roi, scales, sizes}, {output});
+    resize.AddAttribute("mode", "linear");
+    resize.AddAttribute("coordinate_transformation_mode", "half_pixel");
+
+    // MakeSymbolicInput doesn't register a feed, so add one ourselves.
+    OrtValue input_value;
+    CreateMLValue<float>(TestCPUExecutionProvider()->CreatePreferredAllocators()[0], input_shape,
+                         builder.rand_gen_.Uniform<float>(input_shape, -1.0f, 1.0f), &input_value);
+    builder.feeds_.insert(std::make_pair(input->Name(), input_value));
+  };
+
+  RunModelTest(model_builder, "xnnpack_test_resize_dynamic_spatial_dimensions",
+               {
+                   ExpectedEPNodeAssignment::None,
+                   1e-4f /* fp32_abs_err */,
+               });
+}
+
 TEST(XnnpackEP, DISABLED_TestResize_u8_and_s8_NCWH_asymmetric_no_node_assiged) {  // [ONNXRuntimeError] : 9 : NOT_IMPLEMENTED : Could not find an implementation for Resize(19) node with name 'node_token_5'
   // NCHW
   RunModelTest(BuildQDQResizeTestCase({1, 3, 64, 64} /* input_shape */,


### PR DESCRIPTION
### Description

- Treat zero-element `scales` and `sizes` initializers as unused Resize inputs before inspecting their values.
- Validate rank-4 geometry inputs and the inferred output shape before indexing dimensions.
- Add an XNNPACK regression test for Resize with empty `scales` and a populated `sizes` input.

### Motivation and Context

ONNX Resize models can represent the unused `scales` input as a zero-element initializer when `sizes` supplies the output geometry. The XNNPACK capability check treated that initializer as populated and indexed its empty span, aborting session initialization.

Fixes #32298.

Local validation:

- Built `onnxruntime_provider_test` with XNNPACK enabled.
- Before the fix, the focused regression ran 1 test and aborted with exit code 6.
- After the fix, `XnnpackEP.TestResizeEmptyScalesUsesSizes` passed (1 test).
- `XnnpackEP.*Resize*` passed (2 tests).
- `XnnpackEP.*` passed (20 tests).
- `clang-format 19.1.5 --dry-run --Werror --style=file` passed for both changed files.
- `git diff --check` passed.