### PR TITLE
Fix initializer fusion crash when Cast node and output names differ

### DIFF
--- a/onnxruntime/core/optimizer/fuse_initializers_transformer.cc
+++ b/onnxruntime/core/optimizer/fuse_initializers_transformer.cc
@@ -104,16 +104,9 @@ static void FuseInitializerWithNode(Graph& graph,
                                     Node& node,
                                     const onnxruntime::MLDataType next_node_arg_type,
                                     onnxruntime::concurrency::ThreadPool* thread_pool) {
-  // Get next node
-  Node& next_node = *graph.GetNode(node.OutputNodesBegin()->Index());
-
-  // Get the index in next node at which the initializer must be replaced
-  NodeIndex next_node_arg_index = 0;
-  for (; next_node_arg_index < next_node.InputDefs().size(); ++next_node_arg_index) {
-    if (node.Name() == next_node.InputDefs()[next_node_arg_index]->Name()) {
-      break;
-    }
-  }
+  const auto& output_edge = *node.OutputEdgesBegin();
+  Node& next_node = *graph.GetNode(output_edge.GetNode().Index());
+  const int next_node_arg_index = output_edge.GetDstArgIndex();
 
   // Get the src initialized tensor at input def index 0
   const auto* constant_initializer_tensor = graph_utils::GetConstantInitializer(graph, node.InputDefs()[0]->Name());
@@ -134,7 +127,7 @@ static void FuseInitializerWithNode(Graph& graph,
     return;
 
   // Remove the edge between the current node output def at index 0 and next node arg at relative arg index.
-  graph.RemoveEdge(node.Index(), next_node.Index(), 0, static_cast<int>(next_node_arg_index));
+  graph.RemoveEdge(node.Index(), next_node.Index(), 0, next_node_arg_index);
 
   // Add the new converted Tensor in next node as initializer potentially with external data
   ONNX_NAMESPACE::TensorProto dst_tensor = utils::TensorToTensorProto(new_data.Get<Tensor>(), new_arg_name, true);
@@ -143,7 +136,7 @@ static void FuseInitializerWithNode(Graph& graph,
   }
 
   auto& new_arg = graph_utils::AddInitializerWithOrtValue(graph, dst_tensor, std::move(new_data));
-  graph_utils::ReplaceNodeInput(next_node, static_cast<int>(next_node_arg_index), new_arg);
+  graph_utils::ReplaceNodeInput(next_node, next_node_arg_index, new_arg);
 }
 
 Status FuseInitializersTransformer::ApplyImpl(Graph& graph, bool& modified, int /*graph_level*/, const logging::Logger& /*logger*/) const {

--- a/onnxruntime/test/optimizer/fuse_initializers_transformer_test.cc
+++ b/onnxruntime/test/optimizer/fuse_initializers_transformer_test.cc
@@ -512,6 +512,40 @@ TEST(TransformerTest, FuseFp16InitializersWithGraphOutputs) {
   ASSERT_STATUS_OK(session.Run(inputs, output_names, &outputs));
 }  // FuseFp16InitializersWithGraphOutputs
 
+TEST(TransformerTest, FuseInitializersUsesConsumerEdgeInputIndex) {
+  auto& logger = DefaultLoggingManager().DefaultLogger();
+  Model model("FuseInitializersUsesConsumerEdgeInputIndex", false, ModelMetaData(), PathString(),
+              IOnnxRuntimeOpSchemaRegistryList(), {{kOnnxDomain, 23}}, {}, logger);
+  Graph& graph = model.MainGraph();
+  ModelTestBuilder builder(graph);
+
+  NodeArg* initializer = builder.MakeInitializer<MLFloat16>({1}, {MLFloat16(1.0f)});
+  NodeArg* cast_output = builder.MakeIntermediate<float>(std::vector<int64_t>{1});
+  Node& cast = graph.AddNode("cast_node", "Cast", "description", {initializer}, {cast_output});
+  cast.AddAttribute("to", static_cast<int64_t>(ONNX_NAMESPACE::TensorProto_DataType_FLOAT));
+  NodeArg* output = builder.MakeOutput<float>(std::vector<int64_t>{1});
+  Node& exp = builder.AddNode("Exp", {cast_output}, {output});
+
+  graph.SetOutputs({output});
+  ASSERT_STATUS_OK(graph.Resolve());
+  ASSERT_NE(cast.Name(), cast_output->Name());
+
+  FuseInitializersTransformer transformer("TransformerTest.FusedInitializers",
+                                          DataTypeImpl::GetTensorType<MLFloat16>(),
+                                          DataTypeImpl::GetTensorType<float>());
+  bool modified = false;
+  ASSERT_STATUS_OK(transformer.Apply(graph, modified, logger));
+
+  EXPECT_TRUE(modified);
+  EXPECT_EQ(0, CountOpsInGraph(graph)["Cast"]);
+  EXPECT_EQ(1, CountOpsInGraph(graph)["Exp"]);
+  ASSERT_EQ(1, exp.InputDefs().size());
+  EXPECT_NE(cast_output->Name(), exp.InputDefs()[0]->Name());
+  EXPECT_NE(nullptr, graph_utils::GetConstantInitializer(graph, exp.InputDefs()[0]->Name()));
+  EXPECT_EQ(DataTypeImpl::GetTensorType<float>(),
+            DataTypeImpl::TypeFromProto(*exp.InputDefs()[0]->TypeAsProto()));
+}
+
 TEST(TransformerTest, FuseInitializersSkipsOverridableInitializer) {
   auto& logger = DefaultLoggingManager().DefaultLogger();
   Model model("FuseInitializersSkipsOverridableInitializer", false, ModelMetaData(), PathString(),


### PR DESCRIPTION
### Description

Use the Cast node's output edge to obtain the consumer node and destination input index when fusing an initializer. Add a regression test where the Cast node name differs from its output value name.

### Motivation and Context

`FuseInitializersTransformer` searched consumer inputs by comparing their value names with the producer node name. ONNX node names and output value names are independent, so a mismatch could make the search run past the consumer input list and cause an access violation. This occurs with Gemma when Constant Folding is disabled.

Fixes #32405

### Testing

```text
onnxruntime_test_all.exe --gtest_filter=TransformerTest.Fuse*Initializers*
[==========] 7 tests from 1 test suite ran.
[  PASSED  ] 7 tests.
```