### PR TITLE
Register ONNX schemas only when static registration is disabled

### DIFF
--- a/onnxruntime/core/session/environment.cc
+++ b/onnxruntime/core/session/environment.cc
@@ -320,15 +320,18 @@ Status Environment::Initialize(std::unique_ptr<logging::LoggingManager> logging_
 #ifdef USE_DML
       dml::RegisterDmlSchemas();
 #endif
-      RegisterOnnxOperatorSetSchema();
+      // ONNX registers these schemas automatically unless static registration was disabled at build time.
+      if (ONNX_NAMESPACE::IsOnnxStaticRegistrationDisabled()) {
+        RegisterOnnxOperatorSetSchema();
 
 #ifndef DISABLE_ML_OPS
-      RegisterOnnxMLOperatorSetSchema();
+        RegisterOnnxMLOperatorSetSchema();
 #endif
 
 #if defined(ENABLE_TRAINING_OPS)
-      RegisterOnnxTrainingOperatorSetSchema();
+        RegisterOnnxTrainingOperatorSetSchema();
 #endif
+      }
 
 #if defined(ENABLE_TRAINING_OPS)
       // preserve this order until <training schemas>: this depends on operatorsetschema registration.


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->

ONNX supports both automatic static schema registration and explicit manual schema registration.

This change checks
`ONNX_NAMESPACE::IsOnnxStaticRegistrationDisabled()` before ONNX Runtime calls:

- `RegisterOnnxOperatorSetSchema()`
- `RegisterOnnxMLOperatorSetSchema()`
- `RegisterOnnxTrainingOperatorSetSchema()`

When static registration is disabled, ONNX Runtime continues to register the schemas manually as before. When static registration is enabled, ONNX has already registered the schemas automatically, so ONNX Runtime skips the manual registration calls.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

Found this issue in https://github.com/microsoft/vcpkg/pull/53714,  https://github.com/microsoft/vcpkg/issues/49060

vcpkg use externally ONNX library, ONNX registers its schemas automatically, and ONNX Runtime's unconditional registration attempts to register the same
schemas again, producing errors such as:

```text
Schema error: Trying to register schema ... but it is already registered
```