### PR TITLE
Use core available for CUDA plugin ARM64 build. Build time 4 hours -> 1.5 hours.

### DIFF
--- a/tools/ci_build/github/linux/build_cuda_plugin_package.sh
+++ b/tools/ci_build/github/linux/build_cuda_plugin_package.sh
@@ -27,7 +27,7 @@ done
 
 # Update parallel to the minimum of the number of processors and 8 for aarch64 to avoid OOM errors during build.
 if [ "$arch" = "aarch64" ]; then
-    PARALLEL=$(( $(nproc) < 8 ? $(nproc) : 8 ))
+    PARALLEL=$(( $(nproc) < 8 ? $(nproc) : $(nproc) - 2 ))
 else
     PARALLEL=""
 fi


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->



### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


