### PR TITLE
Avoid pinned buffers in CUDA Split and Concat fast paths

### DIFF
--- a/onnxruntime/core/providers/cuda/tensor/concat.cc
+++ b/onnxruntime/core/providers/cuda/tensor/concat.cc
@@ -51,36 +51,42 @@ Status Concat::ComputeInternal(OpKernelContext* ctx) const {
 
   std::vector<int64_t> concat_sizes;
   concat_sizes.reserve(input_count);
+  for (int i = 0; i < input_count; ++i) {
+    concat_sizes.push_back(p.inputs[i].tensor->Shape()[p.axis]);
+  }
+
+  auto element_bytes = p.output_tensor->DataType()->Size();
+  int block_size_inside_axis_dim = static_cast<int>(p.output_axis_pitch / p.output_tensor->Shape()[p.axis]);
+  int block_size_including_axis_dim = static_cast<int>(p.output_axis_pitch);
+  const bool same_concat_size =
+      std::all_of(concat_sizes.begin(), concat_sizes.end(), [&](int64_t size) { return size == concat_sizes[0]; });
+  if (same_concat_size && input_count <= 32) {
+    TArray<const void*, 32> input_ptr_array(input_count);
+    for (int i = 0; i < input_count; ++i) {
+      input_ptr_array[i] = p.inputs[i].tensor->DataRaw();
+    }
+
+    return ConcatSameConcatDimImpl(
+        Stream(ctx), element_bytes, block_size_including_axis_dim, block_size_inside_axis_dim, concat_sizes[0],
+        p.output_tensor->MutableDataRaw(), input_ptr_array, static_cast<size_t>(p.output_num_elements));
+  }
 
   CudaAsyncBuffer<const void*> input_ptr(this, input_count);
   gsl::span<const void*> input_ptr_cpuspan = input_ptr.CpuSpan();
   std::vector<int64_t> axis_dimension_input_output_mapping(p.output_tensor->Shape()[p.axis]);
   int index = 0;
   for (int i = 0; i < input_count; ++i) {
-    const auto& input = p.inputs[i];
-    concat_sizes.push_back(input.tensor->Shape()[p.axis]);
-    input_ptr_cpuspan[i] = input.tensor->DataRaw();
-    for (int j = 0; j < input.tensor->Shape()[p.axis]; ++j) {
+    input_ptr_cpuspan[i] = p.inputs[i].tensor->DataRaw();
+    for (int j = 0; j < concat_sizes[i]; ++j) {
       axis_dimension_input_output_mapping.at(index++) = i;
     }
   }
 
-  auto element_bytes = p.output_tensor->DataType()->Size();
-  int block_size_inside_axis_dim = static_cast<int>(p.output_axis_pitch / p.output_tensor->Shape()[p.axis]);
-  int block_size_including_axis_dim = static_cast<int>(p.output_axis_pitch);
-  if (std::all_of(concat_sizes.begin(), concat_sizes.end(), [&](int64_t size) { return size == concat_sizes[0]; })) {
-    if (input_count <= 32) {
-      TArray<const void*, 32> input_ptr_array(input_count);
-      for (int i = 0; i < input_count; ++i) input_ptr_array[i] = input_ptr_cpuspan[i];
-      ORT_RETURN_IF_ERROR(ConcatSameConcatDimImpl(
-          Stream(ctx), element_bytes, block_size_including_axis_dim, block_size_inside_axis_dim, concat_sizes[0],
-          p.output_tensor->MutableDataRaw(), input_ptr_array, static_cast<size_t>(p.output_num_elements)));
-    } else {
-      ORT_RETURN_IF_ERROR(input_ptr.CopyToGpu(GetComputeStream(ctx)));
-      ORT_RETURN_IF_ERROR(ConcatSameConcatDimImpl(
-          Stream(ctx), element_bytes, block_size_including_axis_dim, block_size_inside_axis_dim, concat_sizes[0],
-          p.output_tensor->MutableDataRaw(), input_ptr.GpuPtr(), static_cast<size_t>(p.output_num_elements)));
-    }
+  ORT_RETURN_IF_ERROR(input_ptr.CopyToGpu(GetComputeStream(ctx)));
+  if (same_concat_size) {
+    ORT_RETURN_IF_ERROR(ConcatSameConcatDimImpl(
+        Stream(ctx), element_bytes, block_size_including_axis_dim, block_size_inside_axis_dim, concat_sizes[0],
+        p.output_tensor->MutableDataRaw(), input_ptr.GpuPtr(), static_cast<size_t>(p.output_num_elements)));
   } else {
     CudaAsyncBuffer<int64_t> concat_sizes_gpu(this, concat_sizes);
     CudaAsyncBuffer<int64_t> axis_dimension_input_output_mapping_gpu(this, axis_dimension_input_output_mapping);
@@ -92,7 +98,6 @@ Status Concat::ComputeInternal(OpKernelContext* ctx) const {
     ORT_RETURN_IF_ERROR(concat_sizes_gpu.CopyToGpu(GetComputeStream(ctx)));
     ORT_RETURN_IF_ERROR(axis_dimension_input_output_mapping_gpu.CopyToGpu(GetComputeStream(ctx)));
     ORT_RETURN_IF_ERROR(concat_sizes_range_gpu.CopyToGpu(GetComputeStream(ctx)));
-    ORT_RETURN_IF_ERROR(input_ptr.CopyToGpu(GetComputeStream(ctx)));
     ORT_RETURN_IF_ERROR(ConcatImpl(Stream(ctx), element_bytes, block_size_including_axis_dim, block_size_inside_axis_dim,
                                    concat_sizes_gpu.GpuPtr(), concat_sizes_range_gpu.GpuPtr(),
                                    axis_dimension_input_output_mapping_gpu.GpuPtr(), p.output_tensor->MutableDataRaw(),

--- a/onnxruntime/core/providers/cuda/tensor/concat.cc
+++ b/onnxruntime/core/providers/cuda/tensor/concat.cc
@@ -1,12 +1,19 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+#include <algorithm>
+#include <vector>
+
 #include "core/providers/cuda/tensor/concat.h"
 
 #include "core/providers/cuda/tensor/concat_impl.h"
 
 namespace onnxruntime {
 namespace cuda {
+namespace {
+constexpr int kMaxInlinePointerCount = 32;
+}
+
 ONNX_OPERATOR_VERSIONED_KERNEL_EX(Concat,
                                   kOnnxDomain,
                                   4, 10,
@@ -60,8 +67,10 @@ Status Concat::ComputeInternal(OpKernelContext* ctx) const {
   int block_size_including_axis_dim = static_cast<int>(p.output_axis_pitch);
   const bool same_concat_size =
       std::all_of(concat_sizes.begin(), concat_sizes.end(), [&](int64_t size) { return size == concat_sizes[0]; });
-  if (same_concat_size && input_count <= 32) {
-    TArray<const void*, 32> input_ptr_array(input_count);
+  // Dispatch before allocating the pinned pointer buffer. This path passes pointers by value and
+  // needs no pinned memory, which also keeps it CUDA Graph capturable.
+  if (same_concat_size && input_count <= kMaxInlinePointerCount) {
+    TArray<const void*, kMaxInlinePointerCount> input_ptr_array(input_count);
     for (int i = 0; i < input_count; ++i) {
       input_ptr_array[i] = p.inputs[i].tensor->DataRaw();
     }
@@ -73,13 +82,8 @@ Status Concat::ComputeInternal(OpKernelContext* ctx) const {
 
   CudaAsyncBuffer<const void*> input_ptr(this, input_count);
   gsl::span<const void*> input_ptr_cpuspan = input_ptr.CpuSpan();
-  std::vector<int64_t> axis_dimension_input_output_mapping(p.output_tensor->Shape()[p.axis]);
-  int index = 0;
   for (int i = 0; i < input_count; ++i) {
     input_ptr_cpuspan[i] = p.inputs[i].tensor->DataRaw();
-    for (int j = 0; j < concat_sizes[i]; ++j) {
-      axis_dimension_input_output_mapping.at(index++) = i;
-    }
   }
 
   ORT_RETURN_IF_ERROR(input_ptr.CopyToGpu(GetComputeStream(ctx)));
@@ -88,6 +92,13 @@ Status Concat::ComputeInternal(OpKernelContext* ctx) const {
         Stream(ctx), element_bytes, block_size_including_axis_dim, block_size_inside_axis_dim, concat_sizes[0],
         p.output_tensor->MutableDataRaw(), input_ptr.GpuPtr(), static_cast<size_t>(p.output_num_elements)));
   } else {
+    std::vector<int64_t> axis_dimension_input_output_mapping(p.output_tensor->Shape()[p.axis]);
+    int index = 0;
+    for (int i = 0; i < input_count; ++i) {
+      for (int j = 0; j < concat_sizes[i]; ++j) {
+        axis_dimension_input_output_mapping.at(index++) = i;
+      }
+    }
     CudaAsyncBuffer<int64_t> concat_sizes_gpu(this, concat_sizes);
     CudaAsyncBuffer<int64_t> axis_dimension_input_output_mapping_gpu(this, axis_dimension_input_output_mapping);
     std::vector<int64_t> concat_sizes_range(concat_sizes);

--- a/onnxruntime/core/providers/cuda/tensor/split.cc
+++ b/onnxruntime/core/providers/cuda/tensor/split.cc
@@ -172,18 +172,31 @@ Status SplitKernel::ComputeInternal(OpKernelContext* ctx) const {
                        input_dims);
   }
 
+  size_t element_size = input_tensor->DataType()->Size();
+  const bool same_split_size =
+      std::all_of(split_sizes.begin(), split_sizes.end(), [&](int64_t size) { return size == split_sizes[0]; });
+  if (same_split_size && num_outputs <= 32) {
+    TArray<void*, 32> output_ptr_array(num_outputs);
+    for (int i = 0; i < num_outputs; ++i) {
+      output_dimensions[axis] = split_sizes[i];
+      output_ptr_array[i] = ctx->Output(i, TensorShape{output_dimensions})->MutableDataRaw();
+    }
+
+    if (input_tensor->Shape().Size() <= 0) return Status::OK();
+
+    return SplitSameSplitDimImpl(Stream(ctx), element_size, block_size_including_axis_dim,
+                                 block_size_inside_axis_dim, split_sizes[0], num_outputs, input_data,
+                                 output_ptr_array, static_cast<size_t>(input_shape.Size()));
+  }
+
   CudaAsyncBuffer<void*> output_ptr(this, num_outputs);
   gsl::span<void*> output_ptr_span = output_ptr.CpuSpan();
   TensorShapeVector axis_dimension_input_output_mapping(input_dims[axis]);
   int index = 0;
   for (int i = 0; i < num_outputs; ++i) {
-    // update size of dimension for axis we're splitting on
     auto split_size = gsl::narrow<int>(split_sizes[i]);
     output_dimensions[axis] = split_size;
-
-    Tensor* output = ctx->Output(i, TensorShape{output_dimensions});
-    auto output_data = output->MutableDataRaw();
-    output_ptr_span[i] = output_data;
+    output_ptr_span[i] = ctx->Output(i, TensorShape{output_dimensions})->MutableDataRaw();
     for (int j = 0; j < split_size; ++j) {
       axis_dimension_input_output_mapping.at(index++) = i;
     }
@@ -191,22 +204,12 @@ Status SplitKernel::ComputeInternal(OpKernelContext* ctx) const {
 
   if (input_tensor->Shape().Size() <= 0) return Status::OK();
 
-  size_t element_size = input_tensor->DataType()->Size();
-  if (std::all_of(split_sizes.begin(), split_sizes.end(), [&](int64_t size) { return size == split_sizes[0]; })) {
-    if (num_outputs <= 32) {
-      TArray<void*, 32> output_ptr_array(num_outputs);
-      for (int i = 0; i < num_outputs; ++i) output_ptr_array[i] = output_ptr_span[i];
-      ORT_RETURN_IF_ERROR(SplitSameSplitDimImpl(Stream(ctx), element_size, block_size_including_axis_dim,
-                                                block_size_inside_axis_dim, split_sizes[0], num_outputs, input_data,
-                                                output_ptr_array, static_cast<size_t>(input_shape.Size())));
-    } else {
-      ORT_RETURN_IF_ERROR(output_ptr.CopyToGpu(GetComputeStream(ctx)));
-      ORT_RETURN_IF_ERROR(SplitSameSplitDimImpl(Stream(ctx), element_size, block_size_including_axis_dim,
-                                                block_size_inside_axis_dim, split_sizes[0], num_outputs, input_data,
-                                                output_ptr.GpuPtr(), static_cast<size_t>(input_shape.Size())));
-    }
+  ORT_RETURN_IF_ERROR(output_ptr.CopyToGpu(GetComputeStream(ctx)));
+  if (same_split_size) {
+    ORT_RETURN_IF_ERROR(SplitSameSplitDimImpl(Stream(ctx), element_size, block_size_including_axis_dim,
+                                              block_size_inside_axis_dim, split_sizes[0], num_outputs, input_data,
+                                              output_ptr.GpuPtr(), static_cast<size_t>(input_shape.Size())));
   } else {
-    ORT_RETURN_IF_ERROR(output_ptr.CopyToGpu(GetComputeStream(ctx)));
     CudaAsyncBuffer<int64_t> split_sizes_gpu(this, split_sizes);
     ORT_RETURN_IF_ERROR(split_sizes_gpu.CopyToGpu(GetComputeStream(ctx)));
     std::vector<int64_t> split_sizes_range(split_sizes);

--- a/onnxruntime/core/providers/cuda/tensor/split.cc
+++ b/onnxruntime/core/providers/cuda/tensor/split.cc
@@ -1,6 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+#include <algorithm>
+#include <vector>
+
 #include "core/providers/cuda/tensor/split.h"
 
 #include "core/providers/cuda/tensor/split_impl.h"
@@ -8,6 +11,10 @@
 
 namespace onnxruntime {
 namespace cuda {
+namespace {
+constexpr int kMaxInlinePointerCount = 32;
+}
+
 ONNX_OPERATOR_VERSIONED_KERNEL_EX(Split,
                                   kOnnxDomain,
                                   2, 10,
@@ -175,10 +182,12 @@ Status SplitKernel::ComputeInternal(OpKernelContext* ctx) const {
   size_t element_size = input_tensor->DataType()->Size();
   const bool same_split_size =
       std::all_of(split_sizes.begin(), split_sizes.end(), [&](int64_t size) { return size == split_sizes[0]; });
-  if (same_split_size && num_outputs <= 32) {
-    TArray<void*, 32> output_ptr_array(num_outputs);
+  // Dispatch before allocating the pinned pointer buffer. This path passes pointers by value and
+  // needs no pinned memory, which also keeps it CUDA Graph capturable.
+  if (same_split_size && num_outputs <= kMaxInlinePointerCount) {
+    TArray<void*, kMaxInlinePointerCount> output_ptr_array(num_outputs);
+    output_dimensions[axis] = split_sizes[0];
     for (int i = 0; i < num_outputs; ++i) {
-      output_dimensions[axis] = split_sizes[i];
       output_ptr_array[i] = ctx->Output(i, TensorShape{output_dimensions})->MutableDataRaw();
     }
 
@@ -191,15 +200,10 @@ Status SplitKernel::ComputeInternal(OpKernelContext* ctx) const {
 
   CudaAsyncBuffer<void*> output_ptr(this, num_outputs);
   gsl::span<void*> output_ptr_span = output_ptr.CpuSpan();
-  TensorShapeVector axis_dimension_input_output_mapping(input_dims[axis]);
-  int index = 0;
   for (int i = 0; i < num_outputs; ++i) {
     auto split_size = gsl::narrow<int>(split_sizes[i]);
     output_dimensions[axis] = split_size;
     output_ptr_span[i] = ctx->Output(i, TensorShape{output_dimensions})->MutableDataRaw();
-    for (int j = 0; j < split_size; ++j) {
-      axis_dimension_input_output_mapping.at(index++) = i;
-    }
   }
 
   if (input_tensor->Shape().Size() <= 0) return Status::OK();
@@ -210,6 +214,14 @@ Status SplitKernel::ComputeInternal(OpKernelContext* ctx) const {
                                               block_size_inside_axis_dim, split_sizes[0], num_outputs, input_data,
                                               output_ptr.GpuPtr(), static_cast<size_t>(input_shape.Size())));
   } else {
+    TensorShapeVector axis_dimension_input_output_mapping(input_dims[axis]);
+    int index = 0;
+    for (int i = 0; i < num_outputs; ++i) {
+      const int split_size = gsl::narrow<int>(split_sizes[i]);
+      for (int j = 0; j < split_size; ++j) {
+        axis_dimension_input_output_mapping.at(index++) = i;
+      }
+    }
     CudaAsyncBuffer<int64_t> split_sizes_gpu(this, split_sizes);
     ORT_RETURN_IF_ERROR(split_sizes_gpu.CopyToGpu(GetComputeStream(ctx)));
     std::vector<int64_t> split_sizes_range(split_sizes);

--- a/onnxruntime/test/providers/cpu/tensor/concat_op_test.cc
+++ b/onnxruntime/test/providers/cpu/tensor/concat_op_test.cc
@@ -82,6 +82,25 @@ TEST(ConcatOpTest, Concat1D_2) {
             kQnnExecutionProvider});     // QNN: not support dynamic shape tensor
 }
 
+#ifdef USE_CUDA
+TEST(ConcatOpTest, EqualSized33InputsCuda) {
+  constexpr int kInputCount = 33;
+  OpTester test("Concat");
+  test.AddAttribute("axis", int64_t{0});
+
+  std::vector<float> expected;
+  expected.reserve(kInputCount);
+  for (int i = 0; i < kInputCount; ++i) {
+    const auto value = static_cast<float>(i);
+    const auto input_name = MakeString("input", i);
+    test.AddInput<float>(input_name.c_str(), {1}, {value});
+    expected.push_back(value);
+  }
+  test.AddOutput<float>("concat_result", {kInputCount}, expected);
+  test.ConfigEp(DefaultCudaExecutionProvider()).RunWithConfig();
+}
+#endif
+
 TYPED_TEST(ConcatOpTest, Concat2D_1) {
   OpTester test("Concat");
   test.AddAttribute("axis", int64_t{0});

--- a/onnxruntime/test/providers/cpu/tensor/split_op_test.cc
+++ b/onnxruntime/test/providers/cpu/tensor/split_op_test.cc
@@ -156,6 +156,28 @@ TEST(SplitOperatorTest, Axis0EqualSplit) {
   SplitTestAxis0EqualSplit<std::string>();
 }
 
+#ifdef USE_CUDA
+TEST(SplitOperatorTest, EqualSized33OutputsCuda) {
+  constexpr int kOutputCount = 33;
+  OpTester test("Split", 13);
+  test.AddAttribute("axis", int64_t{0});
+
+  std::vector<float> input;
+  std::vector<int64_t> split_sizes(kOutputCount, 1);
+  input.reserve(kOutputCount);
+  for (int i = 0; i < kOutputCount; ++i) {
+    input.push_back(static_cast<float>(i));
+  }
+  test.AddInput<float>("input", {kOutputCount}, input);
+  test.AddInput<int64_t>("split", {kOutputCount}, split_sizes);
+  for (int i = 0; i < kOutputCount; ++i) {
+    const auto output_name = MakeString("output", i);
+    test.AddOutput<float>(output_name.c_str(), {1}, {input[i]});
+  }
+  test.ConfigEp(DefaultCudaExecutionProvider()).RunWithConfig();
+}
+#endif
+
 TEST(SplitOperatorTest, Axis0UnequalSplitFloat) {
   constexpr int64_t axis = 0;
   std::vector<ShapeAndFloatData> outputs;


### PR DESCRIPTION
Avoid allocating pinned host pointer buffers in the CUDA Split and Concat fast paths when all partitions are equal-sized and there are at most 32 pointers.

These paths pass a `TArray` directly as a kernel argument, so the `CudaAsyncBuffer` allocation and destruction were unnecessary. In a Qwen 3.8 decode trace, their removal reduced pinned allocation/free pairs from 1,635 to 1,355 and reduced time attributed to `cudaFreeHost` from 4.90 seconds to 11.3 milliseconds.

The GPU pointer-buffer fallback is unchanged for more than 32 pointers and for unequal Split/Concat dimensions.

## Motivation

`cudaFreeHost` can synchronize outstanding device work. Allocating pinned pointer metadata before selecting the inline fast path introduced avoidable decode gaps even though the allocation was never copied to or consumed by the GPU.

## Testing

- Release ARM64 CUDA build with CUDA 13.4 for SM120/SM121
- `onnxruntime_provider_test --gtest_filter=*ConcatOpTest*:*SplitOperatorTest*` (53 tests passed across four suites)
- Equal-sized fast paths and existing fallback-path coverage