### PR TITLE
Bundle XNNPACK and pthreadpool into static WebAssembly library

### DIFF
--- a/cmake/onnxruntime_webassembly.cmake
+++ b/cmake/onnxruntime_webassembly.cmake
@@ -105,6 +105,12 @@ endif()
 include(node_helper.cmake)
 
 if (onnxruntime_BUILD_WEBASSEMBLY_STATIC_LIB)
+    # Attached to the provider as include-only deps, so the LINK_LIBRARIES walk below misses them.
+    set(BUNDLED_XNNPACK_LIBS "")
+    if (onnxruntime_USE_XNNPACK)
+      set(BUNDLED_XNNPACK_LIBS XNNPACK pthreadpool)
+    endif()
+
     bundle_static_library(onnxruntime_webassembly
       ${PROTOBUF_LIB}
       onnx
@@ -119,6 +125,7 @@ if (onnxruntime_BUILD_WEBASSEMBLY_STATIC_LIB)
       onnxruntime_providers
       ${PROVIDERS_JS}
       ${PROVIDERS_XNNPACK}
+      ${BUNDLED_XNNPACK_LIBS}
       ${PROVIDERS_WEBNN}
       ${PROVIDERS_WEBGPU}
       onnxruntime_session


### PR DESCRIPTION
### Description
When ORT is built for WASM as a static library with the XNNPACK EP (`--build_wasm --build_wasm_static_lib --use_xnnpack`), the resulting `libonnxruntime_webassembly.a` contains no XNNPACK or pthreadpool objects. The build itself succeeds, so the breakage only shows up downstream: linking the archive into an Emscripten project fails in `wasm-ld` with undefined symbols such as `xnn_initialize`, `xnn_create_convolution2d_nhwc_f32` and `pthreadpool_create`.

`libonnxruntime_providers_xnnpack.a` *is* bundled and references those symbols, but nothing in the archive defines them.

Root cause: `onnxruntime_providers_xnnpack` picks up XNNPACK and pthreadpool through `onnxruntime_add_include_to_target()` (cmake/onnxruntime_providers_xnnpack.cmake), which propagates include directories only and creates no link dependency. Two consequences follow:

1. `bundle_static_library()` in `cmake/onnxruntime_webassembly.cmake` discovers archives by
   recursively walking each target's `LINK_LIBRARIES`. Since XNNPACK and pthreadpool never
   appear there, they are silently left out of the merged archive.
   
2. `googlexnnpack` is declared `EXCLUDE_FROM_ALL` (cmake/external/xnnpack.cmake), and with
   nothing depending on the targets they are never even compiled — there are zero object files
   under `_deps/googlexnnpack-build/` and `_deps/pthreadpool-build/` after a build.

This fix names the two targets explicitly in the static-library `bundle_static_library()` call, guarded by `onnxruntime_USE_XNNPACK`. That mirrors the non-static branch a few lines below, which already does `target_link_libraries(onnxruntime_webassembly PRIVATE XNNPACK)` under the same condition — the asymmetry between the two branches is why the same flags produce a working `.js`/`.wasm` output but a broken static archive. Because `bundle_static_library()` also calls `add_dependencies()` on the targets it is passed, this makes them build as well as be bundled, addressing both consequences above.


### Motivation and Context
`--build_wasm_static_lib` combined with `--use_xnnpack` is an advertised flag combination that currently produces an archive that cannot be linked, with no error at build time. This is a correctness fix for that combination, not a performance change.

Keeping the change at the bundle site also matches the existing convention: component static libraries take external dependencies as includes only (`onnxruntime_common` does exactly this for `cpuinfo::cpuinfo`), with the real linking done at the top level, and other external archives such as `re2::re2` are already listed explicitly in this same `bundle_static_library()` call.

The targets are named explicitly (`XNNPACK pthreadpool`) rather than using `${onnxruntime_EXTERNAL_LIBRARIES_XNNPACK}`, matching how the non-static branch hardcodes `XNNPACK`. Under `onnxruntime_USE_VCPKG` that variable holds resolved library file paths rather than target names, which  bundle_static_library()`'s `$<TARGET_FILE:...>` expansion cannot consume.


Fixes [#32396](https://github.com/microsoft/onnxruntime/issues/32396)


