### PR TITLE
[Build] Fix Win Arm64 Cuda Plugin Packaging

### DIFF
--- a/cmake/external/cudnn_frontend.cmake
+++ b/cmake/external/cudnn_frontend.cmake
@@ -7,7 +7,8 @@ onnxruntime_fetchcontent_declare(
   cudnn_frontend
   URL ${DEP_URL_cudnn_frontend}
   URL_HASH SHA1=${DEP_SHA1_cudnn_frontend}
-  PATCH_COMMAND ${Patch_EXECUTABLE} --binary --ignore-whitespace -p1 < ${PROJECT_SOURCE_DIR}/patches/cudnn_frontend/cudnn_frontend_win_dynamic_loading.patch
+  PATCH_COMMAND ${Patch_EXECUTABLE} --binary --ignore-whitespace -p1 < ${PROJECT_SOURCE_DIR}/patches/cudnn_frontend/cudnn_frontend_win_dynamic_loading.patch &&
+                ${Patch_EXECUTABLE} --binary --ignore-whitespace -p1 < ${PROJECT_SOURCE_DIR}/patches/cudnn_frontend/cudnn_frontend_win_arm64_compat.patch
   EXCLUDE_FROM_ALL
 )
 

--- a/cmake/patches/cudnn_frontend/cudnn_frontend_win_arm64_compat.patch
+++ b/cmake/patches/cudnn_frontend/cudnn_frontend_win_arm64_compat.patch
@@ -1,0 +1,12 @@
+--- a/include/cudnn_frontend_Tensor.h
++++ b/include/cudnn_frontend_Tensor.h
+@@ -507,7 +507,8 @@
+             [[maybe_unused]] auto ragged_offset_multiplier_cudnn_ver_error =
+                 "CUDNN_BACKEND_TENSOR_DESCRIPTOR: SetAttribute "
+                 "CUDNN_ATTR_TENSOR_RAGGED_OFFSET_MULTIPLIER requires cudnn version 9.24.0";
+-#if (CUDNN_VERSION >= 92400)
++            // The Windows ARM64 cuDNN 9.24.0.17 headers do not declare this attribute.
++#if (CUDNN_VERSION >= 92400) && !(defined(_WIN32) && defined(_M_ARM64))
+             NV_CUDNN_FE_DYNAMIC_CHECK_BACKEND_DESCRIPTOR(92400, m_tensor, ragged_offset_multiplier_cudnn_ver_error);
+             if (m_tensor.raggedOffset == nullptr) {
+                 set_error_and_throw_exception(

--- a/tools/ci_build/github/azure-pipelines/stages/plugin-win-cuda-stage.yml
+++ b/tools/ci_build/github/azure-pipelines/stages/plugin-win-cuda-stage.yml
@@ -168,11 +168,15 @@ stages:
           displayName: 'Add CUDA to PATH'
 
       - ${{ else }}:
-        # The win-arm64 agents do not have the Azure CLI installed, so use the
-        # AzCopy executable installed above.
-        - powershell: |
-            azcopy.exe cp --recursive https://lotusscus.blob.core.windows.net/models/cuda_sdk/win-arm64/v${{ parameters.arm64_cuda_version }} "$(Agent.TempDirectory)"
+        - task: AzureCLI@2
           displayName: 'Download CUDA SDK win-arm64 v${{ parameters.arm64_cuda_version }}'
+          inputs:
+            azureSubscription: AIInfraBuildOnnxRuntimeOSS
+            scriptType: 'batch'
+            scriptLocation: 'inlineScript'
+            inlineScript: |
+              set AZCOPY_AUTO_LOGIN_TYPE=AZCLI
+              azcopy.exe cp --recursive https://lotusscus.blob.core.windows.net/models/cuda_sdk/win-arm64/v${{ parameters.arm64_cuda_version }} "$(Agent.TempDirectory)"
 
         - powershell: |
             Write-Host "Adding CUDA to PATH"
@@ -194,12 +198,16 @@ stages:
               azcopy.exe cp --recursive https://lotusscus.blob.core.windows.net/models/cudnn_sdk/$(cuda13_cudnn_folder) "$(Agent.TempDirectory)"
 
       # Download cuDNN for win-arm64 (hosted under cudnn_sdk/win-arm64/<folder>).
-      # Uses the AzCopy executable installed above because the win-arm64 agents do not
-      # have the Azure CLI installed.
       - ${{ if eq(parameters.arch, 'arm64') }}:
-        - powershell: |
-            azcopy.exe cp --recursive https://lotusscus.blob.core.windows.net/models/cudnn_sdk/win-arm64/${{ parameters.arm64_cudnn_folder }} "$(Agent.TempDirectory)"
+        - task: AzureCLI@2
           displayName: 'Download cuDNN for win-arm64 (${{ parameters.arm64_cudnn_folder }})'
+          inputs:
+            azureSubscription: AIInfraBuildOnnxRuntimeOSS
+            scriptType: 'batch'
+            scriptLocation: 'inlineScript'
+            inlineScript: |
+              set AZCOPY_AUTO_LOGIN_TYPE=AZCLI
+              azcopy.exe cp --recursive https://lotusscus.blob.core.windows.net/models/cudnn_sdk/win-arm64/${{ parameters.arm64_cudnn_folder }} "$(Agent.TempDirectory)"
 
       # CUDA 12.x build (no separate cuDNN). win-x64 only — win-arm64 always uses CUDA 13.x.
       - ${{ if and(ne(parameters.arch, 'arm64'), ne(parameters.cuda_version, '13.0')) }}:

--- a/tools/ci_build/github/azure-pipelines/stages/plugin-win-cuda-stage.yml
+++ b/tools/ci_build/github/azure-pipelines/stages/plugin-win-cuda-stage.yml
@@ -125,6 +125,27 @@ stages:
         env:
           TMPDIR: "$(Agent.TempDirectory)"
 
+      - ${{ if eq(parameters.arch, 'arm64') }}:
+        - powershell: |
+            $azCopyArchive = "$(Agent.TempDirectory)\azcopy.zip"
+            $azCopyDirectory = "$(Agent.TempDirectory)\azcopy"
+            Invoke-WebRequest `
+              -Uri "https://aka.ms/downloadazcopy-v10-windows-arm64" `
+              -OutFile $azCopyArchive `
+              -UseBasicParsing
+            Expand-Archive -Path $azCopyArchive -DestinationPath $azCopyDirectory -Force
+
+            $azCopyExecutable = Get-ChildItem -Path $azCopyDirectory -Recurse -Filter azcopy.exe |
+              Select-Object -First 1
+            if (-not $azCopyExecutable) {
+              throw "AzCopy executable was not found after extracting $azCopyArchive."
+            }
+
+            $azCopyPath = $azCopyExecutable.FullName
+            Write-Host "##vso[task.prependpath]$($azCopyExecutable.DirectoryName)"
+            & $azCopyPath --version
+          displayName: 'Install AzCopy for win-arm64'
+
       # CUDA SDK download. win-x64 toolkits live at cuda_sdk/v<ver>; win-arm64 toolkits
       # live at cuda_sdk/win-arm64/v<ver> (NVIDIA Windows-on-ARM CUDA is 13.x only).
       - ${{ if ne(parameters.arch, 'arm64') }}:
@@ -147,8 +168,8 @@ stages:
           displayName: 'Add CUDA to PATH'
 
       - ${{ else }}:
-        # Use azcopy directly for win-arm64, matching the QNN SDK download in
-        # templates/jobs/download_win_qnn_sdk.yml.
+        # The win-arm64 agents do not have the Azure CLI installed, so use the
+        # AzCopy executable installed above.
         - powershell: |
             azcopy.exe cp --recursive https://lotusscus.blob.core.windows.net/models/cuda_sdk/win-arm64/v${{ parameters.arm64_cuda_version }} "$(Agent.TempDirectory)"
           displayName: 'Download CUDA SDK win-arm64 v${{ parameters.arm64_cuda_version }}'
@@ -173,8 +194,8 @@ stages:
               azcopy.exe cp --recursive https://lotusscus.blob.core.windows.net/models/cudnn_sdk/$(cuda13_cudnn_folder) "$(Agent.TempDirectory)"
 
       # Download cuDNN for win-arm64 (hosted under cudnn_sdk/win-arm64/<folder>).
-      # Uses azcopy directly because the win-arm64 agents do not have the Azure CLI installed
-      # (see the CUDA SDK download step above).
+      # Uses the AzCopy executable installed above because the win-arm64 agents do not
+      # have the Azure CLI installed.
       - ${{ if eq(parameters.arch, 'arm64') }}:
         - powershell: |
             azcopy.exe cp --recursive https://lotusscus.blob.core.windows.net/models/cudnn_sdk/win-arm64/${{ parameters.arm64_cudnn_folder }} "$(Agent.TempDirectory)"


### PR DESCRIPTION
Address two issues in Win Arm64 Cuda Plugin Packaging:
(1) Authenticate Windows ARM64 CUDA downloads for new machine pool
(2) Fix cudnn-frontend build error for a missing attribute in Windows ARM64 cuDNN 9.24.0.17 headers