### PR TITLE
Skip EP unregistration during process shutdown

### DIFF
--- a/onnxruntime/core/session/onnxruntime_c_api.cc
+++ b/onnxruntime/core/session/onnxruntime_c_api.cc
@@ -3761,6 +3761,10 @@ ORT_API_STATUS_IMPL(OrtApis::RegisterExecutionProviderLibrary, _In_ OrtEnv* env,
 }
 
 ORT_API_STATUS_IMPL(OrtApis::UnregisterExecutionProviderLibrary, _In_ OrtEnv* env, _In_ const char* registration_name) {
+  if (OrtEnv::ShouldSkipShutdownCleanup()) {
+    return nullptr;
+  }
+
   API_IMPL_BEGIN
   ORT_API_RETURN_IF_STATUS_NOT_OK(env->GetEnvironment().UnregisterExecutionProviderLibrary(registration_name));
   return nullptr;

--- a/onnxruntime/core/session/ort_env.cc
+++ b/onnxruntime/core/session/ort_env.cc
@@ -87,7 +87,7 @@ OrtEnvPtr OrtEnv::GetOrCreateInstance(const OrtEnv::LoggingManagerConstructionIn
       return OrtEnvPtr(nullptr, OrtEnv::Release);
     }
     // Use 'new' to allocate OrtEnv, as it will be managed by p_instance_
-    // and deleted in ReleaseEnv or leaked if g_is_process_shutting_down is true.
+    // and deleted in ReleaseEnv or leaked if process shutdown cleanup should be skipped.
     p_instance_ = new OrtEnv(std::move(env));
   }
 
@@ -109,21 +109,14 @@ void OrtEnv::Release(OrtEnv* env_ptr) {
 
     --ref_count_;
     if (ref_count_ == 0) {
-      if (!g_is_shutting_down.load(std::memory_order_acquire)) {
+      if (!ShouldSkipShutdownCleanup()) {
         instance_to_delete = p_instance_;  // Point to the instance to be deleted.
         p_instance_ = nullptr;             // Set the static instance pointer to nullptr under the lock.
       } else {
-#if !defined(ONNXRUNTIME_ENABLE_MEMLEAK_CHECK)
         // Process is shutting down, let it leak.
         // p_instance_ remains as is (though ref_count_ is 0), future CreateEnv calls
         // would increment ref_count_ on this "leaked" instance.
         // This behavior matches the requirement to "just let the memory leak out".
-#else
-        // we're tracing for memory leaks so we want to avoid as many leaks as possible and the leaks are considered
-        // as failures for test apps.
-        instance_to_delete = p_instance_;
-        p_instance_ = nullptr;
-#endif
       }
     }
   }  // Mutex m_ is released here when lock_guard goes out of scope.
@@ -131,6 +124,15 @@ void OrtEnv::Release(OrtEnv* env_ptr) {
   // Perform the deletion outside the lock if an instance was marked for deletion.
   // instance_to_delete can be null here, but it's perfectly safe to delete a nullptr
   delete instance_to_delete;
+}
+
+/*static*/
+bool OrtEnv::ShouldSkipShutdownCleanup() noexcept {
+#if !defined(ONNXRUNTIME_ENABLE_MEMLEAK_CHECK)
+  return g_is_shutting_down.load(std::memory_order_acquire);
+#else
+  return false;
+#endif
 }
 
 /*static*/

--- a/onnxruntime/core/session/ort_env.h
+++ b/onnxruntime/core/session/ort_env.h
@@ -54,6 +54,7 @@ struct OrtEnv {
   static OrtEnvPtr TryGetInstance();
 
   static void Release(OrtEnv* env_ptr);
+  static bool ShouldSkipShutdownCleanup() noexcept;
 
   const onnxruntime::Environment& GetEnvironment() const {
     return *value_;


### PR DESCRIPTION


### Description
 Make `UnregisterExecutionProviderLibrary` return success without entering environment cleanup when ONNX Runtime has detected Windows process termination.
 
 The change centralizes the existing shutdown policy in `OrtEnv::ShouldSkipShutdownCleanup()`.  Normal explicit unregistration and orderly `FreeLibrary` unload behavior are unchanged


### Motivation and Context
 Calling `OrtApi::UnregisterExecutionProviderLibrary` from late process-shutdown cleanup can crash inside ONNX Runtime.
 
 ONNX Runtime already detects Windows process termination in `onnxruntime/core/dll/dllmain.cc`: when `DLL_PROCESS_DETACH` has a non-null reserved parameter, it sets `g_is_shutting_down`. `OrtEnv::Release` uses this state to intentionally skip destruction during process termination.
 
 However, `OrtApi::UnregisterExecutionProviderLibrary` does not check that state before accessing `OrtEnv::GetEnvironment()`. A consumer that explicitly unregisters an EP from global or DLL teardown can therefore enter `Environment::UnregisterExecutionProviderLibrary` after CRT state has begun shutting down.


