### PR TITLE
Optimize common CUDA Einsum equations

### DIFF
--- a/onnxruntime/core/providers/cpu/math/einsum_utils/einsum_compute_preprocessor.h
+++ b/onnxruntime/core/providers/cpu/math/einsum_utils/einsum_compute_preprocessor.h
@@ -130,6 +130,15 @@ class EinsumComputePreprocessor final {
   }
 
   inline Status Run() {
+    ORT_RETURN_IF_ERROR(Analyze());
+    return MaterializeInputs();
+  }
+
+  inline Status Analyze() {
+    if (analysis_complete_) {
+      return Status::OK();
+    }
+
     ORT_RETURN_IF_ERROR(ProcessSubscripts());
 
     ORT_RETURN_IF_ERROR(PostProcessBroadcastedDims());
@@ -138,8 +147,18 @@ class EinsumComputePreprocessor final {
 
     ORT_RETURN_IF_ERROR(CalculateOutputShape());
 
-    ORT_RETURN_IF_ERROR(PreprocessInputs());
+    analysis_complete_ = true;
+    return Status::OK();
+  }
 
+  inline Status MaterializeInputs() {
+    ORT_RETURN_IF_NOT(analysis_complete_, "Einsum semantic analysis must complete before materializing inputs");
+    if (inputs_materialized_) {
+      return Status::OK();
+    }
+
+    ORT_RETURN_IF_ERROR(PreprocessInputs());
+    inputs_materialized_ = true;
     return Status::OK();
   }
 
@@ -151,7 +170,7 @@ class EinsumComputePreprocessor final {
     return preprocessed_inputs_;
   }
 
-  inline const std::vector<const Tensor*>& GetRawInputTensors() {
+  inline const std::vector<const Tensor*>& GetRawInputTensors() const {
     return inputs_;
   }
 
@@ -169,6 +188,18 @@ class EinsumComputePreprocessor final {
 
   inline size_t GetNumSubscriptIndices() const {
     return num_subscript_indices_;
+  }
+
+  inline size_t GetNumEllipsisDims() const {
+    return num_of_ellipsis_dims_;
+  }
+
+  inline const std::vector<std::vector<int64_t>>& GetInputSubscriptIndices() const {
+    return input_subscript_indices_;
+  }
+
+  inline const std::vector<int64_t>& GetSubscriptIndicesToDimValue() const {
+    return subscript_indices_to_dim_value_;
   }
 
   inline void SetDeviceHelpers(const EinsumOp::DeviceHelpers::Diagonal& device_diagonal_func,
@@ -205,6 +236,8 @@ class EinsumComputePreprocessor final {
 
       std::vector<int64_t> current_subscript_indices;
       current_subscript_indices.reserve(rank);
+      std::array<int64_t, EinsumOp::num_of_letters> current_letter_to_dim;
+      current_letter_to_dim.fill(-1);
 
       // Temp variables to deal with "ellipsis" in the input
       bool is_in_middle_of_ellipsis = false;
@@ -274,16 +307,25 @@ class EinsumComputePreprocessor final {
           }
 
           auto dim_value = dims[dim_counter];
+          const size_t letter_array_index = onnxruntime::narrow<size_t>(letter_index);
+          if (current_letter_to_dim[letter_array_index] >= 0 &&
+              current_letter_to_dim[letter_array_index] != dim_value) {
+            return ORT_MAKE_STATUS(
+                ONNXRUNTIME, INVALID_ARGUMENT,
+                "Einsum repeated labels within one input must have equal dimensions. Input ",
+                input_index, " has incompatible repeated label '", subscript_label, "'.");
+          }
+          current_letter_to_dim[letter_array_index] = dim_value;
 
           // Subscript label not found in global subscript label array
           // Hence add it to both local and global subscript arrays
-          if (letter_to_count_[onnxruntime::narrow<size_t>(letter_index)] == 0) {
-            letter_to_index_[onnxruntime::narrow<size_t>(letter_index)] = num_subscript_indices_++;
+          if (letter_to_count_[letter_array_index] == 0) {
+            letter_to_index_[letter_array_index] = num_subscript_indices_++;
             subscript_indices_to_dim_value_.push_back(dim_value);
             subscript_indices_to_last_input_.push_back(input_index);
           } else {  // This subscript label has been seen in atleast one other operand's subscript
             // It must be equal unless one of them is a 1 (Numpy allows this)
-            auto mapped_index = letter_to_index_[onnxruntime::narrow<size_t>(letter_index)];
+            auto mapped_index = letter_to_index_[letter_array_index];
 
             subscript_indices_to_last_input_[onnxruntime::narrow<size_t>(mapped_index)] = input_index;
 
@@ -306,9 +348,9 @@ class EinsumComputePreprocessor final {
             }
           }
 
-          ++letter_to_count_[onnxruntime::narrow<size_t>(letter_index)];
+          ++letter_to_count_[letter_array_index];
 
-          current_subscript_indices.push_back(letter_to_index_[onnxruntime::narrow<size_t>(letter_index)]);
+          current_subscript_indices.push_back(letter_to_index_[letter_array_index]);
           if (++dim_counter > rank) {
             return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
                                    "Einsum subscripts string contains too many subscript labels when compared to the rank of the input ",
@@ -515,6 +557,27 @@ class EinsumComputePreprocessor final {
     return Status::OK();
   }
 
+  static bool IsReshapeOnlyPermutation(gsl::span<const int64_t> input_dims,
+                                       gsl::span<const size_t> permutation,
+                                       TensorShapeVector& output_dims) {
+    size_t last_non_singleton_axis = 0;
+    for (const size_t input_axis : permutation) {
+      if (input_dims[input_axis] == 1) {
+        continue;
+      }
+      if (input_axis < last_non_singleton_axis) {
+        return false;
+      }
+      last_non_singleton_axis = input_axis;
+    }
+
+    output_dims.resize(permutation.size());
+    for (size_t output_axis = 0; output_axis < permutation.size(); ++output_axis) {
+      output_dims[output_axis] = input_dims[permutation[output_axis]];
+    }
+    return true;
+  }
+
   inline Status PreprocessInputs() {
     preprocessed_inputs_.reserve(inputs_.size());
     homogenized_input_dims_.reserve(inputs_.size());
@@ -570,9 +633,18 @@ class EinsumComputePreprocessor final {
       // (Identify no-op transpose and prevent triggering the transpose)
       if (EinsumOp::IsTransposeRequired(preprocessed ? preprocessed->Shape().GetDims().size() : inputs_[input_iter]->Shape().GetDims().size(),
                                         permutation)) {
-        preprocessed = EinsumOp::Transpose(preprocessed ? *preprocessed : *inputs_[input_iter],
-                                           preprocessed ? preprocessed->Shape().GetDims() : inputs_[input_iter]->Shape().GetDims(),
-                                           permutation, allocator_, einsum_ep_assets_, device_transpose_func_, device_create_tensor_func_);
+        const auto source_dims =
+            preprocessed ? preprocessed->Shape().GetDims() : inputs_[input_iter]->Shape().GetDims();
+        TensorShapeVector reshape_dims;
+        if (IsReshapeOnlyPermutation(source_dims, permutation, reshape_dims)) {
+          if (preprocessed) {
+            preprocessed->Reshape(reshape_dims);
+          }
+        } else {
+          preprocessed = EinsumOp::Transpose(preprocessed ? *preprocessed : *inputs_[input_iter],
+                                             source_dims, permutation, allocator_, einsum_ep_assets_,
+                                             device_transpose_func_, device_create_tensor_func_);
+        }
       }
 
       // pre-processed may be null if the input didn't have need diagonals parsed and didn't need transposing
@@ -653,6 +725,9 @@ class EinsumComputePreprocessor final {
 
   // Holds EP-specific assets required for (auxiliary) ops that need to be executed on non-CPU EPs
   void* einsum_ep_assets_;
+
+  bool analysis_complete_ = false;
+  bool inputs_materialized_ = false;
 };
 
 }  // namespace onnxruntime

--- a/onnxruntime/core/providers/cpu/math/einsum_utils/einsum_typed_compute_processor.h
+++ b/onnxruntime/core/providers/cpu/math/einsum_utils/einsum_typed_compute_processor.h
@@ -460,6 +460,39 @@ inline std::unique_ptr<Tensor> EinsumTypedComputeProcessor<T>::PairwiseOperandPr
     current_subscript_order.insert(current_subscript_order.end(), ro.begin(), ro.end());
   }
 
+  if (is_final_pair) {
+    const auto& label_to_output_axis =
+        einsum_compute_preprocessor_.GetMappedSubscriptIndicesToOutputindices();
+    size_t next_output_axis = 0;
+    bool can_write_output_directly = true;
+    for (const int64_t label : current_subscript_order) {
+      const int64_t output_axis = label_to_output_axis[onnxruntime::narrow<size_t>(label)];
+      if (output_axis >= 0 && output_axis != onnxruntime::narrow<int64_t>(next_output_axis++)) {
+        can_write_output_directly = false;
+        break;
+      }
+    }
+
+    if (can_write_output_directly) {
+      Tensor& final_output = *context_->Output(0, einsum_compute_preprocessor_.GetOutputDims());
+      ORT_ENFORCE(final_output.Shape().Size() == lro_size * lo_size * ro_size);
+      auto status = device_matmul_func_(
+          (current_left ? *current_left : left).Data<T>(),
+          (current_right ? *current_right : right).Data<T>(),
+          final_output.MutableData<T>(),
+          onnxruntime::narrow<size_t>(lo_size * reduced_size),
+          onnxruntime::narrow<size_t>(reduced_size * ro_size),
+          onnxruntime::narrow<size_t>(lo_size * ro_size),
+          onnxruntime::narrow<size_t>(lro_size),
+          onnxruntime::narrow<size_t>(lo_size),
+          onnxruntime::narrow<size_t>(reduced_size),
+          onnxruntime::narrow<size_t>(ro_size),
+          tp_, mlas_backend_config_, einsum_ep_assets_);
+      ORT_ENFORCE(status.IsOK(), "Einsum op: Exception during MatMul operation: ", status.ErrorMessage());
+      return nullptr;
+    }
+  }
+
   // Multiply the mutated inputs
   auto output = EinsumOp::MatMul<T>(current_left ? *current_left : left, TensorShapeVector{lro_size, lo_size, reduced_size},
                                     current_right ? *current_right : right, TensorShapeVector{lro_size, reduced_size, ro_size},
@@ -529,7 +562,8 @@ inline Status EinsumTypedComputeProcessor<T>::Run() {
     all_dims.reserve(num_subscript_labels);  // num_subscript_labels is the number of elements
 
     for (size_t i = 0; i < num_subscript_labels; ++i) {
-      if (mapped_indices_to_last_input_index[i] == 0) {
+      if (mapped_indices_to_last_input_index[i] == 0 &&
+          homogenized_input_dims[0][i] != 1) {
         reduced_dims.push_back(i);
       }
 
@@ -567,8 +601,11 @@ inline Status EinsumTypedComputeProcessor<T>::Run() {
     for (int input = 1; input < num_inputs; ++input) {
       TensorShapeVector reduced_dims;
       reduced_dims.reserve(num_subscript_labels);  // num_subscript_labels is the upper bound. No harm in over-reserving by a small margin.
+      const auto& left_dims = result ? result->Shape().GetDims() : homogenized_input_dims[0].GetDims();
+      const auto& right_dims = homogenized_input_dims[onnxruntime::narrow<size_t>(input)].GetDims();
       for (size_t dim = 0; dim < num_subscript_labels; ++dim) {
-        if (mapped_indices_to_last_input_index[dim] == input) {
+        if (mapped_indices_to_last_input_index[dim] == input &&
+            (left_dims[dim] != 1 || right_dims[dim] != 1)) {
           // This is the last input we are seeing this dimension (and it doesn't occur in the output), so reduce along the dimension
           reduced_dims.push_back(dim);
         }

--- a/onnxruntime/core/providers/cuda/math/einsum.cc
+++ b/onnxruntime/core/providers/cuda/math/einsum.cc
@@ -7,6 +7,7 @@
 #include "core/providers/cuda/tensor/transpose.h"
 #include "core/providers/cuda/shared_inc/fpgeneric.h"
 #include "core/providers/cuda/math/matmul.h"
+#include "einsum_utils/einsum_fast_path.h"
 
 namespace onnxruntime {
 namespace cuda {
@@ -57,11 +58,29 @@ Status Einsum::ComputeInternal(OpKernelContext* context) const {
                                                EinsumOp::DeviceHelpers::CudaDeviceHelpers::Transpose,
                                                EinsumOp::DeviceHelpers::CudaDeviceHelpers::CreateTensor);
 
-  ORT_RETURN_IF_ERROR(einsum_compute_preprocessor.Run());
+  ORT_RETURN_IF_ERROR(einsum_compute_preprocessor.Analyze());
+
+  const bool has_empty_input = std::any_of(inputs.begin(), inputs.end(), [](const Tensor* input) {
+    return input->Shape().Size() == 0;
+  });
+  if (has_empty_input) {
+    Tensor& output = *context->Output(0, einsum_compute_preprocessor.GetOutputDims());
+    return EinsumOp::DeviceHelpers::CudaDeviceHelpers::ZeroBuffer(output, &einsum_cuda_assets);
+  }
+
+  EinsumFastPathPlan fast_path_plan;
+  ORT_RETURN_IF_ERROR(CreateEinsumFastPathPlan(einsum_compute_preprocessor, fast_path_plan));
+  if (fast_path_plan.kind == EinsumFastPathKind::Trace && context->GetUseDeterministicCompute()) {
+    fast_path_plan.kind = EinsumFastPathKind::None;
+  }
 
   const auto& first_input_tensor = inputs[0];
 
   if (first_input_tensor->IsDataType<float>()) {
+    if (fast_path_plan.kind != EinsumFastPathKind::None) {
+      return ExecuteEinsumFastPath<float>(this, context, inputs, fast_path_plan, einsum_cuda_assets);
+    }
+    ORT_RETURN_IF_ERROR(einsum_compute_preprocessor.MaterializeInputs());
     EinsumTypedComputeProcessor<float> einsum_compute_processor(context, allocator, tp, nullptr, einsum_compute_preprocessor, &einsum_cuda_assets);
     einsum_compute_processor.SetDeviceHelpers(EinsumOp::DeviceHelpers::CudaDeviceHelpers::Transpose,
                                               EinsumOp::DeviceHelpers::CudaDeviceHelpers::MatMul<float>,
@@ -72,6 +91,10 @@ Status Einsum::ComputeInternal(OpKernelContext* context) const {
     return einsum_compute_processor.Run();
 
   } else if (first_input_tensor->IsDataType<double>()) {
+    if (fast_path_plan.kind != EinsumFastPathKind::None) {
+      return ExecuteEinsumFastPath<double>(this, context, inputs, fast_path_plan, einsum_cuda_assets);
+    }
+    ORT_RETURN_IF_ERROR(einsum_compute_preprocessor.MaterializeInputs());
     EinsumTypedComputeProcessor<double> einsum_compute_processor(context, allocator, tp, nullptr, einsum_compute_preprocessor, &einsum_cuda_assets);
     einsum_compute_processor.SetDeviceHelpers(EinsumOp::DeviceHelpers::CudaDeviceHelpers::Transpose,
                                               EinsumOp::DeviceHelpers::CudaDeviceHelpers::MatMul<double>,
@@ -82,6 +105,10 @@ Status Einsum::ComputeInternal(OpKernelContext* context) const {
     return einsum_compute_processor.Run();
 
   } else if (first_input_tensor->IsDataType<MLFloat16>()) {
+    if (fast_path_plan.kind != EinsumFastPathKind::None) {
+      return ExecuteEinsumFastPath<MLFloat16>(this, context, inputs, fast_path_plan, einsum_cuda_assets);
+    }
+    ORT_RETURN_IF_ERROR(einsum_compute_preprocessor.MaterializeInputs());
     EinsumTypedComputeProcessor<MLFloat16> einsum_compute_processor(context, allocator, tp, nullptr, einsum_compute_preprocessor, &einsum_cuda_assets);
     einsum_compute_processor.SetDeviceHelpers(EinsumOp::DeviceHelpers::CudaDeviceHelpers::Transpose,
                                               EinsumOp::DeviceHelpers::CudaDeviceHelpers::MatMul<MLFloat16>,

--- a/onnxruntime/core/providers/cuda/math/einsum_utils/einsum_fast_path.cc
+++ b/onnxruntime/core/providers/cuda/math/einsum_utils/einsum_fast_path.cc
@@ -1,0 +1,520 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "core/providers/shared_library/provider_api.h"
+
+#include "einsum_fast_path.h"
+
+#include <limits>
+
+#include "core/providers/cpu/tensor/utils.h"
+#include "core/providers/cuda/math/binary_elementwise_ops.h"
+#include "core/providers/cuda/math/binary_elementwise_ops_impl.h"
+#include "core/providers/cuda/math/matmul.h"
+#include "core/providers/cuda/reduction/reduction_ops.h"
+#include "einsum_fast_path_kernels.h"
+
+namespace onnxruntime {
+namespace cuda {
+namespace {
+
+constexpr size_t kFastPathRankLimit = 8;
+
+std::vector<int64_t> GetOutputLabels(const EinsumComputePreprocessor& preprocessor) {
+  const auto& label_to_output_axis = preprocessor.GetMappedSubscriptIndicesToOutputindices();
+  std::vector<int64_t> output_labels(preprocessor.GetOutputDims().size(), -1);
+  for (size_t label = 0; label < label_to_output_axis.size(); ++label) {
+    const int64_t output_axis = label_to_output_axis[label];
+    if (output_axis >= 0) {
+      output_labels[onnxruntime::narrow<size_t>(output_axis)] = onnxruntime::narrow<int64_t>(label);
+    }
+  }
+  return output_labels;
+}
+
+bool IsExactSequenceIgnoringSizeOne(gsl::span<const int64_t> actual_labels,
+                                    gsl::span<const int64_t> actual_dims,
+                                    gsl::span<const int64_t> expected_labels) {
+  std::vector<int64_t> filtered_actual;
+  filtered_actual.reserve(actual_labels.size());
+  for (size_t i = 0; i < actual_labels.size(); ++i) {
+    if (actual_dims[i] != 1) {
+      filtered_actual.push_back(actual_labels[i]);
+    }
+  }
+
+  std::vector<int64_t> filtered_expected;
+  filtered_expected.reserve(expected_labels.size());
+  for (const int64_t label : expected_labels) {
+    auto actual_axis = std::find(actual_labels.begin(), actual_labels.end(), label);
+    if (actual_axis != actual_labels.end()) {
+      const size_t axis = static_cast<size_t>(std::distance(actual_labels.begin(), actual_axis));
+      if (actual_dims[axis] != 1) {
+        filtered_expected.push_back(label);
+      }
+    }
+  }
+
+  return filtered_actual == filtered_expected;
+}
+
+TensorShapeVector BuildBroadcastViewDims(gsl::span<const int64_t> input_labels,
+                                         gsl::span<const int64_t> input_dims,
+                                         gsl::span<const int64_t> output_labels) {
+  TensorShapeVector view_dims(output_labels.size(), 1);
+  for (size_t input_axis = 0; input_axis < input_labels.size(); ++input_axis) {
+    const auto output_axis = std::find(output_labels.begin(), output_labels.end(), input_labels[input_axis]);
+    ORT_ENFORCE(output_axis != output_labels.end());
+    view_dims[static_cast<size_t>(std::distance(output_labels.begin(), output_axis))] = input_dims[input_axis];
+  }
+  return view_dims;
+}
+
+bool IsRepeatedLabelShapeValid(gsl::span<const int64_t> labels,
+                               gsl::span<const int64_t> dims,
+                               size_t num_labels) {
+  std::vector<int64_t> first_extent(num_labels, -1);
+  for (size_t axis = 0; axis < labels.size(); ++axis) {
+    const size_t label = onnxruntime::narrow<size_t>(labels[axis]);
+    if (first_extent[label] < 0) {
+      first_extent[label] = dims[axis];
+    } else if (first_extent[label] != dims[axis]) {
+      return false;
+    }
+  }
+  return true;
+}
+
+bool ProductFitsCublas(gsl::span<const int64_t> labels,
+                       const std::vector<int64_t>& label_extents,
+                       int64_t& result) {
+  result = 1;
+  for (const int64_t label : labels) {
+    const int64_t dim = label_extents[onnxruntime::narrow<size_t>(label)];
+    if (dim > 0 && result > std::numeric_limits<int>::max() / dim) {
+      return false;
+    }
+    result *= dim;
+  }
+  return true;
+}
+
+std::vector<int64_t> ConcatLabels(gsl::span<const int64_t> first,
+                                  gsl::span<const int64_t> second,
+                                  gsl::span<const int64_t> third = {}) {
+  std::vector<int64_t> result;
+  result.reserve(first.size() + second.size() + third.size());
+  result.insert(result.end(), first.begin(), first.end());
+  result.insert(result.end(), second.begin(), second.end());
+  result.insert(result.end(), third.begin(), third.end());
+  return result;
+}
+
+bool AllBatchDimsAreOne(gsl::span<const int64_t> batch_labels,
+                        gsl::span<const int64_t> input_labels,
+                        gsl::span<const int64_t> input_dims) {
+  for (const int64_t label : batch_labels) {
+    const auto axis = std::find(input_labels.begin(), input_labels.end(), label);
+    if (axis != input_labels.end() &&
+        input_dims[static_cast<size_t>(std::distance(input_labels.begin(), axis))] != 1) {
+      return false;
+    }
+  }
+  return true;
+}
+
+bool AllBatchDimsMatchOutput(gsl::span<const int64_t> batch_labels,
+                             gsl::span<const int64_t> input_labels,
+                             gsl::span<const int64_t> input_dims,
+                             const std::vector<int64_t>& label_extents) {
+  for (const int64_t label : batch_labels) {
+    const auto axis = std::find(input_labels.begin(), input_labels.end(), label);
+    if (axis == input_labels.end() ||
+        input_dims[static_cast<size_t>(std::distance(input_labels.begin(), axis))] !=
+            label_extents[onnxruntime::narrow<size_t>(label)]) {
+      return false;
+    }
+  }
+  return true;
+}
+
+std::unique_ptr<Tensor> MakeTensorView(const Tensor& tensor, const TensorShapeVector& dims) {
+  return Tensor::Create(tensor.DataType(), TensorShape(dims), const_cast<void*>(tensor.DataRaw()), tensor.Location());
+}
+
+std::unique_ptr<Tensor> MakeTensorView(Tensor& tensor, const TensorShapeVector& dims) {
+  return Tensor::Create(tensor.DataType(), TensorShape(dims), tensor.MutableDataRaw(), tensor.Location());
+}
+
+template <typename T>
+Status ExecuteReduceSum(const CudaKernel* cuda_kernel,
+                        OpKernelContext* context,
+                        const Tensor& input,
+                        Tensor& output,
+                        gsl::span<const int64_t> axes,
+                        EinsumOp::EinsumCudaAssets& assets) {
+  PrepareReduceMetadata metadata;
+  ORT_RETURN_IF_ERROR(PrepareForReduce(&input, false, axes, metadata));
+  ORT_RETURN_IF_NOT(TensorShape(metadata.squeezed_output_dims) == output.Shape(),
+                    "CUDA Einsum reduction fast-path output shape mismatch");
+  return ReduceComputeCore<T, CUDNN_REDUCE_TENSOR_NO_INDICES>(
+      assets.gpu_allocator_, cuda_kernel, input, metadata, output, CUDNN_REDUCE_TENSOR_ADD, axes,
+      false, false, false, !context->GetUseDeterministicCompute(), assets.GetCudaStream(),
+      assets.ort_stream_, assets.cudnn_handle_);
+}
+
+Status BuildDiagonalMetadata(const Tensor& input,
+                             const EinsumFastPathPlan& plan,
+                             TArray<int64_t>& input_strides,
+                             TArray<int32_t>& input_axis_to_output_axis,
+                             TArray<fast_divmod>& output_strides,
+                             int64_t& trace_dim,
+                             int64_t& trace_stride) {
+  ORT_RETURN_IF_NOT(input.Shape().NumDimensions() <= kFastPathRankLimit &&
+                        plan.output_dims.size() <= kFastPathRankLimit,
+                    "CUDA Einsum diagonal fast path rank exceeds metadata capacity");
+
+  TensorPitches pitches(input.Shape().GetDims());
+  input_strides.SetSize(onnxruntime::narrow<int32_t>(pitches.size()));
+  input_axis_to_output_axis.SetSize(onnxruntime::narrow<int32_t>(plan.input_axis_to_output_axis.size()));
+  trace_dim = 0;
+  trace_stride = 0;
+  for (size_t axis = 0; axis < pitches.size(); ++axis) {
+    input_strides[onnxruntime::narrow<int32_t>(axis)] = pitches[axis];
+    input_axis_to_output_axis[onnxruntime::narrow<int32_t>(axis)] = plan.input_axis_to_output_axis[axis];
+    if (plan.input_axis_to_output_axis[axis] < 0) {
+      if (trace_dim == 0) {
+        trace_dim = input.Shape()[axis];
+      }
+      trace_stride += pitches[axis];
+    }
+  }
+
+  TensorPitches output_pitches(plan.output_dims);
+  output_strides.SetSize(onnxruntime::narrow<int32_t>(output_pitches.size()));
+  for (size_t axis = 0; axis < output_pitches.size(); ++axis) {
+    ORT_RETURN_IF_NOT(output_pitches[axis] <= std::numeric_limits<int>::max(),
+                      "CUDA Einsum diagonal fast path output stride exceeds int range");
+    output_strides[onnxruntime::narrow<int32_t>(axis)] =
+        fast_divmod(onnxruntime::narrow<int>(output_pitches[axis]));
+  }
+
+  return Status::OK();
+}
+
+}  // namespace
+
+Status CreateEinsumFastPathPlan(const EinsumComputePreprocessor& preprocessor,
+                                EinsumFastPathPlan& plan) {
+  plan = EinsumFastPathPlan{};
+  plan.output_dims = preprocessor.GetOutputDims();
+
+  const auto& inputs = preprocessor.GetRawInputTensors();
+  const auto& input_labels = preprocessor.GetInputSubscriptIndices();
+  const auto& label_to_output_axis = preprocessor.GetMappedSubscriptIndicesToOutputindices();
+  const auto& label_extents = preprocessor.GetSubscriptIndicesToDimValue();
+  const size_t num_labels = preprocessor.GetNumSubscriptIndices();
+  const auto output_labels = GetOutputLabels(preprocessor);
+
+  if (inputs.size() == 1) {
+    const auto& labels = input_labels[0];
+    const auto dims = inputs[0]->Shape().GetDims();
+    std::vector<size_t> counts(num_labels, 0);
+    for (const int64_t label : labels) {
+      ++counts[onnxruntime::narrow<size_t>(label)];
+    }
+
+    bool has_repeated_label = std::any_of(counts.begin(), counts.end(), [](size_t count) { return count > 1; });
+    if (has_repeated_label) {
+      if (labels.size() > kFastPathRankLimit || output_labels.size() > kFastPathRankLimit ||
+          !IsRepeatedLabelShapeValid(labels, dims, num_labels) ||
+          TensorShape(plan.output_dims).Size() > std::numeric_limits<int>::max()) {
+        return Status::OK();
+      }
+
+      plan.input_axis_to_output_axis.reserve(labels.size());
+      std::vector<int64_t> reduced_labels;
+      for (const int64_t label : labels) {
+        plan.input_axis_to_output_axis.push_back(
+            onnxruntime::narrow<int32_t>(label_to_output_axis[onnxruntime::narrow<size_t>(label)]));
+      }
+      for (size_t label = 0; label < num_labels; ++label) {
+        if (counts[label] > 0 && label_to_output_axis[label] < 0) {
+          reduced_labels.push_back(onnxruntime::narrow<int64_t>(label));
+        }
+      }
+
+      if (reduced_labels.empty()) {
+        plan.kind = EinsumFastPathKind::Diagonal;
+      } else if (reduced_labels.size() == 1 && counts[onnxruntime::narrow<size_t>(reduced_labels[0])] > 1) {
+        plan.kind = EinsumFastPathKind::Trace;
+        plan.trace_label = reduced_labels[0];
+        for (size_t axis = 0; axis < labels.size(); ++axis) {
+          if (labels[axis] != plan.trace_label && plan.input_axis_to_output_axis[axis] < 0) {
+            plan.kind = EinsumFastPathKind::None;
+            break;
+          }
+        }
+      }
+      return Status::OK();
+    }
+
+    for (size_t axis = 0; axis < labels.size(); ++axis) {
+      if (label_to_output_axis[onnxruntime::narrow<size_t>(labels[axis])] < 0) {
+        plan.reduce_axes.push_back(onnxruntime::narrow<int64_t>(axis));
+      }
+    }
+
+    if (!plan.reduce_axes.empty()) {
+      std::vector<int64_t> retained_labels;
+      for (const int64_t label : labels) {
+        if (label_to_output_axis[onnxruntime::narrow<size_t>(label)] >= 0) {
+          retained_labels.push_back(label);
+        }
+      }
+      if (retained_labels == output_labels) {
+        plan.kind = EinsumFastPathKind::ReduceSum;
+      }
+      return Status::OK();
+    }
+
+    plan.permutation.reserve(output_labels.size());
+    for (const int64_t output_label : output_labels) {
+      const auto input_axis = std::find(labels.begin(), labels.end(), output_label);
+      ORT_ENFORCE(input_axis != labels.end());
+      plan.permutation.push_back(static_cast<size_t>(std::distance(labels.begin(), input_axis)));
+    }
+    plan.kind = !EinsumOp::IsTransposeRequired(labels.size(), plan.permutation) ||
+                        IsExactSequenceIgnoringSizeOne(labels, dims, output_labels)
+                    ? EinsumFastPathKind::Copy
+                    : EinsumFastPathKind::Transpose;
+    return Status::OK();
+  }
+
+  if (inputs.size() != 2) {
+    return Status::OK();
+  }
+
+  const auto& lhs_labels = input_labels[0];
+  const auto& rhs_labels = input_labels[1];
+  const auto lhs_dims = inputs[0]->Shape().GetDims();
+  const auto rhs_dims = inputs[1]->Shape().GetDims();
+  std::vector<size_t> lhs_counts(num_labels, 0);
+  std::vector<size_t> rhs_counts(num_labels, 0);
+  for (const int64_t label : lhs_labels) ++lhs_counts[onnxruntime::narrow<size_t>(label)];
+  for (const int64_t label : rhs_labels) ++rhs_counts[onnxruntime::narrow<size_t>(label)];
+  if (std::any_of(lhs_counts.begin(), lhs_counts.end(), [](size_t count) { return count > 1; }) ||
+      std::any_of(rhs_counts.begin(), rhs_counts.end(), [](size_t count) { return count > 1; })) {
+    return Status::OK();
+  }
+
+  std::vector<int64_t> batch_labels;
+  std::vector<int64_t> lhs_free_labels;
+  std::vector<int64_t> rhs_free_labels;
+  std::vector<int64_t> contraction_labels;
+  for (const int64_t label : output_labels) {
+    const size_t index = onnxruntime::narrow<size_t>(label);
+    if (lhs_counts[index] && rhs_counts[index]) {
+      batch_labels.push_back(label);
+    } else if (lhs_counts[index]) {
+      lhs_free_labels.push_back(label);
+    } else if (rhs_counts[index]) {
+      rhs_free_labels.push_back(label);
+    } else {
+      return Status::OK();
+    }
+  }
+  for (size_t label = 0; label < num_labels; ++label) {
+    if (label_to_output_axis[label] < 0) {
+      if (!lhs_counts[label] || !rhs_counts[label]) {
+        return Status::OK();
+      }
+      contraction_labels.push_back(onnxruntime::narrow<int64_t>(label));
+    }
+  }
+
+  if (contraction_labels.empty()) {
+    if (output_labels.size() > kFastPathRankLimit ||
+        TensorShape(plan.output_dims).Size() > std::numeric_limits<int>::max() ||
+        !IsExactSequenceIgnoringSizeOne(lhs_labels, lhs_dims, output_labels) ||
+        !IsExactSequenceIgnoringSizeOne(rhs_labels, rhs_dims, output_labels)) {
+      return Status::OK();
+    }
+    plan.kind = EinsumFastPathKind::Multiply;
+    plan.lhs_view_dims = BuildBroadcastViewDims(lhs_labels, lhs_dims, output_labels);
+    plan.rhs_view_dims = BuildBroadcastViewDims(rhs_labels, rhs_dims, output_labels);
+    plan.output_view_dims = plan.output_dims;
+    return Status::OK();
+  }
+
+  const auto expected_output = ConcatLabels(batch_labels, lhs_free_labels, rhs_free_labels);
+  if (expected_output != output_labels) {
+    return Status::OK();
+  }
+
+  std::vector<int64_t> contraction_order;
+  for (const int64_t label : lhs_labels) {
+    if (std::find(contraction_labels.begin(), contraction_labels.end(), label) != contraction_labels.end()) {
+      contraction_order.push_back(label);
+    }
+  }
+  std::vector<int64_t> rhs_contraction_order;
+  for (const int64_t label : rhs_labels) {
+    if (std::find(contraction_labels.begin(), contraction_labels.end(), label) != contraction_labels.end()) {
+      rhs_contraction_order.push_back(label);
+    }
+  }
+  if (contraction_order != rhs_contraction_order) {
+    return Status::OK();
+  }
+  for (const int64_t label : contraction_order) {
+    const auto lhs_axis = std::find(lhs_labels.begin(), lhs_labels.end(), label);
+    const auto rhs_axis = std::find(rhs_labels.begin(), rhs_labels.end(), label);
+    ORT_ENFORCE(lhs_axis != lhs_labels.end() && rhs_axis != rhs_labels.end());
+    const int64_t expected_extent = label_extents[onnxruntime::narrow<size_t>(label)];
+    if (lhs_dims[static_cast<size_t>(std::distance(lhs_labels.begin(), lhs_axis))] != expected_extent ||
+        rhs_dims[static_cast<size_t>(std::distance(rhs_labels.begin(), rhs_axis))] != expected_extent) {
+      return Status::OK();
+    }
+  }
+
+  const auto lhs_normal = ConcatLabels(batch_labels, lhs_free_labels, contraction_order);
+  const auto lhs_transposed = ConcatLabels(batch_labels, contraction_order, lhs_free_labels);
+  const auto rhs_normal = ConcatLabels(batch_labels, contraction_order, rhs_free_labels);
+  const auto rhs_transposed = ConcatLabels(batch_labels, rhs_free_labels, contraction_order);
+  if (IsExactSequenceIgnoringSizeOne(lhs_labels, lhs_dims, lhs_normal)) {
+    plan.trans_a = false;
+  } else if (IsExactSequenceIgnoringSizeOne(lhs_labels, lhs_dims, lhs_transposed)) {
+    plan.trans_a = true;
+  } else {
+    return Status::OK();
+  }
+  if (IsExactSequenceIgnoringSizeOne(rhs_labels, rhs_dims, rhs_normal)) {
+    plan.trans_b = false;
+  } else if (IsExactSequenceIgnoringSizeOne(rhs_labels, rhs_dims, rhs_transposed)) {
+    plan.trans_b = true;
+  } else {
+    return Status::OK();
+  }
+
+  const bool lhs_batch_matches = AllBatchDimsMatchOutput(batch_labels, lhs_labels, lhs_dims, label_extents);
+  const bool rhs_batch_matches = AllBatchDimsMatchOutput(batch_labels, rhs_labels, rhs_dims, label_extents);
+  const bool rhs_batch_is_one = AllBatchDimsAreOne(batch_labels, rhs_labels, rhs_dims);
+  if (!lhs_batch_matches || (!rhs_batch_matches && !rhs_batch_is_one)) {
+    return Status::OK();
+  }
+
+  int64_t m = 1;
+  int64_t k = 1;
+  int64_t n = 1;
+  int64_t batch_count = 1;
+  if (!ProductFitsCublas(batch_labels, label_extents, batch_count) ||
+      !ProductFitsCublas(lhs_free_labels, label_extents, m) ||
+      !ProductFitsCublas(contraction_order, label_extents, k) ||
+      !ProductFitsCublas(rhs_free_labels, label_extents, n)) {
+    return Status::OK();
+  }
+
+  TensorShapeVector batch_dims;
+  for (const int64_t label : batch_labels) {
+    const int64_t dim = label_extents[onnxruntime::narrow<size_t>(label)];
+    if (dim > std::numeric_limits<int>::max()) {
+      return Status::OK();
+    }
+    batch_dims.push_back(dim);
+  }
+
+  plan.lhs_view_dims = batch_dims;
+  plan.lhs_view_dims.push_back(plan.trans_a ? k : m);
+  plan.lhs_view_dims.push_back(plan.trans_a ? m : k);
+
+  if (rhs_batch_is_one && !rhs_batch_matches) {
+    plan.rhs_view_dims = {};
+  } else {
+    plan.rhs_view_dims = batch_dims;
+  }
+  plan.rhs_view_dims.push_back(plan.trans_b ? n : k);
+  plan.rhs_view_dims.push_back(plan.trans_b ? k : n);
+
+  plan.output_view_dims = batch_dims;
+  plan.output_view_dims.push_back(m);
+  plan.output_view_dims.push_back(n);
+  plan.kind = EinsumFastPathKind::MatMul;
+  return Status::OK();
+}
+
+template <typename T>
+Status ExecuteEinsumFastPath(const CudaKernel* cuda_kernel,
+                             OpKernelContext* context,
+                             const std::vector<const Tensor*>& inputs,
+                             const EinsumFastPathPlan& plan,
+                             EinsumOp::EinsumCudaAssets& assets) {
+  Tensor& output = *context->Output(0, plan.output_dims);
+  switch (plan.kind) {
+    case EinsumFastPathKind::Copy:
+      return EinsumOp::DeviceHelpers::CudaDeviceHelpers::DataCopy(*inputs[0], output, &assets);
+    case EinsumFastPathKind::Transpose:
+      return EinsumOp::DeviceHelpers::CudaDeviceHelpers::Transpose(
+          plan.permutation, *inputs[0], output, nullptr, &assets);
+    case EinsumFastPathKind::ReduceSum:
+      return ExecuteReduceSum<T>(cuda_kernel, context, *inputs[0], output, plan.reduce_axes, assets);
+    case EinsumFastPathKind::Diagonal:
+    case EinsumFastPathKind::Trace: {
+      TArray<int64_t> input_strides;
+      TArray<int32_t> input_axis_to_output_axis;
+      TArray<fast_divmod> output_strides;
+      int64_t trace_dim = 0;
+      int64_t trace_stride = 0;
+      ORT_RETURN_IF_ERROR(BuildDiagonalMetadata(*inputs[0], plan, input_strides, input_axis_to_output_axis,
+                                                output_strides, trace_dim, trace_stride));
+      if (plan.kind == EinsumFastPathKind::Diagonal) {
+        return LaunchEinsumDiagonal(assets.GetCudaStream(), inputs[0]->DataRaw(), output.MutableDataRaw(),
+                                    inputs[0]->DataType()->Size(), onnxruntime::narrow<size_t>(output.Shape().Size()),
+                                    input_strides, input_axis_to_output_axis, output_strides);
+      }
+      return LaunchEinsumTrace(assets.GetCudaStream(), inputs[0]->DataRaw(), output.MutableDataRaw(),
+                               inputs[0]->DataType()->Size(), onnxruntime::narrow<size_t>(output.Shape().Size()),
+                               trace_dim, trace_stride, input_strides, input_axis_to_output_axis, output_strides);
+    }
+    case EinsumFastPathKind::Multiply: {
+      auto lhs_view = MakeTensorView(*inputs[0], plan.lhs_view_dims);
+      auto rhs_view = MakeTensorView(*inputs[1], plan.rhs_view_dims);
+      auto output_view = MakeTensorView(output, plan.output_view_dims);
+      BinaryElementwisePreparation preparation;
+      ORT_RETURN_IF_ERROR(BinaryElementwiseBroadcastPrepare(
+          lhs_view.get(), rhs_view.get(), output_view.get(), &preparation));
+      using CudaT = typename ToCudaType<T>::MappedType;
+      Impl_Mul<CudaT>(assets.GetCudaStream(), preparation.output_rank_or_simple_broadcast,
+                      &preparation.lhs_padded_strides, reinterpret_cast<const CudaT*>(lhs_view->Data<T>()),
+                      &preparation.rhs_padded_strides, reinterpret_cast<const CudaT*>(rhs_view->Data<T>()),
+                      &preparation.fdm_output_strides, preparation.fdm_H, preparation.fdm_C,
+                      reinterpret_cast<CudaT*>(output_view->MutableData<T>()),
+                      onnxruntime::narrow<size_t>(output_view->Shape().Size()));
+      return CUDA_CALL(cudaGetLastError());
+    }
+    case EinsumFastPathKind::MatMul: {
+      auto lhs_view = MakeTensorView(*inputs[0], plan.lhs_view_dims);
+      auto rhs_view = MakeTensorView(*inputs[1], plan.rhs_view_dims);
+      auto output_view = MakeTensorView(output, plan.output_view_dims);
+      return FuncMatMul<T>(cuda_kernel, context, lhs_view.get(), rhs_view.get(), 1.0f,
+                           plan.trans_a, plan.trans_b, false, false, output_view.get());
+    }
+    case EinsumFastPathKind::None:
+      return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "Attempted to execute an ineligible CUDA Einsum fast path");
+  }
+
+  return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "Unknown CUDA Einsum fast path");
+}
+
+template Status ExecuteEinsumFastPath<float>(
+    const CudaKernel*, OpKernelContext*, const std::vector<const Tensor*>&,
+    const EinsumFastPathPlan&, EinsumOp::EinsumCudaAssets&);
+template Status ExecuteEinsumFastPath<double>(
+    const CudaKernel*, OpKernelContext*, const std::vector<const Tensor*>&,
+    const EinsumFastPathPlan&, EinsumOp::EinsumCudaAssets&);
+template Status ExecuteEinsumFastPath<MLFloat16>(
+    const CudaKernel*, OpKernelContext*, const std::vector<const Tensor*>&,
+    const EinsumFastPathPlan&, EinsumOp::EinsumCudaAssets&);
+
+}  // namespace cuda
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/cuda/math/einsum_utils/einsum_fast_path.h
+++ b/onnxruntime/core/providers/cuda/math/einsum_utils/einsum_fast_path.h
@@ -1,0 +1,49 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include "core/providers/cpu/math/einsum_utils/einsum_compute_preprocessor.h"
+#include "core/providers/cuda/cuda_kernel.h"
+#include "einsum_auxiliary_ops.h"
+
+namespace onnxruntime {
+namespace cuda {
+
+enum class EinsumFastPathKind {
+  None,
+  Copy,
+  Transpose,
+  ReduceSum,
+  Diagonal,
+  Trace,
+  Multiply,
+  MatMul,
+};
+
+struct EinsumFastPathPlan {
+  EinsumFastPathKind kind = EinsumFastPathKind::None;
+  TensorShapeVector output_dims;
+  std::vector<size_t> permutation;
+  TensorShapeVector reduce_axes;
+  TensorShapeVector lhs_view_dims;
+  TensorShapeVector rhs_view_dims;
+  TensorShapeVector output_view_dims;
+  std::vector<int32_t> input_axis_to_output_axis;
+  int64_t trace_label = -1;
+  bool trans_a = false;
+  bool trans_b = false;
+};
+
+Status CreateEinsumFastPathPlan(const EinsumComputePreprocessor& preprocessor,
+                                EinsumFastPathPlan& plan);
+
+template <typename T>
+Status ExecuteEinsumFastPath(const CudaKernel* cuda_kernel,
+                             OpKernelContext* context,
+                             const std::vector<const Tensor*>& inputs,
+                             const EinsumFastPathPlan& plan,
+                             EinsumOp::EinsumCudaAssets& assets);
+
+}  // namespace cuda
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/cuda/math/einsum_utils/einsum_fast_path_kernels.cu
+++ b/onnxruntime/core/providers/cuda/math/einsum_utils/einsum_fast_path_kernels.cu
@@ -1,0 +1,198 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "core/providers/cuda/cu_inc/common.cuh"
+#include "einsum_fast_path_kernels.h"
+
+namespace onnxruntime {
+namespace cuda {
+
+constexpr int kEinsumFastPathRankLimit = 8;
+constexpr int kTraceThreadsPerBlock = 256;
+
+__device__ __forceinline__ int64_t GetEinsumInputOffset(
+    size_t output_idx,
+    const TArray<int64_t>& input_strides,
+    const TArray<int32_t>& input_axis_to_output_axis,
+    const TArray<fast_divmod>& output_strides) {
+  int64_t output_coordinates[kEinsumFastPathRankLimit] = {};
+  int remaining = static_cast<int>(output_idx);
+  for (int32_t axis = 0; axis < output_strides.Size(); ++axis) {
+    int coordinate = 0;
+    output_strides[axis].divmod(remaining, coordinate, remaining);
+    output_coordinates[axis] = coordinate;
+  }
+
+  int64_t input_offset = 0;
+  for (int32_t axis = 0; axis < input_strides.Size(); ++axis) {
+    const int32_t output_axis = input_axis_to_output_axis[axis];
+    if (output_axis >= 0) {
+      input_offset += input_strides[axis] * output_coordinates[output_axis];
+    }
+  }
+
+  return input_offset;
+}
+
+template <typename T>
+__global__ void EinsumDiagonalKernel(const T* input_data,
+                                     T* output_data,
+                                     size_t output_size,
+                                     TArray<int64_t> input_strides,
+                                     TArray<int32_t> input_axis_to_output_axis,
+                                     TArray<fast_divmod> output_strides) {
+  CALCULATE_ELEMENTWISE_INDEX_OR_EXIT(output_idx, output_size);
+  output_data[output_idx] =
+      input_data[GetEinsumInputOffset(output_idx, input_strides, input_axis_to_output_axis, output_strides)];
+}
+
+template <typename T, typename TAccum>
+__global__ void EinsumTraceKernel(const T* input_data,
+                                  T* output_data,
+                                  size_t output_size,
+                                  int64_t trace_dim,
+                                  int64_t trace_stride,
+                                  TArray<int64_t> input_strides,
+                                  TArray<int32_t> input_axis_to_output_axis,
+                                  TArray<fast_divmod> output_strides) {
+  const size_t output_idx = blockIdx.x;
+  if (output_idx >= output_size) {
+    return;
+  }
+
+  const int64_t input_offset =
+      GetEinsumInputOffset(output_idx, input_strides, input_axis_to_output_axis, output_strides);
+  TAccum thread_sum = TAccum{};
+  for (int64_t diagonal_idx = threadIdx.x; diagonal_idx < trace_dim; diagonal_idx += blockDim.x) {
+    thread_sum += static_cast<TAccum>(input_data[input_offset + diagonal_idx * trace_stride]);
+  }
+
+  using BlockReduce = cub::BlockReduce<TAccum, kTraceThreadsPerBlock>;
+  __shared__ typename BlockReduce::TempStorage temp_storage;
+  const TAccum sum = BlockReduce(temp_storage).Sum(thread_sum);
+  if (threadIdx.x == 0) {
+    output_data[output_idx] = static_cast<T>(sum);
+  }
+}
+
+template <>
+__global__ void EinsumTraceKernel<half, float>(const half* input_data,
+                                               half* output_data,
+                                               size_t output_size,
+                                               int64_t trace_dim,
+                                               int64_t trace_stride,
+                                               TArray<int64_t> input_strides,
+                                               TArray<int32_t> input_axis_to_output_axis,
+                                               TArray<fast_divmod> output_strides) {
+  const size_t output_idx = blockIdx.x;
+  if (output_idx >= output_size) {
+    return;
+  }
+
+  const int64_t input_offset =
+      GetEinsumInputOffset(output_idx, input_strides, input_axis_to_output_axis, output_strides);
+  float thread_sum = 0.0f;
+  for (int64_t diagonal_idx = threadIdx.x; diagonal_idx < trace_dim; diagonal_idx += blockDim.x) {
+    thread_sum += __half2float(input_data[input_offset + diagonal_idx * trace_stride]);
+  }
+
+  using BlockReduce = cub::BlockReduce<float, kTraceThreadsPerBlock>;
+  __shared__ typename BlockReduce::TempStorage temp_storage;
+  const float sum = BlockReduce(temp_storage).Sum(thread_sum);
+  if (threadIdx.x == 0) {
+    output_data[output_idx] = __float2half(sum);
+  }
+}
+
+template <typename T>
+Status LaunchDiagonalTyped(cudaStream_t stream,
+                           const void* input_data,
+                           void* output_data,
+                           size_t output_size,
+                           const TArray<int64_t>& input_strides,
+                           const TArray<int32_t>& input_axis_to_output_axis,
+                           const TArray<fast_divmod>& output_strides) {
+  if (output_size == 0) {
+    return Status::OK();
+  }
+
+  const int blocks = static_cast<int>(
+      (output_size + GridDim::maxThreadsPerBlock - 1) / GridDim::maxThreadsPerBlock);
+  EinsumDiagonalKernel<T><<<blocks, GridDim::maxThreadsPerBlock, 0, stream>>>(
+      reinterpret_cast<const T*>(input_data), reinterpret_cast<T*>(output_data), output_size,
+      input_strides, input_axis_to_output_axis, output_strides);
+  return CUDA_CALL(cudaGetLastError());
+}
+
+template <typename T, typename TAccum>
+Status LaunchTraceTyped(cudaStream_t stream,
+                        const void* input_data,
+                        void* output_data,
+                        size_t output_size,
+                        int64_t trace_dim,
+                        int64_t trace_stride,
+                        const TArray<int64_t>& input_strides,
+                        const TArray<int32_t>& input_axis_to_output_axis,
+                        const TArray<fast_divmod>& output_strides) {
+  if (output_size == 0) {
+    return Status::OK();
+  }
+
+  EinsumTraceKernel<T, TAccum><<<static_cast<int>(output_size), kTraceThreadsPerBlock, 0, stream>>>(
+      reinterpret_cast<const T*>(input_data), reinterpret_cast<T*>(output_data), output_size,
+      trace_dim, trace_stride, input_strides, input_axis_to_output_axis, output_strides);
+  return CUDA_CALL(cudaGetLastError());
+}
+
+Status LaunchEinsumDiagonal(cudaStream_t stream,
+                            const void* input_data,
+                            void* output_data,
+                            size_t element_size,
+                            size_t output_size,
+                            const TArray<int64_t>& input_strides,
+                            const TArray<int32_t>& input_axis_to_output_axis,
+                            const TArray<fast_divmod>& output_strides) {
+  switch (element_size) {
+    case sizeof(half):
+      return LaunchDiagonalTyped<half>(stream, input_data, output_data, output_size, input_strides,
+                                       input_axis_to_output_axis, output_strides);
+    case sizeof(float):
+      return LaunchDiagonalTyped<float>(stream, input_data, output_data, output_size, input_strides,
+                                        input_axis_to_output_axis, output_strides);
+    case sizeof(double):
+      return LaunchDiagonalTyped<double>(stream, input_data, output_data, output_size, input_strides,
+                                         input_axis_to_output_axis, output_strides);
+    default:
+      return ORT_MAKE_STATUS(ONNXRUNTIME, NOT_IMPLEMENTED,
+                             "CUDA Einsum diagonal fast path does not support element size ", element_size);
+  }
+}
+
+Status LaunchEinsumTrace(cudaStream_t stream,
+                         const void* input_data,
+                         void* output_data,
+                         size_t element_size,
+                         size_t output_size,
+                         int64_t trace_dim,
+                         int64_t trace_stride,
+                         const TArray<int64_t>& input_strides,
+                         const TArray<int32_t>& input_axis_to_output_axis,
+                         const TArray<fast_divmod>& output_strides) {
+  switch (element_size) {
+    case sizeof(half):
+      return LaunchTraceTyped<half, float>(stream, input_data, output_data, output_size, trace_dim, trace_stride,
+                                           input_strides, input_axis_to_output_axis, output_strides);
+    case sizeof(float):
+      return LaunchTraceTyped<float, float>(stream, input_data, output_data, output_size, trace_dim, trace_stride,
+                                            input_strides, input_axis_to_output_axis, output_strides);
+    case sizeof(double):
+      return LaunchTraceTyped<double, double>(stream, input_data, output_data, output_size, trace_dim, trace_stride,
+                                              input_strides, input_axis_to_output_axis, output_strides);
+    default:
+      return ORT_MAKE_STATUS(ONNXRUNTIME, NOT_IMPLEMENTED,
+                             "CUDA Einsum trace fast path does not support element size ", element_size);
+  }
+}
+
+}  // namespace cuda
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/cuda/math/einsum_utils/einsum_fast_path_kernels.h
+++ b/onnxruntime/core/providers/cuda/math/einsum_utils/einsum_fast_path_kernels.h
@@ -1,0 +1,32 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include "core/providers/cuda/shared_inc/cuda_utils.h"
+
+namespace onnxruntime {
+namespace cuda {
+
+Status LaunchEinsumDiagonal(cudaStream_t stream,
+                            const void* input_data,
+                            void* output_data,
+                            size_t element_size,
+                            size_t output_size,
+                            const TArray<int64_t>& input_strides,
+                            const TArray<int32_t>& input_axis_to_output_axis,
+                            const TArray<fast_divmod>& output_strides);
+
+Status LaunchEinsumTrace(cudaStream_t stream,
+                         const void* input_data,
+                         void* output_data,
+                         size_t element_size,
+                         size_t output_size,
+                         int64_t trace_dim,
+                         int64_t trace_stride,
+                         const TArray<int64_t>& input_strides,
+                         const TArray<int32_t>& input_axis_to_output_axis,
+                         const TArray<fast_divmod>& output_strides);
+
+}  // namespace cuda
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/cuda/math/matmul.cc
+++ b/onnxruntime/core/providers/cuda/math/matmul.cc
@@ -296,6 +296,18 @@ template Status FuncMatMul<MLFloat16>(
     bool trans_batch_B,
     Tensor* Y);
 
+template Status FuncMatMul<double>(
+    const CudaKernel* cuda_kernel,
+    OpKernelContext* ctx,
+    const Tensor* A,
+    const Tensor* B,
+    float alpha,
+    bool trans_A,
+    bool trans_B,
+    bool trans_batch_A,
+    bool trans_batch_B,
+    Tensor* Y);
+
 template <typename T>
 Status MatMul<T>::ComputeDefault(OpKernelContext* ctx, MatMulComputeHelper& helper) const {
   typedef typename ToCudaType<T>::MappedType CudaT;

--- a/onnxruntime/python/tools/microbench/einsum.py
+++ b/onnxruntime/python/tools/microbench/einsum.py
@@ -1,0 +1,121 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+
+import argparse
+import statistics
+import time
+from dataclasses import dataclass
+
+import numpy as np
+import onnx
+from onnx import TensorProto, helper
+
+import onnxruntime as ort
+
+
+@dataclass(frozen=True)
+class EinsumCase:
+    name: str
+    equation: str
+    input_shapes: tuple[tuple[int, ...], ...]
+    output_shape: tuple[int, ...]
+
+
+CASES = (
+    EinsumCase("copy", "bhsd->bhsd", ((1, 16, 128, 64),), (1, 16, 128, 64)),
+    EinsumCase("transpose", "bhsd->bshd", ((1, 16, 128, 64),), (1, 128, 16, 64)),
+    EinsumCase("reduce", "bsk->bs", ((4, 128, 1024),), (4, 128)),
+    EinsumCase("diagonal", "bii->bi", ((16, 512, 512),), (16, 512)),
+    EinsumCase("trace", "bii->b", ((16, 512, 512),), (16,)),
+    EinsumCase("multiply", "bsh,bsh->bsh", ((4, 128, 768), (4, 128, 768)), (4, 128, 768)),
+    EinsumCase("outer", "i,j->ij", ((1024,), (1024,)), (1024, 1024)),
+    EinsumCase("dot", "i,i->", ((4 * 1024 * 1024,), (4 * 1024 * 1024,)), ()),
+    EinsumCase("gemm", "mk,kn->mn", ((2048, 1024), (1024, 1024)), (2048, 1024)),
+    EinsumCase(
+        "attention_qk",
+        "bhmd,bhnd->bhmn",
+        ((1, 16, 128, 64), (1, 16, 128, 64)),
+        (1, 16, 128, 128),
+    ),
+    EinsumCase(
+        "fallback_three_input",
+        "bik,bkj,bjl->bil",
+        ((4, 128, 256), (4, 256, 128), (4, 128, 64)),
+        (4, 128, 64),
+    ),
+)
+
+
+def create_model(case: EinsumCase, tensor_type: int) -> bytes:
+    input_names = [f"X{i}" for i in range(len(case.input_shapes))]
+    node = helper.make_node("Einsum", input_names, ["Y"], equation=case.equation)
+    graph = helper.make_graph(
+        [node],
+        f"einsum_{case.name}",
+        [
+            helper.make_tensor_value_info(name, tensor_type, shape)
+            for name, shape in zip(input_names, case.input_shapes, strict=False)
+        ],
+        [helper.make_tensor_value_info("Y", tensor_type, case.output_shape)],
+    )
+    model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 12)])
+    model.ir_version = onnx.IR_VERSION
+    return model.SerializeToString()
+
+
+def benchmark_case(case: EinsumCase, dtype, tensor_type: int, args) -> tuple[float, float]:
+    provider_options = {"enable_cuda_graph": "1"} if args.cuda_graph else {}
+    session = ort.InferenceSession(
+        create_model(case, tensor_type),
+        providers=[("CUDAExecutionProvider", provider_options)],
+    )
+    rng = np.random.default_rng(0)
+    inputs = [
+        ort.OrtValue.ortvalue_from_numpy(rng.standard_normal(shape).astype(dtype), "cuda", 0)
+        for shape in case.input_shapes
+    ]
+    output = ort.OrtValue.ortvalue_from_shape_and_type(case.output_shape, dtype, "cuda", 0)
+    binding = session.io_binding()
+    for index, value in enumerate(inputs):
+        binding.bind_ortvalue_input(f"X{index}", value)
+    binding.bind_ortvalue_output("Y", output)
+
+    for _ in range(args.warmup):
+        session.run_with_iobinding(binding)
+    binding.synchronize_outputs()
+
+    samples = []
+    for _ in range(args.iterations):
+        start = time.perf_counter()
+        session.run_with_iobinding(binding)
+        binding.synchronize_outputs()
+        samples.append((time.perf_counter() - start) * 1000)
+
+    return statistics.median(samples), float(np.percentile(samples, 90))
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Benchmark CUDA Einsum fast paths and fallback")
+    parser.add_argument("--precision", choices=("fp16", "fp32"), default="fp16")
+    parser.add_argument("--cuda_graph", action="store_true")
+    parser.add_argument("--warmup", type=int, default=50)
+    parser.add_argument("--iterations", type=int, default=200)
+    parser.add_argument("--case", action="append", choices=[case.name for case in CASES])
+    args = parser.parse_args()
+
+    if "CUDAExecutionProvider" not in ort.get_available_providers():
+        raise RuntimeError("CUDAExecutionProvider is required")
+
+    dtype = np.float16 if args.precision == "fp16" else np.float32
+    tensor_type = TensorProto.FLOAT16 if args.precision == "fp16" else TensorProto.FLOAT
+    selected_cases = [case for case in CASES if not args.case or case.name in args.case]
+    print(f"provider=CUDAExecutionProvider precision={args.precision} cuda_graph={args.cuda_graph}")
+    for case in selected_cases:
+        median_ms, p90_ms = benchmark_case(case, dtype, tensor_type, args)
+        print(f"{case.name:24s} equation={case.equation:20s} median={median_ms:9.4f} ms p90={p90_ms:9.4f} ms")
+
+
+if __name__ == "__main__":
+    main()

--- a/onnxruntime/test/providers/cpu/math/einsum_test.cc
+++ b/onnxruntime/test/providers/cpu/math/einsum_test.cc
@@ -26,6 +26,15 @@ TEST(Einsum, ExplicitEinsumAsIdentity_1D_input) {
   test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kOpenVINOExecutionProvider});
 }
 
+TEST(Einsum, RepeatedLabelDimensionsMustMatchForEmptyInput) {
+  OpTester test("Einsum", 12, onnxruntime::kOnnxDomain);
+  test.AddAttribute<std::string>("equation", "ii->i");
+  test.AddInput<float>("x", {0, 1}, {});
+  test.AddOutput<float>("y", {0}, {});
+  test.Run(OpTester::ExpectResult::kExpectFailure,
+           "Einsum repeated labels within one input must have equal dimensions");
+}
+
 // Implicit
 TEST(Einsum, ImplicitEinsumAsIdentity_1D_input) {
   OpTester test("Einsum", 12, onnxruntime::kOnnxDomain);

--- a/onnxruntime/test/providers/cuda/test_cases/einsum_fast_path_test.cc
+++ b/onnxruntime/test/providers/cuda/test_cases/einsum_fast_path_test.cc
@@ -1,0 +1,81 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "gtest/gtest.h"
+
+#include "core/framework/allocator.h"
+#include "core/framework/tensor.h"
+#include "core/providers/cuda/math/einsum_utils/einsum_fast_path.h"
+
+namespace onnxruntime {
+namespace cuda {
+namespace test {
+namespace {
+
+struct PlannedEinsum {
+  EinsumFastPathKind kind;
+  EinsumFastPathPlan plan;
+};
+
+PlannedEinsum Plan(std::string_view equation,
+                   std::initializer_list<TensorShapeVector> input_shapes) {
+  AllocatorPtr allocator = std::make_shared<CPUAllocator>();
+  uint8_t dummy_data = 0;
+  std::vector<std::unique_ptr<Tensor>> owned_inputs;
+  std::vector<const Tensor*> inputs;
+  owned_inputs.reserve(input_shapes.size());
+  inputs.reserve(input_shapes.size());
+  for (const auto& shape : input_shapes) {
+    owned_inputs.push_back(
+        std::make_unique<Tensor>(
+            DataTypeImpl::GetType<float>(), TensorShape(shape), &dummy_data, allocator->Info()));
+    inputs.push_back(owned_inputs.back().get());
+  }
+
+  EinsumEquationPreprocessor equation_preprocessor{std::string(equation)};
+  EinsumComputePreprocessor compute_preprocessor(equation_preprocessor, inputs, allocator, nullptr);
+  ORT_THROW_IF_ERROR(compute_preprocessor.Analyze());
+
+  EinsumFastPathPlan plan;
+  ORT_THROW_IF_ERROR(CreateEinsumFastPathPlan(compute_preprocessor, plan));
+  return {plan.kind, std::move(plan)};
+}
+
+TEST(EinsumFastPathPlannerTest, ClassifiesSingleInputPaths) {
+  EXPECT_EQ(Plan("ij->ij", {{2, 3}}).kind, EinsumFastPathKind::Copy);
+  EXPECT_EQ(Plan("...ji->...ij", {{2, 3, 4}}).kind, EinsumFastPathKind::Transpose);
+  EXPECT_EQ(Plan("abc->ac", {{2, 3, 4}}).kind, EinsumFastPathKind::ReduceSum);
+  EXPECT_EQ(Plan("iij->ij", {{3, 3, 4}}).kind, EinsumFastPathKind::Diagonal);
+  EXPECT_EQ(Plan("...ii->...", {{2, 4, 4}}).kind, EinsumFastPathKind::Trace);
+  EXPECT_EQ(Plan("iii->i", {{5, 5, 5}}).kind, EinsumFastPathKind::Diagonal);
+}
+
+TEST(EinsumFastPathPlannerTest, ClassifiesTwoInputPaths) {
+  EXPECT_EQ(Plan("ij,ij->ij", {{3, 4}, {3, 4}}).kind, EinsumFastPathKind::Multiply);
+  EXPECT_EQ(Plan("i,j->ji", {{3}, {4}}).kind, EinsumFastPathKind::Multiply);
+  EXPECT_EQ(Plan("bij,bj->bij", {{2, 3, 4}, {2, 4}}).kind, EinsumFastPathKind::Multiply);
+  EXPECT_EQ(Plan("ij,jk->ik", {{3, 4}, {4, 5}}).kind, EinsumFastPathKind::MatMul);
+  EXPECT_EQ(Plan("bhmd,bhnd->bhmn", {{2, 8, 16, 64}, {2, 8, 32, 64}}).kind,
+            EinsumFastPathKind::MatMul);
+  EXPECT_EQ(Plan("abc,cde->abde", {{2, 3, 4}, {4, 5, 6}}).kind,
+            EinsumFastPathKind::MatMul);
+  EXPECT_EQ(Plan("i,i->", {{64}, {64}}).kind, EinsumFastPathKind::MatMul);
+}
+
+TEST(EinsumFastPathPlannerTest, ConservativelyRejectsUnsupportedLayouts) {
+  EXPECT_EQ(Plan("ik,kj->ij", {{3, 1}, {4, 5}}).kind, EinsumFastPathKind::None);
+  EXPECT_EQ(Plan("ij,jk->ki", {{3, 4}, {4, 5}}).kind, EinsumFastPathKind::None);
+  EXPECT_EQ(Plan("bthd,bshd->bhts", {{2, 16, 8, 64}, {2, 32, 8, 64}}).kind,
+            EinsumFastPathKind::None);
+  EXPECT_EQ(Plan("ij,jk,kl->il", {{2, 3}, {3, 4}, {4, 5}}).kind,
+            EinsumFastPathKind::None);
+  EXPECT_EQ(Plan("iij,jk->ik", {{3, 3, 4}, {4, 5}}).kind,
+            EinsumFastPathKind::None);
+  EXPECT_EQ(Plan("i,j->ij", {{65537}, {65536}}).kind,
+            EinsumFastPathKind::None);
+}
+
+}  // namespace
+}  // namespace test
+}  // namespace cuda
+}  // namespace onnxruntime

--- a/onnxruntime/test/python/onnxruntime_test_python_cudagraph.py
+++ b/onnxruntime/test/python/onnxruntime_test_python_cudagraph.py
@@ -4,7 +4,9 @@
 import unittest
 
 import numpy as np
+import onnx
 from helper import get_name
+from onnx import TensorProto, helper
 
 import onnxruntime as onnxrt
 
@@ -60,6 +62,58 @@ class CudaGraphHelper:
 
 
 class TestInferenceSessionWithCudaGraph(unittest.TestCase):
+    @staticmethod
+    def _create_einsum_model(equation, input_shapes, output_shape):
+        input_names = [f"X{i}" for i in range(len(input_shapes))]
+        node = helper.make_node("Einsum", input_names, ["Y"], equation=equation)
+        graph = helper.make_graph(
+            [node],
+            "einsum_cuda_graph",
+            [
+                helper.make_tensor_value_info(name, TensorProto.FLOAT, shape)
+                for name, shape in zip(input_names, input_shapes, strict=False)
+            ],
+            [helper.make_tensor_value_info("Y", TensorProto.FLOAT, output_shape)],
+        )
+        model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 12)])
+        model.ir_version = onnx.IR_VERSION
+        return model.SerializeToString(), input_names
+
+    def test_einsum_cuda_graph_capture_and_replay(self):
+        if "CUDAExecutionProvider" not in onnxrt.get_available_providers():
+            self.skipTest("CUDAExecutionProvider is not available")
+
+        cases = [
+            ("bij->bji", [[2, 3, 4]], [2, 4, 3]),
+            ("bii->b", [[2, 4, 4]], [2]),
+            ("bij,bj->bij", [[2, 3, 4], [2, 4]], [2, 3, 4]),
+            ("bij,bjk->bik", [[2, 3, 4], [2, 4, 5]], [2, 3, 5]),
+            ("bij,bjk,bkl->bil", [[2, 3, 4], [2, 4, 5], [2, 5, 6]], [2, 3, 6]),
+        ]
+
+        for equation, input_shapes, output_shape in cases:
+            with self.subTest(equation=equation):
+                model, input_names = self._create_einsum_model(equation, input_shapes, output_shape)
+                session = onnxrt.InferenceSession(
+                    model,
+                    providers=[("CUDAExecutionProvider", {"enable_cuda_graph": True})],
+                )
+                shapes = dict(zip(input_names, input_shapes, strict=False))
+                shapes["Y"] = output_shape
+                graph_helper = CudaGraphHelper(session, shapes)
+
+                for replay in range(4):
+                    inputs = {
+                        name: (np.arange(np.prod(shape), dtype=np.float32).reshape(shape) + replay + 1) / 17.0
+                        for name, shape in zip(input_names, input_shapes, strict=False)
+                    }
+                    graph_helper.update_inputs(inputs)
+                    graph_helper.io_binding.synchronize_inputs()
+                    session.run_with_iobinding(graph_helper.io_binding)
+                    graph_helper.io_binding.synchronize_outputs()
+                    expected = np.einsum(equation, *(inputs[name] for name in input_names))
+                    np.testing.assert_allclose(graph_helper.get_output("Y"), expected, rtol=1e-4, atol=1e-4)
+
     def test_ort_value_update_in_place(self):
         x0 = np.array([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]], dtype=np.float32)
         ortvalue_cpu = onnxrt.OrtValue.ortvalue_from_numpy(x0)


### PR DESCRIPTION
### Description

Adds a shape-aware CUDA Einsum planner after semantic analysis and before input materialization. The planner matches canonical labels and runtime shapes rather than raw equation strings, then writes directly to the framework output for:

- single-input identity/reshape-only copy, transpose, reduction, generalized diagonal, and trace
- two-input elementwise/scalar/broadcast multiply and outer products
- dot, GEMM, batched GEMM, projection contractions, and contiguous head-major attention contractions

Eligibility is deliberately conservative. Repeated labels, contraction broadcasting, unsupported output/layout permutations, partial batch broadcasting, token-major non-contiguous attention layouts, and arbitrary multi-input contractions stay on the existing decomposition. The fallback keeps left-to-right contraction order while avoiding empty-input preprocessing, singleton-only materialized permutations, extent-one reductions, and compatible final-output copies.

The specialized launches preserve the run stream, output ownership, TF32/type behavior, and CUDA Graph capture constraints. New diagonal/trace kernels use checked fixed-rank metadata and return launch failures through `Status`.

### Motivation and Context

CUDA Einsum currently materializes diagonals/permutations and commonly writes GEMM results to a temporary before copying or transposing into the real output, even for common equations such as `ij,jk->ik`. This targets the overhead described in #5897 while retaining the shared parser as the semantic authority.

The implementation is compatible with the allocation-stream direction in #32354, which overlaps `einsum.cc` and CUDA Einsum helper files. No provider ABI or shared-provider bridge signature is changed here.

### Correctness and dispatch coverage

- Added planner acceptance/rejection tests for identity, transpose, reduction, diagonal/trace, elementwise/broadcast/outer, dot/GEMM/batched GEMM/projection, contraction broadcasting, unsupported output order, token-major layouts, repeated labels, multi-input fallback, and 32-bit indexing limits.
- Added an end-to-end CUDA Graph test using fixed GPU I/O bindings, repeated replay, updated inputs, specialized equations, and a representative three-input fallback.
- Existing shared Einsum tests exercise CUDA when available; added explicit validation that mismatched repeated-label dimensions still fail for empty tensors.
- Added `onnxruntime/python/tools/microbench/einsum.py` with CUDA I/O binding, FP16/FP32, CUDA Graph on/off, warmup, median/p90, matched common equations, and a representative fallback.

### Validation

- `tools/ci_build/build.py --config RelWithDebInfo --build_dir build_cpu_einsum --update --build --parallel --skip_submodule_sync --target onnxruntime_test_all`
- `tools/ci_build/build.py --config RelWithDebInfo --build_dir build_cpu_einsum --build --parallel --skip_submodule_sync --target onnxruntime_provider_test`
- `onnxruntime_provider_test.exe --gtest_filter=Einsum.*` — 85/85 passed
- `lintrunner -a` and `lintrunner` — passed
- Python `py_compile` — passed
- ONNX checker — validated all 11 generated benchmark models and 5 CUDA Graph models
- CPU execution — all 5 generated CUDA Graph test models matched NumPy Einsum

CUDA compilation, CUDA Graph execution, and branch-vs-baseline performance numbers could not be run on this host: it has an RTX 4060 Laptop GPU and driver 591.55, but no CUDA toolkit, cuDNN headers, or `nvcc`. The benchmark driver is included so the exact baseline/branch matrix can run on a configured CUDA machine. This is the current external validation blocker.

### Independent review

Two independent review passes found and prompted fixes for:

- provider-facade Tensor construction in the shared CUDA provider
- missing `FuncMatMul<double>` linkage
- out-of-bounds contraction broadcast reinterpretation
- empty-input bypass of repeated-label dimension validation
- multiply/outer output sizes exceeding the reused CUDA broadcast kernel's 32-bit indexing