### PR TITLE
[CUDA] Optimize TopK for wide last axes

### DIFF
--- a/onnxruntime/contrib_ops/cuda/moe/qmoe_kernels.cu
+++ b/onnxruntime/contrib_ops/cuda/moe/qmoe_kernels.cu
@@ -363,8 +363,9 @@ __global__ void SoftmaxTopKWarpMergeKernel(const T* logits, float* topk_scales, 
   }
   const float inv_sum = SafeInvSum(WarpReduceSum(local_sum));
 
-  __syncwarp();
+  // Each lane reads back only the slots it wrote above, so the sort needs no barrier before it.
   WarpMergeSorter::Sort(s_scores, s_indices, temp_storage, num_experts);
+  // Sort's blocked write-back must be visible to the strided reads below.
   __syncwarp();
 
   // s_scores[r]/s_indices[r] now hold the rank-r logit/expert index.

--- a/onnxruntime/core/providers/cuda/cu_inc/topk_warp_sort.cuh
+++ b/onnxruntime/core/providers/cuda/cu_inc/topk_warp_sort.cuh
@@ -41,6 +41,7 @@ constexpr int kWarpSize = 32;
 constexpr int kWarpBitonicMaxSize = 32;
 constexpr int kWarpMergeMaxSize = 64;
 constexpr float kNegativeInfinity = -std::numeric_limits<float>::infinity();
+constexpr uint64_t kPaddingSortKey = 0;
 
 __device__ __forceinline__ int LaneId() {
   int lane_id;
@@ -127,6 +128,27 @@ __device__ inline void WarpBitonicSortDescending(float& score, int& index) {
       } else {
         score = (lane_id < paired_lane) ? s_min : s_max;
         index = (lane_id < paired_lane) ? i_min : i_max;
+      }
+    }
+  }
+}
+
+__device__ inline void WarpBitonicSortDescending(uint64_t& key) {
+  const int lane_id = LaneId();
+
+  for (int k = 2; k <= kWarpSize; k <<= 1) {
+    for (int j = k >> 1; j > 0; j >>= 1) {
+      const int paired_lane = lane_id ^ j;
+      const uint64_t paired_key = static_cast<uint64_t>(
+          __shfl_sync(0xFFFFFFFFu, static_cast<unsigned long long>(key), paired_lane));
+      const bool direction = ((lane_id & k) == 0);
+      const uint64_t key_max = key > paired_key ? key : paired_key;
+      const uint64_t key_min = key > paired_key ? paired_key : key;
+
+      if (direction) {
+        key = (lane_id < paired_lane) ? key_max : key_min;
+      } else {
+        key = (lane_id < paired_lane) ? key_min : key_max;
       }
     }
   }
@@ -271,8 +293,8 @@ struct WarpMergeSorter {
   using SortT = cub::WarpMergeSort<uint64_t, kItemsPerThread, kWarpSize, cub::NullType>;
   using TempStorage = typename SortT::TempStorage;
 
-  // num_valid_items elements are read from shared memory; the remainder are
-  // padded with (kNegativeInfinity, INT_MAX) so valid -inf scores sort ahead of padding.
+  // num_valid_items elements are read from shared memory; the remainder use the minimum
+  // packed key so every valid score, including a negative NaN, sorts ahead of padding.
   // `temp_storage` may alias `smem_scores`/`smem_indices` (callers often union them to save
   // shared memory), so the write-back is fenced against CUB's final reads of that storage.
   __device__ static void Sort(float* smem_scores, int* smem_indices,
@@ -291,7 +313,7 @@ struct WarpMergeSorter {
       if (idx < num_valid_items) {
         items[i] = PackStableSortKey(smem_scores[idx], smem_indices[idx]);
       } else {
-        items[i] = PackStableSortKey(kNegativeInfinity, INT_MAX);
+        items[i] = kPaddingSortKey;
       }
     }
 

--- a/onnxruntime/core/providers/cuda/cu_inc/topk_warp_sort.cuh
+++ b/onnxruntime/core/providers/cuda/cu_inc/topk_warp_sort.cuh
@@ -274,7 +274,7 @@ struct WarpMergeSorter {
   // num_valid_items elements are read from shared memory; the remainder are
   // padded with (kNegativeInfinity, INT_MAX) so valid -inf scores sort ahead of padding.
   // `temp_storage` may alias `smem_scores`/`smem_indices` (callers often union them to save
-  // shared memory), so the loads and the write-back are fenced against the sort's own traffic.
+  // shared memory), so the write-back is fenced against CUB's final reads of that storage.
   __device__ static void Sort(float* smem_scores, int* smem_indices,
                               TempStorage& temp_storage, int num_valid_items) {
     const int thread_id = LinearThreadIdInBlock();
@@ -294,9 +294,10 @@ struct WarpMergeSorter {
         items[i] = PackStableSortKey(kNegativeInfinity, INT_MAX);
       }
     }
-    __syncwarp();
 
+    // The loads above need no barrier: CUB syncs before its first temp_storage write.
     SortT(temp_storage).Sort(items, Greater<uint64_t>());
+    // CUB's merge loop ends on a read of temp_storage with no trailing sync.
     __syncwarp();
 
     // Blocked write-back: rank r lives at smem[r].

--- a/onnxruntime/core/providers/cuda/cu_inc/topk_warp_sort.cuh
+++ b/onnxruntime/core/providers/cuda/cu_inc/topk_warp_sort.cuh
@@ -137,7 +137,7 @@ __device__ inline void WarpBitonicSortDescending(float& score, int& index) {
 // preferring the smaller original index. This matches the stable Top-K packing
 // used by onnxruntime-genai while avoiding a compound comparator in CUB.
 __device__ __forceinline__ uint64_t PackStableSortKey(float score, int index) {
-  const uint32_t score_bits = __float_as_uint(score);
+  const uint32_t score_bits = score == 0.0f ? 0u : __float_as_uint(score);
   const uint32_t sortable_score =
       (score_bits & 0x80000000u) ? (~score_bits) : (score_bits | 0x80000000u);
   const uint32_t inverted_index = UINT_MAX - static_cast<uint32_t>(index);

--- a/onnxruntime/core/providers/cuda/cu_inc/topk_warp_sort.cuh
+++ b/onnxruntime/core/providers/cuda/cu_inc/topk_warp_sort.cuh
@@ -273,6 +273,8 @@ struct WarpMergeSorter {
 
   // num_valid_items elements are read from shared memory; the remainder are
   // padded with (kNegativeInfinity, INT_MAX) so valid -inf scores sort ahead of padding.
+  // `temp_storage` may alias `smem_scores`/`smem_indices` (callers often union them to save
+  // shared memory), so the loads and the write-back are fenced against the sort's own traffic.
   __device__ static void Sort(float* smem_scores, int* smem_indices,
                               TempStorage& temp_storage, int num_valid_items) {
     const int thread_id = LinearThreadIdInBlock();
@@ -292,8 +294,10 @@ struct WarpMergeSorter {
         items[i] = PackStableSortKey(kNegativeInfinity, INT_MAX);
       }
     }
+    __syncwarp();
 
     SortT(temp_storage).Sort(items, Greater<uint64_t>());
+    __syncwarp();
 
     // Blocked write-back: rank r lives at smem[r].
 #pragma unroll

--- a/onnxruntime/core/providers/cuda/math/topk_hybrid.cuh
+++ b/onnxruntime/core/providers/cuda/math/topk_hybrid.cuh
@@ -81,6 +81,12 @@ inline int PaddedK(int k) {
   return 256;
 }
 
+// H200 sweeps show that Hybrid consistently wins from this dimension for single-row K >= 16
+// and multi-row K >= 64. SmallK or RadixTopK is faster outside those regions, especially for K = 1.
+inline bool IsPreferred(int64_t rows, int64_t dimension, int64_t k) {
+  return dimension >= 8192 && ((rows == 1 && k >= 16) || (rows > 1 && k >= 64));
+}
+
 template <int K>
 constexpr int ReductionBlockSize() {
   return K <= 16 ? 128 : 256;

--- a/onnxruntime/core/providers/cuda/math/topk_hybrid.cuh
+++ b/onnxruntime/core/providers/cuda/math/topk_hybrid.cuh
@@ -113,7 +113,7 @@ __global__ void FindPartitionTopK(const T* __restrict__ input,
     const int index = partition_start + threadIdx.x + item * kStage1Threads;
     keys[item] = index < dimension
                      ? topk::PackStableSortKey(static_cast<float>(row_input[index]), index)
-                     : topk::PackStableSortKey(topk::kNegativeInfinity, INT_MAX);
+                     : topk::kPaddingSortKey;
   }
   Sort(storage).SortDescendingBlockedToStriped(keys);
   if (threadIdx.x < K) {
@@ -158,13 +158,14 @@ __device__ void ReducePartitions(const float* input_scores,
     }
     __syncthreads();
     if (threadIdx.x < topk::kWarpSize) {
-      float score = threadIdx.x < valid_items ? storage.values.scores[threadIdx.x]
-                                              : topk::kNegativeInfinity;
-      int index = threadIdx.x < valid_items ? storage.values.indices[threadIdx.x] : INT_MAX;
-      topk::WarpBitonicSortDescending(score, index);
+      uint64_t key = threadIdx.x < valid_items
+                         ? topk::PackStableSortKey(storage.values.scores[threadIdx.x],
+                                                   storage.values.indices[threadIdx.x])
+                         : topk::kPaddingSortKey;
+      topk::WarpBitonicSortDescending(key);
       if (threadIdx.x < K) {
-        storage.values.scores[threadIdx.x] = score;
-        storage.values.indices[threadIdx.x] = index;
+        storage.values.scores[threadIdx.x] = topk::UnpackStableSortScore(key);
+        storage.values.indices[threadIdx.x] = topk::UnpackStableSortIndex(key);
       }
     }
   } else if constexpr (SortSize <= topk::kWarpMergeMaxSize) {
@@ -190,7 +191,7 @@ __device__ void ReducePartitions(const float* input_scores,
         const size_t offset = static_cast<size_t>(first_partition) * K + item_index;
         keys[item] = topk::PackStableSortKey(input_scores[offset], input_indices[offset]);
       } else {
-        keys[item] = topk::PackStableSortKey(topk::kNegativeInfinity, INT_MAX);
+        keys[item] = topk::kPaddingSortKey;
       }
     }
     Sort(reinterpret_cast<typename Sort::TempStorage&>(storage.block_merge))
@@ -281,7 +282,9 @@ __global__ void WriteOutput(const T* input,
     const size_t input_offset = static_cast<size_t>(row) * stride + threadIdx.x;
     const size_t output_offset = static_cast<size_t>(row) * k + threadIdx.x;
     const int index = indices[input_offset];
-    output_scores[output_offset] = input[static_cast<size_t>(row) * dimension + index];
+    output_scores[output_offset] = index >= 0 && index < dimension
+                                       ? input[static_cast<size_t>(row) * dimension + index]
+                                       : T(0);
     output_indices[output_offset] = index;
   }
 }

--- a/onnxruntime/core/providers/cuda/math/topk_hybrid.cuh
+++ b/onnxruntime/core/providers/cuda/math/topk_hybrid.cuh
@@ -1,0 +1,442 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include <algorithm>
+#include <array>
+#include <cooperative_groups.h>
+#include <cub/block/block_merge_sort.cuh>
+#include <cub/block/block_radix_sort.cuh>
+#include <limits>
+#include <type_traits>
+
+#include "core/providers/cuda/cu_inc/topk_warp_sort.cuh"
+
+namespace onnxruntime {
+namespace cuda {
+namespace hybrid_topk {
+
+namespace cg = cooperative_groups;
+
+constexpr int kMaxK = 256;
+constexpr int kMaxPartitions = 256;
+constexpr int kStage1Threads = 256;
+constexpr std::array<int, 4> kPartitionSizes = {1792, 2304, 2816, 3328};
+
+constexpr int DivUp(int value, int divisor) {
+  return (value + divisor - 1) / divisor;
+}
+
+constexpr int Max(int a, int b, int c) {
+  return std::max(a, std::max(b, c));
+}
+
+struct ReductionFactors {
+  int factor1;
+  int factor2;
+  int factor3;
+  int steps;
+};
+
+constexpr ReductionFactors GetReductionFactors(int partitions) {
+  if (partitions <= 1) return {1, 1, 1, 0};
+  if (partitions <= 4) return {4, 1, 1, 1};
+  if (partitions <= 8) return {8, 1, 1, 1};
+  if (partitions <= 16) return {16, 1, 1, 1};
+  if (partitions <= 32) return {8, 4, 1, 2};
+  if (partitions <= 64) return {8, 8, 1, 2};
+  if (partitions <= 128) return {8, 8, 2, 3};
+  return {8, 8, 4, 3};
+}
+
+inline int EstimateBestPartitionSize(int dimension) {
+  constexpr std::array<int, 8> targets = {2, 4, 8, 16, 32, 64, 128, 256};
+  int best_partition_size = kPartitionSizes[0];
+  double best_waste = std::numeric_limits<double>::infinity();
+  for (int partition_size : kPartitionSizes) {
+    const int partitions = DivUp(dimension, partition_size);
+    if (partitions > kMaxPartitions) {
+      continue;
+    }
+    const auto target = std::lower_bound(targets.begin(), targets.end(), partitions);
+    if (target != targets.end()) {
+      const double waste = static_cast<double>(*target - partitions) / *target;
+      if (waste < best_waste) {
+        best_waste = waste;
+        best_partition_size = partition_size;
+      }
+    }
+  }
+  return best_partition_size;
+}
+
+inline int PaddedK(int k) {
+  if (k <= 4) return 4;
+  if (k <= 8) return 8;
+  if (k <= 16) return 16;
+  if (k <= 32) return 32;
+  if (k <= 64) return 64;
+  if (k <= 128) return 128;
+  return 256;
+}
+
+template <int K>
+constexpr int ReductionBlockSize() {
+  return K <= 16 ? 128 : 256;
+}
+
+template <typename T, int PartitionSize, int K>
+__global__ void FindPartitionTopK(const T* __restrict__ input,
+                                  float* __restrict__ scores,
+                                  int* __restrict__ indices,
+                                  int dimension,
+                                  int num_partitions) {
+  constexpr int items_per_thread = PartitionSize / kStage1Threads;
+  using Sort = cub::BlockRadixSort<uint64_t, kStage1Threads, items_per_thread>;
+  __shared__ typename Sort::TempStorage storage;
+
+  const int row = blockIdx.y;
+  const int partition = blockIdx.x;
+  const int partition_start = partition * PartitionSize;
+  const T* row_input = input + static_cast<size_t>(row) * dimension;
+  uint64_t keys[items_per_thread];
+#pragma unroll
+  for (int item = 0; item < items_per_thread; ++item) {
+    const int index = partition_start + threadIdx.x + item * kStage1Threads;
+    keys[item] = index < dimension
+                     ? topk::PackStableSortKey(static_cast<float>(row_input[index]), index)
+                     : topk::PackStableSortKey(topk::kNegativeInfinity, INT_MAX);
+  }
+  Sort(storage).SortDescendingBlockedToStriped(keys);
+  if (threadIdx.x < K) {
+    const size_t offset =
+        (static_cast<size_t>(row) * num_partitions + partition) * K + threadIdx.x;
+    scores[offset] = topk::UnpackStableSortScore(keys[0]);
+    indices[offset] = topk::UnpackStableSortIndex(keys[0]);
+  }
+}
+
+template <int BlockSize, int MaxSortSize>
+union ReductionStorage {
+  typename cub::WarpMergeSort<uint64_t, DivUp(MaxSortSize, topk::kWarpSize),
+                              topk::kWarpSize, cub::NullType>::TempStorage warp_merge;
+  typename cub::BlockMergeSort<uint64_t, BlockSize, DivUp(MaxSortSize, BlockSize),
+                               cub::NullType>::TempStorage block_merge;
+  struct {
+    __align__(128) float scores[MaxSortSize];
+    __align__(128) int indices[MaxSortSize];
+  } values;
+};
+
+template <int BlockSize, int SortSize, int K, typename Storage>
+__device__ void ReducePartitions(const float* input_scores,
+                                 const int* input_indices,
+                                 float* output_scores,
+                                 int* output_indices,
+                                 int input_partitions,
+                                 int output_partition,
+                                 Storage& storage) {
+  const int first_partition = output_partition * (SortSize / K);
+  const int valid_partitions = min(SortSize / K, input_partitions - first_partition);
+  const int valid_items = valid_partitions * K;
+
+  if constexpr (SortSize <= topk::kWarpBitonicMaxSize) {
+    for (int item = threadIdx.x; item < SortSize; item += BlockSize) {
+      if (item < valid_items) {
+        const size_t offset = static_cast<size_t>(first_partition) * K + item;
+        storage.values.scores[item] = input_scores[offset];
+        storage.values.indices[item] = input_indices[offset];
+      }
+    }
+    __syncthreads();
+    if (threadIdx.x < topk::kWarpSize) {
+      float score = threadIdx.x < valid_items ? storage.values.scores[threadIdx.x]
+                                              : topk::kNegativeInfinity;
+      int index = threadIdx.x < valid_items ? storage.values.indices[threadIdx.x] : INT_MAX;
+      topk::WarpBitonicSortDescending(score, index);
+      if (threadIdx.x < K) {
+        storage.values.scores[threadIdx.x] = score;
+        storage.values.indices[threadIdx.x] = index;
+      }
+    }
+  } else if constexpr (SortSize <= topk::kWarpMergeMaxSize) {
+    for (int item = threadIdx.x; item < SortSize; item += BlockSize) {
+      if (item < valid_items) {
+        const size_t offset = static_cast<size_t>(first_partition) * K + item;
+        storage.values.scores[item] = input_scores[offset];
+        storage.values.indices[item] = input_indices[offset];
+      }
+    }
+    __syncthreads();
+    using Sorter = topk::WarpMergeSorter<SortSize>;
+    Sorter::Sort(storage.values.scores, storage.values.indices,
+                 reinterpret_cast<typename Sorter::TempStorage&>(storage.warp_merge), valid_items);
+  } else {
+    constexpr int items_per_thread = DivUp(SortSize, BlockSize);
+    using Sort = cub::BlockMergeSort<uint64_t, BlockSize, items_per_thread, cub::NullType>;
+    uint64_t keys[items_per_thread];
+#pragma unroll
+    for (int item = 0; item < items_per_thread; ++item) {
+      const int item_index = threadIdx.x * items_per_thread + item;
+      if (item_index < valid_items) {
+        const size_t offset = static_cast<size_t>(first_partition) * K + item_index;
+        keys[item] = topk::PackStableSortKey(input_scores[offset], input_indices[offset]);
+      } else {
+        keys[item] = topk::PackStableSortKey(topk::kNegativeInfinity, INT_MAX);
+      }
+    }
+    Sort(reinterpret_cast<typename Sort::TempStorage&>(storage.block_merge))
+        .Sort(keys, topk::Greater<uint64_t>());
+    float thread_scores[items_per_thread];
+    int thread_indices[items_per_thread];
+#pragma unroll
+    for (int item = 0; item < items_per_thread; ++item) {
+      thread_scores[item] = topk::UnpackStableSortScore(keys[item]);
+      thread_indices[item] = topk::UnpackStableSortIndex(keys[item]);
+    }
+    cub::StoreDirectBlocked(threadIdx.x, output_scores + static_cast<size_t>(output_partition) * K,
+                            thread_scores, K);
+    cub::StoreDirectBlocked(threadIdx.x, output_indices + static_cast<size_t>(output_partition) * K,
+                            thread_indices, K);
+    return;
+  }
+
+  __syncthreads();
+  if (threadIdx.x < K) {
+    const size_t offset = static_cast<size_t>(output_partition) * K + threadIdx.x;
+    output_scores[offset] = storage.values.scores[threadIdx.x];
+    output_indices[offset] = storage.values.indices[threadIdx.x];
+  }
+}
+
+template <int K, int BlockSize, int Factor1, int Factor2, int Factor3>
+__global__ void CooperativeReduce(int* indices1,
+                                  float* scores1,
+                                  int* indices2,
+                                  float* scores2,
+                                  int num_partitions) {
+  cg::grid_group grid = cg::this_grid();
+  constexpr int max_sort_size = Max(K * Factor1, K * Factor2, K * Factor3);
+  __shared__ ReductionStorage<BlockSize, max_sort_size> storage;
+  const int partition = blockIdx.x;
+  const int row = blockIdx.y;
+
+  int partitions1 = num_partitions;
+  if constexpr (Factor1 > 1) {
+    partitions1 = DivUp(num_partitions, Factor1);
+    if (partition < partitions1) {
+      const size_t input_row = static_cast<size_t>(row) * num_partitions * K;
+      const size_t output_row = static_cast<size_t>(row) * partitions1 * K;
+      ReducePartitions<BlockSize, K * Factor1, K>(
+          scores1 + input_row, indices1 + input_row, scores2 + output_row, indices2 + output_row,
+          num_partitions, partition, storage);
+    }
+    grid.sync();
+  }
+
+  int partitions2 = partitions1;
+  if constexpr (Factor2 > 1) {
+    partitions2 = DivUp(partitions1, Factor2);
+    if (partition < partitions2) {
+      const size_t input_row = static_cast<size_t>(row) * partitions1 * K;
+      const size_t output_row = static_cast<size_t>(row) * partitions2 * K;
+      ReducePartitions<BlockSize, K * Factor2, K>(
+          scores2 + input_row, indices2 + input_row, scores1 + output_row, indices1 + output_row,
+          partitions1, partition, storage);
+    }
+    grid.sync();
+  }
+
+  if constexpr (Factor3 > 1) {
+    const int partitions3 = DivUp(partitions2, Factor3);
+    if (partition < partitions3) {
+      const size_t input_row = static_cast<size_t>(row) * partitions2 * K;
+      const size_t output_row = static_cast<size_t>(row) * partitions3 * K;
+      ReducePartitions<BlockSize, K * Factor3, K>(
+          scores1 + input_row, indices1 + input_row, scores2 + output_row, indices2 + output_row,
+          partitions2, partition, storage);
+    }
+  }
+}
+
+template <typename T>
+__global__ void WriteOutput(const float* scores,
+                            const int* indices,
+                            T* output_scores,
+                            int64_t* output_indices,
+                            int rows,
+                            int k,
+                            int stride) {
+  const int row = blockIdx.x;
+  if (row < rows && threadIdx.x < k) {
+    const size_t input_offset = static_cast<size_t>(row) * stride + threadIdx.x;
+    const size_t output_offset = static_cast<size_t>(row) * k + threadIdx.x;
+    output_scores[output_offset] = static_cast<T>(scores[input_offset]);
+    output_indices[output_offset] = indices[input_offset];
+  }
+}
+
+template <int K, int BlockSize>
+void* ReductionKernel(const ReductionFactors& factors) {
+  if (factors.factor1 == 8 && factors.factor2 == 8 && factors.factor3 == 4)
+    return reinterpret_cast<void*>(CooperativeReduce<K, BlockSize, 8, 8, 4>);
+  if (factors.factor1 == 8 && factors.factor2 == 8 && factors.factor3 == 2)
+    return reinterpret_cast<void*>(CooperativeReduce<K, BlockSize, 8, 8, 2>);
+  if (factors.factor1 == 8 && factors.factor2 == 8)
+    return reinterpret_cast<void*>(CooperativeReduce<K, BlockSize, 8, 8, 1>);
+  if (factors.factor1 == 8 && factors.factor2 == 4)
+    return reinterpret_cast<void*>(CooperativeReduce<K, BlockSize, 8, 4, 1>);
+  if (factors.factor1 == 8)
+    return reinterpret_cast<void*>(CooperativeReduce<K, BlockSize, 8, 1, 1>);
+  if (factors.factor1 == 16)
+    return reinterpret_cast<void*>(CooperativeReduce<K, BlockSize, 16, 1, 1>);
+  if (factors.factor1 == 4)
+    return reinterpret_cast<void*>(CooperativeReduce<K, BlockSize, 4, 1, 1>);
+  return reinterpret_cast<void*>(CooperativeReduce<K, BlockSize, 1, 1, 1>);
+}
+
+template <int K>
+bool CheckCooperativeSupport(const CudaKernel* kernel, int rows, int num_partitions) {
+  const ReductionFactors factors = GetReductionFactors(num_partitions);
+  if (factors.steps == 0) {
+    return true;
+  }
+  constexpr int block_size = ReductionBlockSize<K>();
+  void* reduction_kernel = ReductionKernel<K, block_size>(factors);
+  int blocks_per_sm = 0;
+  const cudaError_t result = cudaOccupancyMaxActiveBlocksPerMultiprocessor(
+      &blocks_per_sm, reduction_kernel, block_size, 0);
+  if (result != cudaSuccess) {
+    cudaGetLastError();
+    return false;
+  }
+  const int grid_x = DivUp(num_partitions, factors.factor1);
+  return static_cast<int64_t>(rows) * grid_x <=
+         static_cast<int64_t>(blocks_per_sm) * kernel->GetDeviceProp().multiProcessorCount;
+}
+
+inline bool IsSupported(const CudaKernel* kernel, int64_t rows, int64_t dimension, int64_t k) {
+  if (rows <= 0 || rows > kernel->GetDeviceProp().maxGridSize[1] ||
+      dimension <= 0 || dimension > std::numeric_limits<int>::max() || k <= 0 || k > kMaxK) {
+    return false;
+  }
+  const int partition_size = EstimateBestPartitionSize(static_cast<int>(dimension));
+  const int num_partitions = DivUp(static_cast<int>(dimension), partition_size);
+  if (num_partitions > kMaxPartitions) {
+    return false;
+  }
+  switch (PaddedK(static_cast<int>(k))) {
+    case 4:
+      return CheckCooperativeSupport<4>(kernel, static_cast<int>(rows), num_partitions);
+    case 8:
+      return CheckCooperativeSupport<8>(kernel, static_cast<int>(rows), num_partitions);
+    case 16:
+      return CheckCooperativeSupport<16>(kernel, static_cast<int>(rows), num_partitions);
+    case 32:
+      return CheckCooperativeSupport<32>(kernel, static_cast<int>(rows), num_partitions);
+    case 64:
+      return CheckCooperativeSupport<64>(kernel, static_cast<int>(rows), num_partitions);
+    case 128:
+      return CheckCooperativeSupport<128>(kernel, static_cast<int>(rows), num_partitions);
+    default:
+      return CheckCooperativeSupport<256>(kernel, static_cast<int>(rows), num_partitions);
+  }
+}
+
+template <typename T, int PartitionSize, int K>
+void LaunchStage1(const T* input, float* scores, int* indices,
+                  int dimension, int rows, int num_partitions, cudaStream_t stream) {
+  FindPartitionTopK<T, PartitionSize, K><<<dim3(num_partitions, rows), kStage1Threads, 0, stream>>>(
+      input, scores, indices, dimension, num_partitions);
+}
+
+template <typename T, int K>
+Status Launch(const CudaKernel* kernel,
+              cudaStream_t stream,
+              void* alloc_stream,
+              const T* input,
+              T* output_scores,
+              int64_t* output_indices,
+              int rows,
+              int dimension,
+              int k,
+              int partition_size) {
+  const int num_partitions = DivUp(dimension, partition_size);
+  const size_t elements = SafeInt<size_t>(rows) * num_partitions * K;
+  auto scores1 = kernel->GetScratchBuffer<float>(elements, alloc_stream);
+  auto indices1 = kernel->GetScratchBuffer<int>(elements, alloc_stream);
+  auto scores2 = kernel->GetScratchBuffer<float>(elements, alloc_stream);
+  auto indices2 = kernel->GetScratchBuffer<int>(elements, alloc_stream);
+
+  if (partition_size == kPartitionSizes[0])
+    LaunchStage1<T, kPartitionSizes[0], K>(input, scores1.get(), indices1.get(), dimension, rows, num_partitions, stream);
+  else if (partition_size == kPartitionSizes[1])
+    LaunchStage1<T, kPartitionSizes[1], K>(input, scores1.get(), indices1.get(), dimension, rows, num_partitions, stream);
+  else if (partition_size == kPartitionSizes[2])
+    LaunchStage1<T, kPartitionSizes[2], K>(input, scores1.get(), indices1.get(), dimension, rows, num_partitions, stream);
+  else
+    LaunchStage1<T, kPartitionSizes[3], K>(input, scores1.get(), indices1.get(), dimension, rows, num_partitions, stream);
+  CUDA_RETURN_IF_ERROR(cudaGetLastError());
+
+  const ReductionFactors factors = GetReductionFactors(num_partitions);
+  if (factors.steps > 0) {
+    constexpr int block_size = ReductionBlockSize<K>();
+    void* reduction_kernel = ReductionKernel<K, block_size>(factors);
+    float* scores1_ptr = scores1.get();
+    int* indices1_ptr = indices1.get();
+    float* scores2_ptr = scores2.get();
+    int* indices2_ptr = indices2.get();
+    int num_partitions_arg = num_partitions;
+    void* args[] = {&indices1_ptr, &scores1_ptr, &indices2_ptr, &scores2_ptr, &num_partitions_arg};
+    CUDA_RETURN_IF_ERROR(cudaLaunchCooperativeKernel(
+        reduction_kernel, dim3(DivUp(num_partitions, factors.factor1), rows),
+        dim3(block_size), args, 0, stream));
+  }
+
+  const float* final_scores = (factors.steps == 1 || factors.steps == 3) ? scores2.get() : scores1.get();
+  const int* final_indices = (factors.steps == 1 || factors.steps == 3) ? indices2.get() : indices1.get();
+  WriteOutput<T><<<rows, K, 0, stream>>>(
+      final_scores, final_indices, output_scores, output_indices, rows, k, K);
+  return CUDA_CALL(cudaGetLastError());
+}
+
+template <typename T>
+inline Status Run(const CudaKernel* kernel,
+                  cudaStream_t stream,
+                  void* alloc_stream,
+                  const T* input,
+                  T* output_scores,
+                  int64_t* output_indices,
+                  int rows,
+                  int dimension,
+                  int k) {
+  const int partition_size = EstimateBestPartitionSize(dimension);
+  switch (PaddedK(k)) {
+    case 4:
+      return Launch<T, 4>(kernel, stream, alloc_stream, input, output_scores, output_indices,
+                          rows, dimension, k, partition_size);
+    case 8:
+      return Launch<T, 8>(kernel, stream, alloc_stream, input, output_scores, output_indices,
+                          rows, dimension, k, partition_size);
+    case 16:
+      return Launch<T, 16>(kernel, stream, alloc_stream, input, output_scores, output_indices,
+                           rows, dimension, k, partition_size);
+    case 32:
+      return Launch<T, 32>(kernel, stream, alloc_stream, input, output_scores, output_indices,
+                           rows, dimension, k, partition_size);
+    case 64:
+      return Launch<T, 64>(kernel, stream, alloc_stream, input, output_scores, output_indices,
+                           rows, dimension, k, partition_size);
+    case 128:
+      return Launch<T, 128>(kernel, stream, alloc_stream, input, output_scores, output_indices,
+                            rows, dimension, k, partition_size);
+    default:
+      return Launch<T, 256>(kernel, stream, alloc_stream, input, output_scores, output_indices,
+                            rows, dimension, k, partition_size);
+  }
+}
+
+}  // namespace hybrid_topk
+}  // namespace cuda
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/cuda/math/topk_hybrid.cuh
+++ b/onnxruntime/core/providers/cuda/math/topk_hybrid.cuh
@@ -25,7 +25,7 @@ constexpr int kStage1Threads = 256;
 constexpr std::array<int, 4> kPartitionSizes = {1792, 2304, 2816, 3328};
 
 constexpr int DivUp(int value, int divisor) {
-  return (value + divisor - 1) / divisor;
+  return value / divisor + (value % divisor != 0);
 }
 
 constexpr int Max(int a, int b, int c) {
@@ -81,10 +81,11 @@ inline int PaddedK(int k) {
   return 256;
 }
 
-// H200 sweeps show that Hybrid consistently wins from this dimension for single-row K >= 16
-// and multi-row K >= 64. SmallK or RadixTopK is faster outside those regions, especially for K = 1.
+// H200 sweeps show that the K crossover rises with the row count. SmallK or RadixTopK is faster
+// outside these regions, especially for K = 1.
 inline bool IsPreferred(int64_t rows, int64_t dimension, int64_t k) {
-  return dimension >= 8192 && ((rows == 1 && k >= 16) || (rows > 1 && k >= 64));
+  return dimension >= 8192 &&
+         ((rows <= 2 && k >= 8) || (rows <= 4 && k >= 32) || (rows > 4 && k >= 64));
 }
 
 template <int K>

--- a/onnxruntime/core/providers/cuda/math/topk_hybrid.cuh
+++ b/onnxruntime/core/providers/cuda/math/topk_hybrid.cuh
@@ -268,19 +268,21 @@ __global__ void CooperativeReduce(int* indices1,
 }
 
 template <typename T>
-__global__ void WriteOutput(const float* scores,
+__global__ void WriteOutput(const T* input,
                             const int* indices,
                             T* output_scores,
                             int64_t* output_indices,
                             int rows,
+                            int dimension,
                             int k,
                             int stride) {
   const int row = blockIdx.x;
   if (row < rows && threadIdx.x < k) {
     const size_t input_offset = static_cast<size_t>(row) * stride + threadIdx.x;
     const size_t output_offset = static_cast<size_t>(row) * k + threadIdx.x;
-    output_scores[output_offset] = static_cast<T>(scores[input_offset]);
-    output_indices[output_offset] = indices[input_offset];
+    const int index = indices[input_offset];
+    output_scores[output_offset] = input[static_cast<size_t>(row) * dimension + index];
+    output_indices[output_offset] = index;
   }
 }
 
@@ -324,7 +326,8 @@ bool CheckCooperativeSupport(const CudaKernel* kernel, int rows, int num_partiti
 }
 
 inline bool IsSupported(const CudaKernel* kernel, int64_t rows, int64_t dimension, int64_t k) {
-  if (rows <= 0 || rows > kernel->GetDeviceProp().maxGridSize[1] ||
+  if (kernel->GetDeviceProp().cooperativeLaunch == 0 ||
+      rows <= 0 || rows > kernel->GetDeviceProp().maxGridSize[1] ||
       dimension <= 0 || dimension > std::numeric_limits<int>::max() || k <= 0 || k > kMaxK) {
     return false;
   }
@@ -401,10 +404,9 @@ Status Launch(const CudaKernel* kernel,
         dim3(block_size), args, 0, stream));
   }
 
-  const float* final_scores = (factors.steps == 1 || factors.steps == 3) ? scores2.get() : scores1.get();
   const int* final_indices = (factors.steps == 1 || factors.steps == 3) ? indices2.get() : indices1.get();
   WriteOutput<T><<<rows, K, 0, stream>>>(
-      final_scores, final_indices, output_scores, output_indices, rows, k, K);
+      input, final_indices, output_scores, output_indices, rows, dimension, k, K);
   return CUDA_CALL(cudaGetLastError());
 }
 

--- a/onnxruntime/core/providers/cuda/math/topk_impl.cuh
+++ b/onnxruntime/core/providers/cuda/math/topk_impl.cuh
@@ -6,7 +6,11 @@
 #include "core/providers/cuda/cu_inc/common.cuh"
 #include "core/providers/cuda/shared_inc/cuda_utils.h"
 #include "device_atomic_functions.h"
+#ifdef ORT_TOPK_ENABLE_HYBRID
+#include "topk_hybrid.cuh"
+#endif
 #include <limits>
+#include <type_traits>
 // TODO:fix the warnings
 #ifdef _MSC_VER
 #pragma warning(disable : 4244)
@@ -407,6 +411,143 @@ __global__ void RadixTopK(const T* X, T* V, int64_t* I, const TArray<int64_t> el
   }
 }
 
+// -----------------------------------------------------------------------------
+// Streaming small-K top-K for a long contiguous last axis.
+//
+// RadixTopK gives one CUDA block to each row and makes ~7 passes over it, so an LLM-sized
+// selection (K = 16 over a 248320-wide vocabulary, 8 rows) runs 8 blocks on a 132-SM device and
+// measures 1.36 ms on H200. This path instead makes ONE pass with a grid-wide split.
+//
+// Each warp keeps a 32-entry sorted-descending list, one entry per lane, of 64-bit composite
+// keys `(order_key << 32) | ~index`. The composite makes the comparison total: equal values are
+// broken towards the lower index, which is the tie order RadixTopK's BIGGER/SMALLER produce. An
+// element can only matter if it beats the current K-th entry, so the warp tests that with a
+// single ballot and skips the bitonic merge entirely for all but the first few thousand
+// elements. Warps merge through shared memory, blocks through a small candidate buffer that a
+// second single-warp kernel reduces.
+//
+// HybridTopK is preferred when supported, but this path also covers its gaps: smallest-element
+// selection (largest == 0), dimensions beyond HybridTopK's 256-partition limit (> 851968), and
+// grids that HybridTopK rejects because its cooperative reduction cannot satisfy residency.
+//
+// Restricted to float/half/bfloat16 on the last axis with K <= 32; everything else falls back.
+constexpr int64_t kSmallKTopKMaxK = 32;
+constexpr int kSmallKTopKThreads = 256;
+constexpr int kSmallKTopKMaxBlocksPerRow = 64;
+
+template <typename T>
+struct SmallKTopKSupported : std::false_type {};
+template <>
+struct SmallKTopKSupported<float> : std::true_type {};
+template <>
+struct SmallKTopKSupported<__half> : std::true_type {};
+template <>
+struct SmallKTopKSupported<BFloat16> : std::true_type {};
+
+// Monotone float -> uint32 map: ordering the bit patterns as unsigned integers reproduces the
+// float ordering (negatives are inverted, positives get their sign bit set).
+__device__ __forceinline__ uint32_t SmallKOrderKey(float v) {
+  const uint32_t u = __float_as_uint(v);
+  return (u & 0x80000000u) ? ~u : (u | 0x80000000u);
+}
+
+__device__ __forceinline__ float SmallKToFloat(float v) { return v; }
+__device__ __forceinline__ float SmallKToFloat(__half v) { return __half2float(v); }
+__device__ __forceinline__ float SmallKToFloat(BFloat16 v) { return static_cast<float>(v); }
+
+template <typename T>
+__device__ __forceinline__ uint64_t SmallKComposite(T value, int64_t index, int64_t largest) {
+  const uint32_t key = SmallKOrderKey(SmallKToFloat(value));
+  const uint32_t ordered = (1 == largest) ? key : ~key;
+  return (static_cast<uint64_t>(ordered) << 32) | static_cast<uint32_t>(~static_cast<uint32_t>(index));
+}
+
+// Sorts one value per lane into descending order across the warp.
+__device__ __forceinline__ uint64_t SmallKWarpSortDesc(uint64_t v) {
+  const int lane = static_cast<int>(threadIdx.x) & 31;
+#pragma unroll
+  for (int k = 2; k <= 32; k <<= 1) {
+#pragma unroll
+    for (int j = k >> 1; j > 0; j >>= 1) {
+      const uint64_t p = __shfl_xor_sync(0xffffffffu, v, j);
+      const bool desc_half = (lane & k) == 0;
+      const bool keep_larger = ((lane & j) == 0) == desc_half;
+      v = keep_larger ? (v > p ? v : p) : (v < p ? v : p);
+    }
+  }
+  return v;
+}
+
+// Keeps the 32 largest of two descending warp-sorted sequences (bitonic merge).
+__device__ __forceinline__ uint64_t SmallKWarpMergeDesc(uint64_t a, uint64_t b) {
+  const int lane = static_cast<int>(threadIdx.x) & 31;
+  const uint64_t br = __shfl_xor_sync(0xffffffffu, b, 31);
+  uint64_t m = a > br ? a : br;
+#pragma unroll
+  for (int j = 16; j > 0; j >>= 1) {
+    const uint64_t p = __shfl_xor_sync(0xffffffffu, m, j);
+    m = ((lane & j) == 0) ? (m > p ? m : p) : (m < p ? m : p);
+  }
+  return m;
+}
+
+template <typename T>
+__global__ void SmallKTopKPartial(const T* __restrict__ X, uint64_t* __restrict__ candidates,
+                                  int64_t dimension, int64_t K, int64_t largest, int blocks_per_row) {
+  __shared__ uint64_t warp_best[kSmallKTopKThreads];
+
+  const int row = static_cast<int>(blockIdx.y);
+  const int lane = static_cast<int>(threadIdx.x) & 31;
+  const int warp = static_cast<int>(threadIdx.x) >> 5;
+  const int warps = kSmallKTopKThreads >> 5;
+  const T* row_x = X + static_cast<size_t>(row) * dimension;
+
+  const int64_t stride = static_cast<int64_t>(blocks_per_row) * kSmallKTopKThreads;
+  uint64_t best = 0;
+  uint64_t threshold = 0;
+  for (int64_t base = static_cast<int64_t>(blockIdx.x) * kSmallKTopKThreads + threadIdx.x;
+       base - lane < dimension; base += stride) {
+    const uint64_t v = base < dimension ? SmallKComposite<T>(row_x[base], base, largest) : 0;
+    if (__any_sync(0xffffffffu, v > threshold)) {
+      best = SmallKWarpMergeDesc(best, SmallKWarpSortDesc(v));
+      threshold = __shfl_sync(0xffffffffu, best, static_cast<int>(K) - 1);
+    }
+  }
+
+  warp_best[warp * 32 + lane] = best;
+  __syncthreads();
+  if (warp != 0) {
+    return;
+  }
+  uint64_t m = warp_best[lane];
+  for (int w = 1; w < warps; ++w) {
+    m = SmallKWarpMergeDesc(m, warp_best[w * 32 + lane]);
+  }
+  if (lane < K) {
+    candidates[(static_cast<size_t>(row) * blocks_per_row + blockIdx.x) * K + lane] = m;
+  }
+}
+
+template <typename T>
+__global__ void SmallKTopKFinal(const T* __restrict__ X, T* __restrict__ V, int64_t* __restrict__ I,
+                                const uint64_t* __restrict__ candidates, int64_t dimension, int64_t K,
+                                int total_candidates) {
+  const int row = static_cast<int>(blockIdx.x);
+  const int lane = static_cast<int>(threadIdx.x);
+  const uint64_t* row_cand = candidates + static_cast<size_t>(row) * total_candidates;
+
+  uint64_t m = 0;
+  for (int base = 0; base < total_candidates; base += 32) {
+    const uint64_t v = (base + lane) < total_candidates ? row_cand[base + lane] : 0;
+    m = SmallKWarpMergeDesc(m, SmallKWarpSortDesc(v));
+  }
+  if (lane < K) {
+    const int64_t index = static_cast<int64_t>(~static_cast<uint32_t>(m & 0xffffffffu));
+    V[static_cast<size_t>(row) * K + lane] = X[static_cast<size_t>(row) * dimension + index];
+    I[static_cast<size_t>(row) * K + lane] = index;
+  }
+}
+
 template <typename T>
 __global__ void FillInput(const T* input_x, T* output_v, int64_t* output_i, const TArray<int64_t> elem_nums, size_t size, int32_t axis, int64_t K, int64_t offset, int64_t dimension) {
   CALCULATE_ELEMENTWISE_INDEX_OR_EXIT(id, dimension);
@@ -445,6 +586,36 @@ Status TopKImpl(const CudaKernel* kernel, bool use_deterministic_compute,
   using CubT = typename CubSortType<CudaT>::type;
   const CudaT* input_x_ptr = reinterpret_cast<const CudaT*>(input_x);
   CudaT* output_v_ptr = reinterpret_cast<CudaT*>(output_v);
+
+#ifdef ORT_TOPK_ENABLE_HYBRID
+  if constexpr (std::is_same_v<CudaT, float> || std::is_same_v<CudaT, __half> ||
+                std::is_same_v<CudaT, BFloat16>) {
+    if (axis == static_cast<int32_t>(size) - 1 && largest == 1 && sorted == 1 &&
+        hybrid_topk::IsSupported(kernel, N, dimension, K)) {
+      return hybrid_topk::Run(kernel, stream, alloc_stream, input_x_ptr, output_v_ptr, output_i,
+                              static_cast<int>(N), static_cast<int>(dimension), static_cast<int>(K));
+    }
+  }
+#endif
+
+  if constexpr (SmallKTopKSupported<CudaT>::value) {
+    if (axis == static_cast<int32_t>(size) - 1 && K >= 1 && K <= kSmallKTopKMaxK &&
+        dimension > 4096 && dimension <= static_cast<int64_t>(std::numeric_limits<int32_t>::max())) {
+      constexpr int64_t kElementsPerBlock = 16384;
+      int blocks_per_row = static_cast<int>((dimension + kElementsPerBlock - 1) / kElementsPerBlock);
+      blocks_per_row = blocks_per_row < 1 ? 1 : blocks_per_row;
+      blocks_per_row = blocks_per_row > kSmallKTopKMaxBlocksPerRow ? kSmallKTopKMaxBlocksPerRow : blocks_per_row;
+      const int total_candidates = blocks_per_row * static_cast<int>(K);
+      auto candidates = kernel->GetScratchBuffer<uint64_t>(
+          static_cast<size_t>(N) * total_candidates, alloc_stream);
+      const dim3 partial_grid{static_cast<unsigned>(blocks_per_row), static_cast<unsigned>(N)};
+      SmallKTopKPartial<CudaT><<<partial_grid, kSmallKTopKThreads, 0, stream>>>(
+          input_x_ptr, candidates.get(), dimension, K, largest, blocks_per_row);
+      SmallKTopKFinal<CudaT><<<static_cast<unsigned>(N), 32, 0, stream>>>(
+          input_x_ptr, output_v_ptr, output_i, candidates.get(), dimension, K, total_candidates);
+      return CUDA_CALL(cudaGetLastError());
+    }
+  }
 
   auto aligned_K = ALIGN(K);
   auto aligned_dimension = ALIGN(dimension);

--- a/onnxruntime/core/providers/cuda/math/topk_impl.cuh
+++ b/onnxruntime/core/providers/cuda/math/topk_impl.cuh
@@ -591,6 +591,7 @@ Status TopKImpl(const CudaKernel* kernel, bool use_deterministic_compute,
   if constexpr (std::is_same_v<CudaT, float> || std::is_same_v<CudaT, __half> ||
                 std::is_same_v<CudaT, BFloat16>) {
     if (axis == static_cast<int32_t>(size) - 1 && largest == 1 && sorted == 1 &&
+        hybrid_topk::IsPreferred(N, dimension, K) &&
         hybrid_topk::IsSupported(kernel, N, dimension, K)) {
       return hybrid_topk::Run(kernel, stream, alloc_stream, input_x_ptr, output_v_ptr, output_i,
                               static_cast<int>(N), static_cast<int>(dimension), static_cast<int>(K));

--- a/onnxruntime/core/providers/cuda/math/topk_impl.cuh
+++ b/onnxruntime/core/providers/cuda/math/topk_impl.cuh
@@ -465,6 +465,7 @@ Status TopKImpl(const CudaKernel* kernel, bool use_deterministic_compute,
 
   if constexpr (smallk_topk::Supported<CudaT>::value) {
     if (smallk_topk::IsSupported(kernel, axis, size, N, dimension, K)) {
+      // ONNX leaves output order unspecified when sorted == 0. SmallK keeps value order in both modes.
       return smallk_topk::Run(kernel, stream, alloc_stream, input_x_ptr, output_v_ptr, output_i,
                               N, dimension, K, largest);
     }

--- a/onnxruntime/core/providers/cuda/math/topk_impl.cuh
+++ b/onnxruntime/core/providers/cuda/math/topk_impl.cuh
@@ -443,17 +443,20 @@ template <>
 struct SmallKTopKSupported<__half> : std::true_type {};
 template <>
 struct SmallKTopKSupported<BFloat16> : std::true_type {};
+template <>
+struct SmallKTopKSupported<__nv_bfloat16> : std::true_type {};
 
 // Monotone float -> uint32 map: ordering the bit patterns as unsigned integers reproduces the
 // float ordering (negatives are inverted, positives get their sign bit set).
 __device__ __forceinline__ uint32_t SmallKOrderKey(float v) {
-  const uint32_t u = __float_as_uint(v);
+  const uint32_t u = v == 0.0f ? 0u : __float_as_uint(v);
   return (u & 0x80000000u) ? ~u : (u | 0x80000000u);
 }
 
 __device__ __forceinline__ float SmallKToFloat(float v) { return v; }
 __device__ __forceinline__ float SmallKToFloat(__half v) { return __half2float(v); }
 __device__ __forceinline__ float SmallKToFloat(BFloat16 v) { return static_cast<float>(v); }
+__device__ __forceinline__ float SmallKToFloat(__nv_bfloat16 v) { return __bfloat162float(v); }
 
 template <typename T>
 __device__ __forceinline__ uint64_t SmallKComposite(T value, int64_t index, int64_t largest) {
@@ -589,7 +592,7 @@ Status TopKImpl(const CudaKernel* kernel, bool use_deterministic_compute,
 
 #ifdef ORT_TOPK_ENABLE_HYBRID
   if constexpr (std::is_same_v<CudaT, float> || std::is_same_v<CudaT, __half> ||
-                std::is_same_v<CudaT, BFloat16>) {
+                std::is_same_v<CudaT, BFloat16> || std::is_same_v<CudaT, __nv_bfloat16>) {
     if (axis == static_cast<int32_t>(size) - 1 && largest == 1 && sorted == 1 &&
         hybrid_topk::IsPreferred(N, dimension, K) &&
         hybrid_topk::IsSupported(kernel, N, dimension, K)) {

--- a/onnxruntime/core/providers/cuda/math/topk_impl.cuh
+++ b/onnxruntime/core/providers/cuda/math/topk_impl.cuh
@@ -6,6 +6,7 @@
 #include "core/providers/cuda/cu_inc/common.cuh"
 #include "core/providers/cuda/shared_inc/cuda_utils.h"
 #include "device_atomic_functions.h"
+#include "topk_smallk.cuh"
 #ifdef ORT_TOPK_ENABLE_HYBRID
 #include "topk_hybrid.cuh"
 #endif
@@ -411,146 +412,6 @@ __global__ void RadixTopK(const T* X, T* V, int64_t* I, const TArray<int64_t> el
   }
 }
 
-// -----------------------------------------------------------------------------
-// Streaming small-K top-K for a long contiguous last axis.
-//
-// RadixTopK gives one CUDA block to each row and makes ~7 passes over it, so an LLM-sized
-// selection (K = 16 over a 248320-wide vocabulary, 8 rows) runs 8 blocks on a 132-SM device and
-// measures 1.36 ms on H200. This path instead makes ONE pass with a grid-wide split.
-//
-// Each warp keeps a 32-entry sorted-descending list, one entry per lane, of 64-bit composite
-// keys `(order_key << 32) | ~index`. The composite makes the comparison total: equal values are
-// broken towards the lower index, which is the tie order RadixTopK's BIGGER/SMALLER produce. An
-// element can only matter if it beats the current K-th entry, so the warp tests that with a
-// single ballot and skips the bitonic merge entirely for all but the first few thousand
-// elements. Warps merge through shared memory, blocks through a small candidate buffer that a
-// second single-warp kernel reduces.
-//
-// HybridTopK is preferred when supported, but this path also covers its gaps: smallest-element
-// selection (largest == 0), dimensions beyond HybridTopK's 256-partition limit (> 851968), and
-// grids that HybridTopK rejects because its cooperative reduction cannot satisfy residency.
-//
-// Restricted to float/half/bfloat16 on the last axis with K <= 32; everything else falls back.
-constexpr int64_t kSmallKTopKMaxK = 32;
-constexpr int kSmallKTopKThreads = 256;
-constexpr int kSmallKTopKMaxBlocksPerRow = 64;
-
-template <typename T>
-struct SmallKTopKSupported : std::false_type {};
-template <>
-struct SmallKTopKSupported<float> : std::true_type {};
-template <>
-struct SmallKTopKSupported<__half> : std::true_type {};
-template <>
-struct SmallKTopKSupported<BFloat16> : std::true_type {};
-template <>
-struct SmallKTopKSupported<__nv_bfloat16> : std::true_type {};
-
-// Monotone float -> uint32 map: ordering the bit patterns as unsigned integers reproduces the
-// float ordering (negatives are inverted, positives get their sign bit set).
-__device__ __forceinline__ uint32_t SmallKOrderKey(float v) {
-  const uint32_t u = v == 0.0f ? 0u : __float_as_uint(v);
-  return (u & 0x80000000u) ? ~u : (u | 0x80000000u);
-}
-
-__device__ __forceinline__ float SmallKToFloat(float v) { return v; }
-__device__ __forceinline__ float SmallKToFloat(__half v) { return __half2float(v); }
-__device__ __forceinline__ float SmallKToFloat(BFloat16 v) { return static_cast<float>(v); }
-__device__ __forceinline__ float SmallKToFloat(__nv_bfloat16 v) { return __bfloat162float(v); }
-
-template <typename T>
-__device__ __forceinline__ uint64_t SmallKComposite(T value, int64_t index, int64_t largest) {
-  const uint32_t key = SmallKOrderKey(SmallKToFloat(value));
-  const uint32_t ordered = (1 == largest) ? key : ~key;
-  return (static_cast<uint64_t>(ordered) << 32) | static_cast<uint32_t>(~static_cast<uint32_t>(index));
-}
-
-// Sorts one value per lane into descending order across the warp.
-__device__ __forceinline__ uint64_t SmallKWarpSortDesc(uint64_t v) {
-  const int lane = static_cast<int>(threadIdx.x) & 31;
-#pragma unroll
-  for (int k = 2; k <= 32; k <<= 1) {
-#pragma unroll
-    for (int j = k >> 1; j > 0; j >>= 1) {
-      const uint64_t p = __shfl_xor_sync(0xffffffffu, v, j);
-      const bool desc_half = (lane & k) == 0;
-      const bool keep_larger = ((lane & j) == 0) == desc_half;
-      v = keep_larger ? (v > p ? v : p) : (v < p ? v : p);
-    }
-  }
-  return v;
-}
-
-// Keeps the 32 largest of two descending warp-sorted sequences (bitonic merge).
-__device__ __forceinline__ uint64_t SmallKWarpMergeDesc(uint64_t a, uint64_t b) {
-  const int lane = static_cast<int>(threadIdx.x) & 31;
-  const uint64_t br = __shfl_xor_sync(0xffffffffu, b, 31);
-  uint64_t m = a > br ? a : br;
-#pragma unroll
-  for (int j = 16; j > 0; j >>= 1) {
-    const uint64_t p = __shfl_xor_sync(0xffffffffu, m, j);
-    m = ((lane & j) == 0) ? (m > p ? m : p) : (m < p ? m : p);
-  }
-  return m;
-}
-
-template <typename T>
-__global__ void SmallKTopKPartial(const T* __restrict__ X, uint64_t* __restrict__ candidates,
-                                  int64_t dimension, int64_t K, int64_t largest, int blocks_per_row) {
-  __shared__ uint64_t warp_best[kSmallKTopKThreads];
-
-  const int row = static_cast<int>(blockIdx.y);
-  const int lane = static_cast<int>(threadIdx.x) & 31;
-  const int warp = static_cast<int>(threadIdx.x) >> 5;
-  const int warps = kSmallKTopKThreads >> 5;
-  const T* row_x = X + static_cast<size_t>(row) * dimension;
-
-  const int64_t stride = static_cast<int64_t>(blocks_per_row) * kSmallKTopKThreads;
-  uint64_t best = 0;
-  uint64_t threshold = 0;
-  for (int64_t base = static_cast<int64_t>(blockIdx.x) * kSmallKTopKThreads + threadIdx.x;
-       base - lane < dimension; base += stride) {
-    const uint64_t v = base < dimension ? SmallKComposite<T>(row_x[base], base, largest) : 0;
-    if (__any_sync(0xffffffffu, v > threshold)) {
-      best = SmallKWarpMergeDesc(best, SmallKWarpSortDesc(v));
-      threshold = __shfl_sync(0xffffffffu, best, static_cast<int>(K) - 1);
-    }
-  }
-
-  warp_best[warp * 32 + lane] = best;
-  __syncthreads();
-  if (warp != 0) {
-    return;
-  }
-  uint64_t m = warp_best[lane];
-  for (int w = 1; w < warps; ++w) {
-    m = SmallKWarpMergeDesc(m, warp_best[w * 32 + lane]);
-  }
-  if (lane < K) {
-    candidates[(static_cast<size_t>(row) * blocks_per_row + blockIdx.x) * K + lane] = m;
-  }
-}
-
-template <typename T>
-__global__ void SmallKTopKFinal(const T* __restrict__ X, T* __restrict__ V, int64_t* __restrict__ I,
-                                const uint64_t* __restrict__ candidates, int64_t dimension, int64_t K,
-                                int total_candidates) {
-  const int row = static_cast<int>(blockIdx.x);
-  const int lane = static_cast<int>(threadIdx.x);
-  const uint64_t* row_cand = candidates + static_cast<size_t>(row) * total_candidates;
-
-  uint64_t m = 0;
-  for (int base = 0; base < total_candidates; base += 32) {
-    const uint64_t v = (base + lane) < total_candidates ? row_cand[base + lane] : 0;
-    m = SmallKWarpMergeDesc(m, SmallKWarpSortDesc(v));
-  }
-  if (lane < K) {
-    const int64_t index = static_cast<int64_t>(~static_cast<uint32_t>(m & 0xffffffffu));
-    V[static_cast<size_t>(row) * K + lane] = X[static_cast<size_t>(row) * dimension + index];
-    I[static_cast<size_t>(row) * K + lane] = index;
-  }
-}
-
 template <typename T>
 __global__ void FillInput(const T* input_x, T* output_v, int64_t* output_i, const TArray<int64_t> elem_nums, size_t size, int32_t axis, int64_t K, int64_t offset, int64_t dimension) {
   CALCULATE_ELEMENTWISE_INDEX_OR_EXIT(id, dimension);
@@ -602,22 +463,10 @@ Status TopKImpl(const CudaKernel* kernel, bool use_deterministic_compute,
   }
 #endif
 
-  if constexpr (SmallKTopKSupported<CudaT>::value) {
-    if (axis == static_cast<int32_t>(size) - 1 && K >= 1 && K <= kSmallKTopKMaxK &&
-        dimension > 4096 && dimension <= static_cast<int64_t>(std::numeric_limits<int32_t>::max())) {
-      constexpr int64_t kElementsPerBlock = 16384;
-      int blocks_per_row = static_cast<int>((dimension + kElementsPerBlock - 1) / kElementsPerBlock);
-      blocks_per_row = blocks_per_row < 1 ? 1 : blocks_per_row;
-      blocks_per_row = blocks_per_row > kSmallKTopKMaxBlocksPerRow ? kSmallKTopKMaxBlocksPerRow : blocks_per_row;
-      const int total_candidates = blocks_per_row * static_cast<int>(K);
-      auto candidates = kernel->GetScratchBuffer<uint64_t>(
-          static_cast<size_t>(N) * total_candidates, alloc_stream);
-      const dim3 partial_grid{static_cast<unsigned>(blocks_per_row), static_cast<unsigned>(N)};
-      SmallKTopKPartial<CudaT><<<partial_grid, kSmallKTopKThreads, 0, stream>>>(
-          input_x_ptr, candidates.get(), dimension, K, largest, blocks_per_row);
-      SmallKTopKFinal<CudaT><<<static_cast<unsigned>(N), 32, 0, stream>>>(
-          input_x_ptr, output_v_ptr, output_i, candidates.get(), dimension, K, total_candidates);
-      return CUDA_CALL(cudaGetLastError());
+  if constexpr (smallk_topk::Supported<CudaT>::value) {
+    if (smallk_topk::IsSupported(kernel, axis, size, N, dimension, K)) {
+      return smallk_topk::Run(kernel, stream, alloc_stream, input_x_ptr, output_v_ptr, output_i,
+                              N, dimension, K, largest);
     }
   }
 

--- a/onnxruntime/core/providers/cuda/math/topk_impl_bf16.cu
+++ b/onnxruntime/core/providers/cuda/math/topk_impl_bf16.cu
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+#define ORT_TOPK_ENABLE_HYBRID
 #define TOPK_IMPL_TYPE BFloat16
 #include "topk_impl.cuh"

--- a/onnxruntime/core/providers/cuda/math/topk_impl_f16.cu
+++ b/onnxruntime/core/providers/cuda/math/topk_impl_f16.cu
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+#define ORT_TOPK_ENABLE_HYBRID
 #define TOPK_IMPL_TYPE MLFloat16
 #include "topk_impl.cuh"

--- a/onnxruntime/core/providers/cuda/math/topk_impl_f32.cu
+++ b/onnxruntime/core/providers/cuda/math/topk_impl_f32.cu
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+#define ORT_TOPK_ENABLE_HYBRID
 #define TOPK_IMPL_TYPE float
 #include "topk_impl.cuh"

--- a/onnxruntime/core/providers/cuda/math/topk_smallk.cuh
+++ b/onnxruntime/core/providers/cuda/math/topk_smallk.cuh
@@ -1,0 +1,196 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+// Streaming small-K top-K for a long contiguous last axis.
+//
+// RadixTopK gives one CUDA block to each row and makes ~7 passes over it, so an LLM-sized
+// selection (K = 16 over a 248320-wide vocabulary, 8 rows) runs 8 blocks on a 132-SM device and
+// measures 1.36 ms on H200. This path instead makes ONE pass with a grid-wide split.
+//
+// Each warp keeps a 32-entry sorted-descending list, one entry per lane, of 64-bit composite
+// keys `(order_key << 32) | ~index`. The composite makes the comparison total: equal values are
+// broken towards the lower index, which is the tie order RadixTopK's BIGGER/SMALLER produce. An
+// element can only matter if it beats the current K-th entry, so the warp tests that with a
+// single ballot and skips the bitonic merge entirely for all but the first few thousand
+// elements. Warps merge through shared memory, blocks through a small candidate buffer that a
+// second single-warp kernel reduces.
+//
+// HybridTopK is preferred when supported, but this path also covers its gaps: smallest-element
+// selection (largest == 0), dimensions beyond HybridTopK's 256-partition limit (> 851968), and
+// grids that HybridTopK rejects because its cooperative reduction cannot satisfy residency.
+//
+// Restricted to float/half/bfloat16 on the last axis with K <= 32; everything else falls back.
+
+#pragma once
+
+#include <cstdint>
+#include <limits>
+#include <type_traits>
+
+#include "core/providers/cuda/cu_inc/common.cuh"
+#include "topk_impl.h"
+
+namespace onnxruntime {
+namespace cuda {
+namespace smallk_topk {
+
+constexpr int64_t kMaxK = 32;
+constexpr int64_t kMinDimension = 4096;
+constexpr int64_t kElementsPerBlock = 16384;
+constexpr int kThreads = 256;
+constexpr int kMaxBlocksPerRow = 64;
+
+template <typename T>
+struct Supported : std::false_type {};
+template <>
+struct Supported<float> : std::true_type {};
+template <>
+struct Supported<__half> : std::true_type {};
+template <>
+struct Supported<BFloat16> : std::true_type {};
+template <>
+struct Supported<__nv_bfloat16> : std::true_type {};
+
+// Monotone float -> uint32 map: ordering the bit patterns as unsigned integers reproduces the
+// float ordering (negatives are inverted, positives get their sign bit set).
+__device__ __forceinline__ uint32_t OrderKey(float v) {
+  const uint32_t u = v == 0.0f ? 0u : __float_as_uint(v);
+  return (u & 0x80000000u) ? ~u : (u | 0x80000000u);
+}
+
+__device__ __forceinline__ float ToFloat(float v) { return v; }
+__device__ __forceinline__ float ToFloat(__half v) { return __half2float(v); }
+__device__ __forceinline__ float ToFloat(BFloat16 v) { return static_cast<float>(v); }
+__device__ __forceinline__ float ToFloat(__nv_bfloat16 v) { return __bfloat162float(v); }
+
+template <typename T>
+__device__ __forceinline__ uint64_t Composite(T value, int64_t index, int64_t largest) {
+  const uint32_t key = OrderKey(ToFloat(value));
+  const uint32_t ordered = (1 == largest) ? key : ~key;
+  return (static_cast<uint64_t>(ordered) << 32) | static_cast<uint32_t>(~static_cast<uint32_t>(index));
+}
+
+// Sorts one value per lane into descending order across the warp.
+__device__ __forceinline__ uint64_t WarpSortDescending(uint64_t v) {
+  const int lane = static_cast<int>(threadIdx.x) & 31;
+#pragma unroll
+  for (int k = 2; k <= 32; k <<= 1) {
+#pragma unroll
+    for (int j = k >> 1; j > 0; j >>= 1) {
+      const uint64_t p = __shfl_xor_sync(0xffffffffu, v, j);
+      const bool desc_half = (lane & k) == 0;
+      const bool keep_larger = ((lane & j) == 0) == desc_half;
+      v = keep_larger ? (v > p ? v : p) : (v < p ? v : p);
+    }
+  }
+  return v;
+}
+
+// Keeps the 32 largest of two descending warp-sorted sequences (bitonic merge).
+__device__ __forceinline__ uint64_t WarpMergeDescending(uint64_t a, uint64_t b) {
+  const int lane = static_cast<int>(threadIdx.x) & 31;
+  const uint64_t br = __shfl_xor_sync(0xffffffffu, b, 31);
+  uint64_t m = a > br ? a : br;
+#pragma unroll
+  for (int j = 16; j > 0; j >>= 1) {
+    const uint64_t p = __shfl_xor_sync(0xffffffffu, m, j);
+    m = ((lane & j) == 0) ? (m > p ? m : p) : (m < p ? m : p);
+  }
+  return m;
+}
+
+template <typename T>
+__global__ void PartialTopK(const T* __restrict__ X, uint64_t* __restrict__ candidates,
+                            int64_t dimension, int64_t K, int64_t largest, int blocks_per_row) {
+  __shared__ uint64_t warp_best[kThreads];
+
+  const int row = static_cast<int>(blockIdx.y);
+  const int lane = static_cast<int>(threadIdx.x) & 31;
+  const int warp = static_cast<int>(threadIdx.x) >> 5;
+  const int warps = kThreads >> 5;
+  const T* row_x = X + static_cast<size_t>(row) * dimension;
+
+  const int64_t stride = static_cast<int64_t>(blocks_per_row) * kThreads;
+  uint64_t best = 0;
+  uint64_t threshold = 0;
+  for (int64_t base = static_cast<int64_t>(blockIdx.x) * kThreads + threadIdx.x;
+       base - lane < dimension; base += stride) {
+    const uint64_t v = base < dimension ? Composite<T>(row_x[base], base, largest) : 0;
+    if (__any_sync(0xffffffffu, v > threshold)) {
+      best = WarpMergeDescending(best, WarpSortDescending(v));
+      threshold = __shfl_sync(0xffffffffu, best, static_cast<int>(K) - 1);
+    }
+  }
+
+  warp_best[warp * 32 + lane] = best;
+  __syncthreads();
+  if (warp != 0) {
+    return;
+  }
+  uint64_t m = warp_best[lane];
+  for (int w = 1; w < warps; ++w) {
+    m = WarpMergeDescending(m, warp_best[w * 32 + lane]);
+  }
+  if (lane < K) {
+    candidates[(static_cast<size_t>(row) * blocks_per_row + blockIdx.x) * K + lane] = m;
+  }
+}
+
+template <typename T>
+__global__ void FinalTopK(const T* __restrict__ X, T* __restrict__ V, int64_t* __restrict__ I,
+                          const uint64_t* __restrict__ candidates, int64_t dimension, int64_t K,
+                          int total_candidates) {
+  const int row = static_cast<int>(blockIdx.x);
+  const int lane = static_cast<int>(threadIdx.x);
+  const uint64_t* row_cand = candidates + static_cast<size_t>(row) * total_candidates;
+
+  uint64_t m = 0;
+  for (int base = 0; base < total_candidates; base += 32) {
+    const uint64_t v = (base + lane) < total_candidates ? row_cand[base + lane] : 0;
+    m = WarpMergeDescending(m, WarpSortDescending(v));
+  }
+  if (lane < K) {
+    const int64_t index = static_cast<int64_t>(~static_cast<uint32_t>(m & 0xffffffffu));
+    V[static_cast<size_t>(row) * K + lane] = X[static_cast<size_t>(row) * dimension + index];
+    I[static_cast<size_t>(row) * K + lane] = index;
+  }
+}
+
+inline bool IsSupported(const CudaKernel* kernel, int32_t axis, size_t size,
+                        int64_t rows, int64_t dimension, int64_t k) {
+  // The partial pass maps rows onto grid.y, which is far more constrained than grid.x.
+  return axis == static_cast<int32_t>(size) - 1 &&
+         k >= 1 && k <= kMaxK &&
+         dimension > kMinDimension && dimension <= static_cast<int64_t>(std::numeric_limits<int32_t>::max()) &&
+         rows >= 1 && rows <= static_cast<int64_t>(kernel->GetDeviceProp().maxGridSize[1]);
+}
+
+template <typename T>
+Status Run(const CudaKernel* kernel,
+           cudaStream_t stream,
+           void* alloc_stream,
+           const T* input,
+           T* output_v,
+           int64_t* output_i,
+           int64_t rows,
+           int64_t dimension,
+           int64_t k,
+           int64_t largest) {
+  int blocks_per_row = static_cast<int>((dimension + kElementsPerBlock - 1) / kElementsPerBlock);
+  blocks_per_row = blocks_per_row < 1 ? 1 : blocks_per_row;
+  blocks_per_row = blocks_per_row > kMaxBlocksPerRow ? kMaxBlocksPerRow : blocks_per_row;
+  const int total_candidates = blocks_per_row * static_cast<int>(k);
+  auto candidates = kernel->GetScratchBuffer<uint64_t>(
+      SafeInt<size_t>(rows) * total_candidates, alloc_stream);
+
+  const dim3 partial_grid{static_cast<unsigned>(blocks_per_row), static_cast<unsigned>(rows)};
+  PartialTopK<T><<<partial_grid, kThreads, 0, stream>>>(
+      input, candidates.get(), dimension, k, largest, blocks_per_row);
+  FinalTopK<T><<<static_cast<unsigned>(rows), 32, 0, stream>>>(
+      input, output_v, output_i, candidates.get(), dimension, k, total_candidates);
+  return CUDA_CALL(cudaGetLastError());
+}
+
+}  // namespace smallk_topk
+}  // namespace cuda
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/cuda/plugin/cuda_kernel_adapter.h
+++ b/onnxruntime/core/providers/cuda/plugin/cuda_kernel_adapter.h
@@ -857,6 +857,20 @@ struct _IsInf<nv_bfloat16, detect_positive, detect_negative> {
     }
   }
 };
+
+// cuda_utils.h only specializes NumericLimits for onnxruntime::BFloat16. Without this the plugin's
+// nv_bfloat16 mapping falls back to std::numeric_limits, whose primary template returns 0, so
+// kernels that pad with Lowest() (TopK, reductions) rank the padding above every negative input.
+template <>
+struct NumericLimits<nv_bfloat16> {
+  __inline__ __host__ __device__ static nv_bfloat16 Lowest() {
+    return __nv_bfloat16_raw{0xFF7FU};  // -3.38953139e38
+  }
+
+  __inline__ __host__ __device__ static nv_bfloat16 Max() {
+    return __nv_bfloat16_raw{0x7F7FU};  // 3.38953139e38
+  }
+};
 #endif
 
 // ===================================================================

--- a/onnxruntime/test/providers/cpu/math/topk_op_test.cc
+++ b/onnxruntime/test/providers/cpu/math/topk_op_test.cc
@@ -3,6 +3,7 @@
 
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
+#include "core/session/onnxruntime_session_options_config_keys.h"
 #include "test/providers/provider_test_utils.h"
 #include "test/common/cuda_op_test_utils.h"
 
@@ -22,7 +23,8 @@ static void RunTest(int op_set,
                     int64_t largest = 1,
                     int64_t sorted = 1,
                     OpTester::ExpectResult expect_result = OpTester::ExpectResult::kExpectSuccess,
-                    const std::string& expected_err_str = "") {
+                    const std::string& expected_err_str = "",
+                    bool cuda_only = false) {
   OpTester test("TopK", op_set);
 
   // Attributes
@@ -53,6 +55,12 @@ static void RunTest(int op_set,
   std::unordered_set<std::string> excluded_providers;
   if (!is_tensorrt_supported) {
     excluded_providers.insert(kTensorrtExecutionProvider);  // Disable TensorRT because of unsupported data types
+  }
+  if (cuda_only) {
+    SessionOptions session_options;
+    ASSERT_STATUS_OK(session_options.config_options.AddConfigEntry(kOrtSessionOptionsDisableCPUEPFallback, "1"));
+    test.Config(session_options).ConfigEp(DefaultCudaExecutionProvider()).RunWithConfig();
+    return;
   }
   test.Run(expect_result, expected_err_str, excluded_providers);
 }
@@ -868,6 +876,7 @@ TEST(TopKOperator, Top3AllSame) {
   top_3_explicit_axis<double>(11, 0);
 }
 
+#ifdef USE_CUDA
 template <typename T>
 static void RunStableHybridTopKCases(int opset_version,
                                      const std::initializer_list<std::pair<int64_t, int64_t>>& cases) {
@@ -878,7 +887,8 @@ static void RunStableHybridTopKCases(int opset_version,
     std::iota(expected_indices.begin(), expected_indices.end(), 0);
     SCOPED_TRACE("opset=" + std::to_string(opset_version) +
                  ", dimension=" + std::to_string(dimension) + ", k=" + std::to_string(k));
-    RunTest(opset_version, k, input_vals, {1, dimension}, expected_vals, expected_indices, {1, k}, false);
+    RunTest(opset_version, k, input_vals, {1, dimension}, expected_vals, expected_indices, {1, k}, false,
+            -1, 1, 1, OpTester::ExpectResult::kExpectSuccess, "", true);
   }
 }
 
@@ -912,7 +922,8 @@ TEST(TopKOperator, StableSmallKBFloat16Smallest) {
   std::vector<BFloat16> expected_vals(k, BFloat16(1.0f));
   std::vector<int64_t> expected_indices(k);
   std::iota(expected_indices.begin(), expected_indices.end(), 0);
-  RunTest(24, k, input_vals, {1, dimension}, expected_vals, expected_indices, {1, k}, false, -1, 0);
+  RunTest(24, k, input_vals, {1, dimension}, expected_vals, expected_indices, {1, k}, false,
+          -1, 0, 1, OpTester::ExpectResult::kExpectSuccess, "", true);
 }
 
 static void RunStableSignedZeroTopKCase(int64_t dimension, int64_t k, int64_t largest) {
@@ -923,7 +934,8 @@ static void RunStableSignedZeroTopKCase(int64_t dimension, int64_t k, int64_t la
   std::vector<float> expected_vals(k, 0.0f);
   std::vector<int64_t> expected_indices(k);
   std::iota(expected_indices.begin(), expected_indices.end(), 0);
-  RunTest(11, k, input_vals, {1, dimension}, expected_vals, expected_indices, {1, k}, false, -1, largest);
+  RunTest(11, k, input_vals, {1, dimension}, expected_vals, expected_indices, {1, k}, false,
+          -1, largest, 1, OpTester::ExpectResult::kExpectSuccess, "", true);
 }
 
 TEST(TopKOperator, StableHybridSignedZero) {
@@ -934,6 +946,7 @@ TEST(TopKOperator, StableSmallKSignedZero) {
   RunStableSignedZeroTopKCase(5000, 16, 1);
   RunStableSignedZeroTopKCase(5000, 16, 0);
 }
+#endif
 
 template <typename T>
 static void TestThreaded(int64_t k, int64_t n, int64_t batch_size) {

--- a/onnxruntime/test/providers/cpu/math/topk_op_test.cc
+++ b/onnxruntime/test/providers/cpu/math/topk_op_test.cc
@@ -915,6 +915,26 @@ TEST(TopKOperator, StableSmallKBFloat16Smallest) {
   RunTest(24, k, input_vals, {1, dimension}, expected_vals, expected_indices, {1, k}, false, -1, 0);
 }
 
+static void RunStableSignedZeroTopKCase(int64_t dimension, int64_t k, int64_t largest) {
+  std::vector<float> input_vals(dimension, largest == 1 ? -1.0f : 1.0f);
+  for (int64_t i = 0; i < 2 * k; ++i) {
+    input_vals[i] = i % 2 == 0 ? -0.0f : 0.0f;
+  }
+  std::vector<float> expected_vals(k, 0.0f);
+  std::vector<int64_t> expected_indices(k);
+  std::iota(expected_indices.begin(), expected_indices.end(), 0);
+  RunTest(11, k, input_vals, {1, dimension}, expected_vals, expected_indices, {1, k}, false, -1, largest);
+}
+
+TEST(TopKOperator, StableHybridSignedZero) {
+  RunStableSignedZeroTopKCase(8192, 8, 1);
+}
+
+TEST(TopKOperator, StableSmallKSignedZero) {
+  RunStableSignedZeroTopKCase(5000, 16, 1);
+  RunStableSignedZeroTopKCase(5000, 16, 0);
+}
+
 template <typename T>
 static void TestThreaded(int64_t k, int64_t n, int64_t batch_size) {
   std::vector<T> input_vals(n * batch_size, 0.0f);

--- a/onnxruntime/test/providers/cpu/math/topk_op_test.cc
+++ b/onnxruntime/test/providers/cpu/math/topk_op_test.cc
@@ -869,6 +869,53 @@ TEST(TopKOperator, Top3AllSame) {
 }
 
 template <typename T>
+static void RunStableHybridTopKCases(int opset_version,
+                                     const std::initializer_list<std::pair<int64_t, int64_t>>& cases) {
+  for (const auto& [dimension, k] : cases) {
+    std::vector<T> input_vals(dimension, T(1.0f));
+    std::vector<T> expected_vals(k, T(1.0f));
+    std::vector<int64_t> expected_indices(k);
+    std::iota(expected_indices.begin(), expected_indices.end(), 0);
+    SCOPED_TRACE("opset=" + std::to_string(opset_version) +
+                 ", dimension=" + std::to_string(dimension) + ", k=" + std::to_string(k));
+    RunTest(opset_version, k, input_vals, {1, dimension}, expected_vals, expected_indices, {1, k}, false);
+  }
+}
+
+TEST(TopKOperator, StableHybridLargeLastAxis) {
+  RunStableHybridTopKCases<float>(11, {{5000, 4},
+                                       {5000, 5},
+                                       {30000, 16},
+                                       {30000, 17},
+                                       {60000, 32},
+                                       {120000, 33},
+                                       {120000, 64},
+                                       {248320, 65},
+                                       {248320, 128},
+                                       {500000, 129},
+                                       {500000, 256},
+                                       {248320, 16}});
+}
+
+TEST(TopKOperator, StableHybridHalfLargeLastAxis) {
+  RunStableHybridTopKCases<MLFloat16>(11, {{248320, 16}, {248320, 65}, {500000, 256}});
+}
+
+TEST(TopKOperator, StableHybridBFloat16LargeLastAxis) {
+  RunStableHybridTopKCases<BFloat16>(24, {{248320, 16}, {248320, 65}, {500000, 256}});
+}
+
+TEST(TopKOperator, StableSmallKBFloat16Smallest) {
+  constexpr int64_t dimension = 5000;
+  constexpr int64_t k = 16;
+  std::vector<BFloat16> input_vals(dimension, BFloat16(1.0f));
+  std::vector<BFloat16> expected_vals(k, BFloat16(1.0f));
+  std::vector<int64_t> expected_indices(k);
+  std::iota(expected_indices.begin(), expected_indices.end(), 0);
+  RunTest(24, k, input_vals, {1, dimension}, expected_vals, expected_indices, {1, k}, false, -1, 0);
+}
+
+template <typename T>
 static void TestThreaded(int64_t k, int64_t n, int64_t batch_size) {
   std::vector<T> input_vals(n * batch_size, 0.0f);
   std::iota(input_vals.begin(), input_vals.end(), 0.0f);

--- a/onnxruntime/test/providers/cpu/math/topk_op_test.cc
+++ b/onnxruntime/test/providers/cpu/math/topk_op_test.cc
@@ -1,6 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+#include <cmath>
+#include <limits>
+
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 #include "core/session/onnxruntime_session_options_config_keys.h"
@@ -935,14 +938,23 @@ static void RunExactCudaTopKCase(const std::vector<float>& input_vals,
   test.AddOutput<float>("Values", {1, k}, expected_vals);
   test.AddOutput<int64_t>("Indices", {1, k}, expected_indices);
   test.SetCustomOutputVerifier(
-      [expected_vals, expected_indices, check_zero_sign](const std::vector<OrtValue>& fetches,
-                                                         const std::string& /*provider_type*/) {
+      [expected_vals, expected_indices, check_zero_sign, dimension](const std::vector<OrtValue>& fetches,
+                                                                    const std::string& /*provider_type*/) {
         ASSERT_EQ(fetches.size(), 2u);
         const auto* values = fetches[0].Get<Tensor>().Data<float>();
         const auto* indices = fetches[1].Get<Tensor>().Data<int64_t>();
         for (size_t i = 0; i < expected_vals.size(); ++i) {
-          EXPECT_EQ(values[i], expected_vals[i]);
+          if (std::isnan(expected_vals[i])) {
+            EXPECT_TRUE(std::isnan(values[i]));
+          } else {
+            EXPECT_EQ(values[i], expected_vals[i]);
+          }
           EXPECT_EQ(indices[i], expected_indices[i]);
+          EXPECT_GE(indices[i], 0);
+          EXPECT_LT(indices[i], dimension);
+          for (size_t j = 0; j < i; ++j) {
+            EXPECT_NE(indices[i], indices[j]);
+          }
           if (check_zero_sign) {
             EXPECT_EQ(std::signbit(values[i]), std::signbit(expected_vals[i]));
           }
@@ -967,6 +979,26 @@ static void RunScatteredCudaTopKCase(int64_t dimension,
 
 TEST(TopKOperator, HybridScatteredWinners) {
   RunScatteredCudaTopKCase(20000, {19999, 17, 4095, 8193, 12001, 2000, 16000, 6001});
+}
+
+TEST(TopKOperator, HybridNaNUsesStablePackedOrdering) {
+  constexpr int64_t dimension = 248320;
+  constexpr int64_t k = 8;
+  constexpr int64_t nan_index = 12345;
+  std::vector<float> input_vals(dimension);
+  for (int64_t i = 0; i < dimension; ++i) {
+    input_vals[i] = static_cast<float>(i % 201 - 100);
+  }
+  input_vals[nan_index] = std::numeric_limits<float>::quiet_NaN();
+
+  RunExactCudaTopKCase(input_vals,
+                       {std::numeric_limits<float>::quiet_NaN(), 100.0f, 100.0f, 100.0f,
+                        100.0f, 100.0f, 100.0f, 100.0f},
+                       {nan_index, 200, 401, 602, 803, 1004, 1205, 1406});
+
+  const float negative_nan = -std::numeric_limits<float>::quiet_NaN();
+  std::fill(input_vals.begin(), input_vals.end(), negative_nan);
+  RunExactCudaTopKCase(input_vals, std::vector<float>(k, negative_nan), {0, 1, 2, 3, 4, 5, 6, 7});
 }
 
 TEST(TopKOperator, SmallKScatteredWinners) {

--- a/onnxruntime/test/providers/cpu/math/topk_op_test.cc
+++ b/onnxruntime/test/providers/cpu/math/topk_op_test.cc
@@ -915,6 +915,74 @@ TEST(TopKOperator, StableHybridBFloat16LargeLastAxis) {
   RunStableHybridTopKCases<BFloat16>(24, {{248320, 16}, {248320, 65}, {500000, 256}});
 }
 
+static void RunExactCudaTopKCase(const std::vector<float>& input_vals,
+                                 const std::vector<float>& expected_vals,
+                                 const std::vector<int64_t>& expected_indices,
+                                 int64_t sorted = 1,
+                                 bool check_zero_sign = false,
+                                 int64_t largest = 1) {
+  const int64_t dimension = static_cast<int64_t>(input_vals.size());
+  const int64_t k = static_cast<int64_t>(expected_vals.size());
+  OpTester test("TopK", 11);
+  if (sorted == 0) {
+    test.AddAttribute("sorted", sorted);
+  }
+  if (largest == 0) {
+    test.AddAttribute("largest", largest);
+  }
+  test.AddInput<float>("X", {1, dimension}, input_vals);
+  test.AddInput<int64_t>("K", {1}, {k});
+  test.AddOutput<float>("Values", {1, k}, expected_vals);
+  test.AddOutput<int64_t>("Indices", {1, k}, expected_indices);
+  test.SetCustomOutputVerifier(
+      [expected_vals, expected_indices, check_zero_sign](const std::vector<OrtValue>& fetches,
+                                                         const std::string& /*provider_type*/) {
+        ASSERT_EQ(fetches.size(), 2u);
+        const auto* values = fetches[0].Get<Tensor>().Data<float>();
+        const auto* indices = fetches[1].Get<Tensor>().Data<int64_t>();
+        for (size_t i = 0; i < expected_vals.size(); ++i) {
+          EXPECT_EQ(values[i], expected_vals[i]);
+          EXPECT_EQ(indices[i], expected_indices[i]);
+          if (check_zero_sign) {
+            EXPECT_EQ(std::signbit(values[i]), std::signbit(expected_vals[i]));
+          }
+        }
+      });
+
+  SessionOptions session_options;
+  ASSERT_STATUS_OK(session_options.config_options.AddConfigEntry(kOrtSessionOptionsDisableCPUEPFallback, "1"));
+  test.Config(session_options).ConfigEp(DefaultCudaExecutionProvider()).RunWithConfig();
+}
+
+static void RunScatteredCudaTopKCase(int64_t dimension,
+                                     const std::vector<int64_t>& expected_indices) {
+  std::vector<float> input_vals(dimension, -1000.0f);
+  std::vector<float> expected_vals(expected_indices.size());
+  for (size_t i = 0; i < expected_indices.size(); ++i) {
+    expected_vals[i] = 100.0f - static_cast<float>(i);
+    input_vals[expected_indices[i]] = expected_vals[i];
+  }
+  RunExactCudaTopKCase(input_vals, expected_vals, expected_indices);
+}
+
+TEST(TopKOperator, HybridScatteredWinners) {
+  RunScatteredCudaTopKCase(20000, {19999, 17, 4095, 8193, 12001, 2000, 16000, 6001});
+}
+
+TEST(TopKOperator, SmallKScatteredWinners) {
+  RunScatteredCudaTopKCase(50000, {17, 17000, 33000, 49999});
+}
+
+TEST(TopKOperator, SmallKUnsortedUsesValueOrder) {
+  constexpr int64_t dimension = 5000;
+  std::vector<float> input_vals(dimension, -1000.0f);
+  input_vals[4000] = 7.0f;
+  input_vals[1000] = 10.0f;
+  input_vals[3000] = 8.0f;
+  input_vals[2000] = 9.0f;
+  RunExactCudaTopKCase(input_vals, {10.0f, 9.0f, 8.0f, 7.0f}, {1000, 2000, 3000, 4000}, 0);
+}
+
 TEST(TopKOperator, StableSmallKBFloat16Smallest) {
   constexpr int64_t dimension = 5000;
   constexpr int64_t k = 16;
@@ -931,11 +999,10 @@ static void RunStableSignedZeroTopKCase(int64_t dimension, int64_t k, int64_t la
   for (int64_t i = 0; i < 2 * k; ++i) {
     input_vals[i] = i % 2 == 0 ? -0.0f : 0.0f;
   }
-  std::vector<float> expected_vals(k, 0.0f);
+  std::vector<float> expected_vals(input_vals.begin(), input_vals.begin() + k);
   std::vector<int64_t> expected_indices(k);
   std::iota(expected_indices.begin(), expected_indices.end(), 0);
-  RunTest(11, k, input_vals, {1, dimension}, expected_vals, expected_indices, {1, k}, false,
-          -1, largest, 1, OpTester::ExpectResult::kExpectSuccess, "", true);
+  RunExactCudaTopKCase(input_vals, expected_vals, expected_indices, 1, true, largest);
 }
 
 TEST(TopKOperator, StableHybridSignedZero) {


### PR DESCRIPTION
### Description

Optimize CUDA TopK for wide contiguous last axes. This adds a streaming small-K implementation and a stable Hybrid implementation ported from ONNX Runtime GenAI for float, float16, and bfloat16.

Each fast path lives in its own header and exposes the same `IsSupported` / `Run` pair, so `topk_impl.cuh` only holds the dispatch order and the pre-existing fallbacks:

| Header | Path |
|---|---|
| `math/topk_hybrid.cuh` | Partitioned + cooperative-reduction Hybrid TopK |
| `math/topk_smallk.cuh` | Streaming small-K TopK |
| `cu_inc/topk_warp_sort.cuh` | Shared warp-level sort/pack primitives |

The Hybrid path handles sorted largest-element selection with K up to 256. It partitions each row, performs stable packed-key block radix sorts, and cooperatively reduces partition candidates. It dynamically selects partition sizes, padded K specializations, and one- to three-step reduction plans.

The streaming small-K path handles K up to 32 and remains as a fallback for smallest-element selection, dimensions beyond Hybrid's 256-partition limit, and grids that cannot satisfy cooperative-launch residency. Other unsupported configurations continue through the existing CUDA TopK implementations.

Stable ties are ordered by ascending source index. The regression test covers padded-K boundaries from 4 through 256 and one-, two-, and three-step reductions.

### Motivation and Context

The existing CUDA TopK implementation assigns one block to each row and scans a wide axis multiple times. This underutilizes the GPU for LLM sampling workloads with few rows and large vocabularies.

On an NVIDIA H200 with CUDA 13, for one FP32 row with dimension 248,320 and K=16:

| Implementation | Mean device time |
|---|---:|
| Existing ORT CUDA TopK | 1.36 ms |
| Hybrid TopK | 25.33 us |

The Hybrid measurement contains 100 calls captured with Nsight Systems: partition selection averaged 16.13 us, cooperative reduction 8.02 us, and output writing 1.18 us.

### Dispatch Policy

The Hybrid path is selected only for dimensions at least 8,192. The minimum K rises with the row count: K=8 for one or two rows, K=32 for three or four rows, and K=64 above four rows. Smaller workloads remain on the existing select-based paths.

This conservative policy comes from H200 Nsight Systems sweeps across K values 1, 2, 4, 8, 16, 32, and 64. The main matrix covered 280 FP32/FP16 cells over rows 1, 2, 4, 8, and 16 and dimensions 8,192 through 248,320. BF16 boundary checks and rows 3, 5, 6, and 7 brought the selected-policy validation to 164 cells. Every selected cell was more than 2% faster than the existing path; the worst ratio was 0.979x. Crossover points may differ on other GPU architectures.

### Additional Fixes

- The small-K partial pass maps rows onto `grid.y`, so `IsSupported` now rejects row counts beyond `maxGridSize[1]` and falls back to RadixTopK instead of failing the launch.
- `WarpMergeSorter`'s CUB temp storage aliases the caller's shared score/index buffers in `hybrid_topk::ReducePartitions` (they are union members). The shared-memory loads and the write-back are now fenced against CUB's own traffic.
- The plugin build maps `BFloat16` onto `nv_bfloat16`, which had no `NumericLimits` specialization and silently fell back to the `std::numeric_limits` primary template (0). Kernels that pad with `Lowest()` therefore ranked the padding above every negative input; `TopKOperator.NthElementBFloat16_NegativeVals` failed in the CUDA plugin configuration before this fix.

### Testing

- `onnxruntime_provider_test --gtest_filter=TopKOperator.*`
  - monolithic CUDA build: 70/70 passed
  - CUDA EP plugin build (`onnxruntime_BUILD_CUDA_EP_AS_PLUGIN=ON`): 70/70 passed
- `onnxruntime_provider_test --gtest_filter=*BFloat16*:*BF16*:*Bfloat16*` on the plugin build: 58/58 passed, covering the shared `NumericLimits` change
- CUDA TopK correctness matrix: 24/24 cases passed across FP32/FP16, largest/smallest, varied rows, dimensions, and K
- Stable large-K matrix: 7/7 previously failing block-merge cases passed
- Signed-zero stability: mixed `-0.0`/`+0.0` cases passed through Hybrid and SmallK
- CUDA Graph capture and replay: 4/4 runs passed with preallocated I/O
- `lintrunner` and `git diff --check`
