### PR TITLE
Fix FuseInitializersTransformer consumer input lookup

### DIFF
--- a/onnxruntime/core/optimizer/fuse_initializers_transformer.cc
+++ b/onnxruntime/core/optimizer/fuse_initializers_transformer.cc
@@ -107,13 +107,18 @@ static void FuseInitializerWithNode(Graph& graph,
   // Get next node
   Node& next_node = *graph.GetNode(node.OutputNodesBegin()->Index());
 
-  // Get the index in next node at which the initializer must be replaced
+  // Get the index in next node at which the initializer must be replaced. Node names and
+  // output value names are independent in ONNX, so match the consumer input against the
+  // Cast output value rather than the Cast node name.
+  const std::string& output_name = node.OutputDefs()[0]->Name();
   NodeIndex next_node_arg_index = 0;
   for (; next_node_arg_index < next_node.InputDefs().size(); ++next_node_arg_index) {
-    if (node.Name() == next_node.InputDefs()[next_node_arg_index]->Name()) {
+    if (output_name == next_node.InputDefs()[next_node_arg_index]->Name()) {
       break;
     }
   }
+  ORT_ENFORCE(next_node_arg_index < next_node.InputDefs().size(),
+              "Could not find Cast output '", output_name, "' in consumer node inputs.");
 
   // Get the src initialized tensor at input def index 0
   const auto* constant_initializer_tensor = graph_utils::GetConstantInitializer(graph, node.InputDefs()[0]->Name());

--- a/onnxruntime/test/optimizer/fuse_initializers_transformer_regression_test.cc
+++ b/onnxruntime/test/optimizer/fuse_initializers_transformer_regression_test.cc
@@ -1,0 +1,47 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "gtest/gtest.h"
+
+#include "core/graph/model.h"
+#include "core/optimizer/fuse_initializers_transformer.h"
+#include "test/test_environment.h"
+#include "test/unittest_util/framework_test_utils.h"
+#include "test/unittest_util/graph_transform_test_builder.h"
+#include "test/util/include/asserts.h"
+
+namespace onnxruntime {
+namespace test {
+
+TEST(TransformerTest, FuseInitializerUsesCastOutputValueName) {
+  auto& logger = DefaultLoggingManager().DefaultLogger();
+  Model model("FuseInitializerUsesCastOutputValueName", false, logger);
+  Graph& graph = model.MainGraph();
+  ModelTestBuilder builder(graph);
+
+  NodeArg* initializer = builder.MakeInitializer<MLFloat16>({1}, {MLFloat16(1.0f)});
+  NodeArg* cast_output = builder.MakeIntermediate<float>(std::vector<int64_t>{1});
+  Node& cast_node = graph.AddNode("cast_node_name", "Cast", "", {initializer}, {cast_output});
+  cast_node.AddAttribute("to", static_cast<int64_t>(ONNX_NAMESPACE::TensorProto_DataType_FLOAT));
+
+  NodeArg* output = builder.MakeOutput<float>(std::vector<int64_t>{1});
+  graph.AddNode("consumer_node_name", "Neg", "", {cast_output}, {output});
+
+  graph.SetOutputs({output});
+  ASSERT_STATUS_OK(graph.Resolve());
+  ASSERT_NE(cast_node.Name(), cast_output->Name());
+
+  FuseInitializersTransformer transformer("TransformerTest.FusedInitializers",
+                                          DataTypeImpl::GetTensorType<MLFloat16>(),
+                                          DataTypeImpl::GetTensorType<float>());
+  bool modified = false;
+  ASSERT_STATUS_OK(transformer.Apply(graph, modified, logger));
+  ASSERT_STATUS_OK(graph.Resolve());
+
+  EXPECT_TRUE(modified);
+  EXPECT_EQ(0, CountOpsInGraph(graph)["Cast"]);
+  EXPECT_EQ(1, CountOpsInGraph(graph)["Neg"]);
+}
+
+}  // namespace test
+}  // namespace onnxruntime


### PR DESCRIPTION
## Description

Fixes #32405.

`FuseInitializersTransformer` locates the consumer input to replace by comparing the producer node name with consumer input value names. ONNX does not require node names and output value names to match.

When they differ, the lookup can reach the end of `InputDefs()` and the following access can go out of bounds.

The transformer now matches the consumer input against the Cast node's output value name and guards against an unexpected missing match.

## Tests

Adds a regression test where the Cast node name differs from its output value name, matching the failure reported in #32405.