### PR TITLE
Add x86 half decode GEMV kernels

### DIFF
--- a/cmake/onnxruntime_mlas.cmake
+++ b/cmake/onnxruntime_mlas.cmake
@@ -871,6 +871,7 @@ else()
           ${MLAS_SRC_DIR}/x86_64/LogisticKernelFma3.S
           ${MLAS_SRC_DIR}/x86_64/TanhKernelFma3.S
           ${MLAS_SRC_DIR}/x86_64/ErfKernelFma3.S
+          ${MLAS_SRC_DIR}/intrinsics/avx2/halfgemv_avx2.cpp
           ${MLAS_SRC_DIR}/intrinsics/avx2/qladd_avx2.cpp
           ${MLAS_SRC_DIR}/intrinsics/avx2/qdwconv_avx2.cpp
           ${MLAS_SRC_DIR}/intrinsics/avx2/saturation_check_avx2.cpp

--- a/onnxruntime/core/mlas/inc/mlas.h
+++ b/onnxruntime/core/mlas/inc/mlas.h
@@ -1739,6 +1739,16 @@ MlasHGemmSupported(
     );
 
 /**
+ * @brief Check whether current CPU supports the M=1 half precision GEMV path.
+ */
+bool
+MLASCALL
+MlasHalfGemmDecodeSupported(
+    CBLAS_TRANSPOSE TransA,
+    CBLAS_TRANSPOSE TransB
+    );
+
+/**
  * @brief Check whether mlas supports GQA kernels with the type and transpose settings.
  */
 template <typename T>

--- a/onnxruntime/core/mlas/lib/halfgemm.cpp
+++ b/onnxruntime/core/mlas/lib/halfgemm.cpp
@@ -60,6 +60,24 @@ MlasFp16AccelerationSupported()
 #endif
 }
 
+bool
+MLASCALL
+MlasHalfGemmDecodeSupported(
+    CBLAS_TRANSPOSE TransA,
+    CBLAS_TRANSPOSE TransB
+    )
+{
+#if defined(MLAS_TARGET_AMD64)
+    return TransA == CblasNoTrans &&
+        (TransB == CblasNoTrans || TransB == CblasTrans) &&
+        GetMlasPlatform().HalfGemmDecodeSupported_;
+#else
+    MLAS_UNREFERENCED_PARAMETER(TransA);
+    MLAS_UNREFERENCED_PARAMETER(TransB);
+    return false;
+#endif
+}
+
 static bool
 TryGetHalfGemmBackendSelectorConfig(
     size_t BatchN,
@@ -648,6 +666,52 @@ HGemmOperation(
     }
 }
 
+static void
+MlasHalfGemmDecodeBatch(
+    CBLAS_TRANSPOSE TransB,
+    size_t N,
+    size_t K,
+    const MLAS_HGEMM_DATA_PARAMS* Data,
+    size_t BatchSize,
+    MLAS_THREADPOOL* ThreadPool
+    )
+{
+#if defined(MLAS_TARGET_AMD64)
+    if (ThreadPool == nullptr) {
+        for (size_t gemm_i = 0; gemm_i < BatchSize; ++gemm_i) {
+            MlasHalfGemmDecodeKernelAvx2(TransB, N, K, &Data[gemm_i], 0, N);
+        }
+        return;
+    }
+
+    const double Complexity = double(N) * double(K) * double(BatchSize);
+    ptrdiff_t TargetThreadCount =
+        ptrdiff_t(Complexity / double(MLAS_HGEMM_THREAD_COMPLEXITY)) + 1;
+    TargetThreadCount = std::min(TargetThreadCount, MlasGetMaximumThreadCount(ThreadPool));
+
+    ptrdiff_t ThreadsPerGemm = std::max<ptrdiff_t>(TargetThreadCount / BatchSize, 1);
+    constexpr size_t ColumnAlignment = 64;
+    size_t StrideN = MlasDivRoundup(N, static_cast<size_t>(ThreadsPerGemm));
+    StrideN = std::min(N, MlasDivRoundup(StrideN, ColumnAlignment) * ColumnAlignment);
+    const size_t ThreadCountN = MlasDivRoundup(N, StrideN);
+
+    MlasTrySimpleParallel(ThreadPool, ThreadCountN * BatchSize, [&](ptrdiff_t tid) {
+        const size_t gemm_i = static_cast<size_t>(tid) / ThreadCountN;
+        const size_t thread_i = static_cast<size_t>(tid) % ThreadCountN;
+        const size_t StartN = thread_i * StrideN;
+        const size_t CountN = std::min(N - StartN, StrideN);
+        MlasHalfGemmDecodeKernelAvx2(TransB, N, K, &Data[gemm_i], StartN, CountN);
+    });
+#else
+    MLAS_UNREFERENCED_PARAMETER(TransB);
+    MLAS_UNREFERENCED_PARAMETER(N);
+    MLAS_UNREFERENCED_PARAMETER(K);
+    MLAS_UNREFERENCED_PARAMETER(Data);
+    MLAS_UNREFERENCED_PARAMETER(BatchSize);
+    MLAS_UNREFERENCED_PARAMETER(ThreadPool);
+#endif
+}
+
 void
 MLASCALL
 MlasGemmBatch(
@@ -660,6 +724,12 @@ MlasGemmBatch(
     size_t BatchSize,
     MLAS_THREADPOOL* ThreadPool
 ) {
+    if (M == 1 && N != 0 && K != 0 && BatchSize != 0 &&
+        MlasHalfGemmDecodeSupported(TransA, TransB)) {
+        MlasHalfGemmDecodeBatch(TransB, N, K, Data, BatchSize, ThreadPool);
+        return;
+    }
+
     if (!ThreadPool) {
         for (size_t gemm_i = 0; gemm_i < BatchSize; gemm_i++) {
             HGemmOperation(TransA, TransB, K, &Data[gemm_i], 0, M, 0, N);

--- a/onnxruntime/core/mlas/lib/intrinsics/avx2/halfgemv_avx2.cpp
+++ b/onnxruntime/core/mlas/lib/intrinsics/avx2/halfgemv_avx2.cpp
@@ -1,0 +1,248 @@
+/*++
+
+Copyright (c) Microsoft Corporation. All rights reserved.
+
+Licensed under the MIT License.
+
+Module Name:
+
+    halfgemv_avx2.cpp
+
+Abstract:
+
+    This module implements AVX2/F16C kernels for M=1 half precision GEMM.
+
+--*/
+
+#include <cmath>
+
+#include "../../mlasi.h"
+
+namespace
+{
+
+MLAS_FORCEINLINE
+__m256
+LoadHalf8(
+    const MLAS_FP16* Source
+)
+{
+    return _mm256_cvtph_ps(
+        _mm_loadu_si128(reinterpret_cast<const __m128i*>(Source))
+    );
+}
+
+MLAS_FORCEINLINE
+void
+StoreHalf8(
+    MLAS_FP16* Destination,
+    __m256 Value
+)
+{
+    const __m128i HalfValue = _mm256_cvtps_ph(Value, _MM_FROUND_TO_NEAREST_INT);
+    _mm_storeu_si128(reinterpret_cast<__m128i*>(Destination), HalfValue);
+}
+
+MLAS_FORCEINLINE
+float
+LoadHalf1(
+    const MLAS_FP16* Source
+)
+{
+    return _mm_cvtss_f32(_mm_cvtph_ps(_mm_cvtsi32_si128(Source->val)));
+}
+
+MLAS_FORCEINLINE
+__m256
+ApplyScale(
+    __m256 Sum,
+    const MLAS_FP16* C,
+    float Alpha,
+    float Beta
+)
+{
+    if (Alpha != 1.0f) {
+        Sum = _mm256_mul_ps(Sum, _mm256_set1_ps(Alpha));
+    }
+
+    if (Beta == 0.0f) {
+        return Sum;
+    }
+
+    const __m256 Existing = LoadHalf8(C);
+    if (Beta == 1.0f) {
+        return _mm256_add_ps(Sum, Existing);
+    }
+
+    return _mm256_fmadd_ps(Existing, _mm256_set1_ps(Beta), Sum);
+}
+
+MLAS_FORCEINLINE
+float
+ApplyScale(
+    float Sum,
+    const MLAS_FP16* C,
+    float Alpha,
+    float Beta
+)
+{
+    const float Existing = Beta == 0.0f ? 0.0f : float(*C);
+    return std::fma(Beta, Existing, Alpha * Sum);
+}
+
+void
+HalfGemmDecodeNoTrans(
+    size_t K,
+    const MLAS_HGEMM_DATA_PARAMS* Data,
+    size_t StartN,
+    size_t CountN
+)
+{
+    const MLAS_FP16* B = Data->B + StartN;
+    MLAS_FP16* C = Data->C + StartN;
+    const size_t ldb = Data->ldb;
+    const float Alpha = float(MLAS_FP16::FromBits(Data->alpha));
+    const float Beta = float(MLAS_FP16::FromBits(Data->beta));
+
+    size_t n = 0;
+    while (n + 64 <= CountN) {
+        __m256 Sum0 = _mm256_setzero_ps();
+        __m256 Sum1 = _mm256_setzero_ps();
+        __m256 Sum2 = _mm256_setzero_ps();
+        __m256 Sum3 = _mm256_setzero_ps();
+        __m256 Sum4 = _mm256_setzero_ps();
+        __m256 Sum5 = _mm256_setzero_ps();
+        __m256 Sum6 = _mm256_setzero_ps();
+        __m256 Sum7 = _mm256_setzero_ps();
+
+        const MLAS_FP16* BRow = B + n;
+        for (size_t k = 0; k < K; ++k) {
+            const __m256 AValue = _mm256_set1_ps(LoadHalf1(Data->A + k));
+            Sum0 = _mm256_fmadd_ps(LoadHalf8(BRow), AValue, Sum0);
+            Sum1 = _mm256_fmadd_ps(LoadHalf8(BRow + 8), AValue, Sum1);
+            Sum2 = _mm256_fmadd_ps(LoadHalf8(BRow + 16), AValue, Sum2);
+            Sum3 = _mm256_fmadd_ps(LoadHalf8(BRow + 24), AValue, Sum3);
+            Sum4 = _mm256_fmadd_ps(LoadHalf8(BRow + 32), AValue, Sum4);
+            Sum5 = _mm256_fmadd_ps(LoadHalf8(BRow + 40), AValue, Sum5);
+            Sum6 = _mm256_fmadd_ps(LoadHalf8(BRow + 48), AValue, Sum6);
+            Sum7 = _mm256_fmadd_ps(LoadHalf8(BRow + 56), AValue, Sum7);
+            BRow += ldb;
+        }
+
+        StoreHalf8(C + n, ApplyScale(Sum0, C + n, Alpha, Beta));
+        StoreHalf8(C + n + 8, ApplyScale(Sum1, C + n + 8, Alpha, Beta));
+        StoreHalf8(C + n + 16, ApplyScale(Sum2, C + n + 16, Alpha, Beta));
+        StoreHalf8(C + n + 24, ApplyScale(Sum3, C + n + 24, Alpha, Beta));
+        StoreHalf8(C + n + 32, ApplyScale(Sum4, C + n + 32, Alpha, Beta));
+        StoreHalf8(C + n + 40, ApplyScale(Sum5, C + n + 40, Alpha, Beta));
+        StoreHalf8(C + n + 48, ApplyScale(Sum6, C + n + 48, Alpha, Beta));
+        StoreHalf8(C + n + 56, ApplyScale(Sum7, C + n + 56, Alpha, Beta));
+        n += 64;
+    }
+
+    while (n + 8 <= CountN) {
+        __m256 Sum = _mm256_setzero_ps();
+        const MLAS_FP16* BRow = B + n;
+        for (size_t k = 0; k < K; ++k) {
+            const __m256 AValue = _mm256_set1_ps(LoadHalf1(Data->A + k));
+            Sum = _mm256_fmadd_ps(LoadHalf8(BRow), AValue, Sum);
+            BRow += ldb;
+        }
+        StoreHalf8(C + n, ApplyScale(Sum, C + n, Alpha, Beta));
+        n += 8;
+    }
+
+    while (n < CountN) {
+        float Sum = 0.0f;
+        const MLAS_FP16* BValue = B + n;
+        for (size_t k = 0; k < K; ++k) {
+            Sum = std::fma(LoadHalf1(Data->A + k), LoadHalf1(BValue), Sum);
+            BValue += ldb;
+        }
+        C[n] = MLAS_FP16(ApplyScale(Sum, C + n, Alpha, Beta));
+        ++n;
+    }
+}
+
+MLAS_FORCEINLINE
+float
+ReduceAdd(
+    __m256 Value
+)
+{
+    __m128 Sum = _mm_add_ps(
+        _mm256_castps256_ps128(Value),
+        _mm256_extractf128_ps(Value, 1)
+    );
+    Sum = _mm_hadd_ps(Sum, Sum);
+    Sum = _mm_hadd_ps(Sum, Sum);
+    return _mm_cvtss_f32(Sum);
+}
+
+void
+HalfGemmDecodeTrans(
+    size_t K,
+    const MLAS_HGEMM_DATA_PARAMS* Data,
+    size_t StartN,
+    size_t CountN
+)
+{
+    MLAS_FP16* C = Data->C + StartN;
+    const float Alpha = float(MLAS_FP16::FromBits(Data->alpha));
+    const float Beta = float(MLAS_FP16::FromBits(Data->beta));
+
+    for (size_t n = 0; n < CountN; ++n) {
+        const MLAS_FP16* BRow = Data->B + (StartN + n) * Data->ldb;
+        __m256 Sum0 = _mm256_setzero_ps();
+        __m256 Sum1 = _mm256_setzero_ps();
+        __m256 Sum2 = _mm256_setzero_ps();
+        __m256 Sum3 = _mm256_setzero_ps();
+
+        size_t k = 0;
+        while (k + 32 <= K) {
+            Sum0 = _mm256_fmadd_ps(LoadHalf8(Data->A + k), LoadHalf8(BRow + k), Sum0);
+            Sum1 = _mm256_fmadd_ps(LoadHalf8(Data->A + k + 8), LoadHalf8(BRow + k + 8), Sum1);
+            Sum2 = _mm256_fmadd_ps(LoadHalf8(Data->A + k + 16), LoadHalf8(BRow + k + 16), Sum2);
+            Sum3 = _mm256_fmadd_ps(LoadHalf8(Data->A + k + 24), LoadHalf8(BRow + k + 24), Sum3);
+            k += 32;
+        }
+
+        while (k + 8 <= K) {
+            Sum0 = _mm256_fmadd_ps(LoadHalf8(Data->A + k), LoadHalf8(BRow + k), Sum0);
+            k += 8;
+        }
+
+        float Sum = ReduceAdd(
+            _mm256_add_ps(_mm256_add_ps(Sum0, Sum1), _mm256_add_ps(Sum2, Sum3))
+        );
+        while (k < K) {
+            Sum = std::fma(LoadHalf1(Data->A + k), LoadHalf1(BRow + k), Sum);
+            ++k;
+        }
+        C[n] = MLAS_FP16(ApplyScale(Sum, C + n, Alpha, Beta));
+    }
+}
+
+}  // namespace
+
+void
+    MLASCALL
+    MlasHalfGemmDecodeKernelAvx2(
+        CBLAS_TRANSPOSE TransB,
+        size_t N,
+        size_t K,
+        const MLAS_HGEMM_DATA_PARAMS* Data,
+        size_t StartN,
+        size_t CountN
+    )
+{
+    MLAS_UNREFERENCED_PARAMETER(N);
+
+    if (TransB == CblasNoTrans) {
+        HalfGemmDecodeNoTrans(K, Data, StartN, CountN);
+    } else {
+        HalfGemmDecodeTrans(K, Data, StartN, CountN);
+    }
+
+    _mm256_zeroupper();
+}

--- a/onnxruntime/core/mlas/lib/mlasi.h
+++ b/onnxruntime/core/mlas/lib/mlasi.h
@@ -1669,6 +1669,19 @@ extern const MLAS_ROPE_DISPATCH MlasRopeDispatchRvv;
 struct MLAS_HGEMM_DISPATCH;
 extern const MLAS_HGEMM_DISPATCH MlasHGemmDispatchNeon;
 
+#if defined(MLAS_TARGET_AMD64)
+void
+MLASCALL
+MlasHalfGemmDecodeKernelAvx2(
+    CBLAS_TRANSPOSE TransB,
+    size_t N,
+    size_t K,
+    const MLAS_HGEMM_DATA_PARAMS* Data,
+    size_t StartN,
+    size_t CountN
+    );
+#endif
+
 // softmax dispatch structure
 struct MLAS_SOFTMAX_DISPATCH;
 extern const MLAS_SOFTMAX_DISPATCH MlasSoftmaxDispatchNeon;
@@ -1758,6 +1771,7 @@ struct MLAS_PLATFORM {
     // TODO: move to cpuinfo
     bool Avx2Supported_ = false;
     bool Avx512Supported_ = false;
+    bool HalfGemmDecodeSupported_ = false;
     bool KVQuantGemmFp16Supported_ = false;
     bool ArmNeonIsQuantActivationsUnsigned = false;
 

--- a/onnxruntime/core/mlas/lib/platform.cpp
+++ b/onnxruntime/core/mlas/lib/platform.cpp
@@ -514,6 +514,7 @@ Return Value:
                 this->CastF32ToF16Kernel = &MlasCastF32ToF16KernelAvx2;
                 this->RopeDispatch = &MlasRopeDispatchAvx2;
                 this->KVQuantGemmDispatch = &MlasKVQuantGemmDispatchAvx2;
+                this->HalfGemmDecodeSupported_ = (Cpuid1[2] & (1u << 29)) != 0;  // F16C
                 this->KVQuantGemmFp16Supported_ = (Cpuid1[2] & (1u << 29)) != 0;  // F16C
 
                 // TODO(vraspar): check if this really goes here or if there are other platform reqs that we need to fulfill

--- a/onnxruntime/core/providers/cpu/math/gemm.cc
+++ b/onnxruntime/core/providers/cpu/math/gemm.cc
@@ -206,6 +206,23 @@ void Gemm_MLFloat16(CBLAS_TRANSPOSE trans_a, CBLAS_TRANSPOSE trans_b,
   if (c_data == nullptr)
     beta = onnxruntime::MLFloat16::Zero;
 
+  if (M == 1 && trans_a == CblasNoTrans &&
+      MlasHalfGemmDecodeSupported(trans_a, trans_b)) {
+    GemmBroadcastBias(M, N, beta, c_data, c_shape, y_data);
+
+    const auto decode_beta = c_data == nullptr
+                                 ? onnxruntime::MLFloat16::Zero
+                                 : beta;
+    MlasGemm(
+        trans_a, trans_b,
+        static_cast<size_t>(M), static_cast<size_t>(N), static_cast<size_t>(K),
+        a_data, static_cast<size_t>(K),
+        b_data, static_cast<size_t>(trans_b == CblasTrans ? K : N),
+        y_data, static_cast<size_t>(N),
+        alpha.val, decode_beta.val, thread_pool);
+    return;
+  }
+
   // Guard against using generic half GEMM when no accelerated implementation is
   // available. Native packing support currently also signals an accelerated
   // backend path.

--- a/onnxruntime/core/providers/cpu/math/matmul.cc
+++ b/onnxruntime/core/providers/cpu/math/matmul.cc
@@ -405,6 +405,26 @@ Status MatMul<MLFloat16>::Compute(OpKernelContext* ctx) const {
   const size_t lda = helper.Lda(false);
   const size_t ldb = helper.Ldb(false);
 
+  if (M == 1 && packed_b_ == nullptr &&
+      MlasHalfGemmDecodeSupported(CblasNoTrans, CblasNoTrans)) {
+    const auto alpha = MLFloat16(1.0f);
+    const auto beta = MLFloat16(0.0f);
+    InlinedVector<MLAS_HGEMM_DATA_PARAMS> data(max_len);
+    for (size_t i = 0; i < max_len; i++) {
+      data[i].A = a_data + helper.LeftOffsets()[i];
+      data[i].lda = lda;
+      data[i].B = b_data + helper.RightOffsets()[i];
+      data[i].ldb = ldb;
+      data[i].C = y_data + helper.OutputOffsets()[i];
+      data[i].ldc = N;
+      data[i].alpha = alpha.val;
+      data[i].beta = beta.val;
+    }
+
+    MlasGemmBatch(CblasNoTrans, CblasNoTrans, M, N, K, data.data(), max_len, thread_pool);
+    return Status::OK();
+  }
+
   // Guard against using generic half GEMM when no accelerated implementation is
   // available. Native packing support currently also signals an accelerated
   // backend path.

--- a/onnxruntime/test/mlas/bench/bench_hgemm.cpp
+++ b/onnxruntime/test/mlas/bench/bench_hgemm.cpp
@@ -3,6 +3,8 @@
 
 #include "mlas.h"
 #include "bench_util.h"
+#include "core/util/math.h"
+#include "core/util/math_cpuonly.h"
 #include "core/util/thread_utils.h"
 
 #include <stdexcept>
@@ -87,3 +89,45 @@ static void GemmLLMSizeProducts(benchmark::internal::Benchmark* b) {
 }
 BENCHMARK_CAPTURE(HGEMM, LLM_TransB, false, true)->Apply(GemmLLMSizeProducts)->UseRealTime();
 BENCHMARK_CAPTURE(HGEMM, LLM_B, false, false)->Apply(GemmLLMSizeProducts)->UseRealTime();
+
+static void GemmDecodeSizes(benchmark::internal::Benchmark* b) {
+  b->ArgNames(hgemm_bench_arg_names);
+  b->Args({1, 4096, 4096});
+  b->Args({1, 11008, 4096});
+  b->Args({1, 4096, 11008});
+}
+BENCHMARK_CAPTURE(HGEMM, Decode_TransB, false, true)->Apply(GemmDecodeSizes)->UseRealTime();
+BENCHMARK_CAPTURE(HGEMM, Decode_B, false, false)->Apply(GemmDecodeSizes)->UseRealTime();
+
+void HGEMMDecodeEigen(benchmark::State& state, bool transB) {
+  const size_t M = static_cast<size_t>(state.range(0));
+  const size_t N = static_cast<size_t>(state.range(1));
+  const size_t K = static_cast<size_t>(state.range(2));
+
+  auto A = RandomVectorUniform(M * K, MLAS_FP16(-1.0f), MLAS_FP16(1.0f));
+  auto B = RandomVectorUniform(N * K, MLAS_FP16(-1.0f), MLAS_FP16(1.0f));
+  std::vector<MLAS_FP16> C(M * N);
+
+  const MLAS_FP16 alpha(1.0f);
+  const MLAS_FP16 beta(0.0f);
+  OrtThreadPoolParams tpo;
+  tpo.thread_pool_size = 8;
+  tpo.auto_set_affinity = true;
+  std::unique_ptr<onnxruntime::concurrency::ThreadPool> tp(
+      onnxruntime::concurrency::CreateThreadPool(&onnxruntime::Env::Default(),
+                                                 tpo, onnxruntime::concurrency::ThreadPoolType::INTRA_OP));
+
+  for (auto _ : state) {
+    onnxruntime::math::Gemm<Eigen::half>(
+        CblasNoTrans, transB ? CblasTrans : CblasNoTrans,
+        static_cast<ptrdiff_t>(M), static_cast<ptrdiff_t>(N), static_cast<ptrdiff_t>(K),
+        *reinterpret_cast<const Eigen::half*>(&alpha),
+        reinterpret_cast<const Eigen::half*>(A.data()),
+        reinterpret_cast<const Eigen::half*>(B.data()),
+        *reinterpret_cast<const Eigen::half*>(&beta),
+        reinterpret_cast<Eigen::half*>(C.data()), tp.get(), nullptr);
+  }
+}
+
+BENCHMARK_CAPTURE(HGEMMDecodeEigen, DecodeEigen_TransB, true)->Apply(GemmDecodeSizes)->UseRealTime();
+BENCHMARK_CAPTURE(HGEMMDecodeEigen, DecodeEigen_B, false)->Apply(GemmDecodeSizes)->UseRealTime();

--- a/onnxruntime/test/mlas/unittest/test_halfgemm.cpp
+++ b/onnxruntime/test/mlas/unittest/test_halfgemm.cpp
@@ -286,6 +286,78 @@ void RunKleidiAIWithoutOutputProcessorCases(const HalfGemmCase* test_cases, size
 
 }  // namespace
 
+TEST(HalfGemmDecode, Avx2F16CLayoutsAndTileBoundaries) {
+  if (!MlasHalfGemmDecodeSupported(CblasNoTrans, CblasNoTrans) ||
+      !MlasHalfGemmDecodeSupported(CblasNoTrans, CblasTrans)) {
+    GTEST_SKIP() << "AVX2/F16C half GEMV is unavailable.";
+  }
+
+  constexpr size_t K = 33;
+  constexpr size_t BatchSize = 1;
+  constexpr std::array<size_t, 9> OutputSizes{1, 7, 8, 9, 63, 64, 65, 137, 2049};
+  const MLFp16 alpha(0.5f);
+  const MLFp16 beta(-0.25f);
+
+  for (CBLAS_TRANSPOSE trans_b : {CblasNoTrans, CblasTrans}) {
+    for (size_t N : OutputSizes) {
+      std::vector<MLFp16> A(BatchSize * K);
+      std::vector<MLFp16> B(BatchSize * K * N);
+      std::vector<MLFp16> C(BatchSize * N);
+      std::vector<MLFp16> CInitial;
+      std::vector<MLFp16> CReference(BatchSize * N);
+      SmallFloatFill(A.data(), A.size());
+      SmallFloatFill(B.data(), B.size());
+      SmallFloatFill(C.data(), C.size());
+      CInitial = C;
+      CReference = C;
+
+      std::array<MLAS_HGEMM_DATA_PARAMS, BatchSize> data{};
+      for (size_t batch = 0; batch < BatchSize; ++batch) {
+        data[batch].A = reinterpret_cast<const MLAS_FP16*>(A.data() + batch * K);
+        data[batch].lda = K;
+        data[batch].B = reinterpret_cast<const MLAS_FP16*>(B.data() + batch * K * N);
+        data[batch].ldb = trans_b == CblasNoTrans ? N : K;
+        data[batch].C = reinterpret_cast<MLAS_FP16*>(C.data() + batch * N);
+        data[batch].ldc = N;
+        data[batch].alpha = alpha.val;
+        data[batch].beta = beta.val;
+
+        for (size_t n = 0; n < N; ++n) {
+          float sum = 0.0f;
+          for (size_t k = 0; k < K; ++k) {
+            const size_t b_index = trans_b == CblasNoTrans ? k * N + n : n * K + k;
+            sum = std::fma(float(A[batch * K + k]),
+                           float(B[batch * K * N + b_index]), sum);
+          }
+          const size_t c_index = batch * N + n;
+          CReference[c_index] = MLFp16(
+              std::fma(float(beta), float(CReference[c_index]), float(alpha) * sum));
+        }
+      }
+
+      for (bool threaded : {false, true}) {
+        MLAS_THREADPOOL* thread_pool = threaded ? GetMlasThreadPool() : nullptr;
+        if (threaded && thread_pool == nullptr) {
+          continue;
+        }
+
+        C = CInitial;
+        for (size_t batch = 0; batch < BatchSize; ++batch) {
+          data[batch].C = reinterpret_cast<MLAS_FP16*>(C.data() + batch * N);
+        }
+        MlasGemmBatch(
+            CblasNoTrans, trans_b, 1, N, K, data.data(), BatchSize, thread_pool);
+
+        for (size_t i = 0; i < C.size(); ++i) {
+          ASSERT_TRUE(CloseEnough(float(C[i]), float(CReference[i])))
+              << "transB=" << (trans_b == CblasTrans) << " threaded=" << threaded
+              << " N=" << N << " index=" << i;
+        }
+      }
+    }
+  }
+}
+
 TEST(HalfGemm, ZeroKInitializesBiasAndRunsOutputProcessor) {
   constexpr size_t M = 3;
   constexpr size_t N = 4;

--- a/onnxruntime/test/providers/cpu/math/gemm_test.cc
+++ b/onnxruntime/test/providers/cpu/math/gemm_test.cc
@@ -9,6 +9,8 @@
 #include "test/common/dnnl_op_test_utils.h"
 #include "test/util/include/default_providers.h"
 
+#include <cmath>
+
 namespace onnxruntime {
 namespace test {
 
@@ -1715,6 +1717,45 @@ TEST(GemmOpTest, GemmTransB_f16_32x32x128) {
   test.ConfigExcludeEps({kTensorrtExecutionProvider})  // TensorRT: fp16 is not supported
       .Config(run_with_tunable_op)
       .RunWithConfig();
+}
+
+TEST(GemmOpTest, GemmFloat16CpuDecodeTransB) {
+  constexpr int64_t K = 33;
+  constexpr int64_t N = 65;
+  const MLFloat16 alpha(0.5f);
+  const MLFloat16 beta(-0.25f);
+  std::vector<MLFloat16> a(K);
+  std::vector<MLFloat16> b(N * K);
+  std::vector<MLFloat16> bias(N);
+  for (int64_t k = 0; k < K; ++k) {
+    a[k] = MLFloat16(static_cast<float>((k % 7) - 3) * 0.125f);
+  }
+  for (int64_t n = 0; n < N; ++n) {
+    bias[n] = MLFloat16(static_cast<float>((n % 5) - 2) * 0.25f);
+    for (int64_t k = 0; k < K; ++k) {
+      b[n * K + k] = MLFloat16(static_cast<float>(((k + n) % 11) - 5) * 0.0625f);
+    }
+  }
+
+  std::vector<MLFloat16> expected(N);
+  for (int64_t n = 0; n < N; ++n) {
+    float sum = 0.0f;
+    for (int64_t k = 0; k < K; ++k) {
+      sum = std::fma(float(a[k]), float(b[n * K + k]), sum);
+    }
+    expected[n] = MLFloat16(std::fma(float(beta), float(bias[n]), float(alpha) * sum));
+  }
+
+  OpTester test("Gemm", 13);
+  test.AddAttribute("transB", int64_t{1});
+  test.AddAttribute("alpha", float(alpha));
+  test.AddAttribute("beta", float(beta));
+  test.AddInput<MLFloat16>("A", {1, K}, a);
+  test.AddInput<MLFloat16>("B", {N, K}, b);
+  test.AddInput<MLFloat16>("C", {N}, bias);
+  test.AddOutput<MLFloat16>("Y", {1, N}, expected);
+  test.SetOutputTolerance(0.005f);
+  test.ConfigEp(DefaultCpuExecutionProvider()).RunWithConfig();
 }
 
 }  // namespace test

--- a/onnxruntime/test/providers/cpu/math/matmul_test.cc
+++ b/onnxruntime/test/providers/cpu/math/matmul_test.cc
@@ -9,6 +9,8 @@
 #include "test/common/tensor_op_test_utils.h"
 #include "default_providers.h"
 
+#include <cmath>
+
 namespace onnxruntime {
 namespace test {
 
@@ -411,6 +413,35 @@ TEST(MathOpTest, MatMulFloat16Cpu) {
                             {MLFloat16(25.0f), MLFloat16(28.0f),
                              MLFloat16(57.0f), MLFloat16(64.0f),
                              MLFloat16(89.0f), MLFloat16(100.0f)});
+  test.ConfigEp(DefaultCpuExecutionProvider()).RunWithConfig();
+}
+
+TEST(MathOpTest, MatMulFloat16CpuDecode) {
+  constexpr int64_t K = 33;
+  constexpr int64_t N = 65;
+  std::vector<MLFloat16> a(K);
+  std::vector<MLFloat16> b(K * N);
+  for (int64_t k = 0; k < K; ++k) {
+    a[k] = MLFloat16(static_cast<float>((k % 7) - 3) * 0.125f);
+    for (int64_t n = 0; n < N; ++n) {
+      b[k * N + n] = MLFloat16(static_cast<float>(((k + n) % 11) - 5) * 0.0625f);
+    }
+  }
+
+  std::vector<MLFloat16> expected(N);
+  for (int64_t n = 0; n < N; ++n) {
+    float sum = 0.0f;
+    for (int64_t k = 0; k < K; ++k) {
+      sum = std::fma(float(a[k]), float(b[k * N + n]), sum);
+    }
+    expected[n] = MLFloat16(sum);
+  }
+
+  OpTester test("MatMul", 14);
+  test.AddInput<MLFloat16>("A", {1, K}, a);
+  test.AddInput<MLFloat16>("B", {K, N}, b);
+  test.AddOutput<MLFloat16>("Y", {1, N}, expected);
+  test.SetOutputTolerance(0.005f);
   test.ConfigEp(DefaultCpuExecutionProvider()).RunWithConfig();
 }
 


### PR DESCRIPTION
## Summary

Current ORT x86 AVX2/F16C dense FP16 `M=1` MatMul and Gemm paths fall back to `math::Gemm<Eigen::half>`. This change adds layout-matching MLAS GEMV kernels for `[K,N]` and transposed `[N,K]` weights, then routes CPU MatMul and Gemm through them.

The `[K,N]` kernel keeps a 64-column output tile in registers across the contraction. The `[N,K]` kernel uses four independent accumulator chains over each contiguous weight row. Runtime AVX2/F16C dispatch preserves existing fallbacks on unsupported hardware.

## Validation

- MLAS layout/tile-boundary correctness test passed for both layouts, `N=1/7/8/9/63/64/65/137`, batch 2, and alpha/beta handling.
- CPU provider routing tests for MatMul and Gemm passed.
- Release MLAS, provider, and benchmark targets built successfully.
- Final diff: 12 files, 569 additions; no line-ending-only churn.

## Performance

Median speedups versus the exact Eigen fallback:

| `(N,K)` | `[N,K]` | `[K,N]` |
|---|---:|---:|
| `4096x4096` | 680.8x | 229.5x |
| `11008x4096` | 249.7x | 129.2x |
| `4096x11008` | 238.2x | 100.9x |
