### PR TITLE
[CUDA] Group columns in the NVFP4 tensor-core GEMV

### DIFF
--- a/docs/contrib_ops/cuda/matmul_block_scaled_fp4.md
+++ b/docs/contrib_ops/cuda/matmul_block_scaled_fp4.md
@@ -318,7 +318,8 @@ GEMM and the original scale tensor for the other paths.
 | `ORT_FP4_GEMV_ROW_TILING` | `1` | Set to `0` to force `RowsPerBlock == 1` in the scalar decode GEMV. |
 | `ORT_FP4_GEMV_KSPLIT` | `0` | Benchmark override for the tensor-core GEMV K-split value (`1, 2, 4, 8, or 16`). |
 | `ORT_FP4_GEMV_COL_TILES` | `0` | Benchmark override for tensor-core GEMV column tiles (`1` or `4`). |
-| `ORT_FP4_GEMV_MATCH_N` / `ORT_FP4_GEMV_MATCH_K` | `0` | Restrict the two benchmark overrides to one `N`/`K` shape; zero means any shape. |
+| `ORT_FP4_GEMV_COL_GROUPS` | `0` | Benchmark override for tensor-core GEMV column groups (`1` or `2`); grouping is supported only for `M <= 8`. |
+| `ORT_FP4_GEMV_MATCH_N` / `ORT_FP4_GEMV_MATCH_K` | `0` | Restrict the three benchmark overrides to one `N`/`K` shape; zero means any shape. |
 
 The default remains the existing weight-only semantics: decode GEMV for small
 `M`, otherwise dequantize `B` and call cuBLAS.

--- a/onnxruntime/contrib_ops/cuda/math/matmul_block_scaled_fp4.cu
+++ b/onnxruntime/contrib_ops/cuda/math/matmul_block_scaled_fp4.cu
@@ -571,7 +571,7 @@ __device__ __forceinline__ void Fp4DecodeWord(uint32_t word, typename Fp4Cvt<T>:
   Fp4Cvt<T>::DecodeQuad(mag >> 16, sgn >> 16, out[2], out[3]);
 }
 
-template <typename T, int KSplit, int ColTiles, int MTiles>
+template <typename T, int KSplit, int ColTiles, int MTiles, int ColGroups>
 __global__ __launch_bounds__(32 * KSplit * ColTiles, 1) void MatMulBlockQuantizedFp4WeightMmaGemvKernel(
     T* __restrict__ y,
     const T* __restrict__ a,
@@ -597,18 +597,29 @@ __global__ __launch_bounds__(32 * KSplit * ColTiles, 1) void MatMulBlockQuantize
   const int warp_k = (KSplit == 1) ? 0 : (warp % KSplit);
   const int warp_c = (KSplit == 1) ? warp : (warp / KSplit);
 
-  const int col_lo = (static_cast<int>(blockIdx.x) * ColTiles + warp_c) * 16 + g;
-  const int col_hi = col_lo + 8;
-  const bool lo_ok = col_lo < n;
-  const bool hi_ok = col_hi < n;
-
-  // Out-of-range columns fold onto column 0 so every load stays in bounds; their results
-  // are masked off at the store.
+  // A warp owns ColGroups adjacent 16-column tiles. The activation fragment is the same for all
+  // of them, so grouping trades registers for L1 traffic: one window costs 2 * ColGroups weight
+  // loads against a fixed 4 activation loads instead of 2 against 4.
+  const int col_base = (static_cast<int>(blockIdx.x) * ColTiles + warp_c) * (16 * ColGroups);
   const int half_k = k >> 1;
-  const uint8_t* b_lo = b_packed + static_cast<size_t>(lo_ok ? col_lo : 0) * half_k;
-  const uint8_t* b_hi = b_packed + static_cast<size_t>(hi_ok ? col_hi : 0) * half_k;
-  const uint8_t* ws_lo = weight_scale + static_cast<size_t>(lo_ok ? col_lo : 0) * k_blocks;
-  const uint8_t* ws_hi = weight_scale + static_cast<size_t>(hi_ok ? col_hi : 0) * k_blocks;
+
+  // Out-of-range columns fold onto column 0 so every load stays in bounds; their results are
+  // masked off at the store. Row bases are hoisted so the K loop carries no 64-bit address math.
+  const uint8_t* b_lo[ColGroups];
+  const uint8_t* b_hi[ColGroups];
+  const uint8_t* ws_lo[ColGroups];
+  const uint8_t* ws_hi[ColGroups];
+#pragma unroll
+  for (int cg = 0; cg < ColGroups; ++cg) {
+    const int col_lo = col_base + (cg << 4) + g;
+    const int col_hi = col_lo + 8;
+    const int src_lo = col_lo < n ? col_lo : 0;
+    const int src_hi = col_hi < n ? col_hi : 0;
+    b_lo[cg] = b_packed + static_cast<size_t>(src_lo) * half_k;
+    b_hi[cg] = b_packed + static_cast<size_t>(src_hi) * half_k;
+    ws_lo[cg] = weight_scale + static_cast<size_t>(src_lo) * k_blocks;
+    ws_hi[cg] = weight_scale + static_cast<size_t>(src_hi) * k_blocks;
+  }
 
   // Each M tile is a different group of 8 activation rows sharing one pass over the packed
   // weight. The weight stream, not the mma, is what this kernel is bound by, so verifying a few
@@ -622,66 +633,87 @@ __global__ __launch_bounds__(32 * KSplit * ColTiles, 1) void MatMulBlockQuantize
     a_row[mt] = a + static_cast<size_t>(a_ok[mt] ? row : 0) * k;
   }
 
-  float acc[MTiles][4] = {};
+  float acc[ColGroups][MTiles][4] = {};
   const int windows = k >> 7;
 
   for (int wi = warp_k; wi < windows; wi += KSplit) {
     const int kbase = (wi << 7) + (t << 5);
-    const uint4 wl4 = *reinterpret_cast<const uint4*>(b_lo + (kbase >> 1));
-    const uint4 wh4 = *reinterpret_cast<const uint4*>(b_hi + (kbase >> 1));
     const int kb = (wi << 3) + (t << 1);
-    const T2 sl[2] = {MmaOp::BroadcastScale(ws_lo[kb]), MmaOp::BroadcastScale(ws_lo[kb + 1])};
-    const T2 sh[2] = {MmaOp::BroadcastScale(ws_hi[kb]), MmaOp::BroadcastScale(ws_hi[kb + 1])};
+
+    // Issue every column group's weight load before any decoding so the loads overlap.
+    uint4 wl4[ColGroups], wh4[ColGroups];
+    T2 sl[ColGroups][2], sh[ColGroups][2];
+#pragma unroll
+    for (int cg = 0; cg < ColGroups; ++cg) {
+      wl4[cg] = *reinterpret_cast<const uint4*>(b_lo[cg] + (kbase >> 1));
+      wh4[cg] = *reinterpret_cast<const uint4*>(b_hi[cg] + (kbase >> 1));
+      // The two E4M3 scales a lane needs are adjacent, and `kb` and `k_blocks` are both
+      // multiples of two, so one 16-bit load replaces two byte loads. This kernel is L1
+      // wavefront bound (86% L1/TEX at 29% DRAM on H200), and the byte loads were half of
+      // its memory instructions for one percent of its bytes.
+      const uint16_t sl_raw = *reinterpret_cast<const uint16_t*>(ws_lo[cg] + kb);
+      const uint16_t sh_raw = *reinterpret_cast<const uint16_t*>(ws_hi[cg] + kb);
+      sl[cg][0] = MmaOp::BroadcastScale(static_cast<uint8_t>(sl_raw));
+      sl[cg][1] = MmaOp::BroadcastScale(static_cast<uint8_t>(sl_raw >> 8));
+      sh[cg][0] = MmaOp::BroadcastScale(static_cast<uint8_t>(sh_raw));
+      sh[cg][1] = MmaOp::BroadcastScale(static_cast<uint8_t>(sh_raw >> 8));
+    }
+
     const uint4* ap[MTiles];
 #pragma unroll
     for (int mt = 0; mt < MTiles; ++mt) {
       ap[mt] = reinterpret_cast<const uint4*>(a_row[mt] + kbase);
     }
-    const uint32_t wl[4] = {wl4.x, wl4.y, wl4.z, wl4.w};
-    const uint32_t wh[4] = {wh4.x, wh4.y, wh4.z, wh4.w};
 
 #pragma unroll
     for (int w = 0; w < 4; ++w) {
-      T2 bl[4], bh[4];
-      Fp4DecodeWord<T>(wl[w], bl);
-      Fp4DecodeWord<T>(wh[w], bh);
-      // Words 0,1 fall in the first 16-element scale block of this lane's slice, words 2,3
-      // in the second.
-      const T2 s0 = sl[w >> 1];
-      const T2 s1 = sh[w >> 1];
-#pragma unroll
-      for (int i = 0; i < 4; ++i) {
-        bl[i] = Cvt::Mul(bl[i], s0);
-        bh[i] = Cvt::Mul(bh[i], s1);
-      }
+      // One activation quarter-window, reused by every column group.
       uint4 av4[MTiles];
 #pragma unroll
       for (int mt = 0; mt < MTiles; ++mt) {
         av4[mt] = a_ok[mt] ? ap[mt][w] : make_uint4(0u, 0u, 0u, 0u);
       }
 #pragma unroll
-      for (int j = 0; j < 2; ++j) {
-        // A regs are (row g, k 2t..2t+1), (row g+8, ...), (row g, k 2t+8..), (row g+8, ...).
-        const uint32_t ra[4] = {MmaOp::Pack(bl[2 * j]), MmaOp::Pack(bh[2 * j]),
-                                MmaOp::Pack(bl[2 * j + 1]), MmaOp::Pack(bh[2 * j + 1])};
+      for (int cg = 0; cg < ColGroups; ++cg) {
+        T2 bl[4], bh[4];
+        Fp4DecodeWord<T>(reinterpret_cast<const uint32_t*>(&wl4[cg])[w], bl);
+        Fp4DecodeWord<T>(reinterpret_cast<const uint32_t*>(&wh4[cg])[w], bh);
+        // Words 0,1 fall in the first 16-element scale block of this lane's slice, words 2,3
+        // in the second.
+        const T2 s0 = sl[cg][w >> 1];
+        const T2 s1 = sh[cg][w >> 1];
 #pragma unroll
-        for (int mt = 0; mt < MTiles; ++mt) {
-          const uint32_t* av = reinterpret_cast<const uint32_t*>(&av4[mt]);
-          const uint32_t rb[2] = {av[2 * j], av[2 * j + 1]};
-          MmaOp::Mma(acc[mt], ra, rb);
+        for (int i = 0; i < 4; ++i) {
+          bl[i] = Cvt::Mul(bl[i], s0);
+          bh[i] = Cvt::Mul(bh[i], s1);
+        }
+#pragma unroll
+        for (int j = 0; j < 2; ++j) {
+          // A regs are (row g, k 2t..2t+1), (row g+8, ...), (row g, k 2t+8..), (row g+8, ...).
+          const uint32_t ra[4] = {MmaOp::Pack(bl[2 * j]), MmaOp::Pack(bh[2 * j]),
+                                  MmaOp::Pack(bl[2 * j + 1]), MmaOp::Pack(bh[2 * j + 1])};
+#pragma unroll
+          for (int mt = 0; mt < MTiles; ++mt) {
+            const uint32_t* av = reinterpret_cast<const uint32_t*>(&av4[mt]);
+            const uint32_t rb[2] = {av[2 * j], av[2 * j + 1]};
+            MmaOp::Mma(acc[cg][mt], ra, rb);
+          }
         }
       }
     }
   }
 
   if constexpr (KSplit > 1) {
-    __shared__ float red[ColTiles * KSplit * 32 * 4 * MTiles];
-    float* mine = red + ((warp_c * KSplit + warp_k) * 32 + lane) * (4 * MTiles);
+    __shared__ float red[ColTiles * KSplit * 32 * 4 * MTiles * ColGroups];
+    float* mine = red + ((warp_c * KSplit + warp_k) * 32 + lane) * (4 * MTiles * ColGroups);
 #pragma unroll
-    for (int mt = 0; mt < MTiles; ++mt) {
+    for (int cg = 0; cg < ColGroups; ++cg) {
 #pragma unroll
-      for (int i = 0; i < 4; ++i) {
-        mine[mt * 4 + i] = acc[mt][i];
+      for (int mt = 0; mt < MTiles; ++mt) {
+#pragma unroll
+        for (int i = 0; i < 4; ++i) {
+          mine[(cg * MTiles + mt) * 4 + i] = acc[cg][mt][i];
+        }
       }
     }
     __syncthreads();
@@ -690,12 +722,15 @@ __global__ __launch_bounds__(32 * KSplit * ColTiles, 1) void MatMulBlockQuantize
     }
 #pragma unroll
     for (int ws = 1; ws < KSplit; ++ws) {
-      const float* other = red + ((warp_c * KSplit + ws) * 32 + lane) * (4 * MTiles);
+      const float* other = red + ((warp_c * KSplit + ws) * 32 + lane) * (4 * MTiles * ColGroups);
 #pragma unroll
-      for (int mt = 0; mt < MTiles; ++mt) {
+      for (int cg = 0; cg < ColGroups; ++cg) {
 #pragma unroll
-        for (int i = 0; i < 4; ++i) {
-          acc[mt][i] += other[mt * 4 + i];
+        for (int mt = 0; mt < MTiles; ++mt) {
+#pragma unroll
+          for (int i = 0; i < 4; ++i) {
+            acc[cg][mt][i] += other[(cg * MTiles + mt) * 4 + i];
+          }
         }
       }
     }
@@ -705,25 +740,32 @@ __global__ __launch_bounds__(32 * KSplit * ColTiles, 1) void MatMulBlockQuantize
   // columns and mma columns are our M rows.
   const float g2 = *weight_scale_2;
   const int r0 = t << 1;
-  const float bias_lo = (bias != nullptr && lo_ok) ? to_float<T>(bias[col_lo]) : 0.0f;
-  const float bias_hi = (bias != nullptr && hi_ok) ? to_float<T>(bias[col_hi]) : 0.0f;
 #pragma unroll
-  for (int mt = 0; mt < MTiles; ++mt) {
-    const int row = r0 + (mt << 3);
-    if (lo_ok) {
-      if (row < m) {
-        y[static_cast<size_t>(row) * n + col_lo] = from_float<T>(acc[mt][0] * g2 + bias_lo);
+  for (int cg = 0; cg < ColGroups; ++cg) {
+    const int col_lo = col_base + (cg << 4) + g;
+    const int col_hi = col_lo + 8;
+    const bool lo_ok = col_lo < n;
+    const bool hi_ok = col_hi < n;
+    const float bias_lo = (bias != nullptr && lo_ok) ? to_float<T>(bias[col_lo]) : 0.0f;
+    const float bias_hi = (bias != nullptr && hi_ok) ? to_float<T>(bias[col_hi]) : 0.0f;
+#pragma unroll
+    for (int mt = 0; mt < MTiles; ++mt) {
+      const int row = r0 + (mt << 3);
+      if (lo_ok) {
+        if (row < m) {
+          y[static_cast<size_t>(row) * n + col_lo] = from_float<T>(acc[cg][mt][0] * g2 + bias_lo);
+        }
+        if (row + 1 < m) {
+          y[static_cast<size_t>(row + 1) * n + col_lo] = from_float<T>(acc[cg][mt][1] * g2 + bias_lo);
+        }
       }
-      if (row + 1 < m) {
-        y[static_cast<size_t>(row + 1) * n + col_lo] = from_float<T>(acc[mt][1] * g2 + bias_lo);
-      }
-    }
-    if (hi_ok) {
-      if (row < m) {
-        y[static_cast<size_t>(row) * n + col_hi] = from_float<T>(acc[mt][2] * g2 + bias_hi);
-      }
-      if (row + 1 < m) {
-        y[static_cast<size_t>(row + 1) * n + col_hi] = from_float<T>(acc[mt][3] * g2 + bias_hi);
+      if (hi_ok) {
+        if (row < m) {
+          y[static_cast<size_t>(row) * n + col_hi] = from_float<T>(acc[cg][mt][2] * g2 + bias_hi);
+        }
+        if (row + 1 < m) {
+          y[static_cast<size_t>(row + 1) * n + col_hi] = from_float<T>(acc[cg][mt][3] * g2 + bias_hi);
+        }
       }
     }
   }
@@ -772,6 +814,8 @@ Fp4MmaConfig ApplyFp4MmaConfigOverrides(Fp4MmaConfig config, int n, int k) {
       onnxruntime::ParseEnvironmentVariableWithDefault<int>("ORT_FP4_GEMV_KSPLIT", 0);
   static int const col_tiles =
       onnxruntime::ParseEnvironmentVariableWithDefault<int>("ORT_FP4_GEMV_COL_TILES", 0);
+  static int const col_groups =
+      onnxruntime::ParseEnvironmentVariableWithDefault<int>("ORT_FP4_GEMV_COL_GROUPS", 0);
   static int const match_n =
       onnxruntime::ParseEnvironmentVariableWithDefault<int>("ORT_FP4_GEMV_MATCH_N", 0);
   static int const match_k =
@@ -781,6 +825,8 @@ Fp4MmaConfig ApplyFp4MmaConfigOverrides(Fp4MmaConfig config, int n, int k) {
               "ORT_FP4_GEMV_KSPLIT must be 0, 1, 2, 4, 8, or 16.");
   ORT_ENFORCE(col_tiles == 0 || col_tiles == 1 || col_tiles == 4,
               "ORT_FP4_GEMV_COL_TILES must be 0, 1, or 4.");
+  ORT_ENFORCE(col_groups == 0 || col_groups == 1 || col_groups == 2,
+              "ORT_FP4_GEMV_COL_GROUPS must be 0, 1, or 2.");
   ORT_ENFORCE(match_n >= 0 && match_k >= 0,
               "ORT_FP4_GEMV_MATCH_N and ORT_FP4_GEMV_MATCH_K must be non-negative.");
 
@@ -794,8 +840,13 @@ Fp4MmaConfig ApplyFp4MmaConfigOverrides(Fp4MmaConfig config, int n, int k) {
   if (col_tiles != 0) {
     config.col_tiles = col_tiles;
   }
+  if (col_groups != 0) {
+    config.col_groups = col_groups;
+  }
   ORT_ENFORCE(config.col_tiles == 1 || config.k_split <= 2,
               "ORT_FP4_GEMV_COL_TILES=4 supports only KSplit 1 or 2.");
+  ORT_ENFORCE(config.col_groups == 1 || config.col_tiles == 1,
+              "ORT_FP4_GEMV_COL_GROUPS=2 supports only ColTiles 1.");
   return config;
 }
 
@@ -978,68 +1029,83 @@ Status LaunchMatMulBlockQuantizedFp4WeightGemv(void* y,
   // GEMV takes over -- and that one re-reads the packed weight once per row tile, which is why the
   // cap below is much lower without the mma.
   if (device_prop.major >= 8 && k % 128 == 0 && m <= kFp4MmaGemvTileM && Fp4GemvMmaEnabled()) {
-    const Fp4MmaConfig cfg = ApplyFp4MmaConfigOverrides(
-        PickFp4MmaConfig(m, n, k, device_prop.multiProcessorCount,
-                         device_prop.major, device_prop.minor),
-        n, k);
-    const int cols_per_block = 16 * cfg.col_tiles;
     const int mtiles = (m > 16) ? 4 : ((m > 8) ? 2 : 1);
+    // Column grouping needs the whole M to live in one mma row tile; see PickFp4MmaGroupedConfig.
+    const Fp4MmaConfig cfg = ApplyFp4MmaConfigOverrides(
+        mtiles == 1 ? PickFp4MmaGroupedConfig(m, n, k, device_prop.multiProcessorCount,
+                                              device_prop.major, device_prop.minor)
+                    : PickFp4MmaConfig(m, n, k, device_prop.multiProcessorCount,
+                                       device_prop.major, device_prop.minor),
+        n, k);
+    ORT_ENFORCE(mtiles == 1 || cfg.col_groups == 1,
+                "ORT_FP4_GEMV_COL_GROUPS=2 supports only M <= 8.");
+    const int cols_per_block = 16 * cfg.col_tiles * cfg.col_groups;
     const dim3 mma_threads{32, static_cast<unsigned int>(cfg.k_split * cfg.col_tiles)};
     const dim3 mma_blocks{static_cast<unsigned int>((n + cols_per_block - 1) / cols_per_block)};
     const uint8_t* mbp = reinterpret_cast<const uint8_t*>(b_packed);
     const uint8_t* mws = reinterpret_cast<const uint8_t*>(weight_scale);
 
-#define ORT_LAUNCH_FP4_MMA_GEMV(T, KS, CT, MT)                                                   \
-  MatMulBlockQuantizedFp4WeightMmaGemvKernel<T, KS, CT, MT>                                      \
+#define ORT_LAUNCH_FP4_MMA_GEMV(T, KS, CT, MT, CG)                                               \
+  MatMulBlockQuantizedFp4WeightMmaGemvKernel<T, KS, CT, MT, CG>                                  \
       <<<mma_blocks, mma_threads, 0, stream>>>(reinterpret_cast<T*>(y),                          \
                                                reinterpret_cast<const T*>(a), mbp, mws,          \
                                                weight_scale_2, reinterpret_cast<const T*>(bias), \
                                                m, n, k, k_blocks)
 
+#define ORT_DISPATCH_FP4_MMA_GEMV_KS(T, MT, CG)    \
+  do {                                             \
+    switch (cfg.k_split) {                         \
+      case 16:                                     \
+        ORT_LAUNCH_FP4_MMA_GEMV(T, 16, 1, MT, CG); \
+        break;                                     \
+      case 8:                                      \
+        ORT_LAUNCH_FP4_MMA_GEMV(T, 8, 1, MT, CG);  \
+        break;                                     \
+      case 4:                                      \
+        ORT_LAUNCH_FP4_MMA_GEMV(T, 4, 1, MT, CG);  \
+        break;                                     \
+      case 2:                                      \
+        ORT_LAUNCH_FP4_MMA_GEMV(T, 2, 1, MT, CG);  \
+        break;                                     \
+      default:                                     \
+        ORT_LAUNCH_FP4_MMA_GEMV(T, 1, 1, MT, CG);  \
+        break;                                     \
+    }                                              \
+  } while (0)
+
 #define ORT_DISPATCH_FP4_MMA_GEMV_MT(T, MT)      \
   do {                                           \
     if (cfg.col_tiles == 4) {                    \
       if (cfg.k_split >= 2) {                    \
-        ORT_LAUNCH_FP4_MMA_GEMV(T, 2, 4, MT);    \
+        ORT_LAUNCH_FP4_MMA_GEMV(T, 2, 4, MT, 1); \
       } else {                                   \
-        ORT_LAUNCH_FP4_MMA_GEMV(T, 1, 4, MT);    \
+        ORT_LAUNCH_FP4_MMA_GEMV(T, 1, 4, MT, 1); \
       }                                          \
     } else {                                     \
-      switch (cfg.k_split) {                     \
-        case 16:                                 \
-          ORT_LAUNCH_FP4_MMA_GEMV(T, 16, 1, MT); \
-          break;                                 \
-        case 8:                                  \
-          ORT_LAUNCH_FP4_MMA_GEMV(T, 8, 1, MT);  \
-          break;                                 \
-        case 4:                                  \
-          ORT_LAUNCH_FP4_MMA_GEMV(T, 4, 1, MT);  \
-          break;                                 \
-        case 2:                                  \
-          ORT_LAUNCH_FP4_MMA_GEMV(T, 2, 1, MT);  \
-          break;                                 \
-        default:                                 \
-          ORT_LAUNCH_FP4_MMA_GEMV(T, 1, 1, MT);  \
-          break;                                 \
-      }                                          \
+      ORT_DISPATCH_FP4_MMA_GEMV_KS(T, MT, 1);    \
     }                                            \
   } while (0)
 
 // Only 1, 2 and 4 row tiles are instantiated; an M of 17..24 rounds up to 4 and masks the
-// remainder, which costs nothing next to the weight traffic it shares.
-#define ORT_DISPATCH_FP4_MMA_GEMV(T)        \
-  do {                                      \
-    switch (mtiles) {                       \
-      case 1:                               \
-        ORT_DISPATCH_FP4_MMA_GEMV_MT(T, 1); \
-        break;                              \
-      case 2:                               \
-        ORT_DISPATCH_FP4_MMA_GEMV_MT(T, 2); \
-        break;                              \
-      default:                              \
-        ORT_DISPATCH_FP4_MMA_GEMV_MT(T, 4); \
-        break;                              \
-    }                                       \
+// remainder, which costs nothing next to the weight traffic it shares. Column grouping is
+// instantiated for the single row tile only.
+#define ORT_DISPATCH_FP4_MMA_GEMV(T)             \
+  do {                                           \
+    switch (mtiles) {                            \
+      case 1:                                    \
+        if (cfg.col_groups == 2) {               \
+          ORT_DISPATCH_FP4_MMA_GEMV_KS(T, 1, 2); \
+        } else {                                 \
+          ORT_DISPATCH_FP4_MMA_GEMV_MT(T, 1);    \
+        }                                        \
+        break;                                   \
+      case 2:                                    \
+        ORT_DISPATCH_FP4_MMA_GEMV_MT(T, 2);      \
+        break;                                   \
+      default:                                   \
+        ORT_DISPATCH_FP4_MMA_GEMV_MT(T, 4);      \
+        break;                                   \
+    }                                            \
   } while (0)
 
     if (is_bf16) {
@@ -1049,6 +1115,7 @@ Status LaunchMatMulBlockQuantizedFp4WeightGemv(void* y,
     }
 #undef ORT_DISPATCH_FP4_MMA_GEMV
 #undef ORT_DISPATCH_FP4_MMA_GEMV_MT
+#undef ORT_DISPATCH_FP4_MMA_GEMV_KS
 #undef ORT_LAUNCH_FP4_MMA_GEMV
     return CUDA_CALL(cudaGetLastError());
   }

--- a/onnxruntime/contrib_ops/cuda/math/matmul_block_scaled_fp4_tiling.h
+++ b/onnxruntime/contrib_ops/cuda/math/matmul_block_scaled_fp4_tiling.h
@@ -67,6 +67,10 @@ inline Fp4MmaConfig PickFp4MmaConfig(int m, int n, int k, int sm_count,
 // reduction buffer past the 48 KB static limit.
 inline Fp4MmaConfig PickFp4MmaGroupedConfig(int m, int n, int k, int sm_count,
                                             int compute_capability_major, int compute_capability_minor) {
+  if (compute_capability_major == 8 && compute_capability_minor == 9) {
+    return PickFp4MmaConfig(m, n, k, sm_count, compute_capability_major, compute_capability_minor);
+  }
+
   constexpr int kColGroups = 2;
   constexpr int kMinBlocksPerSm = 2;
   constexpr int kWarpBudgetPerSm = 24;

--- a/onnxruntime/contrib_ops/cuda/math/matmul_block_scaled_fp4_tiling.h
+++ b/onnxruntime/contrib_ops/cuda/math/matmul_block_scaled_fp4_tiling.h
@@ -8,6 +8,7 @@ namespace onnxruntime::contrib::cuda {
 struct Fp4MmaConfig {
   int k_split;
   int col_tiles;
+  int col_groups;
 };
 
 // Returns the tensor-core GEMV tiling selected for the given shape and device.
@@ -32,22 +33,55 @@ inline Fp4MmaConfig PickFp4MmaConfig(int m, int n, int k, int sm_count,
       sm_count == kSm121TargetSmCount && m <= kSm121MaxM && windows >= kSm121MinWindows &&
       (wide_col_blocks >= kTargetGridWaves * sm_count || windows >= kSm121NarrowGridMinWindows) &&
       wide_col_blocks < kLongReductionGridWaves * sm_count) {
-    return {16, 1};
+    return {16, 1, 1};
   }
 
   if (wide_col_blocks >= kTargetGridWaves * sm_count &&
       (windows < kLongReductionWindows || wide_col_blocks >= kLongReductionGridWaves * sm_count)) {
-    return {windows < 2 ? windows : 2, 4};
+    return {windows < 2 ? windows : 2, 4, 1};
   }
   if (col_tiles >= kTargetGridWaves * sm_count) {
-    return {windows >= kLongReductionWindows ? 8 : (windows < 2 ? windows : 2), 1};
+    return {windows >= kLongReductionWindows ? 8 : (windows < 2 ? windows : 2), 1, 1};
   }
 
   int k_split = 1;
   while (k_split < 16 && k_split * 2 <= windows) {
     k_split <<= 1;
   }
-  return {k_split, 1};
+  return {k_split, 1, 1};
+}
+
+// Returns the tiling for the column-grouped GEMV, where one warp owns two adjacent 16-column
+// tiles and reuses a single activation fragment for both. That halves the activation L1 traffic
+// per weight byte, which is what the ungrouped kernel is bound by at small M: ncu on H200 at
+// N = 17408, K = 5120, M = 8 reports 65.9% L1/TEX against only 33.3% DRAM, at 0.82 waves per SM.
+//
+// Grouping halves the column grid, so it is only taken when the grouped grid still covers a
+// couple of blocks per SM, and KSplit is then raised to land near 16 resident warps per SM.
+// Measured on H200 (132 SMs, M = 8, half), kernel time from nsys:
+//
+//   N = 17408, K =  5120   28.38 -> 24.64 us (1.15x)  KSplit 4, ColGroups 2
+//   N =  5120, K = 17408   28.67 -> 28.35 us          only 160 grouped blocks, not selected
+//
+// Only valid when M fits one mma row tile (M <= 8): a wider M multiplies the shared-memory
+// reduction buffer past the 48 KB static limit.
+inline Fp4MmaConfig PickFp4MmaGroupedConfig(int m, int n, int k, int sm_count,
+                                            int compute_capability_major, int compute_capability_minor) {
+  constexpr int kColGroups = 2;
+  constexpr int kMinBlocksPerSm = 2;
+  constexpr int kWarpBudgetPerSm = 24;
+  const int windows = k >> 7;
+  const int col_blocks = (n + 16 * kColGroups - 1) / (16 * kColGroups);
+  if (col_blocks < kMinBlocksPerSm * sm_count) {
+    return PickFp4MmaConfig(m, n, k, sm_count, compute_capability_major, compute_capability_minor);
+  }
+
+  int k_split = 1;
+  while (k_split < 16 && k_split * 2 <= windows &&
+         col_blocks * (k_split * 2) <= kWarpBudgetPerSm * sm_count) {
+    k_split <<= 1;
+  }
+  return {k_split, 1, kColGroups};
 }
 
 }  // namespace onnxruntime::contrib::cuda

--- a/onnxruntime/contrib_ops/cuda/math/matmul_block_scaled_fp4_tiling.h
+++ b/onnxruntime/contrib_ops/cuda/math/matmul_block_scaled_fp4_tiling.h
@@ -67,7 +67,9 @@ inline Fp4MmaConfig PickFp4MmaConfig(int m, int n, int k, int sm_count,
 // reduction buffer past the 48 KB static limit.
 inline Fp4MmaConfig PickFp4MmaGroupedConfig(int m, int n, int k, int sm_count,
                                             int compute_capability_major, int compute_capability_minor) {
-  if (compute_capability_major == 8 && compute_capability_minor == 9) {
+  // Automatic grouping is enabled only on Hopper, where it has demonstrated a benefit.
+  // Other architectures retain the original tiling unless grouping is explicitly overridden.
+  if (compute_capability_major != 9 || compute_capability_minor != 0) {
     return PickFp4MmaConfig(m, n, k, sm_count, compute_capability_major, compute_capability_minor);
   }
 

--- a/onnxruntime/test/contrib_ops/matmul_block_scaled_fp4_test.cc
+++ b/onnxruntime/test/contrib_ops/matmul_block_scaled_fp4_test.cc
@@ -690,6 +690,50 @@ TEST(MatMulBlockQuantizedFp4WeightOpTest, GemvTensorCoreSm121Tiling) {
   }
 }
 
+TEST(MatMulBlockQuantizedFp4WeightOpTest, GemvTensorCoreGroupedAdaRetainsOriginalTiling) {
+  for (int sm_count : {24, 48, 58, 76, 128, 142}) {
+    for (int m : {1, 4, 8}) {
+      for (int n : {5120, 8416, 8417, 17408, 34816, 248320}) {
+        for (int k : {128, 5120, 17408}) {
+          SCOPED_TRACE("SMs = " + std::to_string(sm_count) + ", M = " + std::to_string(m) +
+                       ", N = " + std::to_string(n) + ", K = " + std::to_string(k));
+          const auto original = onnxruntime::contrib::cuda::PickFp4MmaConfig(m, n, k, sm_count, 8, 9);
+          const auto config = onnxruntime::contrib::cuda::PickFp4MmaGroupedConfig(m, n, k, sm_count, 8, 9);
+          EXPECT_EQ(config.k_split, original.k_split);
+          EXPECT_EQ(config.col_tiles, original.col_tiles);
+          EXPECT_EQ(config.col_groups, 1);
+        }
+      }
+    }
+  }
+}
+
+TEST(MatMulBlockQuantizedFp4WeightOpTest, GemvTensorCoreGroupedArchitectureSelection) {
+  struct Case {
+    int sm_count;
+    int major;
+    int minor;
+    int k_split;
+    int col_groups;
+  };
+  const Case cases[] = {
+      {128, 8, 9, 2, 1},
+      {132, 9, 0, 4, 2},
+      {108, 8, 0, 4, 2},
+      {84, 8, 6, 2, 2},
+      {128, 12, 0, 4, 2},
+      {48, 12, 1, 2, 2},
+  };
+  for (const Case& device : cases) {
+    SCOPED_TRACE("CC = " + std::to_string(device.major) + "." + std::to_string(device.minor));
+    const auto config = onnxruntime::contrib::cuda::PickFp4MmaGroupedConfig(
+        8, 17408, 5120, device.sm_count, device.major, device.minor);
+    EXPECT_EQ(config.k_split, device.k_split);
+    EXPECT_EQ(config.col_tiles, 1);
+    EXPECT_EQ(config.col_groups, device.col_groups);
+  }
+}
+
 // Selection boundaries for the column-grouped tiling. Grouping halves the column grid, so it is
 // only worth taking while the grouped grid still covers kMinBlocksPerSm blocks per SM; below that
 // the launcher must fall back to the ungrouped ladder.
@@ -797,6 +841,10 @@ TEST(MatMulBlockQuantizedFp4WeightOpTest, GemvTensorCoreColumnGroupedFp16) {
   ASSERT_EQ(cudaGetDevice(&device_id), cudaSuccess);
   ASSERT_EQ(cudaGetDeviceProperties(&device_prop, device_id), cudaSuccess);
 
+  if (device_prop.major == 8 && device_prop.minor == 9) {
+    GTEST_SKIP() << "Automatic column grouping is disabled on Ada.";
+  }
+
   // Smallest N that groups: ceil(N / 32) >= 2 * sm_count.
   const int64_t n_grouped = 32 * 2 * device_prop.multiProcessorCount;
   constexpr int64_t k = 256;  // two K windows, and k_blocks = 16 so the paired scale load aligns
@@ -842,6 +890,10 @@ TEST(MatMulBlockQuantizedFp4WeightOpTest, GemvTensorCoreColumnGroupedBf16Bias) {
   int device_id = 0;
   ASSERT_EQ(cudaGetDevice(&device_id), cudaSuccess);
   ASSERT_EQ(cudaGetDeviceProperties(&device_prop, device_id), cudaSuccess);
+
+  if (device_prop.major == 8 && device_prop.minor == 9) {
+    GTEST_SKIP() << "Automatic column grouping is disabled on Ada.";
+  }
 
   constexpr int64_t m = 8;
   constexpr int64_t k = 256;

--- a/onnxruntime/test/contrib_ops/matmul_block_scaled_fp4_test.cc
+++ b/onnxruntime/test/contrib_ops/matmul_block_scaled_fp4_test.cc
@@ -686,7 +686,198 @@ TEST(MatMulBlockQuantizedFp4WeightOpTest, GemvTensorCoreSm121Tiling) {
         shape.compute_capability_major, shape.compute_capability_minor);
     EXPECT_EQ(config.k_split, shape.k_split);
     EXPECT_EQ(config.col_tiles, shape.col_tiles);
+    EXPECT_EQ(config.col_groups, 1);
   }
+}
+
+// Selection boundaries for the column-grouped tiling. Grouping halves the column grid, so it is
+// only worth taking while the grouped grid still covers kMinBlocksPerSm blocks per SM; below that
+// the launcher must fall back to the ungrouped ladder.
+TEST(MatMulBlockQuantizedFp4WeightOpTest, GemvTensorCoreGroupedTilingBoundaries) {
+  struct Case {
+    int64_t n;
+    int64_t k;
+    int k_split;
+    int col_groups;
+  };
+  constexpr int sm_count = 132;
+  // Grouping needs ceil(N / 32) >= 2 * sm_count == 264 blocks, i.e. N >= 32 * 263 + 1 == 8417.
+  const Case cases[] = {
+      {8416, 5120, 16, 1},   // 263 grouped blocks: one short, falls back to the ungrouped ladder
+      {8417, 5120, 8, 2},    // 264 grouped blocks: the first shape that groups
+      {17408, 5120, 4, 2},   // Qwen3.8 gate/up_proj; 544 blocks cap KSplit at 4
+      {17408, 128, 1, 2},    // a single K window leaves nothing to split
+      {5120, 17408, 16, 1},  // tall and narrow: only 160 grouped blocks, so no grouping
+  };
+
+  for (const Case& shape : cases) {
+    SCOPED_TRACE("N = " + std::to_string(shape.n) + ", K = " + std::to_string(shape.k));
+    const auto config = onnxruntime::contrib::cuda::PickFp4MmaGroupedConfig(
+        1, static_cast<int>(shape.n), static_cast<int>(shape.k), sm_count, 9, 0);
+    EXPECT_EQ(config.k_split, shape.k_split);
+    EXPECT_EQ(config.col_tiles, 1);
+    EXPECT_EQ(config.col_groups, shape.col_groups);
+  }
+}
+
+// Runs the column-grouped kernel, which the launcher only selects for M <= 8 and an N wide enough
+// to keep the halved grid busy -- so N has to be derived from the device rather than hard-coded.
+//
+// MakeMmaCase above cannot be reused here. Its weight codes cycle with period 4 along N and its
+// block scales with period 2, and the two tiles a grouped warp owns are 16 columns apart, so both
+// patterns repeat exactly across the group boundary and a warp that applied group 0's weights or
+// scales to group 1 would still produce the right answer. Everything below cycles with period 3
+// instead, which is coprime to both 16 and the 8-column lo/hi split, so every one of the four
+// columns a lane touches carries a different value.
+//
+// The ragged widths are the other half of the test: with 32 columns per block, a tail of 20 leaves
+// the first group full and the second holding 4 of its 16 columns, and a tail of 8 leaves the
+// first group with only its low half in range and the second entirely out of range. Both must be
+// masked per group at the store, which a grid that divides evenly by 32 never exercises.
+namespace {
+
+// E2M1 codes +1.0, -2.0, +0.5, and E4M3 scale bytes 1.0, 2.0, 0.5.
+constexpr uint8_t kGroupCodes[3] = {0x2, 0xC, 0x1};
+constexpr float kGroupValues[3] = {1.0f, -2.0f, 0.5f};
+constexpr uint8_t kGroupScaleBytes[3] = {0x38, 0x40, 0x30};
+constexpr float kGroupScaleValues[3] = {1.0f, 2.0f, 0.5f};
+
+int GroupCodeIndex(int64_t col, int64_t kk) { return static_cast<int>((kk + col) % 3); }
+int GroupScaleIndex(int64_t col, int64_t blk) { return static_cast<int>((col + 2 * blk) % 3); }
+float GroupActValue(int64_t row, int64_t kk) { return static_cast<float>((kk % 3) + 1 + row); }
+
+// Every product is a multiple of 0.25 and every partial sum stays well below 2^23, so the fp32
+// reference is exact and independent of summation order.
+void MakeGroupedCase(int64_t m, int64_t n, int64_t k,
+                     std::vector<uint8_t>& b, std::vector<uint8_t>& weight_scale,
+                     std::vector<float>& a, std::vector<float>& expected) {
+  const int64_t k_blocks = k / 16;
+  b.assign(n * (k / 2), 0);
+  weight_scale.assign(n * k_blocks, 0);
+  for (int64_t col = 0; col < n; ++col) {
+    for (int64_t kk = 0; kk < k; kk += 2) {
+      const uint8_t lo = kGroupCodes[GroupCodeIndex(col, kk)];
+      const uint8_t hi = kGroupCodes[GroupCodeIndex(col, kk + 1)];
+      b[col * (k / 2) + kk / 2] = static_cast<uint8_t>(lo | (hi << 4));
+    }
+    for (int64_t blk = 0; blk < k_blocks; ++blk) {
+      weight_scale[col * k_blocks + blk] = kGroupScaleBytes[GroupScaleIndex(col, blk)];
+    }
+  }
+
+  a.assign(m * k, 0.0f);
+  for (int64_t row = 0; row < m; ++row) {
+    for (int64_t kk = 0; kk < k; ++kk) {
+      a[row * k + kk] = GroupActValue(row, kk);
+    }
+  }
+
+  expected.assign(m * n, 0.0f);
+  for (int64_t row = 0; row < m; ++row) {
+    for (int64_t col = 0; col < n; ++col) {
+      float sum = 0.0f;
+      for (int64_t kk = 0; kk < k; ++kk) {
+        sum += kGroupValues[GroupCodeIndex(col, kk)] *
+               kGroupScaleValues[GroupScaleIndex(col, kk / 16)] * GroupActValue(row, kk);
+      }
+      expected[row * n + col] = sum;
+    }
+  }
+}
+
+}  // namespace
+
+TEST(MatMulBlockQuantizedFp4WeightOpTest, GemvTensorCoreColumnGroupedFp16) {
+  if (!HasCudaEnvironment(800)) {
+    GTEST_SKIP() << "CUDA device is required for MatMulBlockQuantizedFp4Weight.";
+  }
+
+  cudaDeviceProp device_prop{};
+  int device_id = 0;
+  ASSERT_EQ(cudaGetDevice(&device_id), cudaSuccess);
+  ASSERT_EQ(cudaGetDeviceProperties(&device_prop, device_id), cudaSuccess);
+
+  // Smallest N that groups: ceil(N / 32) >= 2 * sm_count.
+  const int64_t n_grouped = 32 * 2 * device_prop.multiProcessorCount;
+  constexpr int64_t k = 256;  // two K windows, and k_blocks = 16 so the paired scale load aligns
+
+  for (int64_t n : {n_grouped, n_grouped + 20, n_grouped + 8}) {
+    ASSERT_EQ(onnxruntime::contrib::cuda::PickFp4MmaGroupedConfig(
+                  1, static_cast<int>(n), static_cast<int>(k), device_prop.multiProcessorCount,
+                  device_prop.major, device_prop.minor)
+                  .col_groups,
+              2)
+        << "N = " << n << " should select the grouped tiling on this device";
+
+    for (int m_val : {1, 2, 7, 8}) {
+      const int64_t m = m_val;
+      SCOPED_TRACE("N = " + std::to_string(n) + ", M = " + std::to_string(m));
+
+      std::vector<uint8_t> b, weight_scale;
+      std::vector<float> a, expected;
+      MakeGroupedCase(m, n, k, b, weight_scale, a, expected);
+
+      OpTester test("MatMulBlockQuantizedFp4Weight", 1, onnxruntime::kMSDomain);
+      test.AddAttribute<int64_t>("block_size", 16);
+      test.AddInput<MLFloat16>("A", {m, k}, FloatsToMLFloat16s(a));
+      test.AddInput<uint8_t>("B", {n, k / 2}, b);
+      test.AddInput<uint8_t>("weight_scale", {n, k / 16}, weight_scale);
+      test.AddInput<float>("weight_scale_2", {1}, {1.0f});
+      test.AddOutput<MLFloat16>("Y", {m, n}, FloatsToMLFloat16s(expected));
+      test.SetOutputTolerance(0.5f);
+
+      std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
+      execution_providers.push_back(DefaultCudaExecutionProvider());
+      test.Run(OpTester::ExpectResult::kExpectSuccess, "", {}, nullptr, &execution_providers);
+    }
+  }
+}
+
+TEST(MatMulBlockQuantizedFp4WeightOpTest, GemvTensorCoreColumnGroupedBf16Bias) {
+  if (!HasCudaEnvironment(800)) {
+    GTEST_SKIP() << "CUDA device is required for MatMulBlockQuantizedFp4Weight.";
+  }
+
+  cudaDeviceProp device_prop{};
+  int device_id = 0;
+  ASSERT_EQ(cudaGetDevice(&device_id), cudaSuccess);
+  ASSERT_EQ(cudaGetDeviceProperties(&device_prop, device_id), cudaSuccess);
+
+  constexpr int64_t m = 8;
+  constexpr int64_t k = 256;
+  const int64_t n = 32 * 2 * device_prop.multiProcessorCount + 20;
+  ASSERT_EQ(onnxruntime::contrib::cuda::PickFp4MmaGroupedConfig(
+                static_cast<int>(m), static_cast<int>(n), static_cast<int>(k),
+                device_prop.multiProcessorCount, device_prop.major, device_prop.minor)
+                .col_groups,
+            2);
+
+  std::vector<uint8_t> b, weight_scale;
+  std::vector<float> a, expected;
+  MakeGroupedCase(m, n, k, b, weight_scale, a, expected);
+
+  std::vector<float> bias(n);
+  for (int64_t col = 0; col < n; ++col) {
+    bias[col] = static_cast<float>((col % 7) - 3);
+    for (int64_t row = 0; row < m; ++row) {
+      expected[row * n + col] += bias[col];
+    }
+  }
+
+  OpTester test("MatMulBlockQuantizedFp4Weight", 1, onnxruntime::kMSDomain);
+  test.AddAttribute<int64_t>("block_size", 16);
+  test.AddInput<BFloat16>("A", {m, k}, FloatsToBFloat16s(a));
+  test.AddInput<uint8_t>("B", {n, k / 2}, b);
+  test.AddInput<uint8_t>("weight_scale", {n, k / 16}, weight_scale);
+  test.AddInput<float>("weight_scale_2", {1}, {1.0f});
+  test.AddOptionalInputEdge<float>();  // input_scale (skipped)
+  test.AddInput<BFloat16>("bias", {n}, FloatsToBFloat16s(bias));
+  test.AddOutput<BFloat16>("Y", {m, n}, FloatsToBFloat16s(expected));
+  test.SetOutputTolerance(0.5f);
+
+  std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
+  execution_providers.push_back(DefaultCudaExecutionProvider());
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {}, nullptr, &execution_providers);
 }
 
 // Lane-ownership probe for the tensor-core path.

--- a/onnxruntime/test/contrib_ops/matmul_block_scaled_fp4_test.cc
+++ b/onnxruntime/test/contrib_ops/matmul_block_scaled_fp4_test.cc
@@ -696,22 +696,23 @@ TEST(MatMulBlockQuantizedFp4WeightOpTest, GemvTensorCoreGroupedArchitectureSelec
     int major;
     int minor;
     int k_split;
+    int col_tiles;
     int col_groups;
   };
   const Case cases[] = {
-      {128, 8, 9, 2, 1},
-      {132, 9, 0, 4, 2},
-      {108, 8, 0, 2, 1},
-      {28, 8, 6, 2, 1},   // RTX 3060
-      {36, 12, 0, 2, 1},  // RTX 5060 Ti
-      {48, 12, 1, 16, 1},
+      {128, 8, 9, 2, 1, 1},
+      {132, 9, 0, 4, 1, 2},
+      {108, 8, 0, 2, 1, 1},
+      {28, 8, 6, 2, 4, 1},   // RTX 3060
+      {36, 12, 0, 2, 4, 1},  // RTX 5060 Ti
+      {48, 12, 1, 16, 1, 1},
   };
   for (const Case& device : cases) {
     SCOPED_TRACE("CC = " + std::to_string(device.major) + "." + std::to_string(device.minor));
     const auto config = onnxruntime::contrib::cuda::PickFp4MmaGroupedConfig(
         8, 17408, 5120, device.sm_count, device.major, device.minor);
     EXPECT_EQ(config.k_split, device.k_split);
-    EXPECT_EQ(config.col_tiles, 1);
+    EXPECT_EQ(config.col_tiles, device.col_tiles);
     EXPECT_EQ(config.col_groups, device.col_groups);
   }
 }
@@ -823,8 +824,8 @@ TEST(MatMulBlockQuantizedFp4WeightOpTest, GemvTensorCoreColumnGroupedFp16) {
   ASSERT_EQ(cudaGetDevice(&device_id), cudaSuccess);
   ASSERT_EQ(cudaGetDeviceProperties(&device_prop, device_id), cudaSuccess);
 
-  if (device_prop.major == 8 && device_prop.minor == 9) {
-    GTEST_SKIP() << "Automatic column grouping is disabled on Ada.";
+  if (device_prop.major != 9 || device_prop.minor != 0) {
+    GTEST_SKIP() << "Automatic column grouping is enabled only on SM90.";
   }
 
   // Smallest N that groups: ceil(N / 32) >= 2 * sm_count.
@@ -873,8 +874,8 @@ TEST(MatMulBlockQuantizedFp4WeightOpTest, GemvTensorCoreColumnGroupedBf16Bias) {
   ASSERT_EQ(cudaGetDevice(&device_id), cudaSuccess);
   ASSERT_EQ(cudaGetDeviceProperties(&device_prop, device_id), cudaSuccess);
 
-  if (device_prop.major == 8 && device_prop.minor == 9) {
-    GTEST_SKIP() << "Automatic column grouping is disabled on Ada.";
+  if (device_prop.major != 9 || device_prop.minor != 0) {
+    GTEST_SKIP() << "Automatic column grouping is enabled only on SM90.";
   }
 
   constexpr int64_t m = 8;

--- a/onnxruntime/test/contrib_ops/matmul_block_scaled_fp4_test.cc
+++ b/onnxruntime/test/contrib_ops/matmul_block_scaled_fp4_test.cc
@@ -690,24 +690,6 @@ TEST(MatMulBlockQuantizedFp4WeightOpTest, GemvTensorCoreSm121Tiling) {
   }
 }
 
-TEST(MatMulBlockQuantizedFp4WeightOpTest, GemvTensorCoreGroupedAdaRetainsOriginalTiling) {
-  for (int sm_count : {24, 48, 58, 76, 128, 142}) {
-    for (int m : {1, 4, 8}) {
-      for (int n : {5120, 8416, 8417, 17408, 34816, 248320}) {
-        for (int k : {128, 5120, 17408}) {
-          SCOPED_TRACE("SMs = " + std::to_string(sm_count) + ", M = " + std::to_string(m) +
-                       ", N = " + std::to_string(n) + ", K = " + std::to_string(k));
-          const auto original = onnxruntime::contrib::cuda::PickFp4MmaConfig(m, n, k, sm_count, 8, 9);
-          const auto config = onnxruntime::contrib::cuda::PickFp4MmaGroupedConfig(m, n, k, sm_count, 8, 9);
-          EXPECT_EQ(config.k_split, original.k_split);
-          EXPECT_EQ(config.col_tiles, original.col_tiles);
-          EXPECT_EQ(config.col_groups, 1);
-        }
-      }
-    }
-  }
-}
-
 TEST(MatMulBlockQuantizedFp4WeightOpTest, GemvTensorCoreGroupedArchitectureSelection) {
   struct Case {
     int sm_count;
@@ -719,10 +701,10 @@ TEST(MatMulBlockQuantizedFp4WeightOpTest, GemvTensorCoreGroupedArchitectureSelec
   const Case cases[] = {
       {128, 8, 9, 2, 1},
       {132, 9, 0, 4, 2},
-      {108, 8, 0, 4, 2},
-      {84, 8, 6, 2, 2},
-      {128, 12, 0, 4, 2},
-      {48, 12, 1, 2, 2},
+      {108, 8, 0, 2, 1},
+      {28, 8, 6, 2, 1},   // RTX 3060
+      {36, 12, 0, 2, 1},  // RTX 5060 Ti
+      {48, 12, 1, 16, 1},
   };
   for (const Case& device : cases) {
     SCOPED_TRACE("CC = " + std::to_string(device.major) + "." + std::to_string(device.minor));


### PR DESCRIPTION
### Description

The NVFP4 tensor-core GEMV (`MatMulBlockQuantizedFp4WeightMmaGemvKernel`) is the decode-time hot path for NVFP4 models. On an H200 it reaches only ~44% of measured streaming bandwidth, and Nsight Compute shows why:

| metric | N=17408, K=5120, M=8 | N=5120, K=17408, M=8 |
| --- | ---: | ---: |
| L1/TEX throughput | 65.9% | **86.3%** |
| DRAM throughput | 33.3% | 28.6% |
| waves per SM | 0.82 | 1.21 |
| achieved warps per SM | 13.5 of 64 | 27.8 of 64 |

The kernel is **L1 bound, not DRAM bound**. Each warp owns one 16-column tile and re-reads the whole activation fragment for it, so activation traffic through L1 grows with the number of column tiles.

This PR lets one warp own `ColGroups` adjacent 16-column tiles that share a single activation fragment. A window then costs `2 * ColGroups` weight loads against a fixed 4 activation loads instead of 2 against 4, halving activation L1 traffic per weight byte. Two smaller changes come with it:

- The two adjacent E4M3 block scales a lane needs are loaded as one 16-bit access instead of two byte loads. `block_size` is fixed at 16 and the mma path requires `K % 128 == 0`, so `k_blocks` is always a multiple of 8 and the paired load is always aligned.
- Weight row base pointers are hoisted out of the K loop so it carries no 64-bit address arithmetic.

Grouping halves the column grid, so `PickFp4MmaGroupedConfig` only selects it when the grouped grid still covers two blocks per SM; otherwise it falls back to the existing ungrouped ladder. It is also restricted to `M <= 8` (one mma row tile), because a wider M would multiply the shared-memory reduction buffer past the 48 KB static limit.

### Measurements

Kernel time from nsys, H200 (132 SMs), M = 8, half. "Before" is the tiling `PickFp4MmaConfig` selects today, confirmed against a full sweep of `KSplit` x `ColTiles` x `ColGroups`:

| shape | before | after | |
| --- | ---: | ---: | ---: |
| N = 17408, K = 5120 (gate/up_proj) | 28.38 us (KSplit 2) | 24.64 us (KSplit 4, ColGroups 2) | **1.15x** |
| N = 5120, K = 17408 (down_proj) | 28.67 us (KSplit 16) | 28.35 us (KSplit 16) | 1.01x |

The second shape yields only 160 grouped blocks, so it is not selected for grouping and picks up just the scale-load change.

End to end the effect is much smaller, because this kernel is about 22% of a decode step and only one of its two shapes groups. Qwen3.8-27B NVFP4 with INT8 KV and a DFlash2 drafter, decode tokens/s, two builds differing **only** in this change, arms back to back on the same GPU:

| context | batch 1 | batch 4 |
| --- | ---: | ---: |
| 512 | 1.004x | 1.004x |
| 2,048 | 1.018x | 1.005x |
| 8,192 | 1.001x | 1.003x |
| 32,768 | 1.018x | 1.003x |
| **geomean** | **1.010x** | **1.004x** |

Speculative acceptance is unchanged in every cell, and TTFT is neutral — the prefill path does not use this kernel.

### Accuracy

The tiling change is a reassociation, not a bitwise no-op, so it was gated on output rather than on bits:

- MMLU-Pro 400, thinking on, greedy: 332/400 before and after, with **all 400 per-item verdicts identical** (McNemar 0/0, p = 1.0).
- A greedy generation produced a byte-identical token stream before and after.
- A numpy dequantize-then-matmul parity sweep over M = 1..33, ragged N (17, 31, 33, 47, 1023, 1025) and K at the 128-element boundary matched to < 5e-4 relative error.

### Tests

`onnxruntime_provider_test --gtest_filter='MatMulBlockQuantizedFp4WeightOpTest.*:MatMulBlockQuantizedFp8WeightOpTest.*'` — 31/31 pass on H200.

Two tests are added:

- `GemvTensorCoreGroupedTilingBoundaries` pins `PickFp4MmaGroupedConfig` at the selection boundary (263 grouped blocks falls back, 264 groups), the KSplit cap, a single-K-window shape, and a tall-narrow shape that must not group.
- `GemvTensorCoreColumnGroupedFp16` runs the grouped kernel at three widths derived from the device SM count: one that divides evenly by 32, one leaving 20 columns in the last block (first group full, second holding 4 of 16) and one leaving 8 (first group low half only, second entirely out of range), so the per-group store masking is exercised.

The existing `MakeMmaCase` generator is deliberately **not** reused for the grouped test. Its weight codes cycle with period 4 along N and its block scales with period 2, and the two tiles a grouped warp owns are 16 columns apart, so both patterns repeat exactly across the group boundary — a kernel that applied group 0's scales to group 1 still passed. The new generator cycles with period 3, coprime to both 16 and the 8-column lo/hi split. This was verified by injecting that exact bug: the new test fails on it, and reverting makes it pass.

### Motivation and Context

Decode of NVFP4 models is bound by weight streaming, and this kernel was leaving roughly half its bandwidth unused for a reason fixable without changing the mma fragment layout. The remaining gap is the 8 L1 wavefronts per `LDG.128` — a warp reads 8 weight columns that are `K/2` bytes apart, where 4 wavefronts would suffice — which would need a shared-memory or shuffle restage of the fragment and is not attempted here.
