### PR TITLE
Add opset 28 FP6 type and CPU QDQ support

### DIFF
--- a/go/onnxruntime/onnxruntime_c_api.h
+++ b/go/onnxruntime/onnxruntime_c_api.h
@@ -223,6 +223,9 @@ typedef enum ONNXTensorElementDataType {
   ONNX_TENSOR_ELEMENT_DATA_TYPE_INT2,   // maps to 4 packed int2 values (size == 1 byte)
   // Float8E8M0 type introduced in ONNX 1.21. 8-bit float with 8 exponent bits, 0 mantissa bits, no sign bit.
   ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT8E8M0,  // Non-IEEE floating-point format, all values are powers of two
+  // Float6 types were introduced in ONNX 1.23. See https://onnx.ai/onnx/technical/float6.html
+  ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT6E2M3,  // 6-bit floating-point format with 2 exponent and 3 mantissa bits
+  ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT6E3M2,  // 6-bit floating-point format with 3 exponent and 2 mantissa bits
 } ONNXTensorElementDataType;
 
 // Synced with onnx TypeProto oneof

--- a/include/onnxruntime/core/framework/data_types.h
+++ b/include/onnxruntime/core/framework/data_types.h
@@ -18,6 +18,7 @@
 #include "core/framework/int4.h"
 #include "core/framework/int2.h"
 #include "core/framework/float4.h"
+#include "core/framework/float6.h"
 #include "core/graph/onnx_protobuf.h"
 #include "core/framework/to_tensor_proto_element_type.h"
 
@@ -213,6 +214,7 @@ class DataTypeImpl {
   static const std::vector<MLDataType>& AllTensorTypesIRv10();
   static const std::vector<MLDataType>& AllTensorTypesIRv11();
   static const std::vector<MLDataType>& AllTensorTypesIRv13();
+  static const std::vector<MLDataType>& AllTensorTypesIRv14();
 
   static const std::vector<MLDataType>& AllFixedSizeTensorTypes();  // up to IR4 (no float 8), deprecated
   static const std::vector<MLDataType>& AllFixedSizeTensorTypesIRv4();
@@ -288,6 +290,8 @@ struct IsTensorContainedType : public IsAnyOf<T, float, uint8_t, int8_t, uint16_
                                               int32_t, int64_t, std::string, bool, MLFloat16,
                                               double, uint32_t, uint64_t, BFloat16,
                                               Int4x2, UInt4x2, Int2x4, UInt2x4
+                                              ,
+                                              Float6E2M3, Float6E3M2
 #if !defined(DISABLE_FLOAT8_TYPES)
                                               ,
                                               Float8E4M3FN, Float8E4M3FNUZ, Float8E5M2, Float8E5M2FNUZ, Float8E8M0
@@ -308,6 +312,8 @@ struct IsSparseTensorContainedType : public IsAnyOf<T, float, uint8_t, int8_t, u
                                                     int32_t, int64_t, std::string, bool, MLFloat16,
                                                     double, uint32_t, uint64_t, BFloat16,
                                                     Int4x2, UInt4x2, Int2x4, UInt2x4
+                                                    ,
+                                                    Float6E2M3, Float6E3M2
 #if !defined(DISABLE_FLOAT8_TYPES)
                                                     ,
                                                     Float8E4M3FN, Float8E4M3FNUZ, Float8E5M2, Float8E5M2FNUZ, Float8E8M0

--- a/include/onnxruntime/core/framework/data_types.h
+++ b/include/onnxruntime/core/framework/data_types.h
@@ -290,8 +290,6 @@ struct IsTensorContainedType : public IsAnyOf<T, float, uint8_t, int8_t, uint16_
                                               int32_t, int64_t, std::string, bool, MLFloat16,
                                               double, uint32_t, uint64_t, BFloat16,
                                               Int4x2, UInt4x2, Int2x4, UInt2x4
-                                              ,
-                                              Float6E2M3, Float6E3M2
 #if !defined(DISABLE_FLOAT8_TYPES)
                                               ,
                                               Float8E4M3FN, Float8E4M3FNUZ, Float8E5M2, Float8E5M2FNUZ, Float8E8M0

--- a/include/onnxruntime/core/framework/data_types.h
+++ b/include/onnxruntime/core/framework/data_types.h
@@ -289,7 +289,8 @@ template <typename T>
 struct IsTensorContainedType : public IsAnyOf<T, float, uint8_t, int8_t, uint16_t, int16_t,
                                               int32_t, int64_t, std::string, bool, MLFloat16,
                                               double, uint32_t, uint64_t, BFloat16,
-                                              Int4x2, UInt4x2, Int2x4, UInt2x4
+                                              Int4x2, UInt4x2, Int2x4, UInt2x4,
+                                              Float6E2M3, Float6E3M2
 #if !defined(DISABLE_FLOAT8_TYPES)
                                               ,
                                               Float8E4M3FN, Float8E4M3FNUZ, Float8E5M2, Float8E5M2FNUZ, Float8E8M0
@@ -310,8 +311,6 @@ struct IsSparseTensorContainedType : public IsAnyOf<T, float, uint8_t, int8_t, u
                                                     int32_t, int64_t, std::string, bool, MLFloat16,
                                                     double, uint32_t, uint64_t, BFloat16,
                                                     Int4x2, UInt4x2, Int2x4, UInt2x4
-                                                    ,
-                                                    Float6E2M3, Float6E3M2
 #if !defined(DISABLE_FLOAT8_TYPES)
                                                     ,
                                                     Float8E4M3FN, Float8E4M3FNUZ, Float8E5M2, Float8E5M2FNUZ, Float8E8M0

--- a/include/onnxruntime/core/framework/float6.h
+++ b/include/onnxruntime/core/framework/float6.h
@@ -1,0 +1,38 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+namespace onnxruntime {
+
+struct Float6E2M3 {
+  uint8_t val{0};
+
+  struct FromBitsT {};
+  static constexpr FromBitsT FromBits() { return FromBitsT(); }
+  constexpr Float6E2M3(uint8_t bits, FromBitsT) : val(bits & 0x3F) {}
+  constexpr uint8_t ToBits() const { return val; }
+  static constexpr size_t CalcNumFloat6Bytes(size_t num_float6_elems) {
+    return num_float6_elems - num_float6_elems / 4;
+  }
+};
+
+struct Float6E3M2 {
+  uint8_t val{0};
+
+  struct FromBitsT {};
+  static constexpr FromBitsT FromBits() { return FromBitsT(); }
+  constexpr Float6E3M2(uint8_t bits, FromBitsT) : val(bits & 0x3F) {}
+  constexpr uint8_t ToBits() const { return val; }
+  static constexpr size_t CalcNumFloat6Bytes(size_t num_float6_elems) {
+    return num_float6_elems - num_float6_elems / 4;
+  }
+};
+
+static_assert(sizeof(Float6E2M3) == sizeof(uint8_t));
+static_assert(sizeof(Float6E3M2) == sizeof(uint8_t));
+
+}  // namespace onnxruntime

--- a/include/onnxruntime/core/framework/float6.h
+++ b/include/onnxruntime/core/framework/float6.h
@@ -5,8 +5,46 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <cmath>
+#include <limits>
 
 namespace onnxruntime {
+
+inline float Float6ToFloat(uint8_t bits, int exponent_bits, int mantissa_bits, int exponent_bias) {
+  const uint8_t sign = bits >> 5;
+  const uint8_t exponent = (bits >> mantissa_bits) & ((1u << exponent_bits) - 1);
+  const uint8_t mantissa = bits & ((1u << mantissa_bits) - 1);
+  const float significand = exponent == 0
+                                ? static_cast<float>(mantissa)
+                                : static_cast<float>((1u << mantissa_bits) | mantissa);
+  const float value = std::ldexp(significand, exponent == 0
+                                                  ? 1 - exponent_bias - mantissa_bits
+                                                  : static_cast<int>(exponent) - exponent_bias - mantissa_bits);
+  return sign == 0 ? value : -value;
+}
+
+inline uint8_t FloatToFloat6(float value, int exponent_bits, int mantissa_bits, int exponent_bias) {
+  if (std::isnan(value)) {
+    return 0x20;
+  }
+
+  const uint8_t sign = std::signbit(value) ? 0x20 : 0;
+  if (std::isinf(value)) {
+    return static_cast<uint8_t>(sign | 0x1F);
+  }
+  const float magnitude = std::abs(value);
+  uint8_t best = sign;
+  float best_distance = std::numeric_limits<float>::infinity();
+  for (uint8_t bits = 0; bits < 0x20; ++bits) {
+    const float candidate = Float6ToFloat(bits, exponent_bits, mantissa_bits, exponent_bias);
+    const float distance = std::abs(magnitude - candidate);
+    if (distance < best_distance || (distance == best_distance && (bits & 1) == 0)) {
+      best = static_cast<uint8_t>(sign | bits);
+      best_distance = distance;
+    }
+  }
+  return best;
+}
 
 struct Float6E2M3 {
   uint8_t val{0};
@@ -14,7 +52,9 @@ struct Float6E2M3 {
   struct FromBitsT {};
   static constexpr FromBitsT FromBits() { return FromBitsT(); }
   constexpr Float6E2M3(uint8_t bits, FromBitsT) : val(bits & 0x3F) {}
+  explicit Float6E2M3(float value) : val(FloatToFloat6(value, 2, 3, 1)) {}
   constexpr uint8_t ToBits() const { return val; }
+  operator float() const { return Float6ToFloat(val, 2, 3, 1); }
   static constexpr size_t CalcNumFloat6Bytes(size_t num_float6_elems) {
     return num_float6_elems - num_float6_elems / 4;
   }
@@ -26,7 +66,9 @@ struct Float6E3M2 {
   struct FromBitsT {};
   static constexpr FromBitsT FromBits() { return FromBitsT(); }
   constexpr Float6E3M2(uint8_t bits, FromBitsT) : val(bits & 0x3F) {}
+  explicit Float6E3M2(float value) : val(FloatToFloat6(value, 3, 2, 3)) {}
   constexpr uint8_t ToBits() const { return val; }
+  operator float() const { return Float6ToFloat(val, 3, 2, 3); }
   static constexpr size_t CalcNumFloat6Bytes(size_t num_float6_elems) {
     return num_float6_elems - num_float6_elems / 4;
   }

--- a/include/onnxruntime/core/framework/float6.h
+++ b/include/onnxruntime/core/framework/float6.h
@@ -33,6 +33,10 @@ inline uint8_t FloatToFloat6(float value, int exponent_bits, int mantissa_bits, 
     return static_cast<uint8_t>(sign | 0x1F);
   }
   const float magnitude = std::abs(value);
+  const float max_finite = Float6ToFloat(0x1F, exponent_bits, mantissa_bits, exponent_bias);
+  if (magnitude > max_finite) {
+    return static_cast<uint8_t>(sign | 0x1F);
+  }
   uint8_t best = sign;
   float best_distance = std::numeric_limits<float>::infinity();
   for (uint8_t bits = 0; bits < 0x20; ++bits) {

--- a/include/onnxruntime/core/framework/to_tensor_proto_element_type.h
+++ b/include/onnxruntime/core/framework/to_tensor_proto_element_type.h
@@ -11,6 +11,7 @@
 #endif
 
 #include "core/framework/float4.h"
+#include "core/framework/float6.h"
 #include "core/common/float8.h"
 #include "core/common/float16.h"
 #include "core/framework/int2.h"
@@ -111,6 +112,15 @@ constexpr ONNX_NAMESPACE::TensorProto_DataType ToTensorProtoElementType<Float4E2
   return ONNX_NAMESPACE::TensorProto_DataType_FLOAT4E2M1;
 }
 #endif
+
+template <>
+constexpr ONNX_NAMESPACE::TensorProto_DataType ToTensorProtoElementType<Float6E2M3>() {
+  return ONNX_NAMESPACE::TensorProto_DataType_FLOAT6E2M3;
+}
+template <>
+constexpr ONNX_NAMESPACE::TensorProto_DataType ToTensorProtoElementType<Float6E3M2>() {
+  return ONNX_NAMESPACE::TensorProto_DataType_FLOAT6E3M2;
+}
 
 template <>
 constexpr ONNX_NAMESPACE::TensorProto_DataType ToTensorProtoElementType<Int4x2>() {

--- a/include/onnxruntime/core/session/onnxruntime_c_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_c_api.h
@@ -223,9 +223,9 @@ typedef enum ONNXTensorElementDataType {
   ONNX_TENSOR_ELEMENT_DATA_TYPE_INT2,   // maps to 4 packed int2 values (size == 1 byte)
   // Float8E8M0 type introduced in ONNX 1.21. 8-bit float with 8 exponent bits, 0 mantissa bits, no sign bit.
   ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT8E8M0,  // Non-IEEE floating-point format, all values are powers of two
-  // Float6 types introduced in ONNX 1.23.
-  ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT6E2M3,  // 6-bit float stored in an int32_data entry
-  ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT6E3M2,  // 6-bit float stored in an int32_data entry
+  // Float6 types were introduced in ONNX 1.23. See https://onnx.ai/onnx/technical/float6.html
+  ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT6E2M3,  // 6-bit floating-point format with 2 exponent and 3 mantissa bits
+  ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT6E3M2,  // 6-bit floating-point format with 3 exponent and 2 mantissa bits
 } ONNXTensorElementDataType;
 
 // Synced with onnx TypeProto oneof

--- a/onnxruntime/core/flatbuffers/schema/ort.fbs
+++ b/onnxruntime/core/flatbuffers/schema/ort.fbs
@@ -66,6 +66,8 @@ enum TensorDataType : int32 {
   FLOAT8E4M3FNUZ = 18,
   FLOAT8E5M2 = 19,
   FLOAT8E5M2FNUZ = 20,
+  FLOAT6E2M3 = 27,
+  FLOAT6E3M2 = 28,
 }
 
 table TensorTypeAndShape {

--- a/onnxruntime/core/flatbuffers/schema/ort.fbs.h
+++ b/onnxruntime/core/flatbuffers/schema/ort.fbs.h
@@ -226,11 +226,13 @@ enum class TensorDataType : int32_t {
   FLOAT8E4M3FNUZ = 18,
   FLOAT8E5M2 = 19,
   FLOAT8E5M2FNUZ = 20,
+  FLOAT6E2M3 = 27,
+  FLOAT6E3M2 = 28,
   MIN = UNDEFINED,
-  MAX = FLOAT8E5M2FNUZ
+  MAX = FLOAT6E3M2
 };
 
-inline const TensorDataType (&EnumValuesTensorDataType())[21] {
+inline const TensorDataType (&EnumValuesTensorDataType())[23] {
   static const TensorDataType values[] = {
     TensorDataType::UNDEFINED,
     TensorDataType::FLOAT,
@@ -252,13 +254,15 @@ inline const TensorDataType (&EnumValuesTensorDataType())[21] {
     TensorDataType::FLOAT8E4M3FN,
     TensorDataType::FLOAT8E4M3FNUZ,
     TensorDataType::FLOAT8E5M2,
-    TensorDataType::FLOAT8E5M2FNUZ
+    TensorDataType::FLOAT8E5M2FNUZ,
+    TensorDataType::FLOAT6E2M3,
+    TensorDataType::FLOAT6E3M2
   };
   return values;
 }
 
 inline const char * const *EnumNamesTensorDataType() {
-  static const char * const names[22] = {
+  static const char * const names[30] = {
     "UNDEFINED",
     "FLOAT",
     "UINT8",
@@ -280,13 +284,21 @@ inline const char * const *EnumNamesTensorDataType() {
     "FLOAT8E4M3FNUZ",
     "FLOAT8E5M2",
     "FLOAT8E5M2FNUZ",
+    nullptr,
+    nullptr,
+    nullptr,
+    nullptr,
+    nullptr,
+    nullptr,
+    "FLOAT6E2M3",
+    "FLOAT6E3M2",
     nullptr
   };
   return names;
 }
 
 inline const char *EnumNameTensorDataType(TensorDataType e) {
-  if (::flatbuffers::IsOutRange(e, TensorDataType::UNDEFINED, TensorDataType::FLOAT8E5M2FNUZ)) return "";
+  if (::flatbuffers::IsOutRange(e, TensorDataType::UNDEFINED, TensorDataType::FLOAT6E3M2)) return "";
   const size_t index = static_cast<size_t>(e);
   return EnumNamesTensorDataType()[index];
 }

--- a/onnxruntime/core/framework/data_types.cc
+++ b/onnxruntime/core/framework/data_types.cc
@@ -666,8 +666,6 @@ ORT_REGISTER_SPARSE_TENSOR_TYPE(uint32_t);
 ORT_REGISTER_SPARSE_TENSOR_TYPE(uint64_t);
 ORT_REGISTER_SPARSE_TENSOR_TYPE(MLFloat16);
 ORT_REGISTER_SPARSE_TENSOR_TYPE(BFloat16);
-ORT_REGISTER_SPARSE_TENSOR_TYPE(Float6E2M3);
-ORT_REGISTER_SPARSE_TENSOR_TYPE(Float6E3M2);
 
 #if !defined(DISABLE_FLOAT8_TYPES)
 ORT_REGISTER_SPARSE_TENSOR_TYPE(Float8E4M3FN);
@@ -870,8 +868,6 @@ void RegisterAllProtos(const std::function<void(MLDataType)>& reg_fn) {
   REGISTER_SPARSE_TENSOR_PROTO(uint64_t, reg_fn);
   REGISTER_SPARSE_TENSOR_PROTO(MLFloat16, reg_fn);
   REGISTER_SPARSE_TENSOR_PROTO(BFloat16, reg_fn);
-  REGISTER_SPARSE_TENSOR_PROTO(Float6E2M3, reg_fn);
-  REGISTER_SPARSE_TENSOR_PROTO(Float6E3M2, reg_fn);
 #if !defined(DISABLE_FLOAT8_TYPES)
   REGISTER_SPARSE_TENSOR_PROTO(Float8E4M3FN, reg_fn);
   REGISTER_SPARSE_TENSOR_PROTO(Float8E4M3FNUZ, reg_fn);
@@ -1257,10 +1253,6 @@ const SparseTensorTypeBase* DataTypeImpl::SparseTensorTypeFromONNXEnum(int type)
     case TensorProto_DataType_FLOAT8E8M0:
       return DataTypeImpl::GetSparseTensorType<Float8E8M0>()->AsSparseTensorType();
 #endif
-    case TensorProto_DataType_FLOAT6E2M3:
-      return DataTypeImpl::GetSparseTensorType<Float6E2M3>()->AsSparseTensorType();
-    case TensorProto_DataType_FLOAT6E3M2:
-      return DataTypeImpl::GetSparseTensorType<Float6E3M2>()->AsSparseTensorType();
 
     default:
       ORT_NOT_IMPLEMENTED("sparse tensor type ", type, " is not supported");

--- a/onnxruntime/core/framework/data_types.cc
+++ b/onnxruntime/core/framework/data_types.cc
@@ -630,6 +630,8 @@ ORT_REGISTER_TENSOR_TYPE(uint32_t);
 ORT_REGISTER_TENSOR_TYPE(uint64_t);
 ORT_REGISTER_TENSOR_TYPE(MLFloat16);
 ORT_REGISTER_TENSOR_TYPE(BFloat16);
+ORT_REGISTER_TENSOR_TYPE(Float6E2M3);
+ORT_REGISTER_TENSOR_TYPE(Float6E3M2);
 
 #if !defined(DISABLE_FLOAT8_TYPES)
 ORT_REGISTER_TENSOR_TYPE(Float8E4M3FN);
@@ -664,6 +666,8 @@ ORT_REGISTER_SPARSE_TENSOR_TYPE(uint32_t);
 ORT_REGISTER_SPARSE_TENSOR_TYPE(uint64_t);
 ORT_REGISTER_SPARSE_TENSOR_TYPE(MLFloat16);
 ORT_REGISTER_SPARSE_TENSOR_TYPE(BFloat16);
+ORT_REGISTER_SPARSE_TENSOR_TYPE(Float6E2M3);
+ORT_REGISTER_SPARSE_TENSOR_TYPE(Float6E3M2);
 
 #if !defined(DISABLE_FLOAT8_TYPES)
 ORT_REGISTER_SPARSE_TENSOR_TYPE(Float8E4M3FN);
@@ -700,6 +704,8 @@ ORT_REGISTER_SEQ_TENSOR_TYPE(bool);
 ORT_REGISTER_SEQ_TENSOR_TYPE(std::string);
 ORT_REGISTER_SEQ_TENSOR_TYPE(MLFloat16);
 ORT_REGISTER_SEQ_TENSOR_TYPE(BFloat16);
+ORT_REGISTER_SEQ_TENSOR_TYPE(Float6E2M3);
+ORT_REGISTER_SEQ_TENSOR_TYPE(Float6E3M2);
 
 #if !defined(DISABLE_FLOAT8_TYPES)
 
@@ -739,6 +745,8 @@ ORT_REGISTER_SEQ(VectorMapInt64ToFloat);
   ORT_REGISTER_OPTIONAL_TYPE(ORT_TYPE, uint64_t);       \
   ORT_REGISTER_OPTIONAL_TYPE(ORT_TYPE, MLFloat16);      \
   ORT_REGISTER_OPTIONAL_TYPE(ORT_TYPE, BFloat16);       \
+  ORT_REGISTER_OPTIONAL_TYPE(ORT_TYPE, Float6E2M3);     \
+  ORT_REGISTER_OPTIONAL_TYPE(ORT_TYPE, Float6E3M2);     \
   ORT_REGISTER_OPTIONAL_TYPE(ORT_TYPE, Float8E4M3FN);   \
   ORT_REGISTER_OPTIONAL_TYPE(ORT_TYPE, Float8E4M3FNUZ); \
   ORT_REGISTER_OPTIONAL_TYPE(ORT_TYPE, Float8E5M2);     \
@@ -766,6 +774,8 @@ ORT_REGISTER_SEQ(VectorMapInt64ToFloat);
   ORT_REGISTER_OPTIONAL_TYPE(ORT_TYPE, uint64_t);    \
   ORT_REGISTER_OPTIONAL_TYPE(ORT_TYPE, MLFloat16);   \
   ORT_REGISTER_OPTIONAL_TYPE(ORT_TYPE, BFloat16);    \
+  ORT_REGISTER_OPTIONAL_TYPE(ORT_TYPE, Float6E2M3);  \
+  ORT_REGISTER_OPTIONAL_TYPE(ORT_TYPE, Float6E3M2);  \
   ORT_REGISTER_OPTIONAL_TYPE(ORT_TYPE, Int4x2);      \
   ORT_REGISTER_OPTIONAL_TYPE(ORT_TYPE, UInt4x2);     \
   ORT_REGISTER_OPTIONAL_TYPE(ORT_TYPE, Int2x4);      \
@@ -828,6 +838,8 @@ void RegisterAllProtos(const std::function<void(MLDataType)>& reg_fn) {
   REGISTER_TENSOR_PROTO(uint64_t, reg_fn);
   REGISTER_TENSOR_PROTO(MLFloat16, reg_fn);
   REGISTER_TENSOR_PROTO(BFloat16, reg_fn);
+  REGISTER_TENSOR_PROTO(Float6E2M3, reg_fn);
+  REGISTER_TENSOR_PROTO(Float6E3M2, reg_fn);
 #if !defined(DISABLE_FLOAT8_TYPES)
   REGISTER_TENSOR_PROTO(Float8E4M3FN, reg_fn);
   REGISTER_TENSOR_PROTO(Float8E4M3FNUZ, reg_fn);
@@ -858,6 +870,8 @@ void RegisterAllProtos(const std::function<void(MLDataType)>& reg_fn) {
   REGISTER_SPARSE_TENSOR_PROTO(uint64_t, reg_fn);
   REGISTER_SPARSE_TENSOR_PROTO(MLFloat16, reg_fn);
   REGISTER_SPARSE_TENSOR_PROTO(BFloat16, reg_fn);
+  REGISTER_SPARSE_TENSOR_PROTO(Float6E2M3, reg_fn);
+  REGISTER_SPARSE_TENSOR_PROTO(Float6E3M2, reg_fn);
 #if !defined(DISABLE_FLOAT8_TYPES)
   REGISTER_SPARSE_TENSOR_PROTO(Float8E4M3FN, reg_fn);
   REGISTER_SPARSE_TENSOR_PROTO(Float8E4M3FNUZ, reg_fn);
@@ -892,6 +906,8 @@ void RegisterAllProtos(const std::function<void(MLDataType)>& reg_fn) {
   REGISTER_SEQ_TENSOR_PROTO(uint64_t, reg_fn);
   REGISTER_SEQ_TENSOR_PROTO(MLFloat16, reg_fn);
   REGISTER_SEQ_TENSOR_PROTO(BFloat16, reg_fn);
+  REGISTER_SEQ_TENSOR_PROTO(Float6E2M3, reg_fn);
+  REGISTER_SEQ_TENSOR_PROTO(Float6E3M2, reg_fn);
 
 #if !defined(DISABLE_FLOAT8_TYPES)
 
@@ -932,6 +948,8 @@ void RegisterAllProtos(const std::function<void(MLDataType)>& reg_fn) {
   REGISTER_OPTIONAL_PROTO(ORT_TYPE, uint64_t, reg_fn);       \
   REGISTER_OPTIONAL_PROTO(ORT_TYPE, MLFloat16, reg_fn);      \
   REGISTER_OPTIONAL_PROTO(ORT_TYPE, BFloat16, reg_fn);       \
+  REGISTER_OPTIONAL_PROTO(ORT_TYPE, Float6E2M3, reg_fn);     \
+  REGISTER_OPTIONAL_PROTO(ORT_TYPE, Float6E3M2, reg_fn);     \
   REGISTER_OPTIONAL_PROTO(ORT_TYPE, Float8E4M3FN, reg_fn);   \
   REGISTER_OPTIONAL_PROTO(ORT_TYPE, Float8E4M3FNUZ, reg_fn); \
   REGISTER_OPTIONAL_PROTO(ORT_TYPE, Float8E5M2, reg_fn);     \
@@ -959,7 +977,9 @@ void RegisterAllProtos(const std::function<void(MLDataType)>& reg_fn) {
   REGISTER_OPTIONAL_PROTO(ORT_TYPE, uint64_t, reg_fn);     \
   REGISTER_OPTIONAL_PROTO(ORT_TYPE, MLFloat16, reg_fn);    \
   REGISTER_OPTIONAL_PROTO(ORT_TYPE, BFloat16, reg_fn);     \
-  REGISTER_OPTIONAL_PROTO(ORT_TYPE, Int4x2, reg_fn);       \
+  REGISTER_OPTIONAL_PROTO(ORT_TYPE, Float6E2M3, reg_fn);  \
+  REGISTER_OPTIONAL_PROTO(ORT_TYPE, Float6E3M2, reg_fn);  \
+  REGISTER_OPTIONAL_PROTO(ORT_TYPE, Int4x2, reg_fn);      \
   REGISTER_OPTIONAL_PROTO(ORT_TYPE, UInt4x2, reg_fn);      \
   REGISTER_OPTIONAL_PROTO(ORT_TYPE, Int2x4, reg_fn);       \
   REGISTER_OPTIONAL_PROTO(ORT_TYPE, UInt2x4, reg_fn);
@@ -1027,6 +1047,10 @@ const char* DataTypeImpl::ToString(MLDataType type) {
         return "Float8E8M0";
       case TensorProto_DataType_FLOAT4E2M1:
         return "Float4E2M1";
+      case TensorProto_DataType_FLOAT6E2M3:
+        return "Float6E2M3";
+      case TensorProto_DataType_FLOAT6E3M2:
+        return "Float6E3M2";
       case TensorProto_DataType_INT4:
         return "Int4x2";
       case TensorProto_DataType_UINT4:
@@ -1107,6 +1131,10 @@ const TensorTypeBase* DataTypeImpl::TensorTypeFromONNXEnum(int type) {
     case TensorProto_DataType_FLOAT4E2M1:
       return DataTypeImpl::GetTensorType<Float4E2M1x2>()->AsTensorType();
 #endif
+    case TensorProto_DataType_FLOAT6E2M3:
+      return DataTypeImpl::GetTensorType<Float6E2M3>()->AsTensorType();
+    case TensorProto_DataType_FLOAT6E3M2:
+      return DataTypeImpl::GetTensorType<Float6E3M2>()->AsTensorType();
     case TensorProto_DataType_INT4:
       return DataTypeImpl::GetTensorType<Int4x2>()->AsTensorType();
     case TensorProto_DataType_UINT4:
@@ -1174,6 +1202,10 @@ const SequenceTensorTypeBase* DataTypeImpl::SequenceTensorTypeFromONNXEnum(int t
       return DataTypeImpl::GetSequenceTensorType<Int2x4>()->AsSequenceTensorType();
     case TensorProto_DataType_UINT2:
       return DataTypeImpl::GetSequenceTensorType<UInt2x4>()->AsSequenceTensorType();
+    case TensorProto_DataType_FLOAT6E2M3:
+      return DataTypeImpl::GetSequenceTensorType<Float6E2M3>()->AsSequenceTensorType();
+    case TensorProto_DataType_FLOAT6E3M2:
+      return DataTypeImpl::GetSequenceTensorType<Float6E3M2>()->AsSequenceTensorType();
 
     default:
       ORT_NOT_IMPLEMENTED("sequence tensor type ", type, " is not supported");
@@ -1224,8 +1256,11 @@ const SparseTensorTypeBase* DataTypeImpl::SparseTensorTypeFromONNXEnum(int type)
       return DataTypeImpl::GetSparseTensorType<Float8E5M2FNUZ>()->AsSparseTensorType();
     case TensorProto_DataType_FLOAT8E8M0:
       return DataTypeImpl::GetSparseTensorType<Float8E8M0>()->AsSparseTensorType();
-
 #endif
+    case TensorProto_DataType_FLOAT6E2M3:
+      return DataTypeImpl::GetSparseTensorType<Float6E2M3>()->AsSparseTensorType();
+    case TensorProto_DataType_FLOAT6E3M2:
+      return DataTypeImpl::GetSparseTensorType<Float6E3M2>()->AsSparseTensorType();
 
     default:
       ORT_NOT_IMPLEMENTED("sparse tensor type ", type, " is not supported");
@@ -1260,6 +1295,8 @@ ORT_REGISTER_PRIM_TYPE(uint32_t);
 ORT_REGISTER_PRIM_TYPE(uint64_t);
 ORT_REGISTER_PRIM_TYPE(MLFloat16);
 ORT_REGISTER_PRIM_TYPE(BFloat16);
+ORT_REGISTER_PRIM_TYPE(Float6E2M3);
+ORT_REGISTER_PRIM_TYPE(Float6E3M2);
 
 #if !defined(DISABLE_FLOAT8_TYPES)
 
@@ -1386,6 +1423,12 @@ const std::vector<MLDataType>& DataTypeImpl::AllTensorTypesIRv11() {
 const std::vector<MLDataType>& DataTypeImpl::AllTensorTypesIRv13() {
   static std::vector<MLDataType> all_tensor_types =
       GetTensorTypesFromTypeList<element_type_lists::AllIRv13>();
+  return all_tensor_types;
+}
+
+const std::vector<MLDataType>& DataTypeImpl::AllTensorTypesIRv14() {
+  static std::vector<MLDataType> all_tensor_types =
+      GetTensorTypesFromTypeList<element_type_lists::AllIRv14>();
   return all_tensor_types;
 }
 

--- a/onnxruntime/core/framework/element_type_lists.h
+++ b/onnxruntime/core/framework/element_type_lists.h
@@ -14,6 +14,7 @@
 #include "core/framework/int4.h"
 #include "core/framework/int2.h"
 #include "core/framework/float4.h"
+#include "core/framework/float6.h"
 
 namespace onnxruntime {
 
@@ -116,6 +117,13 @@ using AllIRv13 =
         AllIRv12,
         UInt2x4,
         Int2x4>;
+
+// IR v14 adds FLOAT6E2M3 and FLOAT6E3M2 (6-bit floating-point types).
+using AllIRv14 =
+    boost::mp11::mp_push_back<
+        AllIRv13,
+        Float6E2M3,
+        Float6E3M2>;
 
 // TODO: This needs upgrade to some newer version ,buit it has been
 // at this version for a while and it needs changes at the use sites

--- a/onnxruntime/core/framework/onnxruntime_map_type_info.h
+++ b/onnxruntime/core/framework/onnxruntime_map_type_info.h
@@ -26,8 +26,7 @@ constexpr ONNXTensorElementDataType ToONNXTensorElementDataType(
     return ONNX_TENSOR_ELEMENT_DATA_TYPE_UNDEFINED;
   }
 
-  // The enums have the same values through FLOAT4E2M1. The following three entries
-  // differ because ONNX inserted FLOAT8E8M0 before UINT2 and INT2.
+  // The enums differ because ONNX inserted FLOAT8E8M0 before UINT2 and INT2.
   switch (data_type) {
     case ONNX_NAMESPACE::TensorProto_DataType_FLOAT8E8M0:
       return ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT8E8M0;
@@ -35,6 +34,10 @@ constexpr ONNXTensorElementDataType ToONNXTensorElementDataType(
       return ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT2;
     case ONNX_NAMESPACE::TensorProto_DataType_INT2:
       return ONNX_TENSOR_ELEMENT_DATA_TYPE_INT2;
+    case ONNX_NAMESPACE::TensorProto_DataType_FLOAT6E2M3:
+      return ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT6E2M3;
+    case ONNX_NAMESPACE::TensorProto_DataType_FLOAT6E3M2:
+      return ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT6E3M2;
     default:
       return static_cast<ONNXTensorElementDataType>(value);
   }

--- a/onnxruntime/core/framework/tensor_type_and_shape.cc
+++ b/onnxruntime/core/framework/tensor_type_and_shape.cc
@@ -238,6 +238,12 @@ constexpr ONNXTensorElementDataType TensorDataTypeToOnnxRuntimeTensorElementData
     case o::TensorProto_DataType_FLOAT4E2M1:
       type = ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT4E2M1;
       break;
+    case o::TensorProto_DataType_FLOAT6E2M3:
+      type = ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT6E2M3;
+      break;
+    case o::TensorProto_DataType_FLOAT6E3M2:
+      type = ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT6E3M2;
+      break;
     case o::TensorProto_DataType_INT2:
       type = ONNX_TENSOR_ELEMENT_DATA_TYPE_INT2;
       break;

--- a/onnxruntime/core/framework/tensorprotoutils.cc
+++ b/onnxruntime/core/framework/tensorprotoutils.cc
@@ -1797,6 +1797,16 @@ Status GetExtDataFromTensorProto(const Env& env,
   // In-memory address markers are passed through; their validity is enforced upstream.
   ORT_RETURN_IF_ERROR(ValidateExternalFilePathForTensor(tensor_proto, model_path));
 
+  if (tensor_proto.data_type() == TensorProto_DataType_FLOAT6E2M3 ||
+      tensor_proto.data_type() == TensorProto_DataType_FLOAT6E3M2) {
+    const TensorShape tensor_shape = utils::GetTensorShapeFromTensorProto(tensor_proto);
+    const DataTypeImpl* type = DataTypeImpl::TensorTypeFromONNXEnum(tensor_proto.data_type())->GetElementType();
+    Tensor tensor{type, tensor_shape, CPUAllocator::DefaultInstance()};
+    ORT_RETURN_IF_ERROR(TensorProtoToTensor(env, model_path, tensor_proto, tensor));
+    Tensor::InitOrtValue(std::move(tensor), ort_value);
+    return Status::OK();
+  }
+
   std::basic_string<ORTCHAR_T> tensor_proto_dir;
   if (!model_path.empty()) {
     ORT_RETURN_IF_ERROR(GetDirNameFromFilePath(model_path, tensor_proto_dir));

--- a/onnxruntime/core/framework/tensorprotoutils.cc
+++ b/onnxruntime/core/framework/tensorprotoutils.cc
@@ -1999,6 +1999,8 @@ Status LoadExtDataToTensorFromTensorProto(const Env& env, const std::filesystem:
 
   if (tensor_proto.data_type() == TensorProto_DataType_FLOAT6E2M3 ||
       tensor_proto.data_type() == TensorProto_DataType_FLOAT6E3M2) {
+    ORT_RETURN_IF(tensor.Location().device.Type() != OrtDevice::CPU,
+                  "FP6 external data requires a CPU destination when loaded through IExternalDataLoader.");
     Tensor packed_tensor{DataTypeImpl::GetType<uint8_t>(), TensorShape({static_cast<int64_t>(raw_data_safe_len)}),
                          CPUAllocator::DefaultInstance()};
     ORT_RETURN_IF_ERROR(ext_data_loader.LoadTensor(env, external_data_file_path, file_offset, raw_data_safe_len,

--- a/onnxruntime/core/framework/tensorprotoutils.cc
+++ b/onnxruntime/core/framework/tensorprotoutils.cc
@@ -1994,6 +1994,8 @@ Status LoadExtDataToTensorFromTensorProto(const Env& env, const std::filesystem:
   ORT_RETURN_IF(external_data_file_path == onnxruntime::utils::kTensorProtoLittleEndianMemoryAddressTag ||
                     external_data_file_path == onnxruntime::utils::kTensorProtoNativeEndianMemoryAddressTag,
                 "Memory address tag is not supported by custom external data loader.");
+  ORT_RETURN_IF(file_offset < 0, "External initializer: ", tensor_proto.name(),
+                " has a negative offset: ", file_offset);
 
   if (tensor_proto.data_type() == TensorProto_DataType_FLOAT6E2M3 ||
       tensor_proto.data_type() == TensorProto_DataType_FLOAT6E3M2) {

--- a/onnxruntime/core/framework/tensorprotoutils.cc
+++ b/onnxruntime/core/framework/tensorprotoutils.cc
@@ -194,6 +194,93 @@ DEFINE_4BIT_UNPACK_TENSOR_WITH_RAW_DATA_IMPL(UInt2x4, CalcNumInt2Quads)
 DEFINE_4BIT_UNPACK_TENSOR_WITH_RAW_DATA_IMPL(Float4E2M1x2, CalcNumFloat4Pairs)
 #endif
 
+template <typename FLOAT6_TYPE>
+Status UnpackFloat6Tensor(const ONNX_NAMESPACE::TensorProto& tensor, const void* raw_data, size_t raw_data_len,
+                         /*out*/ FLOAT6_TYPE* p_data, size_t expected_num_elems) {
+  if (p_data == nullptr) {
+    const size_t size = raw_data != nullptr ? raw_data_len : static_cast<size_t>(tensor.int32_data_size());
+    return size == 0 ? Status::OK() : Status(common::ONNXRUNTIME, common::INVALID_ARGUMENT);
+  }
+
+  if (raw_data != nullptr) {
+    const size_t expected_num_bytes = FLOAT6_TYPE::CalcNumFloat6Bytes(expected_num_elems);
+    ORT_RETURN_IF_NOT(raw_data_len == expected_num_bytes, "Unexpected number of packed float6 bytes");
+    const auto* packed_data = static_cast<const uint8_t*>(raw_data);
+    for (size_t i = 0; i < expected_num_elems; ++i) {
+      const uint8_t* packed_group = packed_data + (i / 4) * 3;
+      uint8_t bits;
+      switch (i % 4) {
+        case 0:
+          bits = packed_group[0] & 0x3F;
+          break;
+        case 1:
+          bits = static_cast<uint8_t>((packed_group[0] >> 6) | ((packed_group[1] & 0x0F) << 2));
+          break;
+        case 2:
+          bits = static_cast<uint8_t>((packed_group[1] >> 4) | ((packed_group[2] & 0x03) << 4));
+          break;
+        default:
+          bits = packed_group[2] >> 2;
+          break;
+      }
+      p_data[i] = FLOAT6_TYPE(bits, FLOAT6_TYPE::FromBits());
+    }
+    return Status::OK();
+  }
+
+  ORT_RETURN_IF_NOT(static_cast<size_t>(tensor.int32_data_size()) == expected_num_elems,
+                    "UnpackTensor: the pre-allocated size does not match the size in proto");
+  for (int i = 0; i < tensor.int32_data_size(); ++i) {
+    const int32_t value = tensor.int32_data(i);
+    ORT_RETURN_IF(value < 0 || value > 0x3F, "Float6 int32_data values must use only bits 0-5");
+    p_data[i] = FLOAT6_TYPE(static_cast<uint8_t>(value), FLOAT6_TYPE::FromBits());
+  }
+  return Status::OK();
+}
+
+template <>
+Status UnpackTensor(const ONNX_NAMESPACE::TensorProto& tensor, const void* raw_data, size_t raw_data_len,
+                    /*out*/ Float6E2M3* p_data, size_t expected_num_elems) {
+  ORT_RETURN_IF(tensor.data_type() != ONNX_NAMESPACE::TensorProto_DataType_FLOAT6E2M3,
+                "Unexpected Float6E2M3 tensor type");
+  return UnpackFloat6Tensor(tensor, raw_data, raw_data_len, p_data, expected_num_elems);
+}
+
+template <>
+Status UnpackTensor(const ONNX_NAMESPACE::TensorProto& tensor, const void* raw_data, size_t raw_data_len,
+                    /*out*/ Float6E3M2* p_data, size_t expected_num_elems) {
+  ORT_RETURN_IF(tensor.data_type() != ONNX_NAMESPACE::TensorProto_DataType_FLOAT6E3M2,
+                "Unexpected Float6E3M2 tensor type");
+  return UnpackFloat6Tensor(tensor, raw_data, raw_data_len, p_data, expected_num_elems);
+}
+
+template <typename FLOAT6_TYPE>
+std::string PackFloat6Tensor(const FLOAT6_TYPE* data, size_t num_elements) {
+  std::string packed_data(FLOAT6_TYPE::CalcNumFloat6Bytes(num_elements), '\0');
+  auto* packed_bytes = reinterpret_cast<uint8_t*>(packed_data.data());
+  for (size_t i = 0; i < num_elements; ++i) {
+    const uint8_t bits = data[i].ToBits();
+    uint8_t* packed_group = packed_bytes + (i / 4) * 3;
+    switch (i % 4) {
+      case 0:
+        packed_group[0] |= bits;
+        break;
+      case 1:
+        packed_group[0] |= bits << 6;
+        packed_group[1] |= bits >> 2;
+        break;
+      case 2:
+        packed_group[1] |= bits << 4;
+        packed_group[2] |= bits >> 4;
+        break;
+      default:
+        packed_group[2] |= bits << 2;
+        break;
+    }
+  }
+  return packed_data;
+}
+
 // Read external data for tensor in unint8_t* form and return Status::OK() if the data is read successfully.
 // Uses the tensor_proto_dir to construct the full path for external data. If tensor_proto_dir == nullptr
 // then uses the current directory instead.
@@ -1386,6 +1473,8 @@ static common::Status GetSizeInBytesFromTensorElemCountAndType(size_t elem_count
     CASE_PROTO_TRACE(FLOAT8E5M2FNUZ, Float8E5M2FNUZ);
     CASE_PROTO_TRACE(FLOAT8E8M0, Float8E8M0);
 #endif
+    CASE_PROTO_TRACE(FLOAT6E2M3, Float6E2M3);
+    CASE_PROTO_TRACE(FLOAT6E3M2, Float6E3M2);
     CASE_PROTO_TRACE_INT4(UINT4, UInt4x2);
     CASE_PROTO_TRACE_INT4(INT4, Int4x2);
     CASE_PROTO_TRACE_INT2(UINT2, UInt2x4);
@@ -1466,10 +1555,15 @@ common::Status ValidateEmbeddedTensorProtoDataSizeAndShape(const ONNX_NAMESPACE:
                     " byte limit for embedded initializer data. Use external data for large initializers.");
 
   if (HasRawData(tensor_proto)) {
-    ORT_RETURN_IF_NOT(tensor_proto.raw_data().size() == byte_size_from_shape,
+    size_t expected_raw_data_size = byte_size_from_shape;
+    if (tensor_proto.data_type() == TensorProto_DataType_FLOAT6E2M3 ||
+        tensor_proto.data_type() == TensorProto_DataType_FLOAT6E3M2) {
+      expected_raw_data_size = Float6E2M3::CalcNumFloat6Bytes(num_elems_unsigned);
+    }
+    ORT_RETURN_IF_NOT(tensor_proto.raw_data().size() == expected_raw_data_size,
                       "Initializer '", tensor_proto.name(), "': raw_data size (", tensor_proto.raw_data().size(),
                       " bytes) does not match expected size from shape and data type (",
-                      byte_size_from_shape, " bytes)");
+                      expected_raw_data_size, " bytes)");
   } else if (HasString(tensor_proto)) {
     ORT_RETURN_IF_NOT(tensor_proto.string_data_size() == num_elems_signed,
                       "Initializer '", tensor_proto.name(), "': string_data count (", tensor_proto.string_data_size(),
@@ -1506,6 +1600,11 @@ common::Status ValidateEmbeddedTensorProtoDataSizeAndShape(const ONNX_NAMESPACE:
       case TensorProto_DataType_INT2:
       case TensorProto_DataType_UINT2:
         expected_count = static_cast<int64_t>(Int2x4::CalcNumInt2Quads(num_elems_unsigned));
+        actual_count = tensor_proto.int32_data_size();
+        break;
+      case TensorProto_DataType_FLOAT6E2M3:
+      case TensorProto_DataType_FLOAT6E3M2:
+        expected_count = num_elems_signed;
         actual_count = tensor_proto.int32_data_size();
         break;
 #if !defined(DISABLE_FLOAT4_TYPES)
@@ -1955,6 +2054,8 @@ Status TensorProtoToTensor(const Env& env, const std::filesystem::path& model_pa
     CASE_PROTO(UINT4, UInt4x2);
     CASE_PROTO(INT2, Int2x4);
     CASE_PROTO(UINT2, UInt2x4);
+    CASE_PROTO(FLOAT6E2M3, Float6E2M3);
+    CASE_PROTO(FLOAT6E3M2, Float6E3M2);
 
 #if !defined(DISABLE_FLOAT4_TYPES)
     CASE_PROTO(FLOAT4E2M1, Float4E2M1x2);
@@ -2053,6 +2154,8 @@ ONNXTensorElementDataType CApiElementTypeFromProtoType(int type) {
 #if !defined(DISABLE_FLOAT4_TYPES)
     CASE_TYPE(FLOAT4E2M1)
 #endif
+    CASE_TYPE(FLOAT6E2M3)
+    CASE_TYPE(FLOAT6E3M2)
 
     default:
       return ONNX_TENSOR_ELEMENT_DATA_TYPE_UNDEFINED;
@@ -2079,6 +2182,8 @@ ONNX_NAMESPACE::TensorProto TensorToTensorProto(const Tensor& tensor,
   // String tensors cannot use the external data in-memory optimization because their raw buffer
   // contains std::string objects (with internal pointers), not serializable string content.
   if (use_tensor_buffer && !tensor.IsDataTypeString() &&
+      tensor.GetElementType() != ONNX_NAMESPACE::TensorProto_DataType_FLOAT6E2M3 &&
+      tensor.GetElementType() != ONNX_NAMESPACE::TensorProto_DataType_FLOAT6E3M2 &&
       tensor.SizeInBytes() > kSmallTensorExternalDataThreshold) {
     // https://github.com/microsoft/onnxruntime/blob/main/onnxruntime/core/graph/graph_flatbuffers_utils.cc#L302
     const auto* raw_data = tensor.DataRaw();
@@ -2101,6 +2206,10 @@ ONNX_NAMESPACE::TensorProto TensorToTensorProto(const Tensor& tensor,
       for (; f < end; ++f) {
         *mutable_string_data->Add() = *f;
       }
+    } else if (tensor.GetElementType() == ONNX_NAMESPACE::TensorProto_DataType_FLOAT6E2M3) {
+      *tensor_proto.mutable_raw_data() = PackFloat6Tensor(tensor.Data<Float6E2M3>(), tensor.Shape().Size());
+    } else if (tensor.GetElementType() == ONNX_NAMESPACE::TensorProto_DataType_FLOAT6E3M2) {
+      *tensor_proto.mutable_raw_data() = PackFloat6Tensor(tensor.Data<Float6E3M2>(), tensor.Shape().Size());
     } else {
       SetRawDataInTensorProto(tensor_proto, tensor.DataRaw(), tensor.SizeInBytes());
     }
@@ -2851,6 +2960,24 @@ Status UnpackInitializerData(const onnx::TensorProto& initializer,
 #if !defined(DISABLE_FLOAT4_TYPES)
     CASE_UNPACK_SUBBYTE_TYPE(FLOAT4E2M1, Float4E2M1x2, int32_data_size, CalcNumFloat4Pairs);
 #endif
+    case ONNX_NAMESPACE::TensorProto_DataType::TensorProto_DataType_FLOAT6E2M3: {
+      TensorShape tensor_shape = GetTensorShapeFromTensorProto(initializer);
+      const size_t element_count = static_cast<size_t>(tensor_shape.Size());
+      unpacked_tensor.resize(element_count * sizeof(Float6E2M3));
+      return onnxruntime::utils::UnpackTensor(initializer,
+                                              initializer.has_raw_data() ? initializer.raw_data().data() : nullptr,
+                                              initializer.has_raw_data() ? initializer.raw_data().size() : 0,
+                                              reinterpret_cast<Float6E2M3*>(unpacked_tensor.data()), element_count);
+    }
+    case ONNX_NAMESPACE::TensorProto_DataType::TensorProto_DataType_FLOAT6E3M2: {
+      TensorShape tensor_shape = GetTensorShapeFromTensorProto(initializer);
+      const size_t element_count = static_cast<size_t>(tensor_shape.Size());
+      unpacked_tensor.resize(element_count * sizeof(Float6E3M2));
+      return onnxruntime::utils::UnpackTensor(initializer,
+                                              initializer.has_raw_data() ? initializer.raw_data().data() : nullptr,
+                                              initializer.has_raw_data() ? initializer.raw_data().size() : 0,
+                                              reinterpret_cast<Float6E3M2*>(unpacked_tensor.data()), element_count);
+    }
 
     default:
       break;

--- a/onnxruntime/core/framework/tensorprotoutils.cc
+++ b/onnxruntime/core/framework/tensorprotoutils.cc
@@ -1802,7 +1802,15 @@ Status GetExtDataFromTensorProto(const Env& env,
     const TensorShape tensor_shape = utils::GetTensorShapeFromTensorProto(tensor_proto);
     const DataTypeImpl* type = DataTypeImpl::TensorTypeFromONNXEnum(tensor_proto.data_type())->GetElementType();
     Tensor tensor{type, tensor_shape, CPUAllocator::DefaultInstance()};
-    ORT_RETURN_IF_ERROR(TensorProtoToTensor(env, model_path, tensor_proto, tensor));
+    const size_t num_elements = gsl::narrow_cast<size_t>(tensor_shape.Size());
+    const auto tensor_proto_dir = model_path.empty() ? std::filesystem::path{} : model_path.parent_path();
+    if (tensor_proto.data_type() == TensorProto_DataType_FLOAT6E2M3) {
+      ORT_RETURN_IF_ERROR(UnpackTensorWithExternalData(
+          tensor_proto, tensor_proto_dir, num_elements, tensor.MutableData<Float6E2M3>()));
+    } else {
+      ORT_RETURN_IF_ERROR(UnpackTensorWithExternalData(
+          tensor_proto, tensor_proto_dir, num_elements, tensor.MutableData<Float6E3M2>()));
+    }
     Tensor::InitOrtValue(std::move(tensor), ort_value);
     return Status::OK();
   }
@@ -1983,13 +1991,27 @@ Status LoadExtDataToTensorFromTensorProto(const Env& env, const std::filesystem:
   ORT_RETURN_IF_ERROR(
       GetExternalDataInfo(tensor_proto, tensor_proto_dir, external_data_file_path, file_offset, raw_data_safe_len));
 
+  ORT_RETURN_IF(external_data_file_path == onnxruntime::utils::kTensorProtoLittleEndianMemoryAddressTag ||
+                    external_data_file_path == onnxruntime::utils::kTensorProtoNativeEndianMemoryAddressTag,
+                "Memory address tag is not supported by custom external data loader.");
+
+  if (tensor_proto.data_type() == TensorProto_DataType_FLOAT6E2M3 ||
+      tensor_proto.data_type() == TensorProto_DataType_FLOAT6E3M2) {
+    Tensor packed_tensor{DataTypeImpl::GetType<uint8_t>(), TensorShape({static_cast<int64_t>(raw_data_safe_len)}),
+                         CPUAllocator::DefaultInstance()};
+    ORT_RETURN_IF_ERROR(ext_data_loader.LoadTensor(env, external_data_file_path, file_offset, raw_data_safe_len,
+                                                    packed_tensor));
+    ONNX_NAMESPACE::TensorProto packed_proto = tensor_proto;
+    packed_proto.clear_external_data();
+    packed_proto.set_data_location(TensorProto_DataLocation_DEFAULT);
+    packed_proto.set_raw_data(packed_tensor.DataRaw(), raw_data_safe_len);
+    return TensorProtoToTensor(env, model_path, packed_proto, tensor);
+  }
+
   ORT_RETURN_IF(file_offset < 0 || raw_data_safe_len != tensor.SizeInBytes(),
                 "External initializer: ", tensor_proto.name(), " offset: ", file_offset,
                 " size to read: ", static_cast<size_t>(raw_data_safe_len),
                 " does not match the tensor size: ", tensor.SizeInBytes());
-  ORT_RETURN_IF(external_data_file_path == onnxruntime::utils::kTensorProtoLittleEndianMemoryAddressTag || external_data_file_path == onnxruntime::utils::kTensorProtoNativeEndianMemoryAddressTag,
-                "Memory address tag is not supported by custom external data loader.");
-
   return ext_data_loader.LoadTensor(env, external_data_file_path, file_offset, raw_data_safe_len, tensor);
 }
 

--- a/onnxruntime/core/framework/tensorprotoutils.cc
+++ b/onnxruntime/core/framework/tensorprotoutils.cc
@@ -238,22 +238,6 @@ Status UnpackFloat6Tensor(const ONNX_NAMESPACE::TensorProto& tensor, const void*
   return Status::OK();
 }
 
-template <>
-Status UnpackTensor(const ONNX_NAMESPACE::TensorProto& tensor, const void* raw_data, size_t raw_data_len,
-                    /*out*/ Float6E2M3* p_data, size_t expected_num_elems) {
-  ORT_RETURN_IF(tensor.data_type() != ONNX_NAMESPACE::TensorProto_DataType_FLOAT6E2M3,
-                "Unexpected Float6E2M3 tensor type");
-  return UnpackFloat6Tensor(tensor, raw_data, raw_data_len, p_data, expected_num_elems);
-}
-
-template <>
-Status UnpackTensor(const ONNX_NAMESPACE::TensorProto& tensor, const void* raw_data, size_t raw_data_len,
-                    /*out*/ Float6E3M2* p_data, size_t expected_num_elems) {
-  ORT_RETURN_IF(tensor.data_type() != ONNX_NAMESPACE::TensorProto_DataType_FLOAT6E3M2,
-                "Unexpected Float6E3M2 tensor type");
-  return UnpackFloat6Tensor(tensor, raw_data, raw_data_len, p_data, expected_num_elems);
-}
-
 template <typename FLOAT6_TYPE>
 std::string PackFloat6Tensor(const FLOAT6_TYPE* data, size_t num_elements) {
   std::string packed_data(FLOAT6_TYPE::CalcNumFloat6Bytes(num_elements), '\0');
@@ -941,6 +925,22 @@ Status UnpackTensorWithExternalData(const ONNX_NAMESPACE::TensorProto& /*tensor*
 template <typename T>
 Status UnpackTensor(const ONNX_NAMESPACE::TensorProto& tensor, const void* raw_data, size_t raw_data_len,
                     /*out*/ T* p_data, size_t expected_num_elements);
+
+template <>
+Status UnpackTensor(const ONNX_NAMESPACE::TensorProto& tensor, const void* raw_data, size_t raw_data_len,
+                    /*out*/ Float6E2M3* p_data, size_t expected_num_elems) {
+  ORT_RETURN_IF(tensor.data_type() != ONNX_NAMESPACE::TensorProto_DataType_FLOAT6E2M3,
+                "Unexpected Float6E2M3 tensor type");
+  return UnpackFloat6Tensor(tensor, raw_data, raw_data_len, p_data, expected_num_elems);
+}
+
+template <>
+Status UnpackTensor(const ONNX_NAMESPACE::TensorProto& tensor, const void* raw_data, size_t raw_data_len,
+                    /*out*/ Float6E3M2* p_data, size_t expected_num_elems) {
+  ORT_RETURN_IF(tensor.data_type() != ONNX_NAMESPACE::TensorProto_DataType_FLOAT6E3M2,
+                "Unexpected Float6E3M2 tensor type");
+  return UnpackFloat6Tensor(tensor, raw_data, raw_data_len, p_data, expected_num_elems);
+}
 
 #define DEFINE_UNPACK_TENSOR_IMPL(T, Type, field_name, field_size)                                          \
   template <>                                                                                               \

--- a/onnxruntime/core/framework/tensorprotoutils.cc
+++ b/onnxruntime/core/framework/tensorprotoutils.cc
@@ -676,7 +676,14 @@ Status GetExternalDataInfo(const ONNX_NAMESPACE::TensorProto& tensor_proto,
                            ? std::filesystem::path(location)
                            : (tensor_proto_dir / location);
 
-  ORT_RETURN_IF_ERROR(GetSizeInBytesFromTensorProto<0>(tensor_proto, &tensor_byte_size));
+  if (tensor_proto.data_type() == TensorProto_DataType_FLOAT6E2M3 ||
+      tensor_proto.data_type() == TensorProto_DataType_FLOAT6E3M2) {
+    const TensorShape tensor_shape = GetTensorShapeFromTensorProto(tensor_proto);
+    ORT_RETURN_IF(tensor_shape.Size() < 0, "External initializer has negative dimensions");
+    tensor_byte_size = Float6E2M3::CalcNumFloat6Bytes(gsl::narrow_cast<size_t>(tensor_shape.Size()));
+  } else {
+    ORT_RETURN_IF_ERROR(GetSizeInBytesFromTensorProto<0>(tensor_proto, &tensor_byte_size));
+  }
   const size_t external_data_length = external_data_info->GetLength();
   ORT_RETURN_IF_NOT(external_data_length == 0 || external_data_length == tensor_byte_size,
                     "TensorProto: ", tensor_proto.name(),
@@ -869,6 +876,30 @@ DEFINE_4BIT_UNPACK_TENSOR_WITH_EXT_DATA_IMPL(UInt2x4, CalcNumInt2Quads)
 #if !defined(DISABLE_FLOAT4_TYPES)
 DEFINE_4BIT_UNPACK_TENSOR_WITH_EXT_DATA_IMPL(Float4E2M1x2, CalcNumFloat4Pairs)
 #endif
+
+template <typename FLOAT6_TYPE>
+Status UnpackFloat6TensorWithExternalData(const ONNX_NAMESPACE::TensorProto& tensor,
+                                          const std::filesystem::path& tensor_proto_dir,
+                                          size_t expected_num_elements, FLOAT6_TYPE* p_data) {
+  ORT_RETURN_IF(p_data == nullptr, "nullptr == p_data");
+  std::vector<uint8_t> packed_data;
+  ORT_RETURN_IF_ERROR(ReadExternalDataForTensor(tensor, tensor_proto_dir, packed_data));
+  return UnpackFloat6Tensor(tensor, packed_data.data(), packed_data.size(), p_data, expected_num_elements);
+}
+
+template <>
+Status UnpackTensorWithExternalData(const ONNX_NAMESPACE::TensorProto& tensor,
+                                    const std::filesystem::path& tensor_proto_dir,
+                                    size_t expected_num_elements, Float6E2M3* p_data) {
+  return UnpackFloat6TensorWithExternalData(tensor, tensor_proto_dir, expected_num_elements, p_data);
+}
+
+template <>
+Status UnpackTensorWithExternalData(const ONNX_NAMESPACE::TensorProto& tensor,
+                                    const std::filesystem::path& tensor_proto_dir,
+                                    size_t expected_num_elements, Float6E3M2* p_data) {
+  return UnpackFloat6TensorWithExternalData(tensor, tensor_proto_dir, expected_num_elements, p_data);
+}
 
 #define INSTANTIATE_UNPACK_EXTERNAL_TENSOR(type)                                                                 \
   template Status UnpackTensorWithExternalData(const ONNX_NAMESPACE::TensorProto&, const std::filesystem::path&, \

--- a/onnxruntime/core/framework/tensorprotoutils.cc
+++ b/onnxruntime/core/framework/tensorprotoutils.cc
@@ -2991,6 +2991,14 @@ Status UnpackInitializerData(const onnx::TensorProto& initializer,
         initializer,
         model_path.parent_path(),
         unpacked_tensor));
+    if (initializer.data_type() == ONNX_NAMESPACE::TensorProto_DataType_FLOAT6E2M3 ||
+        initializer.data_type() == ONNX_NAMESPACE::TensorProto_DataType_FLOAT6E3M2) {
+      ONNX_NAMESPACE::TensorProto packed_initializer = initializer;
+      packed_initializer.clear_external_data();
+      packed_initializer.set_data_location(ONNX_NAMESPACE::TensorProto_DataLocation_DEFAULT);
+      packed_initializer.set_raw_data(unpacked_tensor.data(), unpacked_tensor.size());
+      return UnpackInitializerData(packed_initializer, {}, unpacked_tensor);
+    }
     return Status::OK();
   }
 

--- a/onnxruntime/core/framework/utils.cc
+++ b/onnxruntime/core/framework/utils.cc
@@ -988,6 +988,10 @@ int32_t ONNXTensorElementDataTypeToProtoTensorType(ONNXTensorElementDataType onn
       return onnx::TensorProto_DataType::TensorProto_DataType_FLOAT16;
     case ONNX_TENSOR_ELEMENT_DATA_TYPE_BFLOAT16:
       return onnx::TensorProto_DataType::TensorProto_DataType_BFLOAT16;
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT6E2M3:
+      return onnx::TensorProto_DataType::TensorProto_DataType_FLOAT6E2M3;
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT6E3M2:
+      return onnx::TensorProto_DataType::TensorProto_DataType_FLOAT6E3M2;
     case ONNX_TENSOR_ELEMENT_DATA_TYPE_COMPLEX64:
       return onnx::TensorProto_DataType::TensorProto_DataType_COMPLEX64;
     case ONNX_TENSOR_ELEMENT_DATA_TYPE_COMPLEX128:

--- a/onnxruntime/core/framework/utils.h
+++ b/onnxruntime/core/framework/utils.h
@@ -231,6 +231,16 @@ constexpr ONNXTensorElementDataType GetONNXTensorElementDataType<Float8E8M0>() {
 #endif
 
 template <>
+constexpr ONNXTensorElementDataType GetONNXTensorElementDataType<Float6E2M3>() {
+  return ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT6E2M3;
+}
+
+template <>
+constexpr ONNXTensorElementDataType GetONNXTensorElementDataType<Float6E3M2>() {
+  return ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT6E3M2;
+}
+
+template <>
 constexpr ONNXTensorElementDataType GetONNXTensorElementDataType<Int4x2>() {
   return ONNX_TENSOR_ELEMENT_DATA_TYPE_INT4;
 }

--- a/onnxruntime/core/graph/graph_flatbuffers_utils.cc
+++ b/onnxruntime/core/graph/graph_flatbuffers_utils.cc
@@ -595,6 +595,7 @@ Status SaveOrtTensorOrtFormat(
   // To avoid issues with vtable offsets, raw_data fbs::vector must be constructed before the TensorBuilder begins
   // building the tensor. See flatbuffer_builder.h's NotNested() function for more details.
   flatbuffers::Offset<flatbuffers::Vector<uint8_t>> raw_data;
+  std::vector<uint8_t> packed_tensor_data;
 
   auto unpack_tensor_data_be = [&ort_tensor](std::vector<uint8_t>& unpacked_tensor_data) -> Status {
     unpacked_tensor_data.resize(ort_tensor.SizeInBytes());

--- a/onnxruntime/core/graph/graph_flatbuffers_utils.cc
+++ b/onnxruntime/core/graph/graph_flatbuffers_utils.cc
@@ -29,6 +29,31 @@ SaveDims(flatbuffers::FlatBufferBuilder& builder, const DimsFieldType& dims) {
 
 #if !defined(ORT_MINIMAL_BUILD)
 
+static std::vector<uint8_t> PackFloat6Data(gsl::span<const uint8_t> unpacked_data) {
+  std::vector<uint8_t> packed_data(unpacked_data.size() - unpacked_data.size() / 4, 0);
+  for (size_t i = 0; i < unpacked_data.size(); ++i) {
+    const uint8_t value = unpacked_data[i] & 0x3F;
+    uint8_t* group = packed_data.data() + (i / 4) * 3;
+    switch (i % 4) {
+      case 0:
+        group[0] |= value;
+        break;
+      case 1:
+        group[0] |= value << 6;
+        group[1] |= value >> 2;
+        break;
+      case 2:
+        group[1] |= value << 4;
+        group[2] |= value >> 4;
+        break;
+      default:
+        group[2] |= value << 2;
+        break;
+    }
+  }
+  return packed_data;
+}
+
 Status SaveInitializerOrtFormat(flatbuffers::FlatBufferBuilder& builder,
                                 const TensorProto& initializer,
                                 const std::filesystem::path& model_path,
@@ -66,6 +91,11 @@ Status SaveInitializerOrtFormat(flatbuffers::FlatBufferBuilder& builder,
             element_size,
             gsl::make_span(reinterpret_cast<std::byte*>(unpacked_tensor.data()), unpacked_tensor.size()));
       }
+    }
+
+    if (src_type == ONNX_NAMESPACE::TensorProto_DataType_FLOAT6E2M3 ||
+        src_type == ONNX_NAMESPACE::TensorProto_DataType_FLOAT6E3M2) {
+      unpacked_tensor = PackFloat6Data(unpacked_tensor);
     }
 
     if (external_writer && unpacked_tensor.size() >= kMinimumSizeForExternalData) {

--- a/onnxruntime/core/graph/graph_flatbuffers_utils.cc
+++ b/onnxruntime/core/graph/graph_flatbuffers_utils.cc
@@ -266,6 +266,10 @@ Status GetSizeInBytesFromFbsTensor(const fbs::Tensor& tensor, size_t& size_in_by
   size_t byte_size_of_one_element;
 
   switch (tensor.data_type()) {
+    case fbs::TensorDataType::FLOAT6E2M3:
+    case fbs::TensorDataType::FLOAT6E3M2:
+      size_in_bytes = num_elements - num_elements / 4;
+      return Status::OK();
     case fbs::TensorDataType::FLOAT:
       byte_size_of_one_element = sizeof(float);
       break;
@@ -382,7 +386,9 @@ Status LoadInitializerOrtFormat(const fbs::Tensor& fbs_tensor, TensorProto& init
           "'. Expected ", expected_num_bytes, " bytes but found ", fbs_raw_data->size(),
           ". Invalid ORT format model.");
 
-      if (load_options.can_use_flatbuffer_for_initializers && fbs_raw_data->size() > 127) {
+      if (load_options.can_use_flatbuffer_for_initializers && fbs_raw_data->size() > 127 &&
+          fbs_data_type != fbs::TensorDataType::FLOAT6E2M3 &&
+          fbs_data_type != fbs::TensorDataType::FLOAT6E3M2) {
         static_assert(sizeof(void*) <= sizeof(ExternalDataInfo::OFFSET_TYPE));
         const void* data_offset = fbs_raw_data->Data();
         // we reinterpret_cast this back to void* in tensorprotoutils.cc:GetExtDataFromTensorProto.

--- a/onnxruntime/core/graph/graph_flatbuffers_utils.cc
+++ b/onnxruntime/core/graph/graph_flatbuffers_utils.cc
@@ -67,6 +67,7 @@ Status SaveInitializerOrtFormat(flatbuffers::FlatBufferBuilder& builder,
   // issues.
   flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<flatbuffers::String>>> string_data;
   flatbuffers::Offset<flatbuffers::Vector<uint8_t>> raw_data;
+  std::vector<uint8_t> packed_tensor_data;
   int64_t external_data_offset = -1;
 
   auto src_type = initializer.data_type();
@@ -608,13 +609,27 @@ Status SaveOrtTensorOrtFormat(
     return onnxruntime::utils::WriteLittleEndian(element_size, src_span, dst_span);
   };
 
+  const bool is_float6 = ort_tensor.GetElementType() == ONNX_NAMESPACE::TensorProto_DataType_FLOAT6E2M3 ||
+                         ort_tensor.GetElementType() == ONNX_NAMESPACE::TensorProto_DataType_FLOAT6E3M2;
+  if (is_float6) {
+    packed_tensor_data = PackFloat6Data(gsl::make_span(
+        static_cast<const uint8_t*>(ort_tensor.DataRaw()), ort_tensor.SizeInBytes()));
+  }
+
   if (!external_data_writer) {
     if constexpr (endian::native != endian::little) {
       std::vector<uint8_t> unpacked_tensor;
 
       ORT_RETURN_IF_ERROR(unpack_tensor_data_be(unpacked_tensor));
 
-      raw_data = builder.CreateVector(unpacked_tensor.data(), unpacked_tensor.size());
+      if (is_float6) {
+        const auto packed_data = PackFloat6Data(unpacked_tensor);
+        raw_data = builder.CreateVector(packed_data.data(), packed_data.size());
+      } else {
+        raw_data = builder.CreateVector(unpacked_tensor.data(), unpacked_tensor.size());
+      }
+    } else if (is_float6) {
+      raw_data = builder.CreateVector(packed_tensor_data.data(), packed_tensor_data.size());
     } else {
       raw_data = builder.CreateVector(static_cast<const uint8_t*>(ort_tensor.DataRaw()),
                                       ort_tensor.SizeInBytes());
@@ -633,7 +648,11 @@ Status SaveOrtTensorOrtFormat(
 
       ORT_RETURN_IF_ERROR(unpack_tensor_data_be(unpacked_tensor));
 
-      gsl::span<const uint8_t> ort_tensor_data_span(static_cast<const uint8_t*>(unpacked_tensor.data()), unpacked_tensor.size());
+      const auto serialized_data = is_float6 ? PackFloat6Data(unpacked_tensor) : std::move(unpacked_tensor);
+      gsl::span<const uint8_t> ort_tensor_data_span(serialized_data.data(), serialized_data.size());
+      ORT_RETURN_IF_ERROR(external_data_writer(ort_tensor.GetElementType(), ort_tensor_data_span, offset));
+    } else if (is_float6) {
+      gsl::span<const uint8_t> ort_tensor_data_span(packed_tensor_data.data(), packed_tensor_data.size());
       ORT_RETURN_IF_ERROR(external_data_writer(ort_tensor.GetElementType(), ort_tensor_data_span, offset));
     } else {
       gsl::span<const uint8_t> ort_tensor_data_span(static_cast<const uint8_t*>(ort_tensor.DataRaw()), ort_tensor.SizeInBytes());
@@ -729,7 +748,7 @@ Status LoadOrtTensorOrtFormat(const fbs::Tensor& fbs_tensor, const AllocatorPtr 
   unused_tensor_proto.set_data_type(tensor_data_type);
 
   onnxruntime::utils::MLTypeCallDispatcher<float, bool, double, int8_t, uint8_t, int16_t, uint16_t,
-                                           int32_t, uint32_t, int64_t, uint64_t>
+                                           int32_t, uint32_t, int64_t, uint64_t, Float6E2M3, Float6E3M2>
       dispatcher(tensor_data_type);
   return dispatcher.InvokeRet<Status, UnpackTensorWithType>(unused_tensor_proto, fbs_tensor, ort_tensor, external_data_reader);
 }

--- a/onnxruntime/core/providers/cpu/quantization/quantize_linear.cc
+++ b/onnxruntime/core/providers/cpu/quantization/quantize_linear.cc
@@ -6,6 +6,7 @@
 #include "core/framework/element_type_lists.h"
 #include "core/common/float8.h"
 #include "core/common/float16.h"
+#include "core/framework/float6.h"
 #include "core/framework/int4.h"
 #include "core/framework/op_kernel.h"
 #include "core/providers/common.h"
@@ -119,13 +120,24 @@ static void PrepareForQDQ(const TensorShape& input_shape,
 }
 
 #define REGISTER_DEQUANTIZELINEAR(T)                                         \
-  ONNX_CPU_OPERATOR_TYPED_KERNEL(                                            \
+  ONNX_CPU_OPERATOR_VERSIONED_TYPED_KERNEL(                                  \
       DequantizeLinear,                                                      \
-      25,                                                                    \
+      25, 27,                                                                \
       T,                                                                     \
       KernelDefBuilder()                                                     \
           .TypeConstraint("T1", DataTypeImpl::GetTensorType<T>())            \
           .TypeConstraint("T2", {DataTypeImpl::GetTensorType<float>(),       \
+                                 DataTypeImpl::GetTensorType<MLFloat16>()}), \
+      DequantizeLinear<T>);
+
+#define REGISTER_DEQUANTIZELINEAR_28(T)                                     \
+  ONNX_CPU_OPERATOR_TYPED_KERNEL(                                           \
+      DequantizeLinear,                                                     \
+      28,                                                                   \
+      T,                                                                    \
+      KernelDefBuilder()                                                    \
+          .TypeConstraint("T1", DataTypeImpl::GetTensorType<T>())           \
+          .TypeConstraint("T2", {DataTypeImpl::GetTensorType<float>(),      \
                                  DataTypeImpl::GetTensorType<MLFloat16>()}), \
       DequantizeLinear<T>);
 
@@ -160,7 +172,7 @@ static void PrepareForQDQ(const TensorShape& input_shape,
           .TypeConstraint("T", DataTypeImpl::GetTensorType<T>()), \
       DequantizeLinear<T>);
 
-// Opset25
+// Opset 25-27
 REGISTER_DEQUANTIZELINEAR(int8_t)
 REGISTER_DEQUANTIZELINEAR(uint8_t)
 REGISTER_DEQUANTIZELINEAR(int16_t)
@@ -175,6 +187,25 @@ REGISTER_DEQUANTIZELINEAR(Float8E4M3FN)
 REGISTER_DEQUANTIZELINEAR(Float8E4M3FNUZ)
 REGISTER_DEQUANTIZELINEAR(Float8E5M2)
 REGISTER_DEQUANTIZELINEAR(Float8E5M2FNUZ)
+#endif
+
+// Opset 28 adds float6 quantization types.
+REGISTER_DEQUANTIZELINEAR_28(int8_t)
+REGISTER_DEQUANTIZELINEAR_28(uint8_t)
+REGISTER_DEQUANTIZELINEAR_28(int16_t)
+REGISTER_DEQUANTIZELINEAR_28(uint16_t)
+REGISTER_DEQUANTIZELINEAR_28(int32_t)
+REGISTER_DEQUANTIZELINEAR_28(Int4x2)
+REGISTER_DEQUANTIZELINEAR_28(UInt4x2)
+REGISTER_DEQUANTIZELINEAR_28(Int2x4)
+REGISTER_DEQUANTIZELINEAR_28(UInt2x4)
+REGISTER_DEQUANTIZELINEAR_28(Float6E2M3)
+REGISTER_DEQUANTIZELINEAR_28(Float6E3M2)
+#if !defined(DISABLE_FLOAT8_TYPES)
+REGISTER_DEQUANTIZELINEAR_28(Float8E4M3FN)
+REGISTER_DEQUANTIZELINEAR_28(Float8E4M3FNUZ)
+REGISTER_DEQUANTIZELINEAR_28(Float8E5M2)
+REGISTER_DEQUANTIZELINEAR_28(Float8E5M2FNUZ)
 #endif
 
 // opset24
@@ -536,6 +567,38 @@ DEQUANTIZE_LINEAR_APPLY_FLOAT8(Float8E5M2FNUZ)
 
 #endif
 
+#define DEQUANTIZE_LINEAR_APPLY_FLOAT6(T)                                                           \
+  template <typename OutT, int elements_per_byte>                                                   \
+  struct DequantizeLinearApply<T, OutT, false, elements_per_byte> {                                 \
+    void op(size_t M, size_t K, size_t N,                                                           \
+            const T* input, const OutT* scale, OutT* output, const T*, concurrency::ThreadPool*) { \
+      for (size_t m = 0; m < M; ++m) {                                                              \
+        for (size_t bd = 0; bd < K; ++bd) {                                                         \
+          const auto sc = scale[bd];                                                                \
+          for (size_t bs = 0; bs < N; ++bs, ++input) {                                              \
+            *output++ = static_cast<OutT>(static_cast<float>(*input) * sc);                        \
+          }                                                                                         \
+        }                                                                                           \
+      }                                                                                             \
+    }                                                                                               \
+    void op(size_t M, size_t K, size_t N, size_t quant_block_size,                                 \
+            const T* input, const OutT* scale, OutT* output, const T*, concurrency::ThreadPool*) { \
+      for (size_t m = 0; m < M; ++m) {                                                              \
+        for (size_t bd = 0; bd < K; bd += quant_block_size) {                                      \
+          for (size_t qb = 0, qb_end = std::min(quant_block_size, K - bd); qb < qb_end; ++qb) {    \
+            for (size_t bs = 0; bs < N; ++bs, ++input) {                                           \
+              *output++ = static_cast<OutT>(static_cast<float>(*input) * scale[bs]);               \
+            }                                                                                       \
+          }                                                                                         \
+          scale += N;                                                                               \
+        }                                                                                           \
+      }                                                                                             \
+    }                                                                                               \
+  };
+
+DEQUANTIZE_LINEAR_APPLY_FLOAT6(Float6E2M3)
+DEQUANTIZE_LINEAR_APPLY_FLOAT6(Float6E3M2)
+
 // formula is Y = (X - ZeroPoint) * Scale
 template <typename T>
 Status DequantizeLinear<T>::Compute(OpKernelContext* ctx) const {
@@ -564,6 +627,13 @@ Status DequantizeLinear<T>::Compute(OpKernelContext* ctx) const {
                 "DequantizeLinear with type float8 should have no zero point or all zero points should be 0");
   }
 #endif
+  if constexpr (std::is_same_v<T, Float6E2M3> || std::is_same_v<T, Float6E3M2>) {
+    ORT_ENFORCE(zero_point == nullptr ||
+                    std::all_of(zero_point,
+                                zero_point + x_zero_point->Shape().Size(),
+                                [](T zp) { return static_cast<float>(zp) == 0.0f; }),
+                "DequantizeLinear with type float6 should have no zero point or all zero points should be 0");
+  }
 
   const auto to = x_scale.GetElementType();
   const T* input = x.Data<T>();
@@ -614,9 +684,22 @@ Status DequantizeLinear<T>::Compute(OpKernelContext* ctx) const {
 }
 
 #define REGISTER_QUANTIZELINEAR(T)                                          \
+  ONNX_CPU_OPERATOR_VERSIONED_TYPED_KERNEL(                                 \
+      QuantizeLinear,                                                       \
+      25, 27,                                                               \
+      T,                                                                    \
+      KernelDefBuilder()                                                    \
+          .TypeConstraint("T1", {DataTypeImpl::GetTensorType<float>(),      \
+                                 DataTypeImpl::GetTensorType<MLFloat16>()}) \
+          .TypeConstraint("T2", {DataTypeImpl::GetTensorType<float>(),      \
+                                 DataTypeImpl::GetTensorType<MLFloat16>()}) \
+          .TypeConstraint("T3", DataTypeImpl::GetTensorType<T>()),          \
+      QuantizeLinear<T>);
+
+#define REGISTER_QUANTIZELINEAR_28(T)                                       \
   ONNX_CPU_OPERATOR_TYPED_KERNEL(                                           \
       QuantizeLinear,                                                       \
-      25,                                                                   \
+      28,                                                                   \
       T,                                                                    \
       KernelDefBuilder()                                                    \
           .TypeConstraint("T1", {DataTypeImpl::GetTensorType<float>(),      \
@@ -673,7 +756,7 @@ Status DequantizeLinear<T>::Compute(OpKernelContext* ctx) const {
           .TypeConstraint("T2", DataTypeImpl::GetTensorType<T>()),    \
       QuantizeLinear<T>);
 
-// Opset 25
+// Opset 25-27
 REGISTER_QUANTIZELINEAR(int8_t)
 REGISTER_QUANTIZELINEAR(uint8_t)
 REGISTER_QUANTIZELINEAR(int16_t)
@@ -687,6 +770,24 @@ REGISTER_QUANTIZELINEAR(Float8E4M3FN)
 REGISTER_QUANTIZELINEAR(Float8E4M3FNUZ)
 REGISTER_QUANTIZELINEAR(Float8E5M2)
 REGISTER_QUANTIZELINEAR(Float8E5M2FNUZ)
+#endif
+
+// Opset 28 adds float6 quantization types.
+REGISTER_QUANTIZELINEAR_28(int8_t)
+REGISTER_QUANTIZELINEAR_28(uint8_t)
+REGISTER_QUANTIZELINEAR_28(int16_t)
+REGISTER_QUANTIZELINEAR_28(uint16_t)
+REGISTER_QUANTIZELINEAR_28(Int4x2)
+REGISTER_QUANTIZELINEAR_28(UInt4x2)
+REGISTER_QUANTIZELINEAR_28(Int2x4)
+REGISTER_QUANTIZELINEAR_28(UInt2x4)
+REGISTER_QUANTIZELINEAR_28(Float6E2M3)
+REGISTER_QUANTIZELINEAR_28(Float6E3M2)
+#if !defined(DISABLE_FLOAT8_TYPES)
+REGISTER_QUANTIZELINEAR_28(Float8E4M3FN)
+REGISTER_QUANTIZELINEAR_28(Float8E4M3FNUZ)
+REGISTER_QUANTIZELINEAR_28(Float8E5M2)
+REGISTER_QUANTIZELINEAR_28(Float8E5M2FNUZ)
 #endif
 
 // Opset 24
@@ -815,19 +916,21 @@ void ParQuantizeLinear(const InputType* Input,
                        const OutputType* ZeroPoint,
                        bool saturate,
                        concurrency::ThreadPool* thread_pool) {
-#if !defined(DISABLE_FLOAT8_TYPES)
-  if constexpr (!boost::mp11::mp_contains<element_type_lists::AllFloat8, OutputType>::value) {
-#endif
+  if constexpr (!IsFloatQuantizationType<OutputType>) {
     ORT_UNUSED_PARAMETER(saturate);
     ParQuantizeLinearStd(Input, Output, N, Scale, ZeroPoint != nullptr ? ZeroPoint[bd] : (OutputType)0, thread_pool);
-#if !defined(DISABLE_FLOAT8_TYPES)
   } else {
+    const auto default_zero_point = []() {
+      if constexpr (std::is_same_v<OutputType, Float6E2M3> || std::is_same_v<OutputType, Float6E3M2>) {
+        return OutputType(0.0f);
+      } else {
+        return OutputType(static_cast<InputType>(0), true);
+      }
+    }();
     ParQuantizeLinearSat(Input, Output, N, Scale,
-                         ZeroPoint != nullptr ? ZeroPoint[bd]
-                                              : OutputType(static_cast<InputType>(static_cast<float>(0)), true),
+                         ZeroPoint != nullptr ? ZeroPoint[bd] : default_zero_point,
                          saturate, thread_pool);
   }
-#endif
 }
 
 /**
@@ -944,12 +1047,21 @@ Status QuantizeLinear<T>::Compute(OpKernelContext* ctx) const {
   const T* zero_point = y_zero_point != nullptr ? y_zero_point->Data<T>() : nullptr;
   T* output = y.MutableData<T>();
 
+  if constexpr (std::is_same_v<T, Float6E2M3> || std::is_same_v<T, Float6E3M2>) {
+    ORT_ENFORCE(zero_point == nullptr ||
+                    std::all_of(zero_point,
+                                zero_point + y_zero_point->Shape().Size(),
+                                [](T zp) { return static_cast<float>(zp) == 0.0f; }),
+                "QuantizeLinear with type float6 should have no zero point or all zero points should be 0");
+  }
+
   constexpr int output_type_group_ =
       boost::mp11::mp_contains<TypeList<Int4x2, UInt4x2>, T>::value   ? 2
       : boost::mp11::mp_contains<TypeList<Int2x4, UInt2x4>, T>::value ? 3
 #if !defined(DISABLE_FLOAT8_TYPES)
       : boost::mp11::mp_contains<element_type_lists::AllFloat8, T>::value ? 1
 #endif
+      : (std::is_same_v<T, Float6E2M3> || std::is_same_v<T, Float6E3M2>) ? 1
                                                                           : 0;
 
   if (x.IsDataType<float>()) {

--- a/onnxruntime/core/providers/cpu/quantization/quantize_linear.cc
+++ b/onnxruntime/core/providers/cpu/quantization/quantize_linear.cc
@@ -924,7 +924,7 @@ void ParQuantizeLinear(const InputType* Input,
       if constexpr (std::is_same_v<OutputType, Float6E2M3> || std::is_same_v<OutputType, Float6E3M2>) {
         return OutputType(0.0f);
       } else {
-        return OutputType(static_cast<InputType>(0), true);
+        return OutputType(0.0f, true);
       }
     }();
     ParQuantizeLinearSat(Input, Output, N, Scale,

--- a/onnxruntime/core/providers/cpu/tensor/cast_op.cc
+++ b/onnxruntime/core/providers/cpu/tensor/cast_op.cc
@@ -1016,8 +1016,10 @@ class Cast final : public OpKernel {
                           to != ONNX_NAMESPACE::TensorProto::FLOAT8E4M3FNUZ &&
                           to != ONNX_NAMESPACE::TensorProto::FLOAT8E5M2 &&
                           to != ONNX_NAMESPACE::TensorProto::FLOAT8E5M2FNUZ &&
-                          to != ONNX_NAMESPACE::TensorProto::FLOAT8E8M0)) {
-      ORT_THROW("Attribute saturate is only used for cast to float 8 types.");
+                          to != ONNX_NAMESPACE::TensorProto::FLOAT8E8M0 &&
+                          to != ONNX_NAMESPACE::TensorProto::FLOAT6E2M3 &&
+                          to != ONNX_NAMESPACE::TensorProto::FLOAT6E3M2)) {
+      ORT_THROW("Attribute saturate is only used for cast to low-precision floating-point types.");
     }
 #else
     if (saturate == 0) {
@@ -1172,6 +1174,10 @@ Status Cast::Compute(OpKernelContext* context) const {
     utils::MLTypeCallDispatcherFromTypeList<EnabledSrcTypes> dispatcher{from};
     dispatcher.Invoke<SrcDispatcher>(to_, *context, shape, *X, *Y);
 #if !defined(DISABLE_FLOAT8_TYPES)
+  } else if (to_ == ONNX_NAMESPACE::TensorProto::FLOAT6E2M3 ||
+             to_ == ONNX_NAMESPACE::TensorProto::FLOAT6E3M2) {
+    utils::MLTypeCallDispatcherFromTypeList<EnabledSrcTypes> dispatcher{from};
+    dispatcher.Invoke<SrcDispatcher>(to_, *context, shape, *X, *Y);
   } else if (to_ == ONNX_NAMESPACE::TensorProto::FLOAT8E4M3FN ||
              to_ == ONNX_NAMESPACE::TensorProto::FLOAT8E4M3FNUZ ||
              to_ == ONNX_NAMESPACE::TensorProto::FLOAT8E5M2 ||

--- a/onnxruntime/core/providers/cpu/tensor/cast_op.cc
+++ b/onnxruntime/core/providers/cpu/tensor/cast_op.cc
@@ -535,6 +535,24 @@ struct TensorCaster {
   }
 };
 
+// FP6 values are logical elements stored in byte-sized runtime storage. Route their
+// scalar conversions around Eigen, which cannot represent the custom FP6 formats.
+template <typename SrcType, typename DstType>
+struct TensorCaster<SrcType, DstType,
+                    std::enable_if_t<(IsOrtFloat6Type<SrcType>::value || IsOrtFloat6Type<DstType>::value) &&
+                                     !IsOrtInt4Type<SrcType>::value && !IsOrtInt4Type<DstType>::value &&
+                                     !IsOrtInt2Type<SrcType>::value && !IsOrtInt2Type<DstType>::value &&
+                                     !std::is_same_v<SrcType, std::string> && !std::is_same_v<DstType, std::string>>> {
+  void Cast(const OpKernelContext&, const TensorShape& shape, const Tensor& in, Tensor& out) const {
+    const std::ptrdiff_t shape_size = narrow<std::ptrdiff_t>(shape.Size());
+    const auto* in_data = in.Data<SrcType>();
+    auto* out_data = out.MutableData<DstType>();
+    for (std::ptrdiff_t i = 0; i < shape_size; ++i) {
+      out_data[i] = DstType(static_cast<float>(in_data[i]));
+    }
+  }
+};
+
 // tensor X -> string, if X != (U)Int4x2 and X != (U)Int2x4
 template <typename SrcType>
 struct TensorCaster<SrcType, std::string,

--- a/onnxruntime/core/providers/cpu/tensor/cast_op.cc
+++ b/onnxruntime/core/providers/cpu/tensor/cast_op.cc
@@ -402,7 +402,7 @@ template <typename SrcType, typename DstType>
 struct ToInt4Converter<SrcType, DstType,
                        std::enable_if_t<IsOrtFloat6Type<SrcType>::value && IsOrtInt4Type<DstType>::value>> {
   static typename DstType::UnpackedType Convert(const SrcType& val) {
-    return ToInt4Converter<float, DstType>::Convert(static_cast<float>(val));
+    return ToInt4Converter<int, DstType>::Convert(static_cast<int>(static_cast<float>(val)));
   }
 };
 
@@ -527,7 +527,7 @@ template <typename SrcType, typename DstType>
 struct ToInt2Converter<SrcType, DstType,
                        std::enable_if_t<IsOrtFloat6Type<SrcType>::value && IsOrtInt2Type<DstType>::value>> {
   static typename DstType::UnpackedType Convert(const SrcType& val) {
-    return ToInt2Converter<float, DstType>::Convert(static_cast<float>(val));
+    return ToInt2Converter<int, DstType>::Convert(static_cast<int>(static_cast<float>(val)));
   }
 };
 

--- a/onnxruntime/core/providers/cpu/tensor/cast_op.cc
+++ b/onnxruntime/core/providers/cpu/tensor/cast_op.cc
@@ -36,9 +36,7 @@ using AllIRv10WithInt2Base =
     boost::mp11::mp_push_back<
         element_type_lists::AllIRv10,
         UInt2x4,
-        Int2x4,
-        Float6E2M3,
-        Float6E3M2>;
+        Int2x4>;
 
 #if !defined(DISABLE_FLOAT8_TYPES)
 // Float8E8M0 was added in opset 24 (IR v12), so include it in the full type list
@@ -48,13 +46,16 @@ using AllIRv10WithInt2 =
 #else
 using AllIRv10WithInt2 = AllIRv10WithInt2Base;
 #endif
+
+using AllIRv10WithInt2AndFloat6 =
+    boost::mp11::mp_push_back<AllIRv10WithInt2, Float6E2M3, Float6E3M2>;
 }  // namespace
 
 namespace op_kernel_type_control {
-// Type list for all opsets of Cast (includes Float8E8M0 for runtime dispatch).
+// Type list for all opsets of Cast (includes Float8E8M0 and Float6 types for runtime dispatch).
 ORT_SPECIFY_OP_KERNEL_ARG_DEFAULT_TYPE_LIST_ALL_OPSETS(
     kCpuExecutionProvider, kOnnxDomain, Cast, Input, 0,
-    AllIRv10WithInt2);
+    AllIRv10WithInt2AndFloat6);
 
 ORT_SPECIFY_OP_KERNEL_ARG_REQUIRED_TYPES_ALL_OPSETS(
     kCpuExecutionProvider, kOnnxDomain, Cast, Input, 0,
@@ -62,7 +63,7 @@ ORT_SPECIFY_OP_KERNEL_ARG_REQUIRED_TYPES_ALL_OPSETS(
 
 ORT_SPECIFY_OP_KERNEL_ARG_DEFAULT_TYPE_LIST_ALL_OPSETS(
     kCpuExecutionProvider, kOnnxDomain, Cast, Output, 0,
-    AllIRv10WithInt2);
+    AllIRv10WithInt2AndFloat6);
 
 ORT_SPECIFY_OP_KERNEL_ARG_REQUIRED_TYPES_ALL_OPSETS(
     kCpuExecutionProvider, kOnnxDomain, Cast, Output, 0,
@@ -75,16 +76,23 @@ using EnabledSrcTypes = ORT_OP_KERNEL_ARG_ENABLED_TYPE_LIST_ALL_OPSETS(kCpuExecu
 using EnabledDstTypes = ORT_OP_KERNEL_ARG_ENABLED_TYPE_LIST_ALL_OPSETS(kCpuExecutionProvider, kOnnxDomain,
                                                                        Cast, Output, 0);
 
-// Pre-opset-24 type lists (without Float8E8M0) for kernel registration TypeConstraints.
-// Float8E8M0 was introduced in opset 24.
+// Pre-opset-24 type lists exclude types introduced after opset 23.
 #if !defined(DISABLE_FLOAT8_TYPES)
-using EnabledSrcTypesPreOpset24 = boost::mp11::mp_remove<EnabledSrcTypes, Float8E8M0>;
-using EnabledDstTypesPreOpset24 = boost::mp11::mp_remove<EnabledDstTypes, Float8E8M0>;
+using EnabledSrcTypesPreOpset24 =
+    boost::mp11::mp_remove<boost::mp11::mp_remove<EnabledSrcTypes, Float8E8M0>, Float6E2M3, Float6E3M2>;
+using EnabledDstTypesPreOpset24 =
+    boost::mp11::mp_remove<boost::mp11::mp_remove<EnabledDstTypes, Float8E8M0>, Float6E2M3, Float6E3M2>;
 #else
-// When float8 types are disabled, Float8E8M0 is not in the type lists, so no removal needed.
-using EnabledSrcTypesPreOpset24 = EnabledSrcTypes;
-using EnabledDstTypesPreOpset24 = EnabledDstTypes;
+using EnabledSrcTypesPreOpset24 =
+    boost::mp11::mp_remove<boost::mp11::mp_remove<EnabledSrcTypes, Float6E2M3>, Float6E3M2>;
+using EnabledDstTypesPreOpset24 =
+    boost::mp11::mp_remove<boost::mp11::mp_remove<EnabledDstTypes, Float6E2M3>, Float6E3M2>;
 #endif
+
+using EnabledSrcTypesPreOpset28 =
+    boost::mp11::mp_remove<boost::mp11::mp_remove<EnabledSrcTypes, Float6E2M3>, Float6E3M2>;
+using EnabledDstTypesPreOpset28 =
+    boost::mp11::mp_remove<boost::mp11::mp_remove<EnabledDstTypes, Float6E2M3>, Float6E3M2>;
 
 template <typename T>
 using IsOrtFloat16Type = boost::mp11::mp_contains<TypeList<BFloat16, MLFloat16>, T>;
@@ -1216,14 +1224,23 @@ ONNX_CPU_OPERATOR_VERSIONED_KERNEL(
     24,
     24,
     KernelDefBuilder()
-        .TypeConstraint("T1", BuildKernelDefConstraintsFromTypeList<EnabledSrcTypes>())
-        .TypeConstraint("T2", BuildKernelDefConstraintsFromTypeList<EnabledDstTypes>())
+        .TypeConstraint("T1", BuildKernelDefConstraintsFromTypeList<EnabledSrcTypesPreOpset28>())
+        .TypeConstraint("T2", BuildKernelDefConstraintsFromTypeList<EnabledDstTypesPreOpset28>())
+        .MayInplace(0, 0),  // allocation planner will check input and output sizes match before inplacing
+    Cast);
+
+ONNX_CPU_OPERATOR_VERSIONED_KERNEL(
+    Cast,
+    25, 27,
+    KernelDefBuilder()
+        .TypeConstraint("T1", BuildKernelDefConstraintsFromTypeList<EnabledSrcTypesPreOpset28>())
+        .TypeConstraint("T2", BuildKernelDefConstraintsFromTypeList<EnabledDstTypesPreOpset28>())
         .MayInplace(0, 0),  // allocation planner will check input and output sizes match before inplacing
     Cast);
 
 ONNX_CPU_OPERATOR_KERNEL(
     Cast,
-    25,
+    28,
     KernelDefBuilder()
         .TypeConstraint("T1", BuildKernelDefConstraintsFromTypeList<EnabledSrcTypes>())
         .TypeConstraint("T2", BuildKernelDefConstraintsFromTypeList<EnabledDstTypes>())

--- a/onnxruntime/core/providers/cpu/tensor/cast_op.cc
+++ b/onnxruntime/core/providers/cpu/tensor/cast_op.cc
@@ -36,7 +36,9 @@ using AllIRv10WithInt2Base =
     boost::mp11::mp_push_back<
         element_type_lists::AllIRv10,
         UInt2x4,
-        Int2x4>;
+        Int2x4,
+        Float6E2M3,
+        Float6E3M2>;
 
 #if !defined(DISABLE_FLOAT8_TYPES)
 // Float8E8M0 was added in opset 24 (IR v12), so include it in the full type list
@@ -94,6 +96,9 @@ using IsOrtFloat8Type = boost::mp11::mp_contains<element_type_lists::AllFloat8, 
 template <typename T>
 struct IsOrtFloat8Type : std::false_type {};
 #endif
+
+template <typename T>
+using IsOrtFloat6Type = boost::mp11::mp_contains<TypeList<Float6E2M3, Float6E3M2>, T>;
 
 template <typename T>
 using IsOrtInt4Type = boost::mp11::mp_contains<TypeList<Int4x2, UInt4x2>, T>;
@@ -202,7 +207,9 @@ CastToString(const SrcType& input, std::string& output) {
 }
 
 template <typename SrcType>
-typename std::enable_if<IsOrtFloat16Type<SrcType>::value || IsOrtFloat8Type<SrcType>::value, void>::type
+typename std::enable_if<IsOrtFloat16Type<SrcType>::value || IsOrtFloat8Type<SrcType>::value ||
+                            IsOrtFloat6Type<SrcType>::value,
+                        void>::type
 CastToString(const SrcType& input, std::string& output) {
   CastToString(static_cast<float>(input), output);
 }
@@ -232,7 +239,9 @@ CastFromString(const std::string& input, DstType& output) {
 }
 
 template <typename DstType>
-typename std::enable_if<IsOrtFloat16Type<DstType>::value || IsOrtFloat8Type<DstType>::value, void>::type
+typename std::enable_if<IsOrtFloat16Type<DstType>::value || IsOrtFloat8Type<DstType>::value ||
+                            IsOrtFloat6Type<DstType>::value,
+                        void>::type
 CastFromString(const std::string& input, DstType& output) {
   float intermediate;
   CastFromString(input, intermediate);

--- a/onnxruntime/core/providers/cpu/tensor/cast_op.cc
+++ b/onnxruntime/core/providers/cpu/tensor/cast_op.cc
@@ -639,6 +639,30 @@ struct TensorCaster<float, MLFloat16> {
   }
 };
 
+template <>
+struct TensorCaster<MLFloat16, Float6E2M3> {
+  void Cast(const OpKernelContext&, const TensorShape& shape, const Tensor& in, Tensor& out) const {
+    const std::ptrdiff_t shape_size = narrow<std::ptrdiff_t>(shape.Size());
+    const auto* in_data = in.Data<MLFloat16>();
+    auto* out_data = out.MutableData<Float6E2M3>();
+    for (std::ptrdiff_t i = 0; i < shape_size; ++i) {
+      out_data[i] = Float6E2M3(static_cast<float>(in_data[i]));
+    }
+  }
+};
+
+template <>
+struct TensorCaster<MLFloat16, Float6E3M2> {
+  void Cast(const OpKernelContext&, const TensorShape& shape, const Tensor& in, Tensor& out) const {
+    const std::ptrdiff_t shape_size = narrow<std::ptrdiff_t>(shape.Size());
+    const auto* in_data = in.Data<MLFloat16>();
+    auto* out_data = out.MutableData<Float6E3M2>();
+    for (std::ptrdiff_t i = 0; i < shape_size; ++i) {
+      out_data[i] = Float6E3M2(static_cast<float>(in_data[i]));
+    }
+  }
+};
+
 // (U)Int4x2 -> string or numeric types
 template <typename SrcType, typename DstType>
 struct TensorCaster<SrcType, DstType,

--- a/onnxruntime/core/providers/cpu/tensor/cast_op.cc
+++ b/onnxruntime/core/providers/cpu/tensor/cast_op.cc
@@ -134,7 +134,8 @@ struct IsOrtInt4NumericConversionType {
       IsStandardIntegerType<T>::value ||
       std::is_floating_point_v<T> ||
       IsOrtFloat16Type<T>::value ||
-      IsOrtFloat8Type<T>::value;
+      IsOrtFloat8Type<T>::value ||
+      IsOrtFloat6Type<T>::value;
 };
 
 template <typename T>
@@ -154,7 +155,8 @@ struct IsOrtInt2NumericConversionType {
       IsStandardIntegerType<T>::value ||
       std::is_floating_point_v<T> ||
       IsOrtFloat16Type<T>::value ||
-      IsOrtFloat8Type<T>::value;
+      IsOrtFloat8Type<T>::value ||
+      IsOrtFloat6Type<T>::value;
 };
 
 template <typename T>
@@ -287,6 +289,8 @@ struct FromInt4Converter {
       return DstType(static_cast<float>(val));
     } else if constexpr (IsOrtFloat8Type<DstType>::value) {
       return DstType(static_cast<float>(val), true);
+    } else if constexpr (IsOrtFloat6Type<DstType>::value) {
+      return DstType(static_cast<float>(val));
     } else if constexpr (std::is_same_v<bool, DstType>) {
       return val != 0;
     } else if constexpr (std::is_same_v<std::string, DstType>) {
@@ -394,6 +398,14 @@ struct ToInt4Converter<SrcType, DstType,
   }
 };
 
+template <typename SrcType, typename DstType>
+struct ToInt4Converter<SrcType, DstType,
+                       std::enable_if_t<IsOrtFloat6Type<SrcType>::value && IsOrtInt4Type<DstType>::value>> {
+  static typename DstType::UnpackedType Convert(const SrcType& val) {
+    return ToInt4Converter<float, DstType>::Convert(static_cast<float>(val));
+  }
+};
+
 // string -> (U)Int4x2
 template <typename DstType>
 struct ToInt4Converter<std::string, DstType,
@@ -415,6 +427,8 @@ struct FromInt2Converter {
       return DstType(static_cast<float>(val));
     } else if constexpr (IsOrtFloat8Type<DstType>::value) {
       return DstType(static_cast<float>(val), true);
+    } else if constexpr (IsOrtFloat6Type<DstType>::value) {
+      return DstType(static_cast<float>(val));
     } else if constexpr (std::is_same_v<bool, DstType>) {
       return val != 0;
     } else if constexpr (std::is_same_v<std::string, DstType>) {
@@ -506,6 +520,14 @@ struct ToInt2Converter<SrcType, DstType,
   static typename DstType::UnpackedType Convert(const SrcType& val) {
     float f_val = static_cast<float>(val);
     return ToInt2Converter<float, DstType>::Convert(f_val);
+  }
+};
+
+template <typename SrcType, typename DstType>
+struct ToInt2Converter<SrcType, DstType,
+                       std::enable_if_t<IsOrtFloat6Type<SrcType>::value && IsOrtInt2Type<DstType>::value>> {
+  static typename DstType::UnpackedType Convert(const SrcType& val) {
+    return ToInt2Converter<float, DstType>::Convert(static_cast<float>(val));
   }
 };
 

--- a/onnxruntime/core/providers/cpu/tensor/cast_op.cc
+++ b/onnxruntime/core/providers/cpu/tensor/cast_op.cc
@@ -79,9 +79,11 @@ using EnabledDstTypes = ORT_OP_KERNEL_ARG_ENABLED_TYPE_LIST_ALL_OPSETS(kCpuExecu
 // Pre-opset-24 type lists exclude types introduced after opset 23.
 #if !defined(DISABLE_FLOAT8_TYPES)
 using EnabledSrcTypesPreOpset24 =
-    boost::mp11::mp_remove<boost::mp11::mp_remove<EnabledSrcTypes, Float8E8M0>, Float6E2M3, Float6E3M2>;
+    boost::mp11::mp_remove<boost::mp11::mp_remove<boost::mp11::mp_remove<EnabledSrcTypes, Float8E8M0>, Float6E2M3>,
+                           Float6E3M2>;
 using EnabledDstTypesPreOpset24 =
-    boost::mp11::mp_remove<boost::mp11::mp_remove<EnabledDstTypes, Float8E8M0>, Float6E2M3, Float6E3M2>;
+    boost::mp11::mp_remove<boost::mp11::mp_remove<boost::mp11::mp_remove<EnabledDstTypes, Float8E8M0>, Float6E2M3>,
+                           Float6E3M2>;
 #else
 using EnabledSrcTypesPreOpset24 =
     boost::mp11::mp_remove<boost::mp11::mp_remove<EnabledSrcTypes, Float6E2M3>, Float6E3M2>;

--- a/onnxruntime/core/providers/cpu/tensor/cast_op.cc
+++ b/onnxruntime/core/providers/cpu/tensor/cast_op.cc
@@ -562,6 +562,8 @@ struct TensorCaster {
 template <typename SrcType, typename DstType>
 struct TensorCaster<SrcType, DstType,
                     std::enable_if_t<(IsOrtFloat6Type<SrcType>::value || IsOrtFloat6Type<DstType>::value) &&
+                                     !std::is_same_v<SrcType, MLFloat16> &&
+                                     !std::is_same_v<DstType, MLFloat16> &&
                                      !IsOrtInt4Type<SrcType>::value && !IsOrtInt4Type<DstType>::value &&
                                      !IsOrtInt2Type<SrcType>::value && !IsOrtInt2Type<DstType>::value &&
                                      !std::is_same_v<SrcType, std::string> && !std::is_same_v<DstType, std::string>>> {
@@ -571,6 +573,18 @@ struct TensorCaster<SrcType, DstType,
     auto* out_data = out.MutableData<DstType>();
     for (std::ptrdiff_t i = 0; i < shape_size; ++i) {
       out_data[i] = DstType(static_cast<float>(in_data[i]));
+    }
+  }
+};
+
+template <typename SrcType>
+struct TensorCaster<SrcType, MLFloat16, std::enable_if_t<IsOrtFloat6Type<SrcType>::value>> {
+  void Cast(const OpKernelContext&, const TensorShape& shape, const Tensor& in, Tensor& out) const {
+    const std::ptrdiff_t shape_size = narrow<std::ptrdiff_t>(shape.Size());
+    const auto* in_data = in.Data<SrcType>();
+    auto* out_data = out.MutableData<MLFloat16>();
+    for (std::ptrdiff_t i = 0; i < shape_size; ++i) {
+      out_data[i] = MLFloat16(static_cast<float>(in_data[i]));
     }
   }
 };
@@ -1044,8 +1058,9 @@ class Cast final : public OpKernel {
       ORT_THROW("Attribute saturate is only used for cast to low-precision floating-point types.");
     }
 #else
-    if (saturate == 0) {
-      ORT_THROW("Attribute saturate is only used for cast to float 8 types.");
+    if (saturate == 0 && to != ONNX_NAMESPACE::TensorProto::FLOAT6E2M3 &&
+        to != ONNX_NAMESPACE::TensorProto::FLOAT6E3M2) {
+      ORT_THROW("Attribute saturate is only used for cast to low-precision floating-point types.");
     }
 #endif
     saturate_ = saturate == 1;

--- a/onnxruntime/core/providers/shared_library/provider_api.h
+++ b/onnxruntime/core/providers/shared_library/provider_api.h
@@ -41,6 +41,7 @@
 #include "core/framework/allocator.h"
 #include "core/common/float8.h"
 #include "core/common/float16.h"
+#include "core/framework/float6.h"
 #include "core/framework/int4.h"
 #include "core/framework/int2.h"
 #include "core/framework/float4.h"
@@ -95,6 +96,8 @@ enum TensorProto_DataType : int {
   TensorProto_DataType_FLOAT8E8M0 = 24,
   TensorProto_DataType_UINT2 = 25,
   TensorProto_DataType_INT2 = 26,
+  TensorProto_DataType_FLOAT6E2M3 = 27,
+  TensorProto_DataType_FLOAT6E3M2 = 28,
 };
 
 enum TensorProto_DataLocation : int {
@@ -412,6 +415,11 @@ constexpr ONNXTensorElementDataType GetONNXTensorElementDataType<Float8E5M2FNUZ>
 template <>
 constexpr ONNXTensorElementDataType GetONNXTensorElementDataType<Float4E2M1x2>() { return ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT4E2M1; }
 #endif
+
+template <>
+constexpr ONNXTensorElementDataType GetONNXTensorElementDataType<Float6E2M3>() { return ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT6E2M3; }
+template <>
+constexpr ONNXTensorElementDataType GetONNXTensorElementDataType<Float6E3M2>() { return ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT6E3M2; }
 
 template <>
 constexpr ONNXTensorElementDataType GetONNXTensorElementDataType<Int4x2>() {

--- a/onnxruntime/core/providers/shared_library/provider_bridge_provider.cc
+++ b/onnxruntime/core/providers/shared_library/provider_bridge_provider.cc
@@ -279,14 +279,6 @@ template <>
 MLDataType DataTypeImpl::GetSparseTensorType<BFloat16>() { return Provider_GetHost()->DataTypeImpl__GetSparseTensorType_BFloat16(); }
 template <>
 MLDataType DataTypeImpl::GetSparseTensorType<MLFloat16>() { return Provider_GetHost()->DataTypeImpl__GetSparseTensorType_MLFloat16(); }
-template <>
-MLDataType DataTypeImpl::GetSparseTensorType<Float6E2M3>() {
-  return Provider_GetHost()->DataTypeImpl__GetSparseTensorType_Float6E2M3();
-}
-template <>
-MLDataType DataTypeImpl::GetSparseTensorType<Float6E3M2>() {
-  return Provider_GetHost()->DataTypeImpl__GetSparseTensorType_Float6E3M2();
-}
 
 #if !defined(DISABLE_FLOAT8_TYPES)
 template <>

--- a/onnxruntime/core/providers/shared_library/provider_bridge_provider.cc
+++ b/onnxruntime/core/providers/shared_library/provider_bridge_provider.cc
@@ -185,6 +185,10 @@ MLDataType DataTypeImpl::GetType<UInt2x4>() { return Provider_GetHost()->DataTyp
 template <>
 MLDataType DataTypeImpl::GetType<Float4E2M1x2>() { return Provider_GetHost()->DataTypeImpl__GetType_Float4E2M1x2(); }
 #endif
+template <>
+MLDataType DataTypeImpl::GetType<Float6E2M3>() { return Provider_GetHost()->DataTypeImpl__GetType_Float6E2M3(); }
+template <>
+MLDataType DataTypeImpl::GetType<Float6E3M2>() { return Provider_GetHost()->DataTypeImpl__GetType_Float6E3M2(); }
 
 template <>
 MLDataType DataTypeImpl::GetType<std::string>() { return Provider_GetHost()->DataTypeImpl__GetType_string(); }
@@ -241,6 +245,10 @@ MLDataType DataTypeImpl::GetTensorType<UInt2x4>() { return Provider_GetHost()->D
 template <>
 MLDataType DataTypeImpl::GetTensorType<Float4E2M1x2>() { return Provider_GetHost()->DataTypeImpl__GetTensorType_Float4E2M1x2(); }
 #endif
+template <>
+MLDataType DataTypeImpl::GetTensorType<Float6E2M3>() { return Provider_GetHost()->DataTypeImpl__GetTensorType_Float6E2M3(); }
+template <>
+MLDataType DataTypeImpl::GetTensorType<Float6E3M2>() { return Provider_GetHost()->DataTypeImpl__GetTensorType_Float6E3M2(); }
 
 #if !defined(DISABLE_SPARSE_TENSORS)
 template <>
@@ -271,6 +279,14 @@ template <>
 MLDataType DataTypeImpl::GetSparseTensorType<BFloat16>() { return Provider_GetHost()->DataTypeImpl__GetSparseTensorType_BFloat16(); }
 template <>
 MLDataType DataTypeImpl::GetSparseTensorType<MLFloat16>() { return Provider_GetHost()->DataTypeImpl__GetSparseTensorType_MLFloat16(); }
+template <>
+MLDataType DataTypeImpl::GetSparseTensorType<Float6E2M3>() {
+  return Provider_GetHost()->DataTypeImpl__GetSparseTensorType_Float6E2M3();
+}
+template <>
+MLDataType DataTypeImpl::GetSparseTensorType<Float6E3M2>() {
+  return Provider_GetHost()->DataTypeImpl__GetSparseTensorType_Float6E3M2();
+}
 
 #if !defined(DISABLE_FLOAT8_TYPES)
 template <>

--- a/onnxruntime/core/providers/shared_library/provider_interfaces.h
+++ b/onnxruntime/core/providers/shared_library/provider_interfaces.h
@@ -773,8 +773,6 @@ struct ProviderHost {
 #if !defined(DISABLE_FLOAT4_TYPES)
   virtual MLDataType DataTypeImpl__GetType_Float4E2M1x2() = 0;
 #endif
-  virtual MLDataType DataTypeImpl__GetType_Float6E2M3() = 0;
-  virtual MLDataType DataTypeImpl__GetType_Float6E3M2() = 0;
   virtual MLDataType DataTypeImpl__GetType_Int4x2() = 0;
   virtual MLDataType DataTypeImpl__GetType_UInt4x2() = 0;
   virtual MLDataType DataTypeImpl__GetType_Int2x4() = 0;
@@ -803,8 +801,6 @@ struct ProviderHost {
 #if !defined(DISABLE_FLOAT4_TYPES)
   virtual MLDataType DataTypeImpl__GetTensorType_Float4E2M1x2() = 0;
 #endif
-  virtual MLDataType DataTypeImpl__GetTensorType_Float6E2M3() = 0;
-  virtual MLDataType DataTypeImpl__GetTensorType_Float6E3M2() = 0;
 
   virtual MLDataType DataTypeImpl__GetTensorType_Int4x2() = 0;
   virtual MLDataType DataTypeImpl__GetTensorType_UInt4x2() = 0;
@@ -1268,8 +1264,6 @@ struct ProviderHost {
 #if !defined(DISABLE_FLOAT4_TYPES)
   virtual Float4E2M1x2* Tensor__MutableData_Float4E2M1x2(Tensor* p) = 0;
 #endif
-  virtual Float6E2M3* Tensor__MutableData_Float6E2M3(Tensor* p) = 0;
-  virtual Float6E3M2* Tensor__MutableData_Float6E3M2(Tensor* p) = 0;
   virtual Int4x2* Tensor__MutableData_Int4x2(Tensor* p) = 0;
   virtual UInt4x2* Tensor__MutableData_UInt4x2(Tensor* p) = 0;
   virtual Int2x4* Tensor__MutableData_Int2x4(Tensor* p) = 0;
@@ -1298,8 +1292,6 @@ struct ProviderHost {
 #if !defined(DISABLE_FLOAT4_TYPES)
   virtual const Float4E2M1x2* Tensor__Data_Float4E2M1x2(const Tensor* p) = 0;
 #endif
-  virtual const Float6E2M3* Tensor__Data_Float6E2M3(const Tensor* p) = 0;
-  virtual const Float6E3M2* Tensor__Data_Float6E3M2(const Tensor* p) = 0;
   virtual const Int4x2* Tensor__Data_Int4x2(const Tensor* p) = 0;
   virtual const UInt4x2* Tensor__Data_UInt4x2(const Tensor* p) = 0;
   virtual const Int2x4* Tensor__Data_Int2x4(const Tensor* p) = 0;
@@ -1339,8 +1331,6 @@ struct ProviderHost {
 #if !defined(DISABLE_FLOAT4_TYPES)
   virtual bool Tensor__IsDataType_Float4E2M1x2(const Tensor* p) noexcept = 0;
 #endif
-  virtual bool Tensor__IsDataType_Float6E2M3(const Tensor* p) noexcept = 0;
-  virtual bool Tensor__IsDataType_Float6E3M2(const Tensor* p) noexcept = 0;
   virtual bool Tensor__IsDataType_Int4x2(const Tensor* p) noexcept = 0;
   virtual bool Tensor__IsDataType_UInt4x2(const Tensor* p) noexcept = 0;
   virtual bool Tensor__IsDataType_Int2x4(const Tensor* p) noexcept = 0;
@@ -1432,6 +1422,22 @@ struct ProviderHost {
   virtual const Float8E8M0* Tensor__Data_Float8E8M0(const Tensor* p) = 0;
   virtual bool Tensor__IsDataType_Float8E8M0(const Tensor* p) noexcept = 0;
 #endif
+
+  // Float6 support — appended at end to preserve vtable ABI compatibility.
+  virtual MLDataType DataTypeImpl__GetType_Float6E2M3() = 0;
+  virtual MLDataType DataTypeImpl__GetType_Float6E3M2() = 0;
+  virtual MLDataType DataTypeImpl__GetTensorType_Float6E2M3() = 0;
+  virtual MLDataType DataTypeImpl__GetTensorType_Float6E3M2() = 0;
+#if !defined(DISABLE_SPARSE_TENSORS)
+  virtual MLDataType DataTypeImpl__GetSparseTensorType_Float6E2M3() = 0;
+  virtual MLDataType DataTypeImpl__GetSparseTensorType_Float6E3M2() = 0;
+#endif
+  virtual Float6E2M3* Tensor__MutableData_Float6E2M3(Tensor* p) = 0;
+  virtual Float6E3M2* Tensor__MutableData_Float6E3M2(Tensor* p) = 0;
+  virtual const Float6E2M3* Tensor__Data_Float6E2M3(const Tensor* p) = 0;
+  virtual const Float6E3M2* Tensor__Data_Float6E3M2(const Tensor* p) = 0;
+  virtual bool Tensor__IsDataType_Float6E2M3(const Tensor* p) noexcept = 0;
+  virtual bool Tensor__IsDataType_Float6E3M2(const Tensor* p) noexcept = 0;
 };
 
 #if defined(_MSC_VER) && !defined(__clang__)

--- a/onnxruntime/core/providers/shared_library/provider_interfaces.h
+++ b/onnxruntime/core/providers/shared_library/provider_interfaces.h
@@ -773,6 +773,8 @@ struct ProviderHost {
 #if !defined(DISABLE_FLOAT4_TYPES)
   virtual MLDataType DataTypeImpl__GetType_Float4E2M1x2() = 0;
 #endif
+  virtual MLDataType DataTypeImpl__GetType_Float6E2M3() = 0;
+  virtual MLDataType DataTypeImpl__GetType_Float6E3M2() = 0;
   virtual MLDataType DataTypeImpl__GetType_Int4x2() = 0;
   virtual MLDataType DataTypeImpl__GetType_UInt4x2() = 0;
   virtual MLDataType DataTypeImpl__GetType_Int2x4() = 0;
@@ -801,6 +803,8 @@ struct ProviderHost {
 #if !defined(DISABLE_FLOAT4_TYPES)
   virtual MLDataType DataTypeImpl__GetTensorType_Float4E2M1x2() = 0;
 #endif
+  virtual MLDataType DataTypeImpl__GetTensorType_Float6E2M3() = 0;
+  virtual MLDataType DataTypeImpl__GetTensorType_Float6E3M2() = 0;
 
   virtual MLDataType DataTypeImpl__GetTensorType_Int4x2() = 0;
   virtual MLDataType DataTypeImpl__GetTensorType_UInt4x2() = 0;
@@ -1264,6 +1268,8 @@ struct ProviderHost {
 #if !defined(DISABLE_FLOAT4_TYPES)
   virtual Float4E2M1x2* Tensor__MutableData_Float4E2M1x2(Tensor* p) = 0;
 #endif
+  virtual Float6E2M3* Tensor__MutableData_Float6E2M3(Tensor* p) = 0;
+  virtual Float6E3M2* Tensor__MutableData_Float6E3M2(Tensor* p) = 0;
   virtual Int4x2* Tensor__MutableData_Int4x2(Tensor* p) = 0;
   virtual UInt4x2* Tensor__MutableData_UInt4x2(Tensor* p) = 0;
   virtual Int2x4* Tensor__MutableData_Int2x4(Tensor* p) = 0;
@@ -1292,6 +1298,8 @@ struct ProviderHost {
 #if !defined(DISABLE_FLOAT4_TYPES)
   virtual const Float4E2M1x2* Tensor__Data_Float4E2M1x2(const Tensor* p) = 0;
 #endif
+  virtual const Float6E2M3* Tensor__Data_Float6E2M3(const Tensor* p) = 0;
+  virtual const Float6E3M2* Tensor__Data_Float6E3M2(const Tensor* p) = 0;
   virtual const Int4x2* Tensor__Data_Int4x2(const Tensor* p) = 0;
   virtual const UInt4x2* Tensor__Data_UInt4x2(const Tensor* p) = 0;
   virtual const Int2x4* Tensor__Data_Int2x4(const Tensor* p) = 0;
@@ -1331,6 +1339,8 @@ struct ProviderHost {
 #if !defined(DISABLE_FLOAT4_TYPES)
   virtual bool Tensor__IsDataType_Float4E2M1x2(const Tensor* p) noexcept = 0;
 #endif
+  virtual bool Tensor__IsDataType_Float6E2M3(const Tensor* p) noexcept = 0;
+  virtual bool Tensor__IsDataType_Float6E3M2(const Tensor* p) noexcept = 0;
   virtual bool Tensor__IsDataType_Int4x2(const Tensor* p) noexcept = 0;
   virtual bool Tensor__IsDataType_UInt4x2(const Tensor* p) noexcept = 0;
   virtual bool Tensor__IsDataType_Int2x4(const Tensor* p) noexcept = 0;

--- a/onnxruntime/core/providers/shared_library/provider_interfaces.h
+++ b/onnxruntime/core/providers/shared_library/provider_interfaces.h
@@ -1428,10 +1428,6 @@ struct ProviderHost {
   virtual MLDataType DataTypeImpl__GetType_Float6E3M2() = 0;
   virtual MLDataType DataTypeImpl__GetTensorType_Float6E2M3() = 0;
   virtual MLDataType DataTypeImpl__GetTensorType_Float6E3M2() = 0;
-#if !defined(DISABLE_SPARSE_TENSORS)
-  virtual MLDataType DataTypeImpl__GetSparseTensorType_Float6E2M3() = 0;
-  virtual MLDataType DataTypeImpl__GetSparseTensorType_Float6E3M2() = 0;
-#endif
   virtual Float6E2M3* Tensor__MutableData_Float6E2M3(Tensor* p) = 0;
   virtual Float6E3M2* Tensor__MutableData_Float6E3M2(Tensor* p) = 0;
   virtual const Float6E2M3* Tensor__Data_Float6E2M3(const Tensor* p) = 0;

--- a/onnxruntime/core/providers/shared_library/provider_wrappedtypes.h
+++ b/onnxruntime/core/providers/shared_library/provider_wrappedtypes.h
@@ -1569,6 +1569,10 @@ inline bool Tensor::IsDataType<Float8E8M0>() const { return g_host->Tensor__IsDa
 template <>
 inline bool Tensor::IsDataType<Float4E2M1x2>() const { return g_host->Tensor__IsDataType_Float4E2M1x2(this); }
 #endif
+template <>
+inline bool Tensor::IsDataType<Float6E2M3>() const { return g_host->Tensor__IsDataType_Float6E2M3(this); }
+template <>
+inline bool Tensor::IsDataType<Float6E3M2>() const { return g_host->Tensor__IsDataType_Float6E3M2(this); }
 
 template <>
 inline bool* Tensor::MutableData<bool>() { return g_host->Tensor__MutableData_bool(this); }
@@ -1622,6 +1626,10 @@ inline Float8E8M0* Tensor::MutableData<Float8E8M0>() { return g_host->Tensor__Mu
 template <>
 inline Float4E2M1x2* Tensor::MutableData<Float4E2M1x2>() { return g_host->Tensor__MutableData_Float4E2M1x2(this); }
 #endif
+template <>
+inline Float6E2M3* Tensor::MutableData<Float6E2M3>() { return g_host->Tensor__MutableData_Float6E2M3(this); }
+template <>
+inline Float6E3M2* Tensor::MutableData<Float6E3M2>() { return g_host->Tensor__MutableData_Float6E3M2(this); }
 
 template <>
 inline const bool* Tensor::Data<bool>() const { return g_host->Tensor__Data_bool(this); }
@@ -1633,6 +1641,10 @@ template <>
 inline const Int2x4* Tensor::Data<Int2x4>() const { return g_host->Tensor__Data_Int2x4(this); }
 template <>
 inline const UInt2x4* Tensor::Data<UInt2x4>() const { return g_host->Tensor__Data_UInt2x4(this); }
+template <>
+inline const Float6E2M3* Tensor::Data<Float6E2M3>() const { return g_host->Tensor__Data_Float6E2M3(this); }
+template <>
+inline const Float6E3M2* Tensor::Data<Float6E3M2>() const { return g_host->Tensor__Data_Float6E3M2(this); }
 template <>
 inline const int8_t* Tensor::Data<int8_t>() const { return g_host->Tensor__Data_int8(this); }
 template <>

--- a/onnxruntime/core/session/provider_bridge_ort.cc
+++ b/onnxruntime/core/session/provider_bridge_ort.cc
@@ -1008,6 +1008,8 @@ struct ProviderHostImpl : ProviderHost {
 #if !defined(DISABLE_FLOAT4_TYPES)
   MLDataType DataTypeImpl__GetType_Float4E2M1x2() override { return DataTypeImpl::GetType<Float4E2M1x2>(); }
 #endif
+  MLDataType DataTypeImpl__GetType_Float6E2M3() override { return DataTypeImpl::GetType<Float6E2M3>(); }
+  MLDataType DataTypeImpl__GetType_Float6E3M2() override { return DataTypeImpl::GetType<Float6E3M2>(); }
 
   MLDataType DataTypeImpl__GetType_Int4x2() override { return DataTypeImpl::GetType<Int4x2>(); }
   MLDataType DataTypeImpl__GetType_UInt4x2() override { return DataTypeImpl::GetType<UInt4x2>(); }
@@ -1039,6 +1041,8 @@ struct ProviderHostImpl : ProviderHost {
 #if !defined(DISABLE_FLOAT4_TYPES)
   MLDataType DataTypeImpl__GetTensorType_Float4E2M1x2() override { return DataTypeImpl::GetTensorType<Float4E2M1x2>(); }
 #endif
+  MLDataType DataTypeImpl__GetTensorType_Float6E2M3() override { return DataTypeImpl::GetTensorType<Float6E2M3>(); }
+  MLDataType DataTypeImpl__GetTensorType_Float6E3M2() override { return DataTypeImpl::GetTensorType<Float6E3M2>(); }
 
   MLDataType DataTypeImpl__GetTensorType_Int4x2() override { return DataTypeImpl::GetTensorType<Int4x2>(); }
   MLDataType DataTypeImpl__GetTensorType_UInt4x2() override { return DataTypeImpl::GetTensorType<UInt4x2>(); }
@@ -1695,6 +1699,8 @@ struct ProviderHostImpl : ProviderHost {
 #if !defined(DISABLE_FLOAT4_TYPES)
   Float4E2M1x2* Tensor__MutableData_Float4E2M1x2(Tensor* p) override { return p->MutableData<Float4E2M1x2>(); }
 #endif
+  Float6E2M3* Tensor__MutableData_Float6E2M3(Tensor* p) override { return p->MutableData<Float6E2M3>(); }
+  Float6E3M2* Tensor__MutableData_Float6E3M2(Tensor* p) override { return p->MutableData<Float6E3M2>(); }
 
   Int4x2* Tensor__MutableData_Int4x2(Tensor* p) override { return p->MutableData<Int4x2>(); }
   UInt4x2* Tensor__MutableData_UInt4x2(Tensor* p) override { return p->MutableData<UInt4x2>(); }
@@ -1725,6 +1731,8 @@ struct ProviderHostImpl : ProviderHost {
 #if !defined(DISABLE_FLOAT4_TYPES)
   const Float4E2M1x2* Tensor__Data_Float4E2M1x2(const Tensor* p) override { return p->Data<Float4E2M1x2>(); }
 #endif
+  const Float6E2M3* Tensor__Data_Float6E2M3(const Tensor* p) override { return p->Data<Float6E2M3>(); }
+  const Float6E3M2* Tensor__Data_Float6E3M2(const Tensor* p) override { return p->Data<Float6E3M2>(); }
 
   const Int4x2* Tensor__Data_Int4x2(const Tensor* p) override { return p->Data<Int4x2>(); }
   const UInt4x2* Tensor__Data_UInt4x2(const Tensor* p) override { return p->Data<UInt4x2>(); }
@@ -1764,6 +1772,8 @@ struct ProviderHostImpl : ProviderHost {
 #if !defined(DISABLE_FLOAT4_TYPES)
   bool Tensor__IsDataType_Float4E2M1x2(const Tensor* p) noexcept override { return p->IsDataType<Float4E2M1x2>(); }
 #endif
+  bool Tensor__IsDataType_Float6E2M3(const Tensor* p) noexcept override { return p->IsDataType<Float6E2M3>(); }
+  bool Tensor__IsDataType_Float6E3M2(const Tensor* p) noexcept override { return p->IsDataType<Float6E3M2>(); }
 
   bool Tensor__IsDataType_Int4x2(const Tensor* p) noexcept override { return p->IsDataType<Int4x2>(); }
   bool Tensor__IsDataType_UInt4x2(const Tensor* p) noexcept override { return p->IsDataType<UInt4x2>(); }

--- a/onnxruntime/core/session/provider_bridge_ort.cc
+++ b/onnxruntime/core/session/provider_bridge_ort.cc
@@ -1064,8 +1064,6 @@ struct ProviderHostImpl : ProviderHost {
   MLDataType DataTypeImpl__GetSparseTensorType_string() override { return DataTypeImpl::GetSparseTensorType<std::string>(); }
   MLDataType DataTypeImpl__GetSparseTensorType_BFloat16() override { return DataTypeImpl::GetSparseTensorType<BFloat16>(); }
   MLDataType DataTypeImpl__GetSparseTensorType_MLFloat16() override { return DataTypeImpl::GetSparseTensorType<MLFloat16>(); }
-  MLDataType DataTypeImpl__GetSparseTensorType_Float6E2M3() override { return DataTypeImpl::GetSparseTensorType<Float6E2M3>(); }
-  MLDataType DataTypeImpl__GetSparseTensorType_Float6E3M2() override { return DataTypeImpl::GetSparseTensorType<Float6E3M2>(); }
 #if !defined(DISABLE_FLOAT8_TYPES)
   MLDataType DataTypeImpl__GetSparseTensorType_Float8E4M3FN() override { return DataTypeImpl::GetSparseTensorType<Float8E4M3FN>(); }
   MLDataType DataTypeImpl__GetSparseTensorType_Float8E4M3FNUZ() override { return DataTypeImpl::GetSparseTensorType<Float8E4M3FNUZ>(); }

--- a/onnxruntime/core/session/provider_bridge_ort.cc
+++ b/onnxruntime/core/session/provider_bridge_ort.cc
@@ -1064,7 +1064,8 @@ struct ProviderHostImpl : ProviderHost {
   MLDataType DataTypeImpl__GetSparseTensorType_string() override { return DataTypeImpl::GetSparseTensorType<std::string>(); }
   MLDataType DataTypeImpl__GetSparseTensorType_BFloat16() override { return DataTypeImpl::GetSparseTensorType<BFloat16>(); }
   MLDataType DataTypeImpl__GetSparseTensorType_MLFloat16() override { return DataTypeImpl::GetSparseTensorType<MLFloat16>(); }
-
+  MLDataType DataTypeImpl__GetSparseTensorType_Float6E2M3() override { return DataTypeImpl::GetSparseTensorType<Float6E2M3>(); }
+  MLDataType DataTypeImpl__GetSparseTensorType_Float6E3M2() override { return DataTypeImpl::GetSparseTensorType<Float6E3M2>(); }
 #if !defined(DISABLE_FLOAT8_TYPES)
   MLDataType DataTypeImpl__GetSparseTensorType_Float8E4M3FN() override { return DataTypeImpl::GetSparseTensorType<Float8E4M3FN>(); }
   MLDataType DataTypeImpl__GetSparseTensorType_Float8E4M3FNUZ() override { return DataTypeImpl::GetSparseTensorType<Float8E4M3FNUZ>(); }

--- a/onnxruntime/core/util/qmath.h
+++ b/onnxruntime/core/util/qmath.h
@@ -8,12 +8,31 @@
 #include "core/common/narrow.h"
 #include "core/framework/element_type_lists.h"
 #include "core/common/float8.h"
+#include "core/framework/float6.h"
 #include "core/framework/int4.h"
 #include <cmath>
 #include <limits>
 #include <algorithm>
 
 namespace onnxruntime {
+
+template <typename T>
+constexpr bool IsFloatQuantizationType =
+#if !defined(DISABLE_FLOAT8_TYPES)
+    boost::mp11::mp_contains<element_type_lists::AllFloat8, T>::value ||
+#endif
+    std::is_same_v<T, Float6E2M3> ||
+    std::is_same_v<T, Float6E3M2>;
+
+template <typename T>
+T FloatQuantize(float value, bool saturate) {
+  if constexpr (std::is_same_v<T, Float6E2M3> || std::is_same_v<T, Float6E3M2>) {
+    ORT_UNUSED_PARAMETER(saturate);
+    return T(value);
+  } else {
+    return T(value, saturate);
+  }
+}
 
 inline float RoundHalfToEven(float input) {
   if (!std::isfinite(input)) {
@@ -114,11 +133,7 @@ void GetQuantizationParameter(const float* data, int64_t num_of_elements, float&
  */
 
 template <typename OutputType>
-#if !defined(DISABLE_FLOAT8_TYPES)
-typename std::enable_if<!boost::mp11::mp_contains<element_type_lists::AllFloat8, OutputType>::value, void>::type
-#else
-void
-#endif
+typename std::enable_if<!IsFloatQuantizationType<OutputType>, void>::type
 ParQuantizeLinearStd(const float* Input,
                      OutputType* Output,
                      size_t N,
@@ -319,11 +334,7 @@ DEFINE_PAR_QUANT_LINEAR_STD_2BIT_GENERIC(ParQuantizeLinearStdU2, UInt2x4)
 // This implementation could be more efficient however the cast from float16 to other types
 // usually happens on GPU.
 template <typename OutputType>
-#if !defined(DISABLE_FLOAT8_TYPES)
-typename std::enable_if<!boost::mp11::mp_contains<element_type_lists::AllFloat8, OutputType>::value, void>::type
-#else
-void
-#endif
+typename std::enable_if<!IsFloatQuantizationType<OutputType>, void>::type
 ParQuantizeLinearStd(const MLFloat16* Input,
                      OutputType* Output,
                      size_t N,
@@ -345,15 +356,13 @@ ParQuantizeLinearStd(const MLFloat16* Input,
   });
 }
 
-#if !defined(DISABLE_FLOAT8_TYPES)
-
-template <typename OutputFloat8Type>
-typename std::enable_if<boost::mp11::mp_contains<element_type_lists::AllFloat8, OutputFloat8Type>::value, void>::type
+template <typename OutputFloatType>
+typename std::enable_if<IsFloatQuantizationType<OutputFloatType>, void>::type
 ParQuantizeLinearSat(const float* Input,
-                     OutputFloat8Type* Output,
+                     OutputFloatType* Output,
                      size_t N,
                      float Scale,
-                     const OutputFloat8Type& /* ORT_UNUSED_PARAMETER(ZeroPoint) */,
+                     const OutputFloatType& /* ORT_UNUSED_PARAMETER(ZeroPoint) */,
                      bool saturate,
                      concurrency::ThreadPool* thread_pool) {
   constexpr std::ptrdiff_t block_size = 128;
@@ -363,7 +372,7 @@ ParQuantizeLinearSat(const float* Input,
     auto begin_idx = begin * block_size;
     auto end_idx = std::min(static_cast<std::ptrdiff_t>(N), end * block_size);
     for (; begin_idx < end_idx; ++begin_idx) {
-      Output[begin_idx] = OutputFloat8Type(Input[begin_idx] / Scale, saturate);
+      Output[begin_idx] = FloatQuantize<OutputFloatType>(Input[begin_idx] / Scale, saturate);
     }
   });
 }
@@ -371,13 +380,13 @@ ParQuantizeLinearSat(const float* Input,
 // The implementation converts float16 to float and then do a quantization.
 // This is not efficient and is mostly added to enable unittest on CPU.
 // This case usually happens on GPU.
-template <typename OutputFloat8Type>
-typename std::enable_if<boost::mp11::mp_contains<element_type_lists::AllFloat8, OutputFloat8Type>::value, void>::type
+template <typename OutputFloatType>
+typename std::enable_if<IsFloatQuantizationType<OutputFloatType>, void>::type
 ParQuantizeLinearSat(const MLFloat16* Input,
-                     OutputFloat8Type* Output,
+                     OutputFloatType* Output,
                      size_t N,
                      MLFloat16 Scale,
-                     const OutputFloat8Type& /* ORT_UNUSED_PARAMETER(ZeroPoint) */,
+                     const OutputFloatType& /* ORT_UNUSED_PARAMETER(ZeroPoint) */,
                      bool saturate,
                      concurrency::ThreadPool* thread_pool) {
   constexpr std::ptrdiff_t block_size = 128;
@@ -387,12 +396,10 @@ ParQuantizeLinearSat(const MLFloat16* Input,
     auto begin_idx = begin * block_size;
     auto end_idx = std::min(static_cast<std::ptrdiff_t>(N), end * block_size);
     for (; begin_idx < end_idx; ++begin_idx) {
-      Output[begin_idx] = OutputFloat8Type(Input[begin_idx].ToFloat() / Scale.ToFloat(), saturate);
+      Output[begin_idx] = FloatQuantize<OutputFloatType>(Input[begin_idx].ToFloat() / Scale.ToFloat(), saturate);
     }
   });
 }
-
-#endif
 
 /**
  * @brief  compute blocked quantization
@@ -400,7 +407,7 @@ ParQuantizeLinearSat(const MLFloat16* Input,
  * @tparam TIn
  * @tparam TOut
  * @tparam output_type_group        0: int other than int4.
- *                                  1: float8
+ *                                  1: float8 or float6
  *                                  2: int4
  * @method op0                      baseline implementation. Single thread. Scalar instructions.
  * @method op1                      multi-threading implementation. Vector instructions.
@@ -1116,8 +1123,6 @@ struct BlockedQuantizeLinear<MLFloat16, TOut, 3> {
   }
 };
 
-#if !defined(DISABLE_FLOAT8_TYPES)
-
 template <typename TOut>
 struct BlockedQuantizeLinear<float, TOut, 1> {
   static void opNotLastAxis(concurrency::ThreadPool* thread_pool, const float* input, const float* scale,
@@ -1148,7 +1153,7 @@ struct BlockedQuantizeLinear<float, TOut, 1> {
           for (; begin < end; ++begin) {
             auto n_end = std::min(N, n + thread_block_size);
             for (; n < n_end; ++n, ++output_idx, ++quant_param_idx_t) {
-              output[output_idx] = TOut(input[output_idx] / scale[quant_param_idx_t], saturate);
+              output[output_idx] = FloatQuantize<TOut>(input[output_idx] / scale[quant_param_idx_t], saturate);
             }
 
             if (n == N) {
@@ -1189,7 +1194,7 @@ struct BlockedQuantizeLinear<float, TOut, 1> {
             auto sc = scale[begin];
             auto output_idx_end = std::min(K - k, quant_block_size) + output_idx;
             for (; output_idx < output_idx_end; ++output_idx) {
-              output[output_idx] = TOut(input[output_idx] / sc, saturate);
+              output[output_idx] = FloatQuantize<TOut>(input[output_idx] / sc, saturate);
             }
             k = output_idx % K;
           }
@@ -1227,7 +1232,8 @@ struct BlockedQuantizeLinear<MLFloat16, TOut, 1> {
           for (; begin < end; ++begin) {
             auto n_end = std::min(N, n + thread_block_size);
             for (; n < n_end; ++n, ++output_idx, ++quant_param_idx_t) {
-              output[output_idx] = TOut(input[output_idx].ToFloat() / scale[quant_param_idx_t].ToFloat(), saturate);
+              output[output_idx] = FloatQuantize<TOut>(
+                  input[output_idx].ToFloat() / scale[quant_param_idx_t].ToFloat(), saturate);
             }
 
             if (n == N) {
@@ -1267,15 +1273,13 @@ struct BlockedQuantizeLinear<MLFloat16, TOut, 1> {
             auto sc = scale[begin].ToFloat();
             auto output_idx_end = std::min(K - k, quant_block_size) + output_idx;
             for (; output_idx < output_idx_end; ++output_idx) {
-              output[output_idx] = TOut(input[output_idx].ToFloat() / sc, saturate);
+              output[output_idx] = FloatQuantize<TOut>(input[output_idx].ToFloat() / sc, saturate);
             }
             k = output_idx % K;
           }
         });
   }
 };
-
-#endif
 
 /**
  * @brief Run MlasDequantizeLinear in parallel, with provided thread pool

--- a/onnxruntime/python/onnxruntime_pybind_mlvalue.cc
+++ b/onnxruntime/python/onnxruntime_pybind_mlvalue.cc
@@ -461,6 +461,8 @@ int OnnxRuntimeTensorToNumpyType(const DataTypeImpl* tensor_type) {
 #if !defined(DISABLE_FLOAT4_TYPES)
       {DataTypeImpl::GetType<Float4E2M1x2>(), NPY_UINT8},
 #endif
+      {DataTypeImpl::GetType<Float6E2M3>(), NPY_UINT8},
+      {DataTypeImpl::GetType<Float6E3M2>(), NPY_UINT8},
 #if !defined(DISABLE_FLOAT8_TYPES)
       {DataTypeImpl::GetType<Float8E4M3FN>(), NPY_UINT8},
 #endif

--- a/onnxruntime/test/flatbuffers/flatbuffer_utils_test.cc
+++ b/onnxruntime/test/flatbuffers/flatbuffer_utils_test.cc
@@ -3,6 +3,8 @@
 
 #if !defined(ORT_MINIMAL_BUILD)
 
+#include <algorithm>
+#include <array>
 #include <cstring>
 #include <fstream>
 #include <iostream>
@@ -440,6 +442,77 @@ TEST(FlatbufferUtilsTest, LoadInitializerRejectsExternalTensorWithDimTooLargeFor
 }
 
 #ifdef ENABLE_TRAINING_APIS
+template <typename F6>
+void TestFloat6OrtTensorRoundTrip(bool use_external_data) {
+  static onnxruntime::CPUExecutionProviderInfo info;
+  static onnxruntime::CPUExecutionProvider cpu_provider(info);
+  AllocatorPtr cpu_allocator = cpu_provider.CreatePreferredAllocators()[0];
+
+  Tensor input{DataTypeImpl::GetType<F6>(), TensorShape({4}), cpu_allocator};
+  const std::array<uint8_t, 4> expected_runtime_bits{0x01, 0x02, 0x03, 0x04};
+  auto* input_data = input.MutableData<F6>();
+  for (size_t i = 0; i < expected_runtime_bits.size(); ++i) {
+    input_data[i] = F6(expected_runtime_bits[i], F6::FromBits());
+  }
+
+  std::vector<uint8_t> external_data;
+  ExternalDataWriter writer;
+  if (use_external_data) {
+    writer = [&external_data](int32_t, gsl::span<const uint8_t> bytes, uint64_t& offset) {
+      offset = 0;
+      external_data.assign(bytes.begin(), bytes.end());
+      return Status::OK();
+    };
+  }
+
+  flatbuffers::FlatBufferBuilder builder;
+  flatbuffers::Offset<fbs::Tensor> tensor_offset;
+  ASSERT_STATUS_OK(SaveOrtTensorOrtFormat("float6", input, builder, tensor_offset, writer));
+  builder.Finish(tensor_offset);
+
+  const auto* fbs_tensor = flatbuffers::GetRoot<fbs::Tensor>(builder.GetBufferPointer());
+  const std::array<uint8_t, 3> expected_packed_bytes{0x81, 0x30, 0x10};
+  if (use_external_data) {
+    ASSERT_EQ(fbs_tensor->external_data_offset(), 0);
+    ASSERT_EQ(external_data, std::vector<uint8_t>(expected_packed_bytes.begin(), expected_packed_bytes.end()));
+  } else {
+    ASSERT_NE(fbs_tensor->raw_data(), nullptr);
+    ASSERT_EQ(fbs_tensor->raw_data()->size(), expected_packed_bytes.size());
+    ASSERT_TRUE(std::equal(expected_packed_bytes.begin(), expected_packed_bytes.end(), fbs_tensor->raw_data()->begin()));
+  }
+
+  ExternalDataReader reader = [&external_data](uint64_t offset, gsl::span<uint8_t> bytes) {
+    ORT_ENFORCE(offset == 0 && bytes.size() == external_data.size());
+    std::copy(external_data.begin(), external_data.end(), bytes.begin());
+    return Status::OK();
+  };
+  Tensor output;
+  std::string tensor_name;
+  ASSERT_STATUS_OK(LoadOrtTensorOrtFormat(*fbs_tensor, cpu_allocator, tensor_name, output,
+                                          use_external_data ? reader : ExternalDataReader{}));
+  ASSERT_EQ(tensor_name, "float6");
+  const auto* output_data = output.Data<F6>();
+  for (size_t i = 0; i < expected_runtime_bits.size(); ++i) {
+    ASSERT_EQ(output_data[i].ToBits(), expected_runtime_bits[i]);
+  }
+}
+
+TEST(FlatbufferUtilsTest, Float6E2M3OrtTensorInlineRoundTrip) {
+  TestFloat6OrtTensorRoundTrip<Float6E2M3>(false);
+}
+
+TEST(FlatbufferUtilsTest, Float6E3M2OrtTensorInlineRoundTrip) {
+  TestFloat6OrtTensorRoundTrip<Float6E3M2>(false);
+}
+
+TEST(FlatbufferUtilsTest, Float6E2M3OrtTensorExternalRoundTrip) {
+  TestFloat6OrtTensorRoundTrip<Float6E2M3>(true);
+}
+
+TEST(FlatbufferUtilsTest, Float6E3M2OrtTensorExternalRoundTrip) {
+  TestFloat6OrtTensorRoundTrip<Float6E3M2>(true);
+}
+
 // tests method that loads to OrtTensor (used when loading a checkpoint into a checkpoint state)
 TEST(FlatbufferUtilsTest, ExternalWriteReadWithLoadOrtTensor) {
   // create data

--- a/onnxruntime/test/framework/type_info_test.cc
+++ b/onnxruntime/test/framework/type_info_test.cc
@@ -47,6 +47,8 @@ constexpr bool TensorElementTypeConversionIsConstexpr() {
           ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT8E8M0,
           ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT2,
           ONNX_TENSOR_ELEMENT_DATA_TYPE_INT2,
+          ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT6E2M3,
+          ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT6E3M2,
       };
 
   for (size_t index = 0; index < expected_types.size(); ++index) {

--- a/onnxruntime/test/providers/cpu/tensor/cast_op_test.cc
+++ b/onnxruntime/test/providers/cpu/tensor/cast_op_test.cc
@@ -12,6 +12,7 @@
 #include "gtest/gtest.h"
 
 #include "core/framework/data_types_internal.h"
+#include "core/framework/float6.h"
 #include "core/framework/int2.h"
 #include "core/framework/tensor.h"
 #include "core/providers/cpu/tensor/utils.h"
@@ -2372,6 +2373,35 @@ TEST(CastOpTest, Int32ToInt2x4EmptyTensor) {
 
   // WHEN, THEN
   TestCastOpInt2(gsl::make_span(empty_input), gsl::make_span(expected_empty_output), empty_shape);
+}
+
+template <typename F6>
+void CastOpTestFloat6() {
+  const std::vector<int64_t> shape{2, 2, 2};
+  const std::vector<float> float_input = {-8.0f, -1.0f, -0.125f, 0.0f, 0.125f, 1.0f, 3.5f, 8.0f};
+  std::vector<F6> float6_output;
+  std::vector<float> expected_float_output;
+  float6_output.reserve(float_input.size());
+  expected_float_output.reserve(float_input.size());
+
+  for (float value : float_input) {
+    const F6 quantized(value);
+    float6_output.push_back(quantized);
+    expected_float_output.push_back(static_cast<float>(quantized));
+  }
+
+  TestCastOp<float, F6>(gsl::make_span(float_input), gsl::make_span(float6_output), shape,
+                        OpTester::ExpectResult::kExpectSuccess, "", 28);
+  TestCastOp<F6, float>(gsl::make_span(float6_output), gsl::make_span(expected_float_output), shape,
+                        OpTester::ExpectResult::kExpectSuccess, "", 28);
+}
+
+TEST(CastOpTest, Float6E2M3) {
+  CastOpTestFloat6<Float6E2M3>();
+}
+
+TEST(CastOpTest, Float6E3M2) {
+  CastOpTestFloat6<Float6E3M2>();
 }
 
 #if !defined(DISABLE_FLOAT8_TYPES)

--- a/onnxruntime/test/providers/cpu/tensor/cast_op_test.cc
+++ b/onnxruntime/test/providers/cpu/tensor/cast_op_test.cc
@@ -2435,7 +2435,10 @@ TEST(CastOpTest, Float6EncodingBoundaries) {
 template <typename F6>
 void TestFloat6ToPackedIntegerTruncation() {
   const std::vector<int64_t> shape{2};
-  const std::vector<F6> input{F6(0x0C, F6::FromBits()), F6(0x2C, F6::FromBits())};  // +1.5, -1.5
+  const uint8_t positive_fractional_bits = std::is_same_v<F6, Float6E2M3> ? 0x0C : 0x0E;
+  const uint8_t negative_fractional_bits = std::is_same_v<F6, Float6E2M3> ? 0x2C : 0x2E;
+  const std::vector<F6> input{F6(positive_fractional_bits, F6::FromBits()),
+                              F6(negative_fractional_bits, F6::FromBits())};  // +1.5, -1.5
 
   const std::vector<Int4x2> int4_output{Int4x2(0xF1, Int4x2::FromBits())};
   TestCastOp(gsl::make_span(input), gsl::make_span(int4_output), shape,

--- a/onnxruntime/test/providers/cpu/tensor/cast_op_test.cc
+++ b/onnxruntime/test/providers/cpu/tensor/cast_op_test.cc
@@ -2440,19 +2440,19 @@ void TestFloat6ToPackedIntegerTruncation() {
   const std::vector<F6> input{F6(positive_fractional_bits, F6::FromBits()),
                               F6(negative_fractional_bits, F6::FromBits())};  // +1.5, -1.5
 
-  const std::vector<Int4x2> int4_output{Int4x2(0xF1, Int4x2::FromBits())};
+  const std::vector<Int4x2> int4_output{Int4x2(std::byte{0xF1})};
   TestCastOp(gsl::make_span(input), gsl::make_span(int4_output), shape,
              OpTester::ExpectResult::kExpectSuccess, "", 28);
 
-  const std::vector<UInt4x2> uint4_output{UInt4x2(0xF1, UInt4x2::FromBits())};
+  const std::vector<UInt4x2> uint4_output{UInt4x2(std::byte{0xF1})};
   TestCastOp(gsl::make_span(input), gsl::make_span(uint4_output), shape,
              OpTester::ExpectResult::kExpectSuccess, "", 28);
 
-  const std::vector<Int2x4> int2_output{Int2x4(0x0D, Int2x4::FromBits())};
+  const std::vector<Int2x4> int2_output{Int2x4(std::byte{0x0D})};
   TestCastOp(gsl::make_span(input), gsl::make_span(int2_output), shape,
              OpTester::ExpectResult::kExpectSuccess, "", 28);
 
-  const std::vector<UInt2x4> uint2_output{UInt2x4(0x0D, UInt2x4::FromBits())};
+  const std::vector<UInt2x4> uint2_output{UInt2x4(std::byte{0x0D})};
   TestCastOp(gsl::make_span(input), gsl::make_span(uint2_output), shape,
              OpTester::ExpectResult::kExpectSuccess, "", 28);
 }

--- a/onnxruntime/test/providers/cpu/tensor/cast_op_test.cc
+++ b/onnxruntime/test/providers/cpu/tensor/cast_op_test.cc
@@ -2417,6 +2417,14 @@ TEST(CastOpTest, Float6EncodingBoundaries) {
   EXPECT_EQ(Float6E2M3(-std::numeric_limits<float>::max()).ToBits(), 0x3F);
   EXPECT_EQ(Float6E3M2(std::numeric_limits<float>::max()).ToBits(), 0x1F);
   EXPECT_EQ(Float6E3M2(-std::numeric_limits<float>::max()).ToBits(), 0x3F);
+  EXPECT_EQ(Float6E2M3(std::numeric_limits<float>::quiet_NaN()).ToBits(), 0x20);
+  EXPECT_EQ(Float6E3M2(std::numeric_limits<float>::quiet_NaN()).ToBits(), 0x20);
+
+  // Round-to-nearest-even at adjacent normalized E2M3 and E3M2 values.
+  EXPECT_EQ(Float6E2M3(1.0625f).ToBits(), 0x08);
+  EXPECT_EQ(Float6E2M3(1.1875f).ToBits(), 0x0A);
+  EXPECT_EQ(Float6E3M2(1.125f).ToBits(), 0x0C);
+  EXPECT_EQ(Float6E3M2(1.375f).ToBits(), 0x0E);
 
   EXPECT_EQ(static_cast<float>(Float6E2M3(0x01, Float6E2M3::FromBits())), 0.125f);
   EXPECT_EQ(static_cast<float>(Float6E2M3(0x1F, Float6E2M3::FromBits())), 7.5f);

--- a/onnxruntime/test/providers/cpu/tensor/cast_op_test.cc
+++ b/onnxruntime/test/providers/cpu/tensor/cast_op_test.cc
@@ -2404,6 +2404,26 @@ TEST(CastOpTest, Float6E3M2) {
   CastOpTestFloat6<Float6E3M2>();
 }
 
+TEST(CastOpTest, Float6EncodingBoundaries) {
+  const float infinity = std::numeric_limits<float>::infinity();
+
+  EXPECT_EQ(Float6E2M3(-0.0f).ToBits(), 0x20);
+  EXPECT_EQ(Float6E3M2(-0.0f).ToBits(), 0x20);
+  EXPECT_EQ(Float6E2M3(infinity).ToBits(), 0x1F);
+  EXPECT_EQ(Float6E2M3(-infinity).ToBits(), 0x3F);
+  EXPECT_EQ(Float6E3M2(infinity).ToBits(), 0x1F);
+  EXPECT_EQ(Float6E3M2(-infinity).ToBits(), 0x3F);
+  EXPECT_EQ(Float6E2M3(std::numeric_limits<float>::max()).ToBits(), 0x1F);
+  EXPECT_EQ(Float6E2M3(-std::numeric_limits<float>::max()).ToBits(), 0x3F);
+  EXPECT_EQ(Float6E3M2(std::numeric_limits<float>::max()).ToBits(), 0x1F);
+  EXPECT_EQ(Float6E3M2(-std::numeric_limits<float>::max()).ToBits(), 0x3F);
+
+  EXPECT_EQ(static_cast<float>(Float6E2M3(0x01, Float6E2M3::FromBits())), 0.125f);
+  EXPECT_EQ(static_cast<float>(Float6E2M3(0x1F, Float6E2M3::FromBits())), 7.5f);
+  EXPECT_EQ(static_cast<float>(Float6E3M2(0x01, Float6E3M2::FromBits())), 0.0625f);
+  EXPECT_EQ(static_cast<float>(Float6E3M2(0x1F, Float6E3M2::FromBits())), 28.0f);
+}
+
 #if !defined(DISABLE_FLOAT8_TYPES)
 
 template <typename F8>

--- a/onnxruntime/test/providers/cpu/tensor/cast_op_test.cc
+++ b/onnxruntime/test/providers/cpu/tensor/cast_op_test.cc
@@ -2432,6 +2432,36 @@ TEST(CastOpTest, Float6EncodingBoundaries) {
   EXPECT_EQ(static_cast<float>(Float6E3M2(0x1F, Float6E3M2::FromBits())), 28.0f);
 }
 
+template <typename F6>
+void TestFloat6ToPackedIntegerTruncation() {
+  const std::vector<int64_t> shape{2};
+  const std::vector<F6> input{F6(0x0C, F6::FromBits()), F6(0x2C, F6::FromBits())};  // +1.5, -1.5
+
+  const std::vector<Int4x2> int4_output{Int4x2(0xF1, Int4x2::FromBits())};
+  TestCastOp(gsl::make_span(input), gsl::make_span(int4_output), shape,
+             OpTester::ExpectResult::kExpectSuccess, "", 28);
+
+  const std::vector<UInt4x2> uint4_output{UInt4x2(0xF1, UInt4x2::FromBits())};
+  TestCastOp(gsl::make_span(input), gsl::make_span(uint4_output), shape,
+             OpTester::ExpectResult::kExpectSuccess, "", 28);
+
+  const std::vector<Int2x4> int2_output{Int2x4(0x0D, Int2x4::FromBits())};
+  TestCastOp(gsl::make_span(input), gsl::make_span(int2_output), shape,
+             OpTester::ExpectResult::kExpectSuccess, "", 28);
+
+  const std::vector<UInt2x4> uint2_output{UInt2x4(0x0D, UInt2x4::FromBits())};
+  TestCastOp(gsl::make_span(input), gsl::make_span(uint2_output), shape,
+             OpTester::ExpectResult::kExpectSuccess, "", 28);
+}
+
+TEST(CastOpTest, Float6E2M3ToPackedIntegerTruncation) {
+  TestFloat6ToPackedIntegerTruncation<Float6E2M3>();
+}
+
+TEST(CastOpTest, Float6E3M2ToPackedIntegerTruncation) {
+  TestFloat6ToPackedIntegerTruncation<Float6E3M2>();
+}
+
 #if !defined(DISABLE_FLOAT8_TYPES)
 
 template <typename F8>

--- a/onnxruntime/test/providers/cpu/tensor/quantize_linear_test.cc
+++ b/onnxruntime/test/providers/cpu/tensor/quantize_linear_test.cc
@@ -7,6 +7,7 @@
 #include "test/common/cuda_op_test_utils.h"
 #include "test/providers/provider_test_utils.h"
 #include "test/util/include/default_providers.h"
+#include "core/framework/float6.h"
 #include "core/framework/int4.h"
 #include "core/framework/int2.h"
 #include "core/session/onnxruntime_session_options_config_keys.h"
@@ -1398,6 +1399,49 @@ TEST(QuantizeLinearOpTest, Per_Channel_Axis_neg) {
                            0, 1, 2, 255,
                            0, 0, 1, 250});
   test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider});  // TensorRT doesn't support support UINT8 for quantization
+}
+
+template <typename F6>
+void QuantizeDequantizeLinearOp28Float6Test() {
+  const std::vector<int64_t> dims{6};
+  const std::vector<float> input{-4.0f, -1.0f, -0.25f, 0.0f, 0.25f, 4.0f};
+  constexpr float scale = 0.5f;
+  const F6 zero_point(0.0f);
+  std::vector<F6> quantized;
+  std::vector<float> dequantized;
+  quantized.reserve(input.size());
+  dequantized.reserve(input.size());
+
+  for (float value : input) {
+    const F6 quantized_value(value / scale);
+    quantized.push_back(quantized_value);
+    dequantized.push_back(static_cast<float>(quantized_value) * scale);
+  }
+
+  OpTester quantize_test("QuantizeLinear", 28);
+  quantize_test.AddAttribute<int64_t>("saturate", 0);
+  quantize_test.AddInput<float>("x", dims, input);
+  quantize_test.AddInput<float>("y_scale", {}, {scale});
+  quantize_test.AddInput<F6>("y_zero_point", {}, {zero_point});
+  quantize_test.AddOutput<F6>("y", dims, quantized);
+  quantize_test.Run(OpTester::ExpectResult::kExpectSuccess, "",
+                    {kTensorrtExecutionProvider, kOpenVINOExecutionProvider});
+
+  OpTester dequantize_test("DequantizeLinear", 28);
+  dequantize_test.AddInput<F6>("x", dims, quantized);
+  dequantize_test.AddInput<float>("x_scale", {}, {scale});
+  dequantize_test.AddInput<F6>("x_zero_point", {}, {zero_point});
+  dequantize_test.AddOutput<float>("y", dims, dequantized);
+  dequantize_test.Run(OpTester::ExpectResult::kExpectSuccess, "",
+                      {kTensorrtExecutionProvider, kOpenVINOExecutionProvider});
+}
+
+TEST(QuantizeLinearOpTest, Float6E2M3) {
+  QuantizeDequantizeLinearOp28Float6Test<Float6E2M3>();
+}
+
+TEST(QuantizeLinearOpTest, Float6E3M2) {
+  QuantizeDequantizeLinearOp28Float6Test<Float6E3M2>();
 }
 
 #if !defined(DISABLE_FLOAT8_TYPES)


### PR DESCRIPTION
### Summary

Adds FLOAT6E2M3 and FLOAT6E3M2 support for the pinned ONNX opset-28/IR-14 dependency.

- Provides FP6 runtime types, C API mappings, TensorProto packing/unpacking, ORT-format loading, Python dtype exposure, and shared-provider bridge support.
- Adds CPU Cast, QuantizeLinear, and DequantizeLinear registrations at opset 28.
- Keeps CUDA, JS, and WebGPU unregistered for FP6 because they lack a valid packed FP6 storage/conversion implementation.
- Loads FP6 external and ORT-format initializers into allocated unpacked runtime tensors; FP6 sparse tensor support is deliberately not registered because sparse packing is not yet implemented.
- Includes provider ABI append-only protection, shared-provider client specializations, MSVC compatibility fixes, and FP6 boundary coverage.

### Validation

- `git diff --check`
- Windows Debug configure reached CMake/MSBuild but the pre-existing `pytorch_cpuinfo` FetchContent dependency build failed before ORT compilation.

### Known external blocker

The vcpkg archive mirror HTTP 404 remains external infrastructure work and is not a blocker for this PR.