### PR TITLE
Add --run_config option to onnxruntime_perf_test

### DIFF
--- a/onnxruntime/test/perftest/README.md
+++ b/onnxruntime/test/perftest/README.md
@@ -40,6 +40,10 @@ Options:
                                       Refer to onnxruntime_session_options_config_keys.h for valid keys and values.
                                       [Example] -C "session.disable_cpu_ep_fallback|1 ep.context_enable|1"
 
+        --run_config: [run_config_entries]: Specify run configuration entries as key-value pairs: --run_config "<key1>|<val1> <key2>|<val2>"
+                                      [Example] --run_config "gpu_graph_id|1 qnn.htp_perf_mode|burst"
+                                      When -g (CUDA IO binding) is enabled, disable_synchronize_execution_providers is forced to 1.
+
 	-h: help.
 
 Model path and input data dependency:

--- a/onnxruntime/test/perftest/ReadMe.txt
+++ b/onnxruntime/test/perftest/ReadMe.txt
@@ -6,6 +6,8 @@ Options:
         -r [repeated_times]: Specifies the repeated times if running in 'times' test mode.Default:1000.
         -t [seconds_to_run]: Specifies the seconds to run for 'duration' mode. Default:600.
         -p [profile_file]: Specifies the profile name to enable profiling and dump the profile data to the file.
+        --run_config [run_config_entries]: Specify run configuration entries as key-value pairs: --run_config "<key1>|<val1> <key2>|<val2>"
+                                      [Example] --run_config "gpu_graph_id|1 qnn.htp_perf_mode|burst"
         -v: Show verbose information
         -h: help
 

--- a/onnxruntime/test/perftest/command_args_parser.cc
+++ b/onnxruntime/test/perftest/command_args_parser.cc
@@ -170,6 +170,10 @@ ABSL_FLAG(std::string, C, "",
           "[Example] -C \"session.disable_cpu_ep_fallback|1 ep.context_enable|1\" \n");
 ABSL_FLAG(std::string, R, "", "Allows user to register custom op by .so or .dll file.");
 ABSL_FLAG(bool, A, !DefaultPerformanceTestConfig().run_config.enable_cpu_mem_arena, "Disables memory arena.");
+ABSL_FLAG(std::string, run_config, "",
+          "Specifies run configuration entries as key-value pairs:\n"
+          " --run_config \"<key1>|<value1> <key2>|<value2>\"\n"
+          "[Example] --run_config \"gpu_graph_id|1 qnn.htp_perf_mode|burst\"\n");
 ABSL_FLAG(std::string, shrink_arena_between_runs, "", "When arena is enabled call Shrink for specified devices 'cpu:0;gpu:0'");
 ABSL_FLAG(std::string, enable_cuda_mempool, "", "When cuda is enabled use CudaMempoolArena with params 'pool_release_threshold;bytes_to_keep_on_shrink'");
 ABSL_FLAG(bool, M, !DefaultPerformanceTestConfig().run_config.enable_memory_pattern, "Disables memory pattern.");
@@ -307,6 +311,22 @@ bool CommandLineParser::ParseArguments(PerformanceTestConfig& test_config, int a
 
   // -A
   test_config.run_config.enable_cpu_mem_arena = !absl::GetFlag(FLAGS_A);
+
+  // --run_config
+  {
+    const auto& run_configs = absl::GetFlag(FLAGS_run_config);
+    if (!run_configs.empty()) {
+      ORT_TRY {
+        ParseSessionConfigs(run_configs, test_config.run_config.run_config_entries);
+      }
+      ORT_CATCH(const std::exception& ex) {
+        ORT_HANDLE_EXCEPTION([&]() {
+          fprintf(stderr, "Error parsing run configuration entries: %s\n", ex.what());
+        });
+        return false;
+      }
+    }
+  }
 
   // --shrink_arena_between_runs
   if (test_config.run_config.enable_cpu_mem_arena) {


### PR DESCRIPTION
## Summary
- Add `--run_config` CLI flag to `onnxruntime_perf_test` for setting RunOptions config entries per run
- Reuse the existing `key|value` parsing format already used by `-C` (session config)
- Update perftest README documentation and `--help` text

## Motivation

`onnxruntime_perf_test` internally supports `RunOptions` config entries, but the CLI only exposed `--shrink_arena_between_runs` for a single key. Users who need other per-run settings - such as `gpu_graph_id` (CUDA Graph), `qnn.htp_perf_mode` (QNN), or arbitrary EP-specific RunOptions read at run time - had no command-line path and had to patch the tool or use the ORT API.

`-C` sets SessionOptions (session-level); `--run_config` sets RunOptions (per-run). This PR adds `--run_config` using the same `key|value` format as `-C`.

## Test plan
- [x] Built `onnxruntime_perf_test` locally
- [x] Verified `onnxruntime_perf_test --help` lists `--run_config`
