### PR TITLE
Add opset 28 SpaceToDepth support

### DIFF
--- a/onnxruntime/core/graph/contrib_ops/internal_nhwc_onnx_schemas.cc
+++ b/onnxruntime/core/graph/contrib_ops/internal_nhwc_onnx_schemas.cc
@@ -109,6 +109,7 @@ void OpSet_Internal_NHWC_ONNX::ForEachSchema(const std::function<void(ONNX_NAMES
   REGISTER_NHWC_SCHEMA(fn, DepthToSpace, 1);
   REGISTER_NHWC_SCHEMA(fn, DepthToSpace, 11);
   REGISTER_NHWC_SCHEMA(fn, DepthToSpace, 13);
+  REGISTER_NHWC_SCHEMA(fn, DepthToSpace, 28);
 
   REGISTER_NHWC_SCHEMA_WITH_ACTIVATION(fn, InstanceNormalization, 6);
 
@@ -144,6 +145,7 @@ void OpSet_Internal_NHWC_ONNX::ForEachSchema(const std::function<void(ONNX_NAMES
 
   REGISTER_NHWC_SCHEMA(fn, SpaceToDepth, 1);
   REGISTER_NHWC_SCHEMA(fn, SpaceToDepth, 13);
+  REGISTER_NHWC_SCHEMA(fn, SpaceToDepth, 28);
 
   // The REGISTER_NCHW_SCHEMA_WITH_NHWC_DOMAIN macro uses the default ONNX type/shape inferencing, which assumes
   // data layouts in NCHW. We use the default ONNX type/shape inferencing for NHWC Resize to avoid having to modify

--- a/onnxruntime/core/providers/cpu/cpu_execution_provider.cc
+++ b/onnxruntime/core/providers/cpu/cpu_execution_provider.cc
@@ -867,8 +867,10 @@ class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 13, float, Log);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 13, double, Log);
 class ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 13, 14, Pow);
-class ONNX_OPERATOR_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 13, DepthToSpace);
-class ONNX_OPERATOR_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 13, SpaceToDepth);
+class ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 13, 27, DepthToSpace);
+class ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 13, 27, SpaceToDepth);
+class ONNX_OPERATOR_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 28, DepthToSpace);
+class ONNX_OPERATOR_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 28, SpaceToDepth);
 class ONNX_OPERATOR_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 13, Slice);
 class ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 13, 17, Split);
 class ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 13, 20, Unsqueeze);
@@ -2803,8 +2805,12 @@ Status RegisterOnnxOperatorKernels(KernelRegistry& kernel_registry) {
       BuildKernelCreateInfo<ONNX_OPERATOR_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 13, Tile)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 13, Gather)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 13, GatherElements)>,
-      BuildKernelCreateInfo<ONNX_OPERATOR_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 13, DepthToSpace)>,
-      BuildKernelCreateInfo<ONNX_OPERATOR_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 13, SpaceToDepth)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 13, 27,
+                                                                      DepthToSpace)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 13, 27,
+                                                                      SpaceToDepth)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 28, DepthToSpace)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 28, SpaceToDepth)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 13, 15,
                                                                       ScatterElements)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kCpuExecutionProvider, kOnnxDomain, 13, 15,

--- a/onnxruntime/core/providers/cpu/tensor/space_depth_ops.cc
+++ b/onnxruntime/core/providers/cpu/tensor/space_depth_ops.cc
@@ -18,9 +18,20 @@ ONNX_CPU_OPERATOR_VERSIONED_KERNEL(
                               DataTypeImpl::GetTensorType<int8_t>()}),
     SpaceToDepth);
 
-ONNX_CPU_OPERATOR_KERNEL(
+ONNX_CPU_OPERATOR_VERSIONED_KERNEL(
     SpaceToDepth,
     13,
+    27,
+    KernelDefBuilder()
+        .TypeConstraint("T", {DataTypeImpl::GetTensorType<float>(),
+                              DataTypeImpl::GetTensorType<double>(),
+                              DataTypeImpl::GetTensorType<uint8_t>(),
+                              DataTypeImpl::GetTensorType<int8_t>()}),
+    SpaceToDepth);
+
+ONNX_CPU_OPERATOR_KERNEL(
+    SpaceToDepth,
+    28,
     KernelDefBuilder()
         .TypeConstraint("T", {DataTypeImpl::GetTensorType<float>(),
                               DataTypeImpl::GetTensorType<double>(),
@@ -47,9 +58,20 @@ ONNX_CPU_OPERATOR_VERSIONED_KERNEL(
                               DataTypeImpl::GetTensorType<int8_t>()}),
     DepthToSpace);
 
-ONNX_CPU_OPERATOR_KERNEL(
+ONNX_CPU_OPERATOR_VERSIONED_KERNEL(
     DepthToSpace,
     13,
+    27,
+    KernelDefBuilder()
+        .TypeConstraint("T", {DataTypeImpl::GetTensorType<float>(),
+                              DataTypeImpl::GetTensorType<double>(),
+                              DataTypeImpl::GetTensorType<uint8_t>(),
+                              DataTypeImpl::GetTensorType<int8_t>()}),
+    DepthToSpace);
+
+ONNX_CPU_OPERATOR_KERNEL(
+    DepthToSpace,
+    28,
     KernelDefBuilder()
         .TypeConstraint("T", {DataTypeImpl::GetTensorType<float>(),
                               DataTypeImpl::GetTensorType<double>(),
@@ -107,7 +129,8 @@ Status SpaceToDepth::Compute(OpKernelContext* context) const {
 
   Tensor& output = *context->Output(0, {batch, output_depth, output_height, output_width});
 
-  std::array<Eigen::DenseIndex, IntermediateTensorRank> permutation{{0, 3, 5, 1, 2, 4}};
+  const auto permutation = is_dcr_ ? std::array<Eigen::DenseIndex, IntermediateTensorRank>{{0, 3, 5, 1, 2, 4}}
+                                   : std::array<Eigen::DenseIndex, IntermediateTensorRank>{{0, 1, 3, 5, 2, 4}};
 
   if (input.IsDataType<float>()) {
     SpaceDepthOpCpuImpl<float>(input.Data<float>(), output.MutableData<float>(), permutation,

--- a/onnxruntime/core/providers/cpu/tensor/space_depth_ops.h
+++ b/onnxruntime/core/providers/cpu/tensor/space_depth_ops.h
@@ -26,13 +26,12 @@ template <typename KernelInfoType>
 inline bool ReadIsDCR(const KernelInfoType& info) {
   bool is_dcr = true;
   std::string mode;
-  // If mode doesn't exist, then it is the default "DCR" mode
-  // (or) it is an opset < 11 model for which the only mode is "DCR" mode.
+  // A missing mode is the default DCR mode, including pre-mode schemas.
   if (info.GetAttr("mode", &mode).IsOK()) {
     if (mode == "CRD") {
       is_dcr = false;
     } else if (mode != "DCR") {
-      ORT_THROW("DepthToSpace op: only 'DCR' and 'CRD' modes are supported");
+      ORT_THROW("SpaceDepth op: only 'DCR' and 'CRD' modes are supported");
     }
   }
 
@@ -130,10 +129,13 @@ class SpaceDepthBase {
 
 class SpaceToDepth final : public OpKernel, SpaceDepthBase {
  public:
-  explicit SpaceToDepth(const OpKernelInfo& info) : OpKernel(info), SpaceDepthBase(info) {
-  }
+  explicit SpaceToDepth(const OpKernelInfo& info)
+      : OpKernel(info), SpaceDepthBase(info), is_dcr_(space_depth_internal::ReadIsDCR(info)) {}
 
   Status Compute(OpKernelContext* context) const override;
+
+ private:
+  bool is_dcr_ = true;
 };
 
 class DepthToSpace final : public OpKernel, SpaceDepthBase {

--- a/onnxruntime/core/providers/cuda/cuda_execution_provider.cc
+++ b/onnxruntime/core/providers/cuda/cuda_execution_provider.cc
@@ -1315,8 +1315,10 @@ class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kO
 class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 13, 17, double, Pad);
 class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 13, 17, MLFloat16, Pad);
 class ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 13, 17, bool, Pad);
-class ONNX_OPERATOR_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 13, SpaceToDepth);
-class ONNX_OPERATOR_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 13, DepthToSpace);
+class ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 13, 27, SpaceToDepth);
+class ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 13, 27, DepthToSpace);
+class ONNX_OPERATOR_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 28, SpaceToDepth);
+class ONNX_OPERATOR_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 28, DepthToSpace);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 13, int8_t, Sign);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 13, int16_t, Sign);
 class ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 13, int32_t, Sign);
@@ -2606,8 +2608,12 @@ static Status RegisterCudaKernels(KernelRegistry& kernel_registry) {
       BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 13, 17, double, Pad)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 13, 17, MLFloat16, Pad)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 13, 17, bool, Pad)>,
-      BuildKernelCreateInfo<ONNX_OPERATOR_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 13, SpaceToDepth)>,
-      BuildKernelCreateInfo<ONNX_OPERATOR_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 13, DepthToSpace)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 13, 27,
+                                                                       SpaceToDepth)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 13, 27,
+                                                                       DepthToSpace)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 28, SpaceToDepth)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 28, DepthToSpace)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 13, int8_t, Sign)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 13, int16_t, Sign)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_TYPED_KERNEL_CLASS_NAME(kCudaExecutionProvider, kOnnxDomain, 13, int32_t, Sign)>,

--- a/onnxruntime/core/providers/cuda/cuda_nhwc_kernels.cc
+++ b/onnxruntime/core/providers/cuda/cuda_nhwc_kernels.cc
@@ -83,9 +83,11 @@ class CUDA_NHWC_OP_TYPED_CLASS_NAME(15, double, BatchNormalization);
 class CUDA_NHWC_OP_TYPED_CLASS_NAME(15, MLFloat16, BatchNormalization);
 class CUDA_NHWC_OP_VERSIONED_CLASS_NAME(1, 10, DepthToSpace);
 class CUDA_NHWC_OP_VERSIONED_CLASS_NAME(11, 12, DepthToSpace);
-class CUDA_NHWC_OP_CLASS_NAME(13, DepthToSpace);
+class CUDA_NHWC_OP_VERSIONED_CLASS_NAME(13, 27, DepthToSpace);
+class CUDA_NHWC_OP_CLASS_NAME(28, DepthToSpace);
 class CUDA_NHWC_OP_VERSIONED_CLASS_NAME(1, 12, SpaceToDepth);
-class CUDA_NHWC_OP_CLASS_NAME(13, SpaceToDepth);
+class CUDA_NHWC_OP_VERSIONED_CLASS_NAME(13, 27, SpaceToDepth);
+class CUDA_NHWC_OP_CLASS_NAME(28, SpaceToDepth);
 class CUDA_NHWC_OP_VERSIONED_TYPED_CLASS_NAME(1, 12, float, LRN);
 class CUDA_NHWC_OP_VERSIONED_TYPED_CLASS_NAME(1, 12, double, LRN);
 class CUDA_NHWC_OP_VERSIONED_TYPED_CLASS_NAME(1, 12, MLFloat16, LRN);
@@ -152,9 +154,11 @@ Status RegisterCudaNhwcKernels(KernelRegistry& kernel_registry) {
       BuildKernelCreateInfo<CUDA_NHWC_OP_VERSIONED_TYPED_CLASS_NAME(1, 10, MLFloat16, ConvTranspose)>,
       BuildKernelCreateInfo<CUDA_NHWC_OP_VERSIONED_CLASS_NAME(1, 10, DepthToSpace)>,
       BuildKernelCreateInfo<CUDA_NHWC_OP_VERSIONED_CLASS_NAME(11, 12, DepthToSpace)>,
-      BuildKernelCreateInfo<CUDA_NHWC_OP_CLASS_NAME(13, DepthToSpace)>,
+      BuildKernelCreateInfo<CUDA_NHWC_OP_VERSIONED_CLASS_NAME(13, 27, DepthToSpace)>,
+      BuildKernelCreateInfo<CUDA_NHWC_OP_CLASS_NAME(28, DepthToSpace)>,
       BuildKernelCreateInfo<CUDA_NHWC_OP_VERSIONED_CLASS_NAME(1, 12, SpaceToDepth)>,
-      BuildKernelCreateInfo<CUDA_NHWC_OP_CLASS_NAME(13, SpaceToDepth)>,
+      BuildKernelCreateInfo<CUDA_NHWC_OP_VERSIONED_CLASS_NAME(13, 27, SpaceToDepth)>,
+      BuildKernelCreateInfo<CUDA_NHWC_OP_CLASS_NAME(28, SpaceToDepth)>,
       BuildKernelCreateInfo<CUDA_NHWC_OP_VERSIONED_TYPED_CLASS_NAME(1, 12, float, LRN)>,
       BuildKernelCreateInfo<CUDA_NHWC_OP_VERSIONED_TYPED_CLASS_NAME(1, 12, double, LRN)>,
       BuildKernelCreateInfo<CUDA_NHWC_OP_VERSIONED_TYPED_CLASS_NAME(1, 12, MLFloat16, LRN)>,

--- a/onnxruntime/core/providers/cuda/tensor/space_depth_ops.cc
+++ b/onnxruntime/core/providers/cuda/tensor/space_depth_ops.cc
@@ -37,10 +37,23 @@ ONNX_OPERATOR_VERSIONED_KERNEL_EX(
     SpaceToDepth<LAYOUT_NHWC>);
 #endif
 
-ONNX_OPERATOR_KERNEL_EX(
+ONNX_OPERATOR_VERSIONED_KERNEL_EX(
     SpaceToDepth,
     kOnnxDomain,
     13,
+    27,
+    kCudaExecutionProvider,
+    (*KernelDefBuilder::Create())
+        .TypeConstraint("T",
+                        {DataTypeImpl::GetTensorType<float>(),
+                         DataTypeImpl::GetTensorType<double>(),
+                         DataTypeImpl::GetTensorType<MLFloat16>()}),
+    SpaceToDepth<LAYOUT_NCHW>);
+
+ONNX_OPERATOR_KERNEL_EX(
+    SpaceToDepth,
+    kOnnxDomain,
+    28,
     kCudaExecutionProvider,
     (*KernelDefBuilder::Create())
         .TypeConstraint("T",
@@ -50,10 +63,23 @@ ONNX_OPERATOR_KERNEL_EX(
     SpaceToDepth<LAYOUT_NCHW>);
 
 #ifdef ENABLE_CUDA_NHWC_OPS
-ONNX_OPERATOR_KERNEL_EX(
+ONNX_OPERATOR_VERSIONED_KERNEL_EX(
     SpaceToDepth,
     kMSInternalNHWCDomain,
     13,
+    27,
+    kCudaExecutionProvider,
+    (*KernelDefBuilder::Create())
+        .TypeConstraint("T",
+                        {DataTypeImpl::GetTensorType<float>(),
+                         DataTypeImpl::GetTensorType<double>(),
+                         DataTypeImpl::GetTensorType<MLFloat16>()}),
+    SpaceToDepth<LAYOUT_NHWC>);
+
+ONNX_OPERATOR_KERNEL_EX(
+    SpaceToDepth,
+    kMSInternalNHWCDomain,
+    28,
     kCudaExecutionProvider,
     (*KernelDefBuilder::Create())
         .TypeConstraint("T",
@@ -119,10 +145,23 @@ ONNX_OPERATOR_VERSIONED_KERNEL_EX(
     DepthToSpace<LAYOUT_NHWC>);
 #endif
 
-ONNX_OPERATOR_KERNEL_EX(
+ONNX_OPERATOR_VERSIONED_KERNEL_EX(
     DepthToSpace,
     kOnnxDomain,
     13,
+    27,
+    kCudaExecutionProvider,
+    (*KernelDefBuilder::Create())
+        .TypeConstraint("T",
+                        {DataTypeImpl::GetTensorType<float>(),
+                         DataTypeImpl::GetTensorType<double>(),
+                         DataTypeImpl::GetTensorType<MLFloat16>()}),
+    DepthToSpace<LAYOUT_NCHW>);
+
+ONNX_OPERATOR_KERNEL_EX(
+    DepthToSpace,
+    kOnnxDomain,
+    28,
     kCudaExecutionProvider,
     (*KernelDefBuilder::Create())
         .TypeConstraint("T",
@@ -132,10 +171,23 @@ ONNX_OPERATOR_KERNEL_EX(
     DepthToSpace<LAYOUT_NCHW>);
 
 #ifdef ENABLE_CUDA_NHWC_OPS
-ONNX_OPERATOR_KERNEL_EX(
+ONNX_OPERATOR_VERSIONED_KERNEL_EX(
     DepthToSpace,
     kMSInternalNHWCDomain,
     13,
+    27,
+    kCudaExecutionProvider,
+    (*KernelDefBuilder::Create())
+        .TypeConstraint("T",
+                        {DataTypeImpl::GetTensorType<float>(),
+                         DataTypeImpl::GetTensorType<double>(),
+                         DataTypeImpl::GetTensorType<MLFloat16>()}),
+    DepthToSpace<LAYOUT_NHWC>);
+
+ONNX_OPERATOR_KERNEL_EX(
+    DepthToSpace,
+    kMSInternalNHWCDomain,
+    28,
     kCudaExecutionProvider,
     (*KernelDefBuilder::Create())
         .TypeConstraint("T",
@@ -191,15 +243,25 @@ Status SpaceToDepth<Layout>::ComputeInternal(OpKernelContext* context) const {
                                                       input_width / blocksize_, blocksize_, input_depth};
 
   // We will pass in the "virtual" output shape to be used by DoTranspose() in SpaceDepthOpCudaImpl(...)
-  TensorShape virtual_output_shape = (Layout == LAYOUT_NCHW)
-                                         ? TensorShape{batch, blocksize_, blocksize_, input_depth,
-                                                       input_height / blocksize_, input_width / blocksize_}
-                                         : TensorShape{batch, input_height / blocksize_, input_width / blocksize_,
-                                                       blocksize_, blocksize_, input_depth};
-
-  std::vector<size_t> permutation = (Layout == LAYOUT_NCHW)
-                                        ? std::vector<size_t>{0, 3, 5, 1, 2, 4}
-                                        : std::vector<size_t>{0, 1, 3, 2, 4, 5};
+  TensorShape virtual_output_shape;
+  std::vector<size_t> permutation;
+  if (is_dcr_) {
+    virtual_output_shape = (Layout == LAYOUT_NCHW)
+                               ? TensorShape{batch, blocksize_, blocksize_, input_depth,
+                                            input_height / blocksize_, input_width / blocksize_}
+                               : TensorShape{batch, input_height / blocksize_, input_width / blocksize_,
+                                            blocksize_, blocksize_, input_depth};
+    permutation = (Layout == LAYOUT_NCHW)
+                      ? std::vector<size_t>{0, 3, 5, 1, 2, 4}
+                      : std::vector<size_t>{0, 1, 3, 2, 4, 5};
+  } else {
+    virtual_output_shape = (Layout == LAYOUT_NCHW)
+                               ? TensorShape{batch, input_depth, blocksize_, blocksize_,
+                                            input_height / blocksize_, input_width / blocksize_}
+                               : TensorShape{batch, input_height / blocksize_, input_width / blocksize_,
+                                            input_depth, blocksize_, blocksize_};
+    permutation = {0, 1, 3, 5, 2, 4};
+  }
 
   ORT_RETURN_IF_ERROR(
       SpaceDepthOpCudaImpl(GetDeviceProp(), Stream(context), GetCublasHandle(context), input, output, permutation,

--- a/onnxruntime/core/providers/cuda/tensor/space_depth_ops.h
+++ b/onnxruntime/core/providers/cuda/tensor/space_depth_ops.h
@@ -13,9 +13,12 @@ template <bool Layout>
 class SpaceToDepth final : public CudaKernel, SpaceDepthBase {
  public:
   explicit SpaceToDepth(const OpKernelInfo& info)
-      : CudaKernel(info), SpaceDepthBase(info) {}
+      : CudaKernel(info), SpaceDepthBase(info), is_dcr_(space_depth_internal::ReadIsDCR(info)) {}
 
   Status ComputeInternal(OpKernelContext* context) const override;
+
+ private:
+  bool is_dcr_ = true;
 };
 
 template <bool Layout>

--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/Operators/DmlOperatorSpaceToDepth.cpp
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/Operators/DmlOperatorSpaceToDepth.cpp
@@ -20,12 +20,16 @@ public:
         ML_CHECK_VALID_ARGUMENT(inputDescs.size() == 1);
         ML_CHECK_VALID_ARGUMENT(outputDescs.size() == 1);
 
-        DML_SPACE_TO_DEPTH_OPERATOR_DESC operatorDesc = {};
+        std::string mode = kernelCreationContext.GetOptionalAttribute<std::string>(AttrName::Mode, "DCR");
+        DML_DEPTH_SPACE_ORDER depthSpaceOrder = Dml::MapStringToDepthSpaceMode(mode);
+
+        DML_SPACE_TO_DEPTH1_OPERATOR_DESC operatorDesc = {};
         operatorDesc.InputTensor = inputDescs.data();
         operatorDesc.OutputTensor = outputDescs.data();
         operatorDesc.BlockSize = m_blockSize;
+        operatorDesc.Order = depthSpaceOrder;
 
-        DML_OPERATOR_DESC opDesc = { DML_OPERATOR_SPACE_TO_DEPTH, &operatorDesc };
+        DML_OPERATOR_DESC opDesc = { DML_OPERATOR_SPACE_TO_DEPTH1, &operatorDesc };
         SetDmlOperatorDesc(opDesc, kernelCreationContext);
     }
 };

--- a/onnxruntime/core/providers/dml/DmlExecutionProvider/src/Operators/OperatorRegistration.cpp
+++ b/onnxruntime/core/providers/dml/DmlExecutionProvider/src/Operators/OperatorRegistration.cpp
@@ -815,9 +815,11 @@ constexpr static OperatorRegistrationInformation operatorRegistrationInformation
 
     {REG_INFO(      7,  SpaceToDepth,                       typeNameListDefault,            supportedTypeListAllScalars,            DmlGraphSupport::Supported)},
     {REG_INFO(     13,  SpaceToDepth,                       typeNameListDefault,            supportedTypeListAllScalars,            DmlGraphSupport::Supported)},
+    {REG_INFO(     28,  SpaceToDepth,                       typeNameListDefault,            supportedTypeListAllScalars,            DmlGraphSupport::Supported)},
     {REG_INFO(      7,  DepthToSpace,                       typeNameListDefault,            supportedTypeListAllScalars,            DmlGraphSupport::Supported)},
     {REG_INFO(     11,  DepthToSpace,                       typeNameListDefault,            supportedTypeListAllScalars,            DmlGraphSupport::Supported)},
     {REG_INFO(     13,  DepthToSpace,                       typeNameListDefault,            supportedTypeListAllScalars,            DmlGraphSupport::Supported)},
+    {REG_INFO(     28,  DepthToSpace,                       typeNameListDefault,            supportedTypeListAllScalars,            DmlGraphSupport::Supported)},
     {REG_INFO(      7,  Tile,                               typeNameListDefault,            supportedTypeListAllScalars,            DmlGraphSupport::Supported,      requiredConstantCpuInputs(1))},
     {REG_INFO(     13,  Tile,                               typeNameListDefault,            supportedTypeListAllScalars,            DmlGraphSupport::Supported,      requiredConstantCpuInputs(1))},
     {REG_INFO(      8,  Expand,                             typeNameListDefault,            supportedTypeListAllScalars,            DmlGraphSupport::Supported,      requiredConstantCpuInputs(1))},

--- a/onnxruntime/core/providers/dml/OperatorAuthorHelper/OperatorVersions.h
+++ b/onnxruntime/core/providers/dml/OperatorAuthorHelper/OperatorVersions.h
@@ -457,6 +457,12 @@ namespace OperatorHelper
         static const int sc_sinceVer_GroupNorm = 21;
     }
 
+    namespace OnnxOperatorSet28
+    {
+        static const int sc_sinceVer_DepthToSpace = 28;
+        static const int sc_sinceVer_SpaceToDepth = 28;
+    }
+
     namespace MsftOperatorSet1
     {
         static const int sc_sinceVer_DmlFusedConv = 1;

--- a/onnxruntime/core/providers/js/js_execution_provider.cc
+++ b/onnxruntime/core/providers/js/js_execution_provider.cc
@@ -253,11 +253,13 @@ class ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kJsExecutionProvider, kOnnxDomai
 class ONNX_OPERATOR_KERNEL_CLASS_NAME(kJsExecutionProvider, kOnnxDomain, 21, Transpose);
 
 class ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kJsExecutionProvider, kOnnxDomain, 11, 12, DepthToSpace);
-class ONNX_OPERATOR_KERNEL_CLASS_NAME(kJsExecutionProvider, kOnnxDomain, 13, DepthToSpace);
+class ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kJsExecutionProvider, kOnnxDomain, 13, 27, DepthToSpace);
+class ONNX_OPERATOR_KERNEL_CLASS_NAME(kJsExecutionProvider, kOnnxDomain, 28, DepthToSpace);
 class ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kJsExecutionProvider, kOnnxDomain, 17, 19, DFT);
 class ONNX_OPERATOR_KERNEL_CLASS_NAME(kJsExecutionProvider, kOnnxDomain, 20, DFT);
 class ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kJsExecutionProvider, kMSInternalNHWCDomain, 11, 12, DepthToSpace);
-class ONNX_OPERATOR_KERNEL_CLASS_NAME(kJsExecutionProvider, kMSInternalNHWCDomain, 13, DepthToSpace);
+class ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kJsExecutionProvider, kMSInternalNHWCDomain, 13, 27, DepthToSpace);
+class ONNX_OPERATOR_KERNEL_CLASS_NAME(kJsExecutionProvider, kMSInternalNHWCDomain, 28, DepthToSpace);
 
 class ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kJsExecutionProvider, kOnnxDomain, 1, 10, Conv);
 class ONNX_OPERATOR_KERNEL_CLASS_NAME(kJsExecutionProvider, kOnnxDomain, 11, Conv);
@@ -596,11 +598,16 @@ std::unique_ptr<KernelRegistry> RegisterKernels() {
       BuildKernelCreateInfo<ONNX_OPERATOR_KERNEL_CLASS_NAME(kJsExecutionProvider, kOnnxDomain, 21, Transpose)>,
 
       BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kJsExecutionProvider, kOnnxDomain, 11, 12, DepthToSpace)>,
-      BuildKernelCreateInfo<ONNX_OPERATOR_KERNEL_CLASS_NAME(kJsExecutionProvider, kOnnxDomain, 13, DepthToSpace)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kJsExecutionProvider, kOnnxDomain, 13, 27,
+                                                                       DepthToSpace)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_KERNEL_CLASS_NAME(kJsExecutionProvider, kOnnxDomain, 28, DepthToSpace)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kJsExecutionProvider, kOnnxDomain, 17, 19, DFT)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_KERNEL_CLASS_NAME(kJsExecutionProvider, kOnnxDomain, 20, DFT)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kJsExecutionProvider, kMSInternalNHWCDomain, 11, 12, DepthToSpace)>,
-      BuildKernelCreateInfo<ONNX_OPERATOR_KERNEL_CLASS_NAME(kJsExecutionProvider, kMSInternalNHWCDomain, 13, DepthToSpace)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kJsExecutionProvider, kMSInternalNHWCDomain,
+                                                                       13, 27, DepthToSpace)>,
+      BuildKernelCreateInfo<ONNX_OPERATOR_KERNEL_CLASS_NAME(kJsExecutionProvider, kMSInternalNHWCDomain, 28,
+                                                            DepthToSpace)>,
 
       BuildKernelCreateInfo<ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kJsExecutionProvider, kOnnxDomain, 1, 10, Conv)>,
       BuildKernelCreateInfo<ONNX_OPERATOR_KERNEL_CLASS_NAME(kJsExecutionProvider, kOnnxDomain, 11, Conv)>,

--- a/onnxruntime/core/providers/js/operators/depth_to_space.cc
+++ b/onnxruntime/core/providers/js/operators/depth_to_space.cc
@@ -6,10 +6,11 @@
 namespace onnxruntime {
 namespace js {
 
-ONNX_OPERATOR_KERNEL_EX(
+ONNX_OPERATOR_VERSIONED_KERNEL_EX(
     DepthToSpace,
     kMSInternalNHWCDomain,
     13,
+    27,
     kJsExecutionProvider,
     KernelDefBuilder()
         .TypeConstraint("T", JsepSupportedDataTypes()),
@@ -17,8 +18,27 @@ ONNX_OPERATOR_KERNEL_EX(
 
 ONNX_OPERATOR_KERNEL_EX(
     DepthToSpace,
+    kMSInternalNHWCDomain,
+    28,
+    kJsExecutionProvider,
+    KernelDefBuilder()
+        .TypeConstraint("T", JsepSupportedDataTypes()),
+    DepthToSpace<true>);
+
+ONNX_OPERATOR_VERSIONED_KERNEL_EX(
+    DepthToSpace,
     kOnnxDomain,
     13,
+    27,
+    kJsExecutionProvider,
+    KernelDefBuilder()
+        .TypeConstraint("T", JsepSupportedDataTypes()),
+    DepthToSpace<false>);
+
+ONNX_OPERATOR_KERNEL_EX(
+    DepthToSpace,
+    kOnnxDomain,
+    28,
     kJsExecutionProvider,
     KernelDefBuilder()
         .TypeConstraint("T", JsepSupportedDataTypes()),

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/simple_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/simple_op_builder.cc
@@ -58,6 +58,12 @@ Status SimpleOpBuilder::ExplicitOpCheck(QnnModelWrapper& qnn_model_wrapper,
                       padding_mode.c_str());
   }
 
+  if (op_type == "SpaceToDepth") {
+    NodeAttrHelper node_helper(node_unit);
+    std::string mode = node_helper.Get("mode", "DCR");
+    ORT_RETURN_IF_NOT(mode == "DCR", "QNN SpaceToDepth only supports DCR mode.");
+  }
+
   // To DO: Remove once QNN CPU supports ScatterND
   const auto qnn_backend_type = qnn_model_wrapper.GetQnnBackendType();
   if (op_type == "ScatterND") {

--- a/onnxruntime/core/providers/webgpu/tensor/depth_to_space.cc
+++ b/onnxruntime/core/providers/webgpu/tensor/depth_to_space.cc
@@ -31,10 +31,12 @@ namespace webgpu {
       DepthToSpace<is_nhwc>);
 
 WEBGPU_DEPTH_TO_SPACE_VERSIONED_KERNEL(11, 12, kOnnxDomain, false)
-WEBGPU_DEPTH_TO_SPACE_KERNEL(13, kOnnxDomain, false)
+WEBGPU_DEPTH_TO_SPACE_VERSIONED_KERNEL(13, 27, kOnnxDomain, false)
+WEBGPU_DEPTH_TO_SPACE_KERNEL(28, kOnnxDomain, false)
 
 WEBGPU_DEPTH_TO_SPACE_VERSIONED_KERNEL(11, 12, kMSInternalNHWCDomain, true)
-WEBGPU_DEPTH_TO_SPACE_KERNEL(13, kMSInternalNHWCDomain, true)
+WEBGPU_DEPTH_TO_SPACE_VERSIONED_KERNEL(13, 27, kMSInternalNHWCDomain, true)
+WEBGPU_DEPTH_TO_SPACE_KERNEL(28, kMSInternalNHWCDomain, true)
 
 void AppendPermFunction(OStringStream& os, const ShaderVariableHelper& input, const int64_t* perm) {
   os << "fn perm(i: input_indices_t) -> input_indices_t {\n"

--- a/onnxruntime/core/providers/webgpu/webgpu_execution_provider.cc
+++ b/onnxruntime/core/providers/webgpu/webgpu_execution_provider.cc
@@ -258,9 +258,14 @@ static const BuildKernelCreateInfoFn build_kernel_create_info_function_table[] =
     BuildKernelCreateInfo<class ONNX_OPERATOR_KERNEL_CLASS_NAME(kWebGpuExecutionProvider, kOnnxDomain, 24, Transpose)>,
 
     BuildKernelCreateInfo<class ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kWebGpuExecutionProvider, kOnnxDomain, 11, 12, DepthToSpace)>,
-    BuildKernelCreateInfo<class ONNX_OPERATOR_KERNEL_CLASS_NAME(kWebGpuExecutionProvider, kOnnxDomain, 13, DepthToSpace)>,
+    BuildKernelCreateInfo<class ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kWebGpuExecutionProvider, kOnnxDomain,
+                                                                          13, 27, DepthToSpace)>,
+    BuildKernelCreateInfo<class ONNX_OPERATOR_KERNEL_CLASS_NAME(kWebGpuExecutionProvider, kOnnxDomain, 28, DepthToSpace)>,
     BuildKernelCreateInfo<class ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kWebGpuExecutionProvider, kMSInternalNHWCDomain, 11, 12, DepthToSpace)>,
-    BuildKernelCreateInfo<class ONNX_OPERATOR_KERNEL_CLASS_NAME(kWebGpuExecutionProvider, kMSInternalNHWCDomain, 13, DepthToSpace)>,
+    BuildKernelCreateInfo<class ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kWebGpuExecutionProvider,
+                                                                          kMSInternalNHWCDomain, 13, 27, DepthToSpace)>,
+    BuildKernelCreateInfo<class ONNX_OPERATOR_KERNEL_CLASS_NAME(kWebGpuExecutionProvider,
+                                                                 kMSInternalNHWCDomain, 28, DepthToSpace)>,
 
     BuildKernelCreateInfo<class ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kWebGpuExecutionProvider, kOnnxDomain, 1, 10, Conv)>,
     BuildKernelCreateInfo<class ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kWebGpuExecutionProvider, kOnnxDomain, 11, 21, Conv)>,

--- a/onnxruntime/test/contrib_ops/function_ops_test.cc
+++ b/onnxruntime/test/contrib_ops/function_ops_test.cc
@@ -113,5 +113,25 @@ TEST_F(ContribFunExpansionTest, FastGeluWithoutBias) {
   CheckFastGelu<MLFloat16, false>(false);
 }
 
+void CheckSpaceDepthFunction(const char* op_type, std::vector<int64_t> input_shape,
+                             int64_t blocksize, const char* mode) {
+  FunctionTestCase test_case(op_type, kOnnxDomain);
+  test_case.AddOpset(kOnnxDomain, 28);
+  test_case.AddInput<float>("input", input_shape);
+  test_case.AddOutput("output");
+  test_case.AddAttribute("blocksize", blocksize);
+  test_case.AddAttribute("mode", mode);
+  test_case.RunTest();
+}
+
+TEST_F(ContribFunExpansionTest, SpaceDepthOpset28FunctionParity) {
+  for (const auto* mode : {"DCR", "CRD"}) {
+    CheckSpaceDepthFunction("SpaceToDepth", {1, 2, 4, 6}, 2, mode);
+    CheckSpaceDepthFunction("SpaceToDepth", {1, 2, 6, 9}, 3, mode);
+    CheckSpaceDepthFunction("DepthToSpace", {1, 8, 2, 3}, 2, mode);
+    CheckSpaceDepthFunction("DepthToSpace", {1, 18, 2, 3}, 3, mode);
+  }
+}
+
 }  // namespace test
 }  // namespace onnxruntime

--- a/onnxruntime/test/providers/cpu/tensor/space_depth_ops_test.cc
+++ b/onnxruntime/test/providers/cpu/tensor/space_depth_ops_test.cc
@@ -60,6 +60,102 @@ TEST(TensorOpTest, RejectsBlocksizeWhoseSquareExceedsInt64) {
   EXPECT_THAT(status.ErrorMessage(), testing::HasSubstr("multiple of (block_size * block_size)"));
 }
 
+TEST(TensorOpTest, SpaceToDepthOpset28Modes) {
+  constexpr int64_t blocksize = 2;
+  const std::vector<float> input = {0.f, 1.f, 2.f, 3.f, 4.f, 5.f, 6.f, 7.f,
+                                    8.f, 9.f, 10.f, 11.f, 12.f, 13.f, 14.f, 15.f};
+
+  for (const auto& [mode, expected] : std::vector<std::pair<std::string, std::vector<float>>>{
+           {"DCR", {0.f, 2.f, 8.f, 10.f, 1.f, 3.f, 9.f, 11.f, 4.f, 6.f, 12.f, 14.f, 5.f, 7.f, 13.f, 15.f}},
+           {"CRD", {0.f, 2.f, 1.f, 3.f, 4.f, 6.f, 5.f, 7.f, 8.f, 10.f, 9.f, 11.f, 12.f, 14.f, 13.f, 15.f}}}) {
+    OpTester test("SpaceToDepth", 28);
+    test.AddAttribute("blocksize", blocksize);
+    test.AddAttribute("mode", mode.c_str());
+    test.AddInput<float>("input", {1, 2, 2, 4}, input);
+    test.AddOutput<float>("output", {1, 8, 1, 2}, expected);
+    test.Run();
+  }
+}
+
+TEST(TensorOpTest, SpaceToDepthOpset28BlocksizeThree) {
+  OpTester test("SpaceToDepth", 28);
+  test.AddAttribute("blocksize", int64_t{3});
+  test.AddAttribute("mode", "CRD");
+  test.AddInput<float>("input", {1, 1, 3, 6},
+                       {0.f, 1.f, 2.f, 3.f, 4.f, 5.f, 6.f, 7.f, 8.f,
+                        9.f, 10.f, 11.f, 12.f, 13.f, 14.f, 15.f, 16.f, 17.f});
+  test.AddOutput<float>("output", {1, 9, 1, 2},
+                        {0.f, 3.f, 6.f, 9.f, 12.f, 15.f, 1.f, 4.f, 7.f,
+                         10.f, 13.f, 16.f, 2.f, 5.f, 8.f, 11.f, 14.f, 17.f});
+  test.Run();
+}
+
+TEST(TensorOpTest, DepthToSpaceOpset28Modes) {
+  constexpr int64_t blocksize = 2;
+  const std::vector<float> expected = {0.f, 1.f, 2.f, 3.f, 4.f, 5.f, 6.f, 7.f,
+                                       8.f, 9.f, 10.f, 11.f, 12.f, 13.f, 14.f, 15.f};
+
+  for (const auto& [mode, input] : std::vector<std::pair<std::string, std::vector<float>>>{
+           {"DCR", {0.f, 2.f, 8.f, 10.f, 1.f, 3.f, 9.f, 11.f, 4.f, 6.f, 12.f, 14.f, 5.f, 7.f, 13.f, 15.f}},
+           {"CRD", {0.f, 2.f, 1.f, 3.f, 4.f, 6.f, 5.f, 7.f, 8.f, 10.f, 9.f, 11.f, 12.f, 14.f, 13.f, 15.f}}}) {
+    OpTester test("DepthToSpace", 28);
+    test.AddAttribute("blocksize", blocksize);
+    test.AddAttribute("mode", mode.c_str());
+    test.AddInput<float>("input", {1, 8, 1, 2}, input);
+    test.AddOutput<float>("output", {1, 2, 2, 4}, expected);
+    test.Run();
+  }
+}
+
+TEST(TensorOpTest, DepthToSpaceOpset28BlocksizeThree) {
+  OpTester test("DepthToSpace", 28);
+  test.AddAttribute("blocksize", int64_t{3});
+  test.AddAttribute("mode", "CRD");
+  test.AddInput<float>("input", {1, 9, 1, 2},
+                       {0.f, 3.f, 6.f, 9.f, 12.f, 15.f, 1.f, 4.f, 7.f,
+                        10.f, 13.f, 16.f, 2.f, 5.f, 8.f, 11.f, 14.f, 17.f});
+  test.AddOutput<float>("output", {1, 1, 3, 6},
+                        {0.f, 1.f, 2.f, 3.f, 4.f, 5.f, 6.f, 7.f, 8.f,
+                         9.f, 10.f, 11.f, 12.f, 13.f, 14.f, 15.f, 16.f, 17.f});
+  test.Run();
+}
+
+TEST(TensorOpTest, SpaceDepthOpset28RejectsInvalidAttributesAndShapes) {
+  {
+    OpTester test("SpaceToDepth", 28);
+    test.AddAttribute("blocksize", int64_t{2});
+    test.AddAttribute("mode", "invalid");
+    test.AddInput<float>("input", {1, 1, 2, 2}, {0.f, 1.f, 2.f, 3.f});
+    test.AddOutput<float>("output", {1, 4, 1, 1}, {0.f, 1.f, 2.f, 3.f});
+    test.Run(OpTester::ExpectResult::kExpectFailure, "only 'DCR' and 'CRD' modes are supported");
+  }
+
+  {
+    OpTester test("DepthToSpace", 28);
+    test.AddAttribute("blocksize", int64_t{2});
+    test.AddAttribute("mode", "invalid");
+    test.AddInput<float>("input", {1, 4, 1, 1}, {0.f, 1.f, 2.f, 3.f});
+    test.AddOutput<float>("output", {1, 1, 2, 2}, {0.f, 1.f, 2.f, 3.f});
+    test.Run(OpTester::ExpectResult::kExpectFailure, "only 'DCR' and 'CRD' modes are supported");
+  }
+
+  {
+    OpTester test("SpaceToDepth", 28);
+    test.AddAttribute("blocksize", int64_t{2});
+    test.AddInput<float>("input", {1, 1, 3, 4}, std::vector<float>(12));
+    test.AddOutput<float>("output", {1, 4, 1, 2}, std::vector<float>(8));
+    test.Run(OpTester::ExpectResult::kExpectFailure, "input height to be a multiple");
+  }
+
+  {
+    OpTester test("DepthToSpace", 28);
+    test.AddAttribute("blocksize", int64_t{2});
+    test.AddInput<float>("input", {1, 3, 1, 1}, std::vector<float>(3));
+    test.AddOutput<float>("output", {1, 1, 2, 2}, std::vector<float>(4));
+    test.Run(OpTester::ExpectResult::kExpectFailure, "input depth to be a multiple");
+  }
+}
+
 TEST(TensorOpTest, SpaceToDepthTest_1) {
   OpTester test("SpaceToDepth");
   constexpr int64_t blocksize = 2;


### PR DESCRIPTION
### Summary
- Add native ONNX opset-28 `SpaceToDepth` support for both `DCR` and `CRD` modes on CPU and CUDA, including internal NHWC kernels.
- Version-split `SpaceToDepth` and `DepthToSpace` registrations at opset 28 across CPU, CUDA, DML, JS, and WebGPU; add DML ordered `SpaceToDepth` support and make QNN decline unsupported CRD nodes for fallback.
- Add opset-28 CPU mode, shape-validation, non-square/blocksize, and native-vs-context-dependent-function parity coverage.

### Validation
- `git diff --check`
- Source-level DCR/CRD layout checks against the pinned ONNX 1.23 function bodies.
- `build.py --config Debug --build --build_dir build\\windows-spacedepth --cmake_generator "Visual Studio 17 2022" --target onnxruntime_provider_test` is blocked by the base branch's unrelated FP6 `TensorProto` datatype-map static assertion in `tensorprotoutils.h`, before producing a test binary.