### PR TITLE
Add signed BitShift support for opset 28

### DIFF
--- a/csharp/test/Microsoft.ML.OnnxRuntime.Tests.NetCoreApp/InferenceTest.netcore.cs
+++ b/csharp/test/Microsoft.ML.OnnxRuntime.Tests.NetCoreApp/InferenceTest.netcore.cs
@@ -491,9 +491,6 @@ namespace Microsoft.ML.OnnxRuntime.Tests
 
                 { "test_mul_uint8", "Could not find an implementation for Mul(14) node with name" },
 
-                { "test_bitshift_right_uint16", "Could not find an implementation for BitShift(11) nodeMeta with name ''"},
-                { "test_bitshift_left_uint16", "Could not find an implementation for BitShift(11)"},
-
                 { "test_pow_types_float32_uint64", "Could not find an implementation for Pow(15) node with name ''"},
                 { "test_pow_types_float32_uint32", "Could not find an implementation for Pow(15) node with name ''"},
 

--- a/docs/OperatorKernels.md
+++ b/docs/OperatorKernels.md
@@ -63,7 +63,8 @@ The **OpSet Version** column uses the following notation:
 |||[9, 13]|**T** = tensor(double), tensor(float)|
 |||[7, 8]|**T** = tensor(double), tensor(float)|
 |BitCast|*in* input:**T1**<br> *out* output:**T2**|26+|**T1** = tensor(bfloat16), tensor(double), tensor(float), tensor(float16), tensor(int16), tensor(int32), tensor(int64), tensor(int8), tensor(uint16), tensor(uint32), tensor(uint64), tensor(uint8)<br/> **T2** = tensor(bfloat16), tensor(double), tensor(float), tensor(float16), tensor(int16), tensor(int32), tensor(int64), tensor(int8), tensor(uint16), tensor(uint32), tensor(uint64), tensor(uint8)|
-|BitShift|*in* X:**T**<br> *in* Y:**T**<br> *out* Z:**T**|11+|**T** = tensor(uint32), tensor(uint64), tensor(uint8)|
+|BitShift|*in* X:**T**<br> *in* Y:**T**<br> *out* Z:**T**|28+|**T** = tensor(int16), tensor(int32), tensor(int64), tensor(int8), tensor(uint16), tensor(uint32), tensor(uint64), tensor(uint8)|
+|||[11, 27]|**T** = tensor(uint16), tensor(uint32), tensor(uint64), tensor(uint8)|
 |BitwiseAnd|*in* A:**T**<br> *in* B:**T**<br> *out* C:**T**|18+|**T** = tensor(int16), tensor(int32), tensor(int64), tensor(int8), tensor(uint16), tensor(uint32), tensor(uint64), tensor(uint8)|
 |BitwiseNot|*in* X:**T**<br> *out* Y:**T**|18+|**T** = tensor(int16), tensor(int32), tensor(int64), tensor(int8), tensor(uint16), tensor(uint32), tensor(uint64), tensor(uint8)|
 |BitwiseOr|*in* A:**T**<br> *in* B:**T**<br> *out* C:**T**|18+|**T** = tensor(int16), tensor(int32), tensor(int64), tensor(int8), tensor(uint16), tensor(uint32), tensor(uint64), tensor(uint8)|
@@ -1221,7 +1222,7 @@ The **OpSet Version** column uses the following notation:
 |||14+|**T** = tensor(float), tensor(float16)|
 |||9+|**T** = tensor(float), tensor(float16)|
 |||7+|**T** = tensor(float), tensor(float16)|
-|BitShift|*in* X:**T**<br> *in* Y:**T**<br> *out* Z:**T**|11+|**T** = tensor(uint16), tensor(uint32), tensor(uint64), tensor(uint8)|
+|BitShift|*in* X:**T**<br> *in* Y:**T**<br> *out* Z:**T**|[11, 27]|**T** = tensor(uint16), tensor(uint32), tensor(uint64), tensor(uint8)|
 |BitwiseAnd|*in* A:**T**<br> *in* B:**T**<br> *out* C:**T**|18+|**T** = tensor(int16), tensor(int32), tensor(int64), tensor(int8), tensor(uint16), tensor(uint32), tensor(uint64), tensor(uint8)|
 |BitwiseNot|*in* X:**T**<br> *out* Y:**T**|18+|**T** = tensor(int16), tensor(int32), tensor(int64), tensor(int8), tensor(uint16), tensor(uint32), tensor(uint64), tensor(uint8)|
 |BitwiseOr|*in* A:**T**<br> *in* B:**T**<br> *out* C:**T**|18+|**T** = tensor(int16), tensor(int32), tensor(int64), tensor(int8), tensor(uint16), tensor(uint32), tensor(uint64), tensor(uint8)|

--- a/onnxruntime/core/providers/cpu/cpu_execution_provider.cc
+++ b/onnxruntime/core/providers/cpu/cpu_execution_provider.cc
@@ -596,9 +596,10 @@ class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOn
 class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 11, 12, MLFloat16, Gemm);
 #endif
 class ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 11, 12, GatherElements);
-class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 11, uint8_t, BitShift);
-class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 11, uint32_t, BitShift);
-class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 11, uint64_t, BitShift);
+class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 11, 27, uint8_t, BitShift);
+class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 11, 27, uint16_t, BitShift);
+class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 11, 27, uint32_t, BitShift);
+class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 11, 27, uint64_t, BitShift);
 class ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 11, 12, Pad);
 class ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 11, 11, GatherND);
 class ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 11, 26, Range);
@@ -1549,6 +1550,16 @@ class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 
 // Opset 27
 class ONNX_OPERATOR_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 27, Range);
 
+// Opset 28
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 28, int8_t, BitShift);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 28, int16_t, BitShift);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 28, int32_t, BitShift);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 28, int64_t, BitShift);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 28, uint8_t, BitShift);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 28, uint16_t, BitShift);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 28, uint32_t, BitShift);
+class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 28, uint64_t, BitShift);
+
 // !!PLEASE READ BELOW!! Following that, add new entries above this comment
 
 /*  *** IMPORTANT! ***
@@ -2311,12 +2322,14 @@ Status RegisterOnnxOperatorKernels(KernelRegistry& kernel_registry) {
                                                                             double, Gemm)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 11, 12,
                                                                       GatherElements)>,
-      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 11, uint8_t,
-                                                                  BitShift)>,
-      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 11, uint32_t,
-                                                                  BitShift)>,
-      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 11, uint64_t,
-                                                                  BitShift)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 11, 27,
+                                                                            uint8_t, BitShift)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 11, 27,
+                                                                            uint16_t, BitShift)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 11, 27,
+                                                                            uint32_t, BitShift)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 11, 27,
+                                                                            uint64_t, BitShift)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 11, 12, Pad)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 11, 11,
                                                                       GatherND)>,
@@ -3742,6 +3755,24 @@ Status RegisterOnnxOperatorKernels(KernelRegistry& kernel_registry) {
 
       // opset 27
       BuildKernelCreateInfo<ONNX_OPERATOR_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 27, Range)>,
+
+      // opset 28
+      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 28, int8_t,
+                                                                  BitShift)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 28, int16_t,
+                                                                  BitShift)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 28, int32_t,
+                                                                  BitShift)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 28, int64_t,
+                                                                  BitShift)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 28, uint8_t,
+                                                                  BitShift)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 28, uint16_t,
+                                                                  BitShift)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 28, uint32_t,
+                                                                  BitShift)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 28, uint64_t,
+                                                                  BitShift)>,
   };
   for (auto& function_table_entry : function_table) {
     KernelCreateInfo info = function_table_entry();

--- a/onnxruntime/core/providers/cpu/math/element_wise_ops.cc
+++ b/onnxruntime/core/providers/cpu/math/element_wise_ops.cc
@@ -1370,9 +1370,9 @@ inline T SafeShiftLeft(T value, T shift) {
   const auto result = static_cast<UnsignedT>(value) << static_cast<UnsignedT>(shift);
   if constexpr (std::is_signed_v<T>) {
     return FromUnsignedBits<T>(result);
-  } else {
-    return result;
   }
+
+  return result;
 }
 
 template <typename T>
@@ -1390,9 +1390,9 @@ inline T SafeShiftRight(T value, T shift) {
       result |= std::numeric_limits<UnsignedT>::max() << (bit_width - shift_amount);
     }
     return FromUnsignedBits<T>(result);
-  } else {
-    return result;
   }
+
+  return result;
 }
 
 template <typename T>

--- a/onnxruntime/core/providers/cpu/math/element_wise_ops.cc
+++ b/onnxruntime/core/providers/cpu/math/element_wise_ops.cc
@@ -12,6 +12,9 @@
 #include "core/mlas/inc/mlas.h"
 
 #include <cmath>
+#include <cstring>
+#include <limits>
+#include <type_traits>
 
 namespace onnxruntime {
 // Supported types for operators that have type reduction enabled
@@ -489,10 +492,18 @@ REG_ELEMENTWISE_VERSIONED_TYPED_KERNEL(Mean, 8, 12, float, Mean_8);
 // Supposed to add BFloat16 but we are not supporting now, however, separate registration
 REG_ELEMENTWISE_TYPED_KERNEL(Mean, 13, float, Mean_8);
 
-REG_ELEMENTWISE_TYPED_KERNEL(BitShift, 11, uint8_t, BitShift);
-// REG_ELEMENTWISE_TYPED_KERNEL(BitShift, 11, uint16_t, BitShift);
-REG_ELEMENTWISE_TYPED_KERNEL(BitShift, 11, uint32_t, BitShift);
-REG_ELEMENTWISE_TYPED_KERNEL(BitShift, 11, uint64_t, BitShift);
+REG_ELEMENTWISE_VERSIONED_TYPED_KERNEL(BitShift, 11, 27, uint8_t, BitShift);
+REG_ELEMENTWISE_VERSIONED_TYPED_KERNEL(BitShift, 11, 27, uint16_t, BitShift);
+REG_ELEMENTWISE_VERSIONED_TYPED_KERNEL(BitShift, 11, 27, uint32_t, BitShift);
+REG_ELEMENTWISE_VERSIONED_TYPED_KERNEL(BitShift, 11, 27, uint64_t, BitShift);
+REG_ELEMENTWISE_TYPED_KERNEL(BitShift, 28, int8_t, BitShift);
+REG_ELEMENTWISE_TYPED_KERNEL(BitShift, 28, int16_t, BitShift);
+REG_ELEMENTWISE_TYPED_KERNEL(BitShift, 28, int32_t, BitShift);
+REG_ELEMENTWISE_TYPED_KERNEL(BitShift, 28, int64_t, BitShift);
+REG_ELEMENTWISE_TYPED_KERNEL(BitShift, 28, uint8_t, BitShift);
+REG_ELEMENTWISE_TYPED_KERNEL(BitShift, 28, uint16_t, BitShift);
+REG_ELEMENTWISE_TYPED_KERNEL(BitShift, 28, uint32_t, BitShift);
+REG_ELEMENTWISE_TYPED_KERNEL(BitShift, 28, uint64_t, BitShift);
 
 REG_ELEMENTWISE_TYPED_KERNEL(BitwiseAnd, 18, int8_t, BitwiseAnd);
 REG_ELEMENTWISE_TYPED_KERNEL(BitwiseAnd, 18, int16_t, BitwiseAnd);
@@ -1334,17 +1345,54 @@ BitShift<T>::BitShift(const OpKernelInfo& info) : OpKernel(info) {
     ORT_THROW("Invalid direction value of '", direction, "'. Valid values are 'LEFT' or 'RIGHT'.");
 }
 
-// Shifting by >= the bit width of an unsigned type is undefined behavior in C++.
-// On x86, 64-bit shifts mask the shift amount to 6 bits, so shift by 64 acts like shift by 0.
-// Guard against this by returning 0 when the shift amount >= the bit width.
+template <typename T>
+T FromUnsignedBits(std::make_unsigned_t<T> bits) {
+  static_assert(std::is_integral_v<T>);
+  T value;
+  std::memcpy(&value, &bits, sizeof(value));
+  return value;
+}
+
+template <typename T>
+inline bool IsInvalidShift(T shift) {
+  using UnsignedT = std::make_unsigned_t<T>;
+  constexpr UnsignedT bit_width = std::numeric_limits<UnsignedT>::digits;
+  return (std::is_signed_v<T> && shift < 0) || static_cast<UnsignedT>(shift) >= bit_width;
+}
+
 template <typename T>
 inline T SafeShiftLeft(T value, T shift) {
-  return shift >= sizeof(T) * 8 ? T{0} : value << shift;
+  if (IsInvalidShift(shift)) {
+    return T{0};
+  }
+
+  using UnsignedT = std::make_unsigned_t<T>;
+  const auto result = static_cast<UnsignedT>(value) << static_cast<UnsignedT>(shift);
+  if constexpr (std::is_signed_v<T>) {
+    return FromUnsignedBits<T>(result);
+  } else {
+    return result;
+  }
 }
 
 template <typename T>
 inline T SafeShiftRight(T value, T shift) {
-  return shift >= sizeof(T) * 8 ? T{0} : value >> shift;
+  if (IsInvalidShift(shift)) {
+    return std::is_signed_v<T> && value < 0 ? T{-1} : T{0};
+  }
+
+  using UnsignedT = std::make_unsigned_t<T>;
+  constexpr UnsignedT bit_width = std::numeric_limits<UnsignedT>::digits;
+  const auto shift_amount = static_cast<UnsignedT>(shift);
+  auto result = static_cast<UnsignedT>(value) >> shift_amount;
+  if constexpr (std::is_signed_v<T>) {
+    if (value < 0 && shift_amount != 0) {
+      result |= std::numeric_limits<UnsignedT>::max() << (bit_width - shift_amount);
+    }
+    return FromUnsignedBits<T>(result);
+  } else {
+    return result;
+  }
 }
 
 template <typename T>

--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/AbiCustomRegistry.cpp
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/AbiCustomRegistry.cpp
@@ -391,6 +391,11 @@ HRESULT STDMETHODCALLTYPE AbiCustomRegistry::RegisterOperatorKernel(
     builder.SetDomain(opKernel->domain)
             .SinceVersion(opKernel->minimumOperatorSetVersion)
             .Provider(providerType);
+    if (std::string_view(opKernel->name) == "BitShift" && opKernel->minimumOperatorSetVersion == 11)
+    {
+        // DirectML masks out-of-range shift counts, which does not satisfy the opset-28 semantics.
+        builder.SinceVersion(11, 27);
+    }
 
     std::string_view name(opKernel->name);
     if (name == "MemcpyToHost")

--- a/onnxruntime/test/onnx/TestCase.cc
+++ b/onnxruntime/test/onnx/TestCase.cc
@@ -1091,8 +1091,6 @@ std::unique_ptr<std::set<BrokenTest>> GetBrokenTests(const std::string& provider
       {"resize_upsample_sizes_nearest_ceil_half_pixel", "Bad onnx test output. Needs test fix."},
       {"resize_upsample_sizes_nearest_floor_align_corners", "Bad onnx test output. Needs test fix."},
       {"resize_upsample_sizes_nearest_round_prefer_ceil_asymmetric", "Bad onnx test output. Needs test fix."},
-      {"bitshift_right_uint16", "BitShift(11) uint16 support not enabled currently"},
-      {"bitshift_left_uint16", "BitShift(11) uint16 support not enabled currently"},
       {"maxunpool_export_with_output_shape",
        "Invalid output in ONNX test. See https://github.com/onnx/onnx/issues/2398"},
       {"cntk_simple_seg", "Bad onnx test output caused by wrong SAME_UPPER/SAME_LOWER for ConvTranspose"},

--- a/onnxruntime/test/providers/cpu/math/element_wise_ops_test.cc
+++ b/onnxruntime/test/providers/cpu/math/element_wise_ops_test.cc
@@ -5000,6 +5000,15 @@ TEST(BitShiftOpTest, UnsignedTypesOpset28) {
   TestUnsignedBitShiftRegistration<uint64_t>(28);
 }
 
+TEST(BitShiftOpTest, RightShiftByBitWidth_Uint64Opset28) {
+  OpTester test("BitShift", 28);
+  test.AddAttribute("direction", "RIGHT");
+  test.AddInput<uint64_t>("X", {4}, {1000, 255, 1, 42});
+  test.AddInput<uint64_t>("Y", {4}, {64, 64, 64, 64});
+  test.AddOutput<uint64_t>("Z", {4}, {0, 0, 0, 0});
+  test.Run();
+}
+
 // Test that shift amounts >= bit width produce 0 (not undefined behavior).
 // DirectML EP has the same hardware-level shift masking behavior, so skip these tests for DML.
 TEST(BitShiftOpTest, RightShiftByBitWidth_Uint64) {

--- a/onnxruntime/test/providers/cpu/math/element_wise_ops_test.cc
+++ b/onnxruntime/test/providers/cpu/math/element_wise_ops_test.cc
@@ -15,6 +15,7 @@
 #include <algorithm>
 #include <limits>
 #include <math.h>
+#include <type_traits>
 
 #if defined(USE_WEBGPU)
 // Pull in the deviceless shared-trailing-dimension helper from the WebGPU EP so it can be
@@ -4919,6 +4920,84 @@ TEST(BitShiftOpTest, BroadcastXRight_Uint8) {
   test.AddInput<uint8_t>("Y", {3, 2}, {1, 2, 3, 4, 5, 6});
   test.AddOutput<uint8_t>("Z", {3, 2}, {32, 8, 8, 2, 2, 0});
   test.Run();
+}
+
+template <typename T>
+void TestSignedBitShiftOpset28() {
+  constexpr T bit_width = static_cast<T>(std::numeric_limits<std::make_unsigned_t<T>>::digits);
+
+  {
+    OpTester test("BitShift", 28);
+    test.AddAttribute("direction", "LEFT");
+    test.AddInput<T>("X", {6}, {T{-8}, T{-3}, T{1}, std::numeric_limits<T>::max(), T{-2}, T{2}});
+    test.AddInput<T>("Y", {6}, {T{1}, T{2}, T{3}, T{1}, T{-1}, bit_width});
+    test.AddOutput<T>("Z", {6}, {T{-16}, T{-12}, T{8}, T{-2}, T{0}, T{0}});
+    test.Run();
+  }
+
+  {
+    OpTester test("BitShift", 28);
+    test.AddAttribute("direction", "RIGHT");
+    test.AddInput<T>("X", {6}, {T{-8}, T{-3}, T{1}, T{-2}, T{-2}, T{2}});
+    test.AddInput<T>("Y", {6}, {T{1}, T{2}, T{3}, T{-1}, bit_width, bit_width});
+    test.AddOutput<T>("Z", {6}, {T{-4}, T{-1}, T{0}, T{-1}, T{-1}, T{0}});
+    test.Run();
+  }
+
+  {
+    OpTester test("BitShift", 28);
+    test.AddAttribute("direction", "RIGHT");
+    test.AddInput<T>("X", {1}, {T{-8}});
+    test.AddInput<T>("Y", {4}, {T{1}, T{2}, bit_width, T{-1}});
+    test.AddOutput<T>("Z", {4}, {T{-4}, T{-2}, T{-1}, T{-1}});
+    test.Run();
+  }
+
+  {
+    OpTester test("BitShift", 28);
+    test.AddAttribute("direction", "LEFT");
+    test.AddInput<T>("X", {2}, {std::numeric_limits<T>::max(), T{-8}});
+    test.AddInput<T>("Y", {1}, {T{1}});
+    test.AddOutput<T>("Z", {2}, {T{-2}, T{-16}});
+    test.Run();
+  }
+}
+
+TEST(BitShiftOpTest, SignedInt8Opset28) {
+  TestSignedBitShiftOpset28<int8_t>();
+}
+
+TEST(BitShiftOpTest, SignedInt16Opset28) {
+  TestSignedBitShiftOpset28<int16_t>();
+}
+
+TEST(BitShiftOpTest, SignedInt32Opset28) {
+  TestSignedBitShiftOpset28<int32_t>();
+}
+
+TEST(BitShiftOpTest, SignedInt64Opset28) {
+  TestSignedBitShiftOpset28<int64_t>();
+}
+
+template <typename T>
+void TestUnsignedBitShiftRegistration(int opset) {
+  OpTester test("BitShift", opset);
+  test.AddAttribute("direction", "LEFT");
+  test.AddInput<T>("X", {2}, {T{1}, T{3}});
+  test.AddInput<T>("Y", {2}, {T{1}, T{2}});
+  test.AddOutput<T>("Z", {2}, {T{2}, T{12}});
+  test.Run();
+}
+
+TEST(BitShiftOpTest, Uint16Opset11) {
+  TestUnsignedBitShiftRegistration<uint16_t>(11);
+}
+
+TEST(BitShiftOpTest, UnsignedTypesOpset28) {
+  TestUnsignedBitShiftRegistration<uint8_t>(28);
+  TestUnsignedBitShiftRegistration<uint16_t>(28);
+  TestUnsignedBitShiftRegistration<uint32_t>(28);
+  TestUnsignedBitShiftRegistration<uint64_t>(28);
 }
 
 // Test that shift amounts >= bit width produce 0 (not undefined behavior).

--- a/onnxruntime/test/testdata/onnx_backend_test_series_filters.jsonc
+++ b/onnxruntime/test/testdata/onnx_backend_test_series_filters.jsonc
@@ -982,9 +982,5 @@
         ["opset11", "^test_unique_not_sorted_without_axis"],
         // those test cases are generated incorrectly
         ["opset14", "^test_convtranspose_autopad_same"]
-    ],
-    "test_with_types_disabled_due_to_binary_size_concerns": [
-        "^test_bitshift_right_uint16",
-        "^test_bitshift_left_uint16"
     ]
 }


### PR DESCRIPTION
## Description

Adds ONNX BitShift opset 28 support for signed `int8`, `int16`, `int32`, and `int64` tensors while preserving unsigned support.

- Implements arithmetic right shift and raw-bit left shift without signed C++ shift undefined behavior.
- Handles negative and out-of-range shift counts with the opset-28 `0`/`-1` saturation semantics.
- Splits CPU registrations at opset 28 and enables the previously missing `uint16` kernel.
- Caps DirectML's native BitShift kernel at opset 27 because DirectML masks out-of-range counts; opset 28 falls back to CPU for correct behavior.
- Adds focused signed, unsigned, scalar, broadcast, wraparound, and out-of-range tests, and enables the ONNX uint16 backend tests.

Stacked on #32359.

## Validation

`onnxruntime_provider_test` build is currently blocked by the base branch's unrelated `tensorprotoutils.h` numeric datatype map static assertion after the ONNX c78026fa update. The failure occurs across unrelated provider translation units before BitShift tests can link.