### PR TITLE
[MLAS] Do not build the POWER MLAS kernels when VSX is unavailable

### DIFF
--- a/cmake/onnxruntime_mlas.cmake
+++ b/cmake/onnxruntime_mlas.cmake
@@ -701,6 +701,15 @@ else()
         endif()
     endif()
     if(POWER AND MLAS_SOURCE_IS_NOT_SET)
+        check_cxx_source_compiles("
+          #ifndef __VSX__
+          #error VSX is not supported
+          #endif
+          int main() { return 0; }"
+          MLAS_HAS_VSX
+        )
+    endif()
+    if(POWER AND MLAS_HAS_VSX AND MLAS_SOURCE_IS_NOT_SET)
         set(mlas_platform_srcs
           ${MLAS_SRC_DIR}/power/SgemmKernelPower.cpp
           ${MLAS_SRC_DIR}/dgemm.cpp


### PR DESCRIPTION
### Description
mlas.h only defines MLAS_TARGET_POWER when __VSX__ is defined, so on
PowerPC targets whose default baseline lacks VSX (for example
FreeBSD/powerpc64, whose big-endian baseline is a 970-class CPU with
AltiVec but no VSX) MLAS itself falls back to the generic
implementation.  onnxruntime_mlas.cmake, however, still adds the power/
kernel sources and dgemm.cpp for every powerpc* processor.  Those
translation units cannot compile without VSX: mlasi.h only includes
<altivec.h> under __VSX__, so vec_splat and friends are undeclared, and
the MLAS_FLOAT64X2 type and the double-precision helpers exist only for
MLAS_VSX_INTRINSICS:

  onnxruntime/core/mlas/lib/power/FgemmKernelpower.h:155:27: error: use of undeclared identifier "vec_splat"
  onnxruntime/core/mlas/lib/power/DgemmKernelPower.cpp: error: unknown type name "MLAS_FLOAT64X2"

### Motivation and Context
Probe for __VSX__ and skip the POWER-specific sources when it is absent,
so that such targets build with the generic kernels, matching what
mlas.h already decides at the preprocessor level.

Tested on FreeBSD 15.1/powerpc64 (big-endian): the build proceeds past
MLAS with the generic kernels; powerpc64le (VSX baseline) is unaffected.
