### PR TITLE
Fix reduction operator shape inference at opset 18 and later

### DIFF
--- a/onnxruntime/python/tools/symbolic_shape_infer.py
+++ b/onnxruntime/python/tools/symbolic_shape_infer.py
@@ -519,6 +519,7 @@ class SymbolicShapeInference:
                 "ReduceLogSumExp",
                 "ReduceMax",
                 "ReduceMin",
+                "ReduceProd",
                 "ReduceSumSquare",
             ]:
                 initializers = [

--- a/onnxruntime/python/tools/symbolic_shape_infer.py
+++ b/onnxruntime/python/tools/symbolic_shape_infer.py
@@ -508,7 +508,19 @@ class SymbolicShapeInference:
             # (2) opset version >= 9. In older version, initializer is required in graph input by onnx spec.
             # (3) The initializer is not in graph input. The means the node input is "constant" in inference.
             initializers = []
-            if (get_opset(self.out_mp_) >= 9) and node.op_type in ["Unsqueeze"]:
+            if (get_opset(self.out_mp_) >= 9) and node.op_type in [
+                "Unsqueeze",
+                # Since opset 18 the reduction operators take axes as an input rather
+                # than an attribute. Without the axes value onnx shape inference cannot
+                # compute the output shape and returns nothing.
+                "ReduceL1",
+                "ReduceL2",
+                "ReduceLogSum",
+                "ReduceLogSumExp",
+                "ReduceMax",
+                "ReduceMin",
+                "ReduceSumSquare",
+            ]:
                 initializers = [
                     self.initializers_[name]
                     for name in node.input
@@ -1627,6 +1639,9 @@ class SymbolicShapeInference:
                 shape = self._get_shape(node, 0)
                 output_shape = []
                 axes = [handle_negative_axis(a, len(shape)) for a in axes]
+                if not axes and not get_attribute(node, "noop_with_empty_axes", 0):
+                    # An empty axes input reduces every axis unless noop_with_empty_axes is set.
+                    axes = list(range(len(shape)))
                 for i, d in enumerate(shape):
                     if i in axes:
                         if keep_dims:

--- a/onnxruntime/test/python/onnxruntime_test_python_symbolic_shape_infer.py
+++ b/onnxruntime/test/python/onnxruntime_test_python_symbolic_shape_infer.py
@@ -725,6 +725,74 @@ class TestSymbolicShapeInferenceForOperators(unittest.TestCase):
         ]
         self._check_shapes(graph, inferred.graph, expected_shapes)
 
+    def test_reduce_ops_opset18_axes_input(self):
+        # Since opset 18 axes is an input. Without the initializer the output shape is lost.
+        for op_type in [
+            "ReduceL1",
+            "ReduceL2",
+            "ReduceLogSum",
+            "ReduceLogSumExp",
+            "ReduceMax",
+            "ReduceMin",
+            "ReduceSumSquare",
+        ]:
+            with self.subTest(op_type=op_type):
+                initializers = [numpy_helper.from_array(numpy.array([1], dtype=numpy.int64), "axes")]
+                graph = helper.make_graph(
+                    [
+                        helper.make_node(op_type, ["input", "axes"], ["temp"], keepdims=0),
+                        helper.make_node("Identity", ["temp"], ["output"]),
+                    ],
+                    f"{op_type}_Opset18_Test",
+                    [
+                        helper.make_tensor_value_info("input", TensorProto.FLOAT, [2, 3, 4]),
+                    ],
+                    [
+                        helper.make_tensor_value_info("output", TensorProto.FLOAT, [2, 4]),
+                    ],
+                    initializers,
+                )
+                model = helper.make_model(graph, producer_name=f"{op_type}_Opset18_Test_Model")
+                model.opset_import[0].version = 18
+
+                inferred = SymbolicShapeInference.infer_shapes(model, auto_merge=True)
+                expected_shapes = [
+                    helper.make_tensor_value_info("temp", TensorProto.FLOAT, [2, 4]),
+                    helper.make_tensor_value_info("output", TensorProto.FLOAT, [2, 4]),
+                ]
+                self._check_shapes(graph, inferred.graph, expected_shapes)
+
+    def test_reduce_sum_empty_axes(self):
+        # An empty axes input reduces every axis unless noop_with_empty_axes is set.
+        for noop, expected in [(0, []), (1, [2, 3, 4])]:
+            with self.subTest(noop_with_empty_axes=noop):
+                initializers = [numpy_helper.from_array(numpy.array([], dtype=numpy.int64), "axes")]
+                graph = helper.make_graph(
+                    [
+                        helper.make_node(
+                            "ReduceSum", ["input", "axes"], ["temp"], keepdims=0, noop_with_empty_axes=noop
+                        ),
+                        helper.make_node("Identity", ["temp"], ["output"]),
+                    ],
+                    "ReduceSum_EmptyAxes_Test",
+                    [
+                        helper.make_tensor_value_info("input", TensorProto.FLOAT, [2, 3, 4]),
+                    ],
+                    [
+                        helper.make_tensor_value_info("output", TensorProto.FLOAT, expected),
+                    ],
+                    initializers,
+                )
+                model = helper.make_model(graph, producer_name="ReduceSum_EmptyAxes_Test_Model")
+                model.opset_import[0].version = 18
+
+                inferred = SymbolicShapeInference.infer_shapes(model, auto_merge=True)
+                expected_shapes = [
+                    helper.make_tensor_value_info("temp", TensorProto.FLOAT, expected),
+                    helper.make_tensor_value_info("output", TensorProto.FLOAT, expected),
+                ]
+                self._check_shapes(graph, inferred.graph, expected_shapes)
+
 
 class TestSymbolicShapeInferenceForSlice(unittest.TestCase):
     def check_slice_of_concat(self, input_dims, start, end, step, expected_output_dim):

--- a/onnxruntime/test/python/onnxruntime_test_python_symbolic_shape_infer.py
+++ b/onnxruntime/test/python/onnxruntime_test_python_symbolic_shape_infer.py
@@ -734,6 +734,7 @@ class TestSymbolicShapeInferenceForOperators(unittest.TestCase):
             "ReduceLogSumExp",
             "ReduceMax",
             "ReduceMin",
+            "ReduceProd",
             "ReduceSumSquare",
         ]:
             with self.subTest(op_type=op_type):


### PR DESCRIPTION
Two shape inference defects for reduction operators at opset 18 and later, where axes
became an input rather than an attribute.

**Seven operators lose their output shape entirely.** `_onnx_infer_single_node` forwards
initializers into its temp graph only for `Unsqueeze`, so `ReduceL1`, `ReduceL2`,
`ReduceLogSum`, `ReduceLogSumExp`, `ReduceMax`, `ReduceMin` and `ReduceSumSquare` reach
`onnx.shape_inference` with no axes value and come back with nothing. `ReduceSum`,
`ReduceMean` and `ReduceProd` escape because they have dedicated handlers.

```python
# ReduceL2 over [2, 3, 4], axes=[1] as an initializer, keepdims=0, opset 18
# inferred output shape: none at all      expected [2, 4]
```

**`ReduceSum` ignores `noop_with_empty_axes`.** An empty axes tensor is not `None`, so
the per-axis loop matches nothing and the input shape is copied through. The spec reduces
every axis unless `noop_with_empty_axes=1`. `ReduceMean` routes to the same handler at
opset 18.

```python
# ReduceSum over [2, 3, 4], empty axes, keepdims=0, noop_with_empty_axes=0
# inferred [2, 3, 4]      expected [] (scalar)
```

`noop_with_empty_axes=1` still passes the shape through unchanged, and an explicit
non-empty axes list is unaffected. Both covered in the added tests.

`onnxruntime_test_python_symbolic_shape_infer.py` goes from 10 failed / 31 passed to
2 failed / 31 passed with 9 subtests passing. The two remaining failures are the
pre-existing `TestSymbolicShapeInferenceForSlice` step tests, unrelated and failing on main.
