### PR TITLE
Tune FP4 GEMV scheduling for the 48-SM SM121 GPU

### DIFF
--- a/onnxruntime/contrib_ops/cuda/math/matmul_block_scaled_fp4.cu
+++ b/onnxruntime/contrib_ops/cuda/math/matmul_block_scaled_fp4.cu
@@ -979,7 +979,7 @@ Status LaunchMatMulBlockQuantizedFp4WeightGemv(void* y,
   // cap below is much lower without the mma.
   if (device_prop.major >= 8 && k % 128 == 0 && m <= kFp4MmaGemvTileM && Fp4GemvMmaEnabled()) {
     const Fp4MmaConfig cfg = ApplyFp4MmaConfigOverrides(
-        PickFp4MmaConfig(n, k, device_prop.multiProcessorCount), n, k);
+        PickFp4MmaConfig(n, k, device_prop.multiProcessorCount, device_prop.major), n, k);
     const int cols_per_block = 16 * cfg.col_tiles;
     const int mtiles = (m > 16) ? 4 : ((m > 8) ? 2 : 1);
     const dim3 mma_threads{32, static_cast<unsigned int>(cfg.k_split * cfg.col_tiles)};

--- a/onnxruntime/contrib_ops/cuda/math/matmul_block_scaled_fp4.cu
+++ b/onnxruntime/contrib_ops/cuda/math/matmul_block_scaled_fp4.cu
@@ -979,7 +979,9 @@ Status LaunchMatMulBlockQuantizedFp4WeightGemv(void* y,
   // cap below is much lower without the mma.
   if (device_prop.major >= 8 && k % 128 == 0 && m <= kFp4MmaGemvTileM && Fp4GemvMmaEnabled()) {
     const Fp4MmaConfig cfg = ApplyFp4MmaConfigOverrides(
-        PickFp4MmaConfig(n, k, device_prop.multiProcessorCount, device_prop.major), n, k);
+        PickFp4MmaConfig(m, n, k, device_prop.multiProcessorCount,
+                         device_prop.major, device_prop.minor),
+        n, k);
     const int cols_per_block = 16 * cfg.col_tiles;
     const int mtiles = (m > 16) ? 4 : ((m > 8) ? 2 : 1);
     const dim3 mma_threads{32, static_cast<unsigned int>(cfg.k_split * cfg.col_tiles)};

--- a/onnxruntime/contrib_ops/cuda/math/matmul_block_scaled_fp4_tiling.h
+++ b/onnxruntime/contrib_ops/cuda/math/matmul_block_scaled_fp4_tiling.h
@@ -13,6 +13,7 @@ struct Fp4MmaConfig {
 // Returns the tensor-core GEMV tiling selected for the given shape and device.
 inline Fp4MmaConfig PickFp4MmaConfig(int m, int n, int k, int sm_count,
                                      int compute_capability_major, int compute_capability_minor) {
+  constexpr int kSm121TargetSmCount = 48;
   constexpr int kSm121MaxM = 16;
   constexpr int kTargetGridWaves = 4;
   constexpr int kLongReductionGridWaves = 8;
@@ -23,12 +24,12 @@ inline Fp4MmaConfig PickFp4MmaConfig(int m, int n, int k, int sm_count,
   const int col_tiles = (n + 15) / 16;
   const int wide_col_blocks = (col_tiles + 3) / 4;
 
-  // Low-SM-count SM121 GPUs benefit from more K parallelism for the wide-grid and long-reduction
+  // The 48-SM SM121 GPU benefits from more K parallelism for the wide-grid and long-reduction
   // regimes below, unless N alone already provides eight waves of four-column blocks. Preserve the
-  // generic selector for shorter reductions, narrower grids, SM120, and the wider M=32 row tiling,
-  // where this schedule can regress.
+  // generic selector for unqualified SM counts, shorter reductions, narrower grids, SM120, and the
+  // wider M=32 row tiling, where this schedule can regress.
   if (compute_capability_major == 12 && compute_capability_minor == 1 &&
-      sm_count <= 64 && m <= kSm121MaxM && windows >= kSm121MinWindows &&
+      sm_count == kSm121TargetSmCount && m <= kSm121MaxM && windows >= kSm121MinWindows &&
       (wide_col_blocks >= kTargetGridWaves * sm_count || windows >= kSm121NarrowGridMinWindows) &&
       wide_col_blocks < kLongReductionGridWaves * sm_count) {
     return {16, 1};

--- a/onnxruntime/contrib_ops/cuda/math/matmul_block_scaled_fp4_tiling.h
+++ b/onnxruntime/contrib_ops/cuda/math/matmul_block_scaled_fp4_tiling.h
@@ -10,15 +10,23 @@ struct Fp4MmaConfig {
   int col_tiles;
 };
 
-// Returns the tensor-core GEMV tiling selected for the given shape and device size.
-inline Fp4MmaConfig PickFp4MmaConfig(int n, int k, int sm_count) {
+// Returns the tensor-core GEMV tiling selected for the given shape and device.
+inline Fp4MmaConfig PickFp4MmaConfig(int n, int k, int sm_count, int compute_capability_major) {
   constexpr int kTargetGridWaves = 4;
   constexpr int kLongReductionGridWaves = 8;
   constexpr int kLongReductionWindows = 64;
   const int windows = k >> 7;
   const int col_tiles = (n + 15) / 16;
-
   const int wide_col_blocks = (col_tiles + 3) / 4;
+
+  // Low-SM-count client Blackwell GPUs need more K parallelism than the H200-oriented
+  // grid heuristic below provides for long reductions, unless N alone already provides
+  // at least eight waves of four-column blocks.
+  if (compute_capability_major == 12 && sm_count <= 64 && windows >= 16 &&
+      wide_col_blocks < kLongReductionGridWaves * sm_count) {
+    return {16, 1};
+  }
+
   if (wide_col_blocks >= kTargetGridWaves * sm_count &&
       (windows < kLongReductionWindows || wide_col_blocks >= kLongReductionGridWaves * sm_count)) {
     return {windows < 2 ? windows : 2, 4};

--- a/onnxruntime/contrib_ops/cuda/math/matmul_block_scaled_fp4_tiling.h
+++ b/onnxruntime/contrib_ops/cuda/math/matmul_block_scaled_fp4_tiling.h
@@ -11,18 +11,25 @@ struct Fp4MmaConfig {
 };
 
 // Returns the tensor-core GEMV tiling selected for the given shape and device.
-inline Fp4MmaConfig PickFp4MmaConfig(int n, int k, int sm_count, int compute_capability_major) {
+inline Fp4MmaConfig PickFp4MmaConfig(int m, int n, int k, int sm_count,
+                                     int compute_capability_major, int compute_capability_minor) {
+  constexpr int kSm121MaxM = 16;
   constexpr int kTargetGridWaves = 4;
   constexpr int kLongReductionGridWaves = 8;
+  constexpr int kSm121MinWindows = 40;
+  constexpr int kSm121NarrowGridMinWindows = 128;
   constexpr int kLongReductionWindows = 64;
   const int windows = k >> 7;
   const int col_tiles = (n + 15) / 16;
   const int wide_col_blocks = (col_tiles + 3) / 4;
 
-  // Low-SM-count client Blackwell GPUs need more K parallelism than the H200-oriented
-  // grid heuristic below provides for long reductions, unless N alone already provides
-  // at least eight waves of four-column blocks.
-  if (compute_capability_major == 12 && sm_count <= 64 && windows >= 16 &&
+  // Low-SM-count SM121 GPUs benefit from more K parallelism for the wide-grid and long-reduction
+  // regimes below, unless N alone already provides eight waves of four-column blocks. Preserve the
+  // generic selector for shorter reductions, narrower grids, SM120, and the wider M=32 row tiling,
+  // where this schedule can regress.
+  if (compute_capability_major == 12 && compute_capability_minor == 1 &&
+      sm_count <= 64 && m <= kSm121MaxM && windows >= kSm121MinWindows &&
+      (wide_col_blocks >= kTargetGridWaves * sm_count || windows >= kSm121NarrowGridMinWindows) &&
       wide_col_blocks < kLongReductionGridWaves * sm_count) {
     return {16, 1};
   }

--- a/onnxruntime/test/contrib_ops/matmul_block_scaled_fp4_test.cc
+++ b/onnxruntime/test/contrib_ops/matmul_block_scaled_fp4_test.cc
@@ -664,8 +664,10 @@ TEST(MatMulBlockQuantizedFp4WeightOpTest, GemvTensorCoreSm121Tiling) {
       {1, 24512, 5120, 48, 12, 1, 16, 1},  // Just below eight wide-grid waves uses the override.
       {1, 24576, 5120, 48, 12, 1, 2, 4},   // Eight wide-grid waves retain the generic selector.
       {1, 248320, 5120, 48, 12, 1, 2, 4},  // Wide output grids retain the generic selector.
-      {1, 17408, 5120, 64, 12, 1, 16, 1},  // The override includes 64-SM SM121 devices.
-      {1, 17408, 5120, 65, 12, 1, 2, 4},   // Larger SM121 devices retain the generic selector.
+      {1, 17408, 5120, 47, 12, 1, 2, 4},   // Other SM counts retain the generic selector.
+      {1, 17408, 5120, 49, 12, 1, 2, 4},   // Other SM counts retain the generic selector.
+      {1, 17408, 5120, 64, 12, 1, 2, 4},   // Other SM counts retain the generic selector.
+      {1, 17408, 5120, 65, 12, 1, 2, 4},   // Other SM counts retain the generic selector.
       {1, 17408, 5120, 132, 12, 1, 2, 1},  // Large SM121 devices retain the generic selector.
       {1, 17408, 5120, 36, 12, 0, 2, 4},   // SM120 retains the generic selector.
       {1, 5120, 17408, 36, 12, 0, 8, 1},   // SM120 retains the generic selector.

--- a/onnxruntime/test/contrib_ops/matmul_block_scaled_fp4_test.cc
+++ b/onnxruntime/test/contrib_ops/matmul_block_scaled_fp4_test.cc
@@ -463,8 +463,9 @@ TEST(MatMulBlockQuantizedFp4WeightOpTest, GemvDecodeRowTiledBf16) {
 // weight (as in the row-tiled tests above) would pass even with a broken k mapping.
 //
 // The shapes cover: a ragged N that is not a multiple of the 16-column warp tile, single and
-// multi window K (128 -> 1 window, 256 -> 2, 512 -> 4), and an N large enough that the launcher
-// picks the wide ColTiles = 4 / KSplit = 2 shape rather than the column-starved KSplit ladder.
+// multi window K (128 -> 1 window, 256 -> 2, 512 -> 4, 2048 -> 16, 2304 -> 18), including exact
+// and ragged KSplit = 16 reductions, and an N large enough that the launcher picks the wide
+// ColTiles = 4 / KSplit = 2 shape rather than the column-starved KSplit ladder.
 namespace {
 
 // FP4 codes cycling along K: +1.0, -2.0, +0.5, +1.5 (E2M1 codes 0x2, 0xC, 0x1, 0x3). Negative
@@ -529,7 +530,8 @@ struct MmaShape {
 // N = 8704 gives 544 column tiles and exercises a large, ragged grid. N = 36 leaves 4 columns in
 // the last 16-column tile, which is the only way to make a lane's *low* column fall out of range
 // (N = 40 only exercises the high column), so it covers the lo_ok == false predication.
-constexpr MmaShape kMmaShapes[] = {{36, 128}, {40, 128}, {512, 256}, {2048, 512}, {8704, 256}};
+constexpr MmaShape kMmaShapes[] = {
+    {36, 128}, {40, 128}, {512, 256}, {2048, 512}, {512, 2048}, {512, 2304}, {8704, 256}};
 
 }  // namespace
 
@@ -628,34 +630,58 @@ TEST(MatMulBlockQuantizedFp4WeightOpTest, GemvTensorCoreQwenTilingBoundaries) {
   for (const Case& shape : cases) {
     SCOPED_TRACE("N = " + std::to_string(shape.n) + ", K = " + std::to_string(shape.k));
     const auto config = onnxruntime::contrib::cuda::PickFp4MmaConfig(
-        static_cast<int>(shape.n), static_cast<int>(shape.k), sm_count, 9);
+        1, static_cast<int>(shape.n), static_cast<int>(shape.k), sm_count, 9, 0);
     EXPECT_EQ(config.k_split, shape.k_split);
     EXPECT_EQ(config.col_tiles, shape.col_tiles);
   }
 }
 
-TEST(MatMulBlockQuantizedFp4WeightOpTest, GemvTensorCoreClientBlackwellTiling) {
+TEST(MatMulBlockQuantizedFp4WeightOpTest, GemvTensorCoreSm121Tiling) {
   struct Case {
+    int m;
     int n;
     int k;
     int sm_count;
     int compute_capability_major;
+    int compute_capability_minor;
     int k_split;
     int col_tiles;
   };
   const Case cases[] = {
-      {17408, 5120, 48, 12, 16, 1},
-      {5120, 17408, 48, 12, 16, 1},
-      {17408, 1024, 48, 12, 2, 4},   // Short reductions retain the generic selector.
-      {248320, 5120, 48, 12, 2, 4},  // Wide output grids retain the generic selector.
-      {17408, 5120, 132, 12, 2, 1},  // Large SM12x devices retain the generic selector.
-      {17408, 5120, 48, 9, 2, 4},    // The override is limited to client Blackwell.
+      {1, 17408, 5120, 48, 12, 1, 16, 1},
+      {16, 5120, 17408, 48, 12, 1, 16, 1},
+      {17, 17408, 5120, 48, 12, 1, 2, 4},  // M=17 retains the generic selector.
+      {32, 17408, 5120, 48, 12, 1, 2, 4},  // M=32 retains the generic selector.
+      {32, 5120, 17408, 48, 12, 1, 8, 1},  // M=32 retains the generic selector.
+      {1, 17408, 1024, 48, 12, 1, 2, 4},   // Short reductions retain the generic selector.
+      {1, 17408, 2048, 48, 12, 1, 2, 4},   // The SM121 override starts at 40 K windows.
+      {1, 7168, 5120, 48, 12, 1, 2, 1},    // Narrow attention grids retain the generic selector.
+      {1, 5120, 7168, 48, 12, 1, 2, 1},    // Narrow attention grids retain the generic selector.
+      {1, 5120, 8192, 48, 12, 1, 8, 1},    // 64-window narrow grids retain the generic selector.
+      {1, 5120, 9216, 48, 12, 1, 8, 1},    // 72-window narrow grids retain the generic selector.
+      {1, 5120, 16256, 48, 12, 1, 8, 1},   // 127-window narrow grids retain the generic selector.
+      {1, 5120, 16384, 48, 12, 1, 16, 1},  // The narrow-grid override starts at 128 windows.
+      {1, 24512, 5120, 48, 12, 1, 16, 1},  // Just below eight wide-grid waves uses the override.
+      {1, 24576, 5120, 48, 12, 1, 2, 4},   // Eight wide-grid waves retain the generic selector.
+      {1, 248320, 5120, 48, 12, 1, 2, 4},  // Wide output grids retain the generic selector.
+      {1, 17408, 5120, 64, 12, 1, 16, 1},  // The override includes 64-SM SM121 devices.
+      {1, 17408, 5120, 65, 12, 1, 2, 4},   // Larger SM121 devices retain the generic selector.
+      {1, 17408, 5120, 132, 12, 1, 2, 1},  // Large SM121 devices retain the generic selector.
+      {1, 17408, 5120, 36, 12, 0, 2, 4},   // SM120 retains the generic selector.
+      {1, 5120, 17408, 36, 12, 0, 8, 1},   // SM120 retains the generic selector.
+      {1, 17408, 5120, 48, 9, 0, 2, 4},    // The override is limited to SM121.
   };
 
   for (const Case& shape : cases) {
-    SCOPED_TRACE("N = " + std::to_string(shape.n) + ", K = " + std::to_string(shape.k));
+    SCOPED_TRACE("M = " + std::to_string(shape.m) +
+                 ", N = " + std::to_string(shape.n) +
+                 ", K = " + std::to_string(shape.k) +
+                 ", SMs = " + std::to_string(shape.sm_count) +
+                 ", CC = " + std::to_string(shape.compute_capability_major) + "." +
+                 std::to_string(shape.compute_capability_minor));
     const auto config = onnxruntime::contrib::cuda::PickFp4MmaConfig(
-        shape.n, shape.k, shape.sm_count, shape.compute_capability_major);
+        shape.m, shape.n, shape.k, shape.sm_count,
+        shape.compute_capability_major, shape.compute_capability_minor);
     EXPECT_EQ(config.k_split, shape.k_split);
     EXPECT_EQ(config.col_tiles, shape.col_tiles);
   }

--- a/onnxruntime/test/contrib_ops/matmul_block_scaled_fp4_test.cc
+++ b/onnxruntime/test/contrib_ops/matmul_block_scaled_fp4_test.cc
@@ -628,7 +628,34 @@ TEST(MatMulBlockQuantizedFp4WeightOpTest, GemvTensorCoreQwenTilingBoundaries) {
   for (const Case& shape : cases) {
     SCOPED_TRACE("N = " + std::to_string(shape.n) + ", K = " + std::to_string(shape.k));
     const auto config = onnxruntime::contrib::cuda::PickFp4MmaConfig(
-        static_cast<int>(shape.n), static_cast<int>(shape.k), sm_count);
+        static_cast<int>(shape.n), static_cast<int>(shape.k), sm_count, 9);
+    EXPECT_EQ(config.k_split, shape.k_split);
+    EXPECT_EQ(config.col_tiles, shape.col_tiles);
+  }
+}
+
+TEST(MatMulBlockQuantizedFp4WeightOpTest, GemvTensorCoreClientBlackwellTiling) {
+  struct Case {
+    int n;
+    int k;
+    int sm_count;
+    int compute_capability_major;
+    int k_split;
+    int col_tiles;
+  };
+  const Case cases[] = {
+      {17408, 5120, 48, 12, 16, 1},
+      {5120, 17408, 48, 12, 16, 1},
+      {17408, 1024, 48, 12, 2, 4},   // Short reductions retain the generic selector.
+      {248320, 5120, 48, 12, 2, 4},  // Wide output grids retain the generic selector.
+      {17408, 5120, 132, 12, 2, 1},  // Large SM12x devices retain the generic selector.
+      {17408, 5120, 48, 9, 2, 4},    // The override is limited to client Blackwell.
+  };
+
+  for (const Case& shape : cases) {
+    SCOPED_TRACE("N = " + std::to_string(shape.n) + ", K = " + std::to_string(shape.k));
+    const auto config = onnxruntime::contrib::cuda::PickFp4MmaConfig(
+        shape.n, shape.k, shape.sm_count, shape.compute_capability_major);
     EXPECT_EQ(config.k_split, shape.k_split);
     EXPECT_EQ(config.col_tiles, shape.col_tiles);
   }


### PR DESCRIPTION
## Description

Tune the tensor-core GEMV decomposition used by `MatMulBlockQuantizedFp4Weight` for the qualified 48-SM SM121 GPU.

The existing H200-oriented selector can provide insufficient K parallelism for specific wide-grid and long-reduction decode shapes on SM121. The new selector uses `KSplit=16, ColTiles=1` only when all of these conditions hold:

- compute capability is exactly 12.1;
- the device has exactly 48 SMs;
- M is at most 16;
- K contains at least 40 128-element windows;
- the shape either provides four wide-grid waves or has at least 128 K windows;
- the wide output grid provides fewer than eight waves.

SM120, other SM12x minors, other SM counts, M above 16, short reductions, narrow attention grids, and already-saturated output grids retain the generic selector.

## Performance

Measured on RTX Spark (SM121, 48 SMs) as end-to-end ORT `Run()` latency with an explicit shared CUDA stream. Each cell includes three alternating process rounds, with 100 warmups and 1,000 measured calls per arm per round.

| Shape | M | Existing | Proposed | Latency reduction |
|---|---:|---:|---:|---:|
| 17408x5120 | 1 | 0.2416 ms | 0.2005 ms | 16.9% |
| 17408x5120 | 8 | 0.3594 ms | 0.3258 ms | 9.3% |
| 17408x5120 | 16 | 0.3634 ms | 0.3336 ms | 8.0% |
| 5120x17408 | 1 | 0.2196 ms | 0.2099 ms | 3.9% |
| 5120x17408 | 8 | 0.2260 ms | 0.2136 ms | 5.4% |
| 5120x17408 | 16 | 0.2283 ms | 0.2182 ms | 4.6% |
| 24512x5120 | 1 | 0.3276 ms | 0.2711 ms | 17.2% |
| 24512x5120 | 8 | 0.4469 ms | 0.3982 ms | 11.2% |

Negative controls established the required exclusions:

| Excluded regime | Existing | Forced `16/1` | Impact |
|---|---:|---:|---:|
| 7168x5120, M=8 attention | 0.1660 ms | 0.1788 ms | 7.7% slower |
| 5120x7168, M=8 attention | 0.1652 ms | 0.1851 ms | 12.0% slower |
| 17408x2048, M=8 short K | 0.0480 ms | 0.0624 ms | 30.6% slower |
| 5120x8192, M=8 narrow grid | 0.1745 ms | 0.1879 ms | 7.7% slower |
| 17408x5120, M=32 | 0.2453 ms | 0.3977 ms | 62.1% slower |
| 5120x17408, M=32 | 0.2964 ms | 0.4005 ms | 35.2% slower |

No-override runs tracked the expected forced arm for every qualified and excluded case, confirming that the compiled selector applies the intended schedule. Randomized activations and varying block scales produced identical natural/expected output and baseline/proposed output within one FP16 ULP.

At the exact eight-wave boundary (`N=24576, K=5120`), forced `16/1` was still 11% to 17% faster. The selector deliberately retains the generic schedule there rather than extrapolating the optimization beyond the conservative less-than-eight-wave rule.