### PR TITLE
[MLAS] Restore the run time vector extension check on riscv64

### DIFF
--- a/onnxruntime/core/mlas/lib/platform.cpp
+++ b/onnxruntime/core/mlas/lib/platform.cpp
@@ -27,14 +27,18 @@ Abstract:
 #include "kleidiai/mlasi_kleidiai.h"
 #endif
 
-#if defined(MLAS_TARGET_RISCV64) && defined(MLAS_USE_RVV)
-#include <riscv_vector.h>
-#endif
-
 #include <cctype>
 #include <cstdlib>
 #include <mutex>
 #include <thread>
+
+#if defined(MLAS_TARGET_RISCV64) && defined(MLAS_USE_RVV) && defined(__linux__)
+#include <sys/auxv.h>
+#include <asm/hwcap.h>
+#ifndef COMPAT_HWCAP_ISA_V
+#define COMPAT_HWCAP_ISA_V (1UL << ('V' - 'A'))
+#endif
+#endif
 
 #if defined(MLAS_TARGET_POWER)
 #if defined(__linux__)
@@ -250,6 +254,47 @@ MLAS_INTERNAL_DATA MLAS_DECLSPEC_ALIGN(const uint32_t MlasMaskMoveTableLasx[16],
 };
 
 #endif
+
+#if defined(MLAS_TARGET_RISCV64) && defined(MLAS_USE_RVV)
+namespace {
+
+bool
+MlasStringEqualsIgnoreCase(
+    const char* value,
+    const char* expected
+    )
+{
+    while (*value != '\0' && *expected != '\0') {
+        const auto lhs = static_cast<unsigned char>(*value);
+        const auto rhs = static_cast<unsigned char>(*expected);
+        if (std::tolower(lhs) != std::tolower(rhs)) {
+            return false;
+        }
+        ++value;
+        ++expected;
+    }
+
+    return *value == '\0' && *expected == '\0';
+}
+
+bool
+MlasShouldForceScalarRiscv(
+    const char* value
+    )
+{
+    if (value == nullptr || value[0] == '\0') {
+        return false;
+    }
+
+    return MlasStringEqualsIgnoreCase(value, "1") ||
+           MlasStringEqualsIgnoreCase(value, "true") ||
+           MlasStringEqualsIgnoreCase(value, "on") ||
+           MlasStringEqualsIgnoreCase(value, "yes");
+}
+
+}  // namespace
+#endif
+
 MLAS_PLATFORM::MLAS_PLATFORM(
     void
     )
@@ -301,34 +346,41 @@ Return Value:
     this->ComputeLogSoftmaxOutputF32Kernel = MlasComputeLogSoftmaxOutputF32Kernel;
 
 #if defined(MLAS_USE_RVV)
-    this->GemmFloatKernel = MlasGemmFloatKernelRvv;
-    this->GemmU8S8Dispatch = &MlasGemmQuantDispatchRvv;
-    this->GemmU8U8Dispatch = &MlasGemmQuantDispatchRvv;
-    this->GemmS8S8Dispatch = &MlasGemmQuantDispatchRvv;
-    this->GemmS8U8Dispatch = &MlasGemmQuantDispatchRvv;
-    this->ErfKernelRoutine = MlasErfKernelRvv;
-    this->LogisticKernelRoutine = MlasLogisticKernelRvv;
-    this->GeluErfKernelRoutine = MlasGeluErfKernelRvv;
-    this->SiluKernelRoutine = MlasSiluKernelRvv;
-    this->TanhKernelRoutine = MlasTanhKernelRvv;
-    this->ComputeExpF32Kernel = MlasComputeExpF32KernelRvv;
-    this->ReduceMaximumF32Kernel = MlasReduceMaximumF32KernelRvv;
-    this->ComputeSumExpF32Kernel = MlasComputeSumExpF32KernelRvv;
-    this->ComputeSoftmaxOutputF32Kernel = MlasComputeSoftmaxOutputF32KernelRvv;
-    this->ComputeLogSoftmaxOutputF32Kernel = MlasComputeLogSoftmaxOutputF32KernelRvv;
-    this->RopeDispatch = &MlasRopeDispatchRvv;
-    this->LayerNormF32Kernel = &MlasLayerNormKernelRvv;
-    this->QNBitGemmDispatch = &MlasSQNBitGemmDispatchRvv;
+    bool has_rvv = true;
+#if defined(__linux__)
+    has_rvv = (getauxval(AT_HWCAP) & COMPAT_HWCAP_ISA_V) != 0;
+#endif
+    if (MlasShouldForceScalarRiscv(std::getenv("ORT_MLAS_RISCV_FORCE_SCALAR"))) {
+        has_rvv = false;
+    }
+    if (has_rvv) {
+        this->GemmFloatKernel = MlasGemmFloatKernelRvv;
+        this->GemmU8S8Dispatch = &MlasGemmQuantDispatchRvv;
+        this->GemmU8U8Dispatch = &MlasGemmQuantDispatchRvv;
+        this->GemmS8S8Dispatch = &MlasGemmQuantDispatchRvv;
+        this->GemmS8U8Dispatch = &MlasGemmQuantDispatchRvv;
+        this->ErfKernelRoutine = MlasErfKernelRvv;
+        this->LogisticKernelRoutine = MlasLogisticKernelRvv;
+        this->GeluErfKernelRoutine = MlasGeluErfKernelRvv;
+        this->SiluKernelRoutine = MlasSiluKernelRvv;
+        this->TanhKernelRoutine = MlasTanhKernelRvv;
+        this->ComputeExpF32Kernel = MlasComputeExpF32KernelRvv;
+        this->ReduceMaximumF32Kernel = MlasReduceMaximumF32KernelRvv;
+        this->ComputeSumExpF32Kernel = MlasComputeSumExpF32KernelRvv;
+        this->ComputeSoftmaxOutputF32Kernel = MlasComputeSoftmaxOutputF32KernelRvv;
+        this->ComputeLogSoftmaxOutputF32Kernel = MlasComputeLogSoftmaxOutputF32KernelRvv;
+        this->RopeDispatch = &MlasRopeDispatchRvv;
+        this->LayerNormF32Kernel = &MlasLayerNormKernelRvv;
+        this->QNBitGemmDispatch = &MlasSQNBitGemmDispatchRvv;
 
 #if defined(MLAS_USE_RVV_ZVFH)
-    if (MLAS_CPUIDINFO::GetCPUIDInfo().HasFp16VectorAcceleration()) {
-        this->CastF16ToF32Kernel = &MlasCastF16ToF32KernelRvv;
-        this->CastF32ToF16Kernel = &MlasCastF32ToF16KernelRvv;
-    }
+        if (MLAS_CPUIDINFO::GetCPUIDInfo().HasFp16VectorAcceleration()) {
+            this->CastF16ToF32Kernel = &MlasCastF16ToF32KernelRvv;
+            this->CastF32ToF16Kernel = &MlasCastF32ToF16KernelRvv;
+        }
 #endif
 
-    // NCHWc kernels require VLEN>=128 so that vfloat32m4_t holds 16 floats.
-    if (__riscv_vlenb() >= 16) {
+        // The V extension implies VLEN>=128, which holds the sixteen-float block.
         this->NchwcBlockSize = 16;
         this->ConvNchwFloatKernel = MlasConvNchwFloatKernelRvv;
         this->ConvNchwcFloatKernel = MlasConvNchwcFloatKernelRvv;


### PR DESCRIPTION
## Description

### Motivation

PR #28261 installed the MLAS RVV kernels only when the runtime reported the RISC-V V extension, and provided `ORT_MLAS_RISCV_FORCE_SCALAR` as an escape hatch. PR #28411 replaced that gate with an unconditional `__riscv_vlenb()` call and removed the override.

This causes two problems:

- `platform.cpp` is compiled without requiring `-march=...v`, but `__riscv_vlenb()` requires the vector extension at compile time. Toolchains whose default architecture does not include V therefore reject the build.
- An RVV-enabled build can install and execute vector kernels on a riscv64 system that does not provide the V extension.

### Changes

- Restore the Linux HWCAP runtime check before installing MLAS RVV kernels.
- Restore the `ORT_MLAS_RISCV_FORCE_SCALAR` override.
- Remove the `__riscv_vlenb()` check from `platform.cpp`. The V extension guarantees VLEN >= 128, which is sufficient for the existing sixteen-float NCHWc block.
- Keep the change confined to `onnxruntime/core/mlas/lib/platform.cpp`.

### Testing

- Cross-compiled the RVV-enabled Release build with the XuanTie toolchain under `-Werror`: 1490 targets completed without errors.
- Ran `onnxruntime_mlas_test` on a SpacemiT K3 (X100, VLEN=256): no failures.
- Ran the relevant MLAS suites on a XuanTie A210 (C920V2, VLEN=128): 2344 passed and 0 failed with RVV enabled; 1800 passed and 0 failed with `ORT_MLAS_RISCV_FORCE_SCALAR=1`.
- The forced-scalar run reduced the NCHWc-related test count from 549 to 5, confirming that the runtime fallback disables the NCHWc RVV path.

A physical riscv64 system without the V extension was not available for testing; the scalar fallback was validated through the environment override.