### PR TITLE
Fix scalar NonZero output shape

### DIFF
--- a/onnxruntime/core/providers/cpu/tensor/nonzero_op.cc
+++ b/onnxruntime/core/providers/cpu/tensor/nonzero_op.cc
@@ -59,43 +59,42 @@ Status NonZero<T>::Compute(OpKernelContext* context) const {
   const auto& X_shape = X->Shape();
   assert(X_shape.Size() >= 0);
 
-  const Eigen::Index coordinate_size = X_shape.IsScalar() ? 1 : onnxruntime::narrow<Eigen::Index>(X_shape.NumDimensions());
+  const Eigen::Index coordinate_size = onnxruntime::narrow<Eigen::Index>(X_shape.NumDimensions());
+  const T* data = X->Data<T>();
+
+  if (X_shape.IsScalar()) {
+    const int64_t num_non_zero_values = *data != T{} ? 1 : 0;
+    context->Output(0, {0, num_non_zero_values});
+    return Status::OK();
+  }
+
   std::vector<int64_t> non_zero_indices_buffer{};
   // reserve enough space for indices for every element of X
   non_zero_indices_buffer.reserve(SafeInt<size_t>(X_shape.Size()) * coordinate_size);
 
-  const T* data = X->Data<T>();
+  std::vector<int64_t> coordinate(coordinate_size, 0);
 
-  if (X_shape.IsScalar()) {
-    const T& value = *data;
+  // as we iterate the entries, increment the coordinate for the current entry
+  // e.g. if shape is {2,2}, we start with 0,0 increment to 0,1 increment to 1,0 and finally 1,1
+  auto increment_coordinate = [&coordinate, &coordinate_size, &X_shape]() {
+    for (Eigen::Index idx = coordinate_size - 1; idx >= 0; --idx) {
+      int64_t& cur_coord = coordinate[idx];
+      if (cur_coord != X_shape[idx] - 1) {
+        ++cur_coord;
+        break;
+      }
+      cur_coord = 0;
+    }
+  };
+
+  for (size_t i = 0, end = onnxruntime::narrow<size_t>(X_shape.Size()); i < end; ++i) {
+    const T& value = *data++;
     if (value != T{}) {
-      non_zero_indices_buffer.push_back(0);
+      non_zero_indices_buffer.insert(non_zero_indices_buffer.end(),
+                                     coordinate.begin(), coordinate.end());
     }
-  } else {
-    std::vector<int64_t> coordinate(coordinate_size, 0);
 
-    // as we iterate the entries, increment the coordinate for the current entry
-    // e.g. if shape is {2,2}, we start with 0,0 increment to 0,1 increment to 1,0 and finally 1,1
-    auto increment_coordinate = [&coordinate, &coordinate_size, &X_shape]() {
-      for (Eigen::Index idx = coordinate_size - 1; idx >= 0; --idx) {
-        int64_t& cur_coord = coordinate[idx];
-        if (cur_coord != X_shape[idx] - 1) {
-          ++cur_coord;
-          break;
-        }
-        cur_coord = 0;
-      }
-    };
-
-    for (size_t i = 0, end = onnxruntime::narrow<size_t>(X_shape.Size()); i < end; ++i) {
-      const T& value = *data++;
-      if (value != T{}) {
-        non_zero_indices_buffer.insert(non_zero_indices_buffer.end(),
-                                       coordinate.begin(), coordinate.end());
-      }
-
-      increment_coordinate();
-    }
+    increment_coordinate();
   }
 
   const Eigen::Index num_non_zero_values = onnxruntime::narrow<Eigen::Index>(non_zero_indices_buffer.size()) / coordinate_size;

--- a/onnxruntime/core/providers/cuda/tensor/nonzero_op.cc
+++ b/onnxruntime/core/providers/cuda/tensor/nonzero_op.cc
@@ -51,13 +51,12 @@ NONZERO_TYPED_KERNEL(float)
 
 template <typename T>
 Status NonZero<T>::ComputeInternal(OpKernelContext* context) const {
-  static const TensorShape kScalarDims{1};
   const auto x = context->Input<Tensor>(0);
 
   int nonzero_elements = 0;
   const auto& x_shape = x->Shape();
-  const int x_rank = x_shape.IsScalar() ? 1 : static_cast<int>(x_shape.NumDimensions());
-  auto x_dims = (x_shape.IsScalar()) ? kScalarDims.GetDims() : x_shape.GetDims();
+  const int x_rank = static_cast<int>(x_shape.NumDimensions());
+  const auto x_dims = x_shape.GetDims();
   const int64_t x_size = x_shape.Size();
   if (x_size > 0) {
     auto x_data = reinterpret_cast<const typename ToCudaType<T>::MappedType*>(x->Data<T>());
@@ -78,17 +77,19 @@ Status NonZero<T>::ComputeInternal(OpKernelContext* context) const {
         &nonzero_elements, prefix_counts + number_of_blocks - 1,
         sizeof(int), cudaMemcpyDeviceToHost, Stream(context)));
 
-    TArray<fast_divmod> fdm_x_strides(x_rank);
-    TensorPitches x_strides(x_dims);
-    for (auto i = 0; i < x_rank; i++) {
-      fdm_x_strides[i] = fast_divmod(static_cast<int>(x_strides[i]));
-    }
-
     auto* output_tensor = context->Output(0, {x_rank, nonzero_elements});
     ORT_ENFORCE(output_tensor, "failed to get first output!");
-    CUDA_RETURN_IF_ERROR(NonZeroOutputPositions(
-        Stream(context), x_data, x_size, x_rank, fdm_x_strides,
-        prefix_counts, nonzero_elements, output_tensor->MutableData<int64_t>()));
+    if (x_rank > 0) {
+      TArray<fast_divmod> fdm_x_strides(x_rank);
+      TensorPitches x_strides(x_dims);
+      for (auto i = 0; i < x_rank; i++) {
+        fdm_x_strides[i] = fast_divmod(static_cast<int>(x_strides[i]));
+      }
+
+      CUDA_RETURN_IF_ERROR(NonZeroOutputPositions(
+          Stream(context), x_data, x_size, x_rank, fdm_x_strides,
+          prefix_counts, nonzero_elements, output_tensor->MutableData<int64_t>()));
+    }
   } else {
     context->Output(0, {x_rank, nonzero_elements});
   }

--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/Operators/DmlOperatorNonZero.cpp
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/Operators/DmlOperatorNonZero.cpp
@@ -18,6 +18,7 @@ public:
         ML_CHECK_VALID_ARGUMENT(kernelCreationContext.GetOutputCount() == 1);
 
         std::vector<DimensionType> inputShape = kernelCreationContext.GetTensorShapeDescription().GetInputTensorShape(0);
+        m_outputRank = static_cast<DimensionType>(inputShape.size());
 
         // Scalars have a rank of 0, but DML only supports 1 and more, which is the same
         if (inputShape.empty())
@@ -117,14 +118,14 @@ public:
         }
 
         // Create the final output tensor, which is cropped to the actual number of nonzero elements
-        std::vector<uint32_t> outputSizes({m_rank, nonzeroElementCount});
+        std::vector<uint32_t> outputSizes({m_outputRank, nonzeroElementCount});
         auto outputTensor = kernelContext.GetOutputTensor(0, outputSizes);
 
-        if (!m_emptyInput && nonzeroElementCount > 0)
+        if (!m_emptyInput && m_outputRank > 0 && nonzeroElementCount > 0)
         {
             // TODO: Remove this hack when DML supports native int64 for NonZero
             // We use the int64/uint32 stride hack here, so zero out the data before writing to it
-            uint64_t tensorSizeInBytes = uint64_t(m_rank) * uint64_t(nonzeroElementCount) * sizeof(int64_t);
+            uint64_t tensorSizeInBytes = uint64_t(m_outputRank) * uint64_t(nonzeroElementCount) * sizeof(int64_t);
             ComPtr<IDMLCompiledOperator> zeroOperator = InitializeZeroInt64Tensor(tensorSizeInBytes);
 
             // TODO: Remove this hack when DML supports native int64 for NonZero
@@ -185,6 +186,7 @@ private:
     onnxruntime::TensorShape m_outputCoordinatesShape;
     bool m_emptyInput = false;
     uint32_t m_rank = 0;
+    uint32_t m_outputRank = 0;
 };
 
 DML_OP_DEFINE_CREATION_FUNCTION(NonZero, DmlOperatorNonZero);

--- a/onnxruntime/test/onnx/TestCase.cc
+++ b/onnxruntime/test/onnx/TestCase.cc
@@ -1254,6 +1254,19 @@ std::unique_ptr<std::set<BrokenTest>> GetBrokenTests(const std::string& provider
                           "CUDA NOT_IMPLEMENTED for qk_matmul_output mode>kQK; skip until onnx#8068 pin + #27712 (#28994)"});
   }
 
+  if (provider_name == "cpu") {
+    // The model computes a scalar (rank-0) mask via ConstantOfShape/NonZero and relies on
+    // NonZero's legacy shape (1, N) for a scalar input: the NonZero output is Transpose'd
+    // ([1,0]) and then Squeeze'd on axis 1, which only works if that axis is of size 1. Per
+    // https://github.com/microsoft/onnxruntime/issues/11232 and the ONNX spec, a rank-0 input
+    // must produce shape (0, N), which breaks this Squeeze. Skip until the model is re-exported
+    // to be spec-compliant.
+    broken_tests->insert({"RoBERTa-SequenceClassification",
+                           "Model relies on NonZero's pre-spec-compliance scalar shape (1, N); "
+                           "breaks with spec-compliant (0, N) output (onnxruntime#11232)",
+                           {"opset9"}});
+  }
+
   if (provider_name == "nnapi") {
     broken_tests->insert({"scan9_sum", "Error with the extra graph"});
     broken_tests->insert({"scan_sum", "Error with the extra graph"});

--- a/onnxruntime/test/providers/cpu/tensor/nonzero_op_test.cc
+++ b/onnxruntime/test/providers/cpu/tensor/nonzero_op_test.cc
@@ -3,7 +3,6 @@
 
 #include "gtest/gtest.h"
 
-#include "core/session/onnxruntime_session_options_config_keys.h"
 #include "test/providers/provider_test_utils.h"
 
 namespace onnxruntime {
@@ -69,32 +68,17 @@ TEST(NonZeroOpTest, ThreeDims) {
 }
 
 TEST(NonZeroOpTest, Scalar) {
-  // TODO: ONNX shape inference disagrees about the output shape.
-  // ONNX spec is ambiguous: https://github.com/onnx/onnx/issues/2428.
-  // Once spec clarified, remove strict_shape_type_inference override.
-  SessionOptions so;
-  ASSERT_STATUS_OK(so.config_options.AddConfigEntry(kOrtSessionOptionsConfigStrictShapeTypeInference, "0"));
   {
     OpTester test{kOpName, kOpVersion};
     test.AddInput<int32_t>("X", {}, {0});
-#ifdef USE_TENSORRT
-    // TensorRT follows ONNX spec where NonZero produces output shape (0, N) instead of (1, N) for scalar input
     test.AddOutput<int64_t>("Y", {0, 0}, {});
-#else
-    test.AddOutput<int64_t>("Y", {1, 0}, {});
-#endif
-    test.Run(so);
+    test.Run();
   }
   {
     OpTester test{kOpName, kOpVersion};
     test.AddInput<int32_t>("X", {}, {1});
-#ifdef USE_TENSORRT
-    // TensorRT follows ONNX spec where NonZero produces output shape (0, N) instead of (1, N) for scalar input
     test.AddOutput<int64_t>("Y", {0, 1}, {});
-#else
-    test.AddOutput<int64_t>("Y", {1, 1}, {0});
-#endif
-    test.Run(so);
+    test.Run();
   }
 }
 


### PR DESCRIPTION
## Description

Align scalar NonZero with ONNX shape inference: rank-0 inputs produce output shape (0, N) on CPU and CUDA instead of being treated as rank 1.

## Validation

- onnxruntime_provider_test.exe --gtest_filter=NonZeroOpTest.Scalar
- git diff --check
