### PR TITLE
Fix symbolic shape inference for Range with float inputs

### DIFF
--- a/onnxruntime/python/tools/symbolic_shape_infer.py
+++ b/onnxruntime/python/tools/symbolic_shape_infer.py
@@ -1591,7 +1591,7 @@ class SymbolicShapeInference:
 
     def _infer_Range(self, node):  # noqa: N802
         vi = self.known_vi_[node.output[0]]
-        input_data = self._get_int_or_float_values(node)
+        input_data = self._get_int_or_float_values(node, allow_float_values=True)
         if all(i is not None for i in input_data):
             start = as_scalar(input_data[0])
             limit = as_scalar(input_data[1])

--- a/onnxruntime/test/python/onnxruntime_test_python_symbolic_shape_infer.py
+++ b/onnxruntime/test/python/onnxruntime_test_python_symbolic_shape_infer.py
@@ -725,6 +725,36 @@ class TestSymbolicShapeInferenceForOperators(unittest.TestCase):
         ]
         self._check_shapes(graph, inferred.graph, expected_shapes)
 
+    def test_range_with_float_inputs(self):
+        # Range start/limit/delta are floats here. Truncating them to int makes delta 0
+        # and the length computation divide by zero.
+        initializers = [
+            numpy_helper.from_array(numpy.array(0.0, dtype=numpy.float32), "start"),
+            numpy_helper.from_array(numpy.array(1.0, dtype=numpy.float32), "limit"),
+            numpy_helper.from_array(numpy.array(0.3, dtype=numpy.float32), "delta"),
+        ]
+        graph = helper.make_graph(
+            [
+                helper.make_node("Range", ["start", "limit", "delta"], ["temp"]),
+                helper.make_node("Identity", ["temp"], ["output"]),
+            ],
+            "Range_Float_Test",
+            [],
+            [
+                helper.make_tensor_value_info("output", TensorProto.FLOAT, [4]),
+            ],
+            initializers,
+        )
+        model = helper.make_model(graph, producer_name="Range_Float_Test_Model")
+        model.opset_import[0].version = 18
+
+        inferred = SymbolicShapeInference.infer_shapes(model, auto_merge=True)
+        expected_shapes = [
+            helper.make_tensor_value_info("temp", TensorProto.FLOAT, [4]),
+            helper.make_tensor_value_info("output", TensorProto.FLOAT, [4]),
+        ]
+        self._check_shapes(graph, inferred.graph, expected_shapes)
+
 
 class TestSymbolicShapeInferenceForSlice(unittest.TestCase):
     def check_slice_of_concat(self, input_dims, start, end, step, expected_output_dim):

--- a/onnxruntime/test/python/onnxruntime_test_python_symbolic_shape_infer.py
+++ b/onnxruntime/test/python/onnxruntime_test_python_symbolic_shape_infer.py
@@ -726,34 +726,78 @@ class TestSymbolicShapeInferenceForOperators(unittest.TestCase):
         self._check_shapes(graph, inferred.graph, expected_shapes)
 
     def test_range_with_float_inputs(self):
-        # Range start/limit/delta are floats here. Truncating them to int makes delta 0
-        # and the length computation divide by zero.
-        initializers = [
-            numpy_helper.from_array(numpy.array(0.0, dtype=numpy.float32), "start"),
-            numpy_helper.from_array(numpy.array(1.0, dtype=numpy.float32), "limit"),
-            numpy_helper.from_array(numpy.array(0.3, dtype=numpy.float32), "delta"),
+        # Range start/limit/delta are floats here. Truncating them to int makes a
+        # sub-unit delta zero (ZeroDivisionError) and rounds larger ones.
+        cases = [
+            (0.0, 1.0, 0.3),
+            (0.0, 1.0, 0.25),
+            (0.0, 2.0, 0.7),
+            (5.0, 0.0, -1.5),
+            (0.0, -1.0, -0.3),
+            (1.0, 1.0, 0.5),
         ]
-        graph = helper.make_graph(
-            [
-                helper.make_node("Range", ["start", "limit", "delta"], ["temp"]),
-                helper.make_node("Identity", ["temp"], ["output"]),
-            ],
-            "Range_Float_Test",
-            [],
-            [
-                helper.make_tensor_value_info("output", TensorProto.FLOAT, [4]),
-            ],
-            initializers,
-        )
-        model = helper.make_model(graph, producer_name="Range_Float_Test_Model")
-        model.opset_import[0].version = 18
+        for start, limit, delta in cases:
+            with self.subTest(start=start, limit=limit, delta=delta):
+                expected = len(numpy.arange(start, limit, delta, dtype=numpy.float32))
+                initializers = [
+                    numpy_helper.from_array(numpy.array(start, dtype=numpy.float32), "start"),
+                    numpy_helper.from_array(numpy.array(limit, dtype=numpy.float32), "limit"),
+                    numpy_helper.from_array(numpy.array(delta, dtype=numpy.float32), "delta"),
+                ]
+                graph = helper.make_graph(
+                    [
+                        helper.make_node("Range", ["start", "limit", "delta"], ["temp"]),
+                        helper.make_node("Identity", ["temp"], ["output"]),
+                    ],
+                    "Range_Float_Test",
+                    [],
+                    [
+                        helper.make_tensor_value_info("output", TensorProto.FLOAT, [expected]),
+                    ],
+                    initializers,
+                )
+                model = helper.make_model(graph, producer_name="Range_Float_Test_Model")
+                model.opset_import[0].version = 18
 
-        inferred = SymbolicShapeInference.infer_shapes(model, auto_merge=True)
-        expected_shapes = [
-            helper.make_tensor_value_info("temp", TensorProto.FLOAT, [4]),
-            helper.make_tensor_value_info("output", TensorProto.FLOAT, [4]),
-        ]
-        self._check_shapes(graph, inferred.graph, expected_shapes)
+                inferred = SymbolicShapeInference.infer_shapes(model, auto_merge=True)
+                expected_shapes = [
+                    helper.make_tensor_value_info("temp", TensorProto.FLOAT, [expected]),
+                    helper.make_tensor_value_info("output", TensorProto.FLOAT, [expected]),
+                ]
+                self._check_shapes(graph, inferred.graph, expected_shapes)
+
+    def test_range_with_int_inputs(self):
+        # Integer Range must be unaffected by allowing float values through.
+        cases = [(0, 10, 1), (0, 10, 3), (10, 0, -1), (10, 0, -3), (5, 5, 1), (0, 7, 2)]
+        for start, limit, delta in cases:
+            with self.subTest(start=start, limit=limit, delta=delta):
+                expected = len(numpy.arange(start, limit, delta))
+                initializers = [
+                    numpy_helper.from_array(numpy.array(start, dtype=numpy.int64), "start"),
+                    numpy_helper.from_array(numpy.array(limit, dtype=numpy.int64), "limit"),
+                    numpy_helper.from_array(numpy.array(delta, dtype=numpy.int64), "delta"),
+                ]
+                graph = helper.make_graph(
+                    [
+                        helper.make_node("Range", ["start", "limit", "delta"], ["temp"]),
+                        helper.make_node("Identity", ["temp"], ["output"]),
+                    ],
+                    "Range_Int_Test",
+                    [],
+                    [
+                        helper.make_tensor_value_info("output", TensorProto.INT64, [expected]),
+                    ],
+                    initializers,
+                )
+                model = helper.make_model(graph, producer_name="Range_Int_Test_Model")
+                model.opset_import[0].version = 18
+
+                inferred = SymbolicShapeInference.infer_shapes(model, auto_merge=True)
+                expected_shapes = [
+                    helper.make_tensor_value_info("temp", TensorProto.INT64, [expected]),
+                    helper.make_tensor_value_info("output", TensorProto.INT64, [expected]),
+                ]
+                self._check_shapes(graph, inferred.graph, expected_shapes)
 
 
 class TestSymbolicShapeInferenceForSlice(unittest.TestCase):


### PR DESCRIPTION
`_infer_Range` calls `_get_int_or_float_values(node)` without `allow_float_values=True`,
so every scalar input is passed through `int()`. A float delta below one truncates to
zero and the next line divides by it, aborting shape inference for the whole model.
Larger float deltas are silently rounded instead: `Range(5.0, 0.0, -1.5)` uses -1.

```python
# start=0.0, limit=1.0, delta=0.3 as initializers, opset 18
SymbolicShapeInference.infer_shapes(model, auto_merge=True)
# ZeroDivisionError: division by zero      expected shape [4]
```

`_get_int_or_float_values` keeps a value as float only when `value % 1 != 0`, so integer
Range nodes still produce sympy Integers and nothing downstream changes.

Checked all 12 combinations in the added sweep against `numpy.arange`, integer and float,
positive and negative deltas, including empty ranges. All match.

`onnxruntime_test_python_symbolic_shape_infer.py` goes from 3 failed / 29 passed to
2 failed / 30 passed. The two remaining failures are the pre-existing
`TestSymbolicShapeInferenceForSlice` step tests, unrelated and failing on main.
