### PR TITLE
fix(Paged Attention): sanitize block_table reads

### DIFF
--- a/onnxruntime/contrib_ops/cpu/bert/paged_attention_helper.h
+++ b/onnxruntime/contrib_ops/cpu/bert/paged_attention_helper.h
@@ -255,8 +255,9 @@ Status CheckBlockTable(const T* block_table, const int batch_size, int& max_num_
 // slot_mapping (input 10) is the scheduler-owned write map: one flat slot index per query token
 // into the cache viewed as [num_blocks * block_size, kv_num_heads, head_size], or -1 to skip the
 // K/V store for that token. Element range is not validated on the host: that would require a
-// device-to-host copy every step. Out-of-range values are undefined behavior, exactly as for
-// block_table today.
+// device-to-host copy every step. The kernel bound-checks it on device instead, skipping any slot
+// outside [0, num_blocks * block_size); block_table is sanitized against num_blocks the same way,
+// via LaunchSanitizeBlockTable, before any attention backend reads it.
 template <typename T = Tensor>
 Status CheckSlotMapping(const T* slot_mapping, const int token_count) {
   const auto& dims = slot_mapping->Shape().GetDims();

--- a/onnxruntime/contrib_ops/cpu/bert/paged_attention_helper.h
+++ b/onnxruntime/contrib_ops/cpu/bert/paged_attention_helper.h
@@ -256,8 +256,10 @@ Status CheckBlockTable(const T* block_table, const int batch_size, int& max_num_
 // into the cache viewed as [num_blocks * block_size, kv_num_heads, head_size], or -1 to skip the
 // K/V store for that token. Element range is not validated on the host: that would require a
 // device-to-host copy every step. The kernel bound-checks it on device instead, skipping any slot
-// outside [0, num_blocks * block_size); block_table is sanitized against num_blocks the same way,
-// via LaunchSanitizeBlockTable, before any attention backend reads it.
+// outside [0, num_blocks * block_size); on the CUDA EP, block_table is sanitized against num_blocks
+// the same way (out-of-range entries redirected to -1), via LaunchSanitizeBlockTable, before most
+// attention backends read it. The WebGPU PagedAttention kernel indexes block_table directly and does
+// not go through this sanitize step.
 template <typename T = Tensor>
 Status CheckSlotMapping(const T* slot_mapping, const int token_count) {
   const auto& dims = slot_mapping->Shape().GetDims();

--- a/onnxruntime/contrib_ops/cuda/bert/paged_attention.cc
+++ b/onnxruntime/contrib_ops/cuda/bert/paged_attention.cc
@@ -355,6 +355,14 @@ Status PagedAttention<T, TCACHE>::ComputeInternal(OpKernelContext* context) cons
   auto cumulative_seqlens_kv_buffer = GetScratchBuffer<void>(cumulative_seqlens_kv_bytes, GetComputeStream(context));
   int* cumulative_seqlens_kv_ptr = reinterpret_cast<int*>(cumulative_seqlens_kv_buffer.get());
 
+  // block_table is a graph input; CheckBlockTable validates only its shape, never entry values.
+  // Sanitize it once into a scratch copy so every attention backend can keep indexing the paged
+  // cache with a raw block_table entry, the way the write path already does.
+  size_t sanitized_block_table_bytes =
+      sizeof(int) * static_cast<size_t>(parameters.batch_size) * parameters.max_num_blocks_per_seq;
+  auto sanitized_block_table_buffer = GetScratchBuffer<void>(sanitized_block_table_bytes, GetComputeStream(context));
+  int* sanitized_block_table_ptr = reinterpret_cast<int*>(sanitized_block_table_buffer.get());
+
   // The fused prologue (QK-Norm and/or rotary) writes densified Q and K into the workspace, so it
   // needs room for both. Plain packed-QKV only needs to densify Q.
   const bool needs_qk_prologue = do_rotary_ || parameters.use_qk_norm;
@@ -374,6 +382,10 @@ Status PagedAttention<T, TCACHE>::ComputeInternal(OpKernelContext* context) cons
       reinterpret_cast<const int*>(cumulative_seqlens_q->Data<int>()),
       reinterpret_cast<const int*>(past_seqlens->Data<int>()),
       parameters.batch_size, cuda_stream));
+
+  ORT_RETURN_IF_ERROR(LaunchSanitizeBlockTable(
+      sanitized_block_table_ptr, reinterpret_cast<const int*>(block_table->Data<int>()), parameters.num_blocks,
+      parameters.batch_size, parameters.max_num_blocks_per_seq, cuda_stream));
 
   int total_kv_tokens = 0;
   int max_query_len = 0;
@@ -801,7 +813,7 @@ Status PagedAttention<T, TCACHE>::ComputeInternal(OpKernelContext* context) cons
   data.cumulative_seqlens_q = reinterpret_cast<const int*>(cumulative_seqlens_q->Data<int>());
   data.past_seqlens = reinterpret_cast<const int*>(past_seqlens->Data<int>());
   data.cumulative_seqlens_kv = cumulative_seqlens_kv_ptr;
-  data.block_table = reinterpret_cast<const int*>(block_table->Data<int>());
+  data.block_table = sanitized_block_table_ptr;
   data.slot_mapping = slot_mapping == nullptr ? nullptr : reinterpret_cast<const int*>(slot_mapping->Data<int>());
   data.head_sink = head_sink == nullptr ? nullptr : reinterpret_cast<const CudaT*>(head_sink->Data<T>());
   data.q_norm_weight = q_norm_weight == nullptr ? nullptr : reinterpret_cast<const CudaT*>(q_norm_weight->Data<T>());

--- a/onnxruntime/contrib_ops/cuda/bert/paged_attention_impl.cu
+++ b/onnxruntime/contrib_ops/cuda/bert/paged_attention_impl.cu
@@ -369,16 +369,15 @@ Status LaunchGetCumulativeSeqlensKV(int32_t* cumulative_seqlens_kv, const int32_
   return CUDA_CALL(cudaGetLastError());
 }
 
-// block_table is a graph input; CheckBlockTable validates only its shape, never entry values. Every
-// read path indexes the paged cache with block_table entries directly, so an entry >= num_blocks
-// would read out of bounds. Sanitize once here, the same way the write path already bound-checks its
-// own slot, so every downstream consumer can keep treating "< 0" as its only unmapped-block check.
+// block_table is a graph input and may contain out-of-range entries. Clamp entries >= num_blocks
+// into range before any read path indexes the paged cache with them; negative entries (the
+// existing "unmapped block" sentinel) are left as-is.
 __global__ void SanitizeBlockTable(int* __restrict__ sanitized_block_table, const int* __restrict__ block_table,
                                     const int num_blocks, const int total_entries) {
   const int i = blockIdx.x * blockDim.x + threadIdx.x;
   if (i >= total_entries) return;
   const int block_id = block_table[i];
-  sanitized_block_table[i] = (block_id < 0 || block_id >= num_blocks) ? -1 : block_id;
+  sanitized_block_table[i] = block_id >= num_blocks ? 0 : block_id;
 }
 
 Status LaunchSanitizeBlockTable(int* sanitized_block_table, const int* block_table, const int num_blocks,

--- a/onnxruntime/contrib_ops/cuda/bert/paged_attention_impl.cu
+++ b/onnxruntime/contrib_ops/cuda/bert/paged_attention_impl.cu
@@ -369,6 +369,27 @@ Status LaunchGetCumulativeSeqlensKV(int32_t* cumulative_seqlens_kv, const int32_
   return CUDA_CALL(cudaGetLastError());
 }
 
+// block_table is a graph input; CheckBlockTable validates only its shape, never entry values. Every
+// read path indexes the paged cache with block_table entries directly, so an entry >= num_blocks
+// would read out of bounds. Sanitize once here, the same way the write path already bound-checks its
+// own slot, so every downstream consumer can keep treating "< 0" as its only unmapped-block check.
+__global__ void SanitizeBlockTable(int* __restrict__ sanitized_block_table, const int* __restrict__ block_table,
+                                    const int num_blocks, const int total_entries) {
+  const int i = blockIdx.x * blockDim.x + threadIdx.x;
+  if (i >= total_entries) return;
+  const int block_id = block_table[i];
+  sanitized_block_table[i] = (block_id < 0 || block_id >= num_blocks) ? -1 : block_id;
+}
+
+Status LaunchSanitizeBlockTable(int* sanitized_block_table, const int* block_table, const int num_blocks,
+                                const int batch_size, const int max_num_blocks_per_seq, cudaStream_t stream) {
+  const int total_entries = batch_size * max_num_blocks_per_seq;
+  constexpr int kThreads = 256;
+  const int blocks = (total_entries + kThreads - 1) / kThreads;
+  SanitizeBlockTable<<<blocks, kThreads, 0, stream>>>(sanitized_block_table, block_table, num_blocks, total_entries);
+  return CUDA_CALL(cudaGetLastError());
+}
+
 // Resolves the flat cache slot that a query token's K/V is written to, in the cache viewed as
 // [num_blocks * block_size, kv_num_heads, head_size]. A negative result suppresses the store.
 //

--- a/onnxruntime/contrib_ops/cuda/bert/paged_attention_impl.cu
+++ b/onnxruntime/contrib_ops/cuda/bert/paged_attention_impl.cu
@@ -373,9 +373,11 @@ Status LaunchGetCumulativeSeqlensKV(int32_t* cumulative_seqlens_kv, const int32_
 // into range before any read path indexes the paged cache with them; negative entries (the
 // existing "unmapped block" sentinel) are left as-is.
 __global__ void SanitizeBlockTable(int* __restrict__ sanitized_block_table, const int* __restrict__ block_table,
-                                    const int num_blocks, const int total_entries) {
+                                   const int num_blocks, const int total_entries) {
   const int i = blockIdx.x * blockDim.x + threadIdx.x;
-  if (i >= total_entries) return;
+  if (i >= total_entries) {
+    return;
+  }
   const int block_id = block_table[i];
   sanitized_block_table[i] = (block_id < 0 || block_id >= num_blocks) ? -1 : block_id;
 }
@@ -383,6 +385,9 @@ __global__ void SanitizeBlockTable(int* __restrict__ sanitized_block_table, cons
 Status LaunchSanitizeBlockTable(int* sanitized_block_table, const int* block_table, const int num_blocks,
                                 const int batch_size, const int max_num_blocks_per_seq, cudaStream_t stream) {
   const int total_entries = batch_size * max_num_blocks_per_seq;
+  if (total_entries == 0) {
+    return Status::OK();
+  }
   constexpr int kThreads = 256;
   const int blocks = (total_entries + kThreads - 1) / kThreads;
   SanitizeBlockTable<<<blocks, kThreads, 0, stream>>>(sanitized_block_table, block_table, num_blocks, total_entries);

--- a/onnxruntime/contrib_ops/cuda/bert/paged_attention_impl.cu
+++ b/onnxruntime/contrib_ops/cuda/bert/paged_attention_impl.cu
@@ -377,7 +377,7 @@ __global__ void SanitizeBlockTable(int* __restrict__ sanitized_block_table, cons
   const int i = blockIdx.x * blockDim.x + threadIdx.x;
   if (i >= total_entries) return;
   const int block_id = block_table[i];
-  sanitized_block_table[i] = block_id >= num_blocks ? 0 : block_id;
+  sanitized_block_table[i] = (block_id < 0 || block_id >= num_blocks) ? -1 : block_id;
 }
 
 Status LaunchSanitizeBlockTable(int* sanitized_block_table, const int* block_table, const int num_blocks,

--- a/onnxruntime/contrib_ops/cuda/bert/paged_attention_impl.h
+++ b/onnxruntime/contrib_ops/cuda/bert/paged_attention_impl.h
@@ -32,6 +32,13 @@ Status LaunchUnpackQKVCumulative(const T* packed_qkv, T* unpacked_q, T* unpacked
 Status LaunchGetCumulativeSeqlensKV(int32_t* cumulative_seqlens_kv, const int32_t* cumulative_seqlens_q,
                                     const int32_t* past_seqlens, const int batch_size, cudaStream_t stream);
 
+// Bound-checks every block_table entry against num_blocks, replacing any out-of-range entry with -1
+// (the existing unmapped-block sentinel). Every attention backend reads block_table only through the
+// sanitized copy this produces, so a single check here protects all of them, including the native
+// FlashAttention and XQA paths that index it directly.
+Status LaunchSanitizeBlockTable(int* sanitized_block_table, const int* block_table, const int num_blocks,
+                                const int batch_size, const int max_num_blocks_per_seq, cudaStream_t stream);
+
 // Paged decode backend sizing helpers, used by paged_attention.cc to test eligibility (the kernel
 // needs more dynamic shared memory than the device provides for very wide heads) and to size the
 // split-KV workspaces.

--- a/onnxruntime/contrib_ops/cuda/bert/paged_attention_impl.h
+++ b/onnxruntime/contrib_ops/cuda/bert/paged_attention_impl.h
@@ -34,8 +34,10 @@ Status LaunchGetCumulativeSeqlensKV(int32_t* cumulative_seqlens_kv, const int32_
 
 // Bound-checks every block_table entry against num_blocks, replacing any out-of-range entry with -1
 // (the existing unmapped-block sentinel). Every attention backend reads block_table only through the
-// sanitized copy this produces, so a single check here protects all of them, including the native
-// FlashAttention and XQA paths that index it directly.
+// sanitized copy this produces. That is enough for the backends that already branch on
+// block_id < 0, but not for native FlashAttention (flash_fwd_kernel.h indexes block_table with an
+// unchecked negative offset) or the XQA paged path, where -1 is a legal in-range value and still
+// reaches the cache unguarded.
 Status LaunchSanitizeBlockTable(int* sanitized_block_table, const int* block_table, const int num_blocks,
                                 const int batch_size, const int max_num_blocks_per_seq, cudaStream_t stream);
 

--- a/onnxruntime/test/contrib_ops/paged_attention_op_test.cc
+++ b/onnxruntime/test/contrib_ops/paged_attention_op_test.cc
@@ -86,6 +86,11 @@ struct IoBindingCase {
   std::vector<int32_t> block_table;
   std::vector<int32_t> attention_metadata;
   std::string expected_error;
+  // When set, the block_table range check below is skipped and the reference
+  // model treats any block_id outside [0, num_blocks) the same as an explicit
+  // -1 (unmapped): excluded from the softmax and never dereferenced. Lets a
+  // test assert that the CUDA kernel does the same.
+  bool allow_out_of_range_block_table = false;
 };
 
 // Softmax with causal masking: masked positions get -inf → 0 after exp.
@@ -323,9 +328,11 @@ void RunIoBindingCase(std::unique_ptr<IExecutionProvider> execution_provider,
   ASSERT_TRUE(c.cumulative_seqlens_q.empty() ||
               (c.cumulative_seqlens_q.size() == static_cast<size_t>(batch_size + 1) &&
                c.cumulative_seqlens_q.front() == 0 && c.cumulative_seqlens_q.back() == token_count));
-  for (int32_t block_id : c.block_table) {
-    ASSERT_GE(block_id, 0);
-    ASSERT_LT(block_id, num_blocks);
+  if (!c.allow_out_of_range_block_table) {
+    for (int32_t block_id : c.block_table) {
+      ASSERT_GE(block_id, 0);
+      ASSERT_LT(block_id, num_blocks);
+    }
   }
 
   std::unordered_map<std::string, int> domain_to_version = {{onnxruntime::kMSDomain, 1}};
@@ -797,6 +804,11 @@ void RunIoBindingCase(std::unique_ptr<IExecutionProvider> execution_provider,
           for (int slot = 0; slot <= new_slot; ++slot) {
             const int block_id =
                 block_table_data[b * max_num_blocks_per_seq + slot / block_size];
+            if (block_id < 0 || block_id >= num_blocks) {
+              // Unmapped: excluded from the softmax, same as the kernel.
+              scores[slot] = -std::numeric_limits<float>::infinity();
+              continue;
+            }
             float dot = 0.0f;
             for (int dim = 0; dim < head_size; ++dim) {
               const int query_index = (token * num_heads + q_head) * head_size + dim;
@@ -821,6 +833,7 @@ void RunIoBindingCase(std::unique_ptr<IExecutionProvider> execution_provider,
             for (int slot = 0; slot <= new_slot; ++slot) {
               const int block_id =
                   block_table_data[b * max_num_blocks_per_seq + slot / block_size];
+              if (block_id < 0 || block_id >= num_blocks) continue;  // unmapped slot, nothing to gather
               const int cache_index = CacheIndex(block_id, slot % block_size, kv_head, dim,
                                                  block_size, kv_num_heads, head_size);
               const float value_element = native_bf16_cache ? value_cache_bf16[cache_index].ToFloat()
@@ -1481,6 +1494,30 @@ TEST(PagedAttention, Cuda_XqaSpecDecFp8CacheHeadSize256Group6) {
   EXPECT_NE(debug_output.find("GqaGroupSize=6"), std::string::npos) << debug_output;
 }
 #endif
+
+// A block_table entry outside [0, num_blocks) must be treated as unmapped,
+// the same as an explicit -1, rather than read out of bounds of the paged
+// cache. Regression test for the read-path bound check: block_table[0]
+// covers the historical KV (slots 0..3); block_table[1] is the write target
+// for the new token and stays valid in both runs. Each run's own reference
+// model (patched above to skip unmapped slots) proves the kernel excludes
+// them from the softmax instead of dereferencing them.
+TEST(PagedAttention, Cuda_OutOfRangeBlockTableTreatedAsUnmapped) {
+  if (DefaultCudaExecutionProvider() == nullptr) {
+    GTEST_SKIP() << "CUDA EP not available.";
+  }
+
+  for (int32_t sentinel : {-1, 99}) {
+    IoBindingCase c;
+    c.block_size = 16;
+    c.num_blocks = 3;
+    c.max_num_blocks_per_seq = 2;
+    c.past_seqlen = 16;
+    c.block_table = {sentinel, 1};
+    c.allow_out_of_range_block_table = true;
+    RunIoBindingCase(DefaultCudaExecutionProvider(), kCudaExecutionProvider, true, false, c);
+  }
+}
 
 TEST(PagedAttention, Cuda_AttentionMetadataValidation) {
   if (DefaultCudaExecutionProvider() == nullptr) {

--- a/onnxruntime/test/contrib_ops/paged_attention_op_test.cc
+++ b/onnxruntime/test/contrib_ops/paged_attention_op_test.cc
@@ -1498,7 +1498,7 @@ TEST(PagedAttention, Cuda_XqaSpecDecFp8CacheHeadSize256Group6) {
 // A block_table entry outside [0, num_blocks) must be treated as unmapped,
 // the same as an explicit -1, rather than read out of bounds of the paged
 // cache. Regression test for the read-path bound check: block_table[0]
-// covers the historical KV (slots 0..3); block_table[1] is the write target
+// covers the historical KV (slots 0..15); block_table[1] is the write target
 // for the new token and stays valid in both runs. Each run's own reference
 // model (patched above to skip unmapped slots) proves the kernel excludes
 // them from the softmax instead of dereferencing them.
@@ -1517,6 +1517,96 @@ TEST(PagedAttention, Cuda_OutOfRangeBlockTableTreatedAsUnmapped) {
     c.allow_out_of_range_block_table = true;
     RunIoBindingCase(DefaultCudaExecutionProvider(), kCudaExecutionProvider, true, false, c);
   }
+}
+
+// Same regression as Cuda_OutOfRangeBlockTableTreatedAsUnmapped, but pinned to the
+// FlashAttention-paged backend (head_size = 64, block_size = 256 satisfies
+// flash_min_block_size), which reads block_table directly rather than through the
+// in-kernel range check the paged-decode kernel uses.
+TEST(PagedAttention, Cuda_OutOfRangeBlockTableFlashEligible) {
+#if defined(USE_FLASH_ATTENTION)
+  ScopedEnvironmentVariables scoped_env_vars{
+      EnvVarMap{
+          {onnxruntime::contrib::attention::kDisableFlashAttention, "0"},
+          {onnxruntime::contrib::attention::kDisableMemoryEfficientAttention, "1"},
+          {onnxruntime::contrib::attention::kDisableDecoderAttention, "1"},
+          {onnxruntime::contrib::attention::kEnableAttentionKernelDebugInfo, "1"}}};
+
+  if (DefaultCudaExecutionProvider() == nullptr) {
+    GTEST_SKIP() << "CUDA EP not available.";
+  }
+  if (GetCudaArchitecture() < 800) {
+    GTEST_SKIP() << "Flash Attention requires compute capability 8.0 or later.";
+  }
+
+  for (int32_t sentinel : {-1, 99}) {
+    IoBindingCase c;
+    c.head_size = 64;
+    c.block_size = 256;
+    c.num_blocks = 3;
+    c.max_num_blocks_per_seq = 2;
+    c.past_seqlen = 256;
+    c.block_table = {sentinel, 1};
+    c.allow_out_of_range_block_table = true;
+
+    testing::internal::CaptureStdout();
+    RunIoBindingCase(DefaultCudaExecutionProvider(), kCudaExecutionProvider, true, false, c);
+    const std::string debug_output = testing::internal::GetCapturedStdout();
+    EXPECT_NE(debug_output.find("SdpaKernel=FLASH_ATTENTION"), std::string::npos) << debug_output;
+  }
+#else
+  GTEST_SKIP() << "FlashAttention is not built in.";
+#endif
+}
+
+// Same regression, pinned to the native-cache XQA backend with pages_per_block == 1
+// (block_size == kXqaTokensPerPage), the other backend the sanitize-copy design is meant to
+// protect. Skips if this build/device cannot dispatch XQA for this shape.
+TEST(PagedAttention, Cuda_OutOfRangeBlockTableXqaEligible) {
+  ScopedEnvironmentVariables scoped_env_vars{
+      EnvVarMap{
+          {onnxruntime::contrib::attention::kDisableFlashAttention, "0"},
+          {onnxruntime::contrib::attention::kDisableMemoryEfficientAttention, "0"},
+          {onnxruntime::contrib::attention::kDisableDecoderAttention, "0"},
+          {onnxruntime::contrib::attention::kEnableAttentionKernelDebugInfo, "1"},
+          {"ORT_ENABLE_XQA", "1"},
+          {"ORT_ENABLE_XQA_NATIVE_KV", "1"}}};
+
+  if (DefaultCudaExecutionProvider() == nullptr) {
+    GTEST_SKIP() << "CUDA EP not available.";
+  }
+  if (GetCudaArchitecture() < 800) {
+    GTEST_SKIP() << "XQA requires compute capability 8.0 or later.";
+  }
+
+  auto make_case = [](int32_t sentinel) {
+    IoBindingCase c;
+    c.num_heads = 6;
+    c.kv_num_heads = 1;
+    c.head_size = 256;
+    c.block_size = 128;  // pages_per_block == 1 (kXqaTokensPerPage == 128).
+    c.num_blocks = 3;
+    c.max_num_blocks_per_seq = 2;
+    c.past_seqlen = 128;
+    c.block_table = {sentinel, 1};
+    c.allow_out_of_range_block_table = true;
+    c.attention_metadata = {1, 256};
+    return c;
+  };
+
+  testing::internal::CaptureStdout();
+  RunIoBindingCase(DefaultCudaExecutionProvider(), kCudaExecutionProvider, true, false, make_case(-1));
+  const std::string baseline_debug_output = testing::internal::GetCapturedStdout();
+  if (baseline_debug_output.find("SdpaKernel=XQA") == std::string::npos) {
+    GTEST_SKIP() << "Paged XQA H256/group6 (pages_per_block=1) is not runnable in this "
+                    "build/device configuration.\n"
+                 << baseline_debug_output;
+  }
+
+  testing::internal::CaptureStdout();
+  RunIoBindingCase(DefaultCudaExecutionProvider(), kCudaExecutionProvider, true, false, make_case(99));
+  const std::string debug_output = testing::internal::GetCapturedStdout();
+  EXPECT_NE(debug_output.find("SdpaKernel=XQA"), std::string::npos) << debug_output;
 }
 
 TEST(PagedAttention, Cuda_AttentionMetadataValidation) {


### PR DESCRIPTION
## Summary

Paged Attention manages the KV cache using fixed-size blocks, mapping each logical block index to a physical (real) block index. This mapping is consumed via two paths: **write** and **read**.

The **write** path bound-checks that `block_id` lies within the valid range (`0 <= block_id < num_blocks`) before touching the cache:

https://github.com/microsoft/onnxruntime/blob/d47fd8824ab29b86308e1c24ebd067d29713ae7b/onnxruntime/contrib_ops/cuda/bert/paged_attention_impl.cu#L446-L448

The **read** paths, however, only check the lower bound:

https://github.com/microsoft/onnxruntime/blob/d47fd8824ab29b86308e1c24ebd067d29713ae7b/onnxruntime/contrib_ops/cuda/bert/paged_attention_impl.cu#L409-L415

So if `block_id >= 0` (i.e. it passes the lower-bound check) but `block_id >= num_blocks` (i.e. the allocated block id exceeds the actual number of KV-cache blocks), an out-of-bounds read occurs.

Rather than duplicating a boundary check across every read path, this PR sanitizes `block_table` once into a scratch copy before dispatch: any entry with `block_id < 0 || block_id >= num_blocks` is clamped to `-1` (treated as
unmapped).

Every backend already reads through this sanitized copy, so it also covers the native FlashAttention and XQA paths that per-kernel parameters couldn't reach.

## Test Plan
setup: RTX 4090 (sm_89), CUDA 12.8, full-build
```bash
./onnxruntime_provider_test --gtest_filter='PagedAttention.Cuda*'
```