### PR TITLE
Prevent Agility SDK use with WebGPU Plugin EP builds

### DIFF
--- a/cmake/external/onnxruntime_external_deps.cmake
+++ b/cmake/external/onnxruntime_external_deps.cmake
@@ -656,7 +656,7 @@ if (onnxruntime_USE_WEBGPU)
     if (NOT onnxruntime_ENABLE_DAWN_BACKEND_D3D12)
       message(FATAL_ERROR "DAWN_USE_AGILITY_SDK requires the Dawn D3D12 backend.")
     endif()
-      if (onnxruntime_USE_EP_API_ADAPTERS)
+    if (onnxruntime_USE_EP_API_ADAPTERS)
       # Plugin EP packages cannot guarantee that the Agility SDK runtime DLLs are deployed
       # next to the host executable.
       message(FATAL_ERROR

--- a/cmake/external/onnxruntime_external_deps.cmake
+++ b/cmake/external/onnxruntime_external_deps.cmake
@@ -656,6 +656,13 @@ if (onnxruntime_USE_WEBGPU)
     if (NOT onnxruntime_ENABLE_DAWN_BACKEND_D3D12)
       message(FATAL_ERROR "DAWN_USE_AGILITY_SDK requires the Dawn D3D12 backend.")
     endif()
+      if (onnxruntime_USE_EP_API_ADAPTERS)
+      # Plugin EP packages cannot guarantee that the Agility SDK runtime DLLs are deployed
+      # next to the host executable.
+      message(FATAL_ERROR
+              "DAWN_USE_AGILITY_SDK is not supported with onnxruntime_USE_EP_API_ADAPTERS=ON (plugin EP build). "
+              "It is intended for local development builds only.")
+    endif()
   endif()
 
   # TODO: the following code is used to disable building Dawn using vcpkg temporarily

--- a/docs/BuildWithDawnAgilitySDK.md
+++ b/docs/BuildWithDawnAgilitySDK.md
@@ -15,9 +15,9 @@ python tools\ci_build\build.py `
 ```
 
 This option is intended for local development and supports Windows desktop x86, x64, and ARM64 targets. Windows ARM32,
-ARM64EC, and WindowsStore/UWP targets are not supported. Python wheels, C#, NuGet, Java, and Node.js packages are also
-not supported because they do not deploy the required D3D12 runtime DLLs. Custom Dawn checkouts selected with
-`onnxruntime_CUSTOM_DAWN_SRC_PATH` are not supported.
+ARM64EC, and WindowsStore/UWP targets are not supported. WebGPU Plugin EP, Python wheels, C#, NuGet, Java, and Node.js
+packages are also not supported because they do not deploy the required D3D12 runtime DLLs. Custom Dawn checkouts
+selected with `onnxruntime_CUSTOM_DAWN_SRC_PATH` are not supported.
 
 The pinned SDK requires Windows 10 version 1909 or newer. For versions 1909, 2004, and 20H2, the minimum OS build
 revisions are:

--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -922,6 +922,15 @@ def generate_build_tree(
                 "Use an x86, x64, or ARM64 target."
             )
 
+        # The plugin EP package is built with `--use_webgpu shared_lib` and packaged in a separate step,
+        # so the `--build_*` check below does not cover it.
+        if args.use_webgpu == "shared_lib":
+            raise BuildError(
+                "Dawn Agility SDK (--use_dawn_agility_sdk) is not supported with the WebGPU plugin EP shared "
+                "library build (--use_webgpu shared_lib), which is the configuration used to produce the released "
+                "plugin EP packages. Use the static library build (--use_webgpu) for local development."
+            )
+
         if args.build_wheel or args.build_csharp or args.build_nuget or args.build_java or args.build_nodejs:
             raise BuildError(
                 "Dawn Agility SDK (--use_dawn_agility_sdk) is currently supported for local development builds only. "

--- a/tools/ci_build/build_args.py
+++ b/tools/ci_build/build_args.py
@@ -833,7 +833,8 @@ def add_execution_provider_args(parser: argparse.ArgumentParser) -> None:
         action="store_true",
         help=(
             "Build Dawn's D3D12 backend with the Agility SDK for local development "
-            "(Windows desktop x86, x64, or ARM64 only; packaging unsupported)."
+            "(Windows desktop x86, x64, or ARM64 only; static library build only; "
+            "packaging and plugin EP builds unsupported)."
         ),
     )
     webgpu_group.add_argument(


### PR DESCRIPTION
Add an explicit check to reject --use_dawn_agility_sdk with --use_webgpu shared_lib. For now, Agility SDK support is limited to local static library builds. PTAL, thanks! @qjia7 @edgchen1 @jchen10