### PR TITLE
Fix QuickGelu fusion for unsupported CPU dtypes

### DIFF
--- a/onnxruntime/core/optimizer/quick_gelu_fusion.cc
+++ b/onnxruntime/core/optimizer/quick_gelu_fusion.cc
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+#include <array>
+
 #include "core/optimizer/quick_gelu_fusion.h"
 
 #include "core/graph/graph_utils.h"
@@ -11,6 +13,13 @@ using namespace ONNX_NAMESPACE;
 using namespace onnxruntime::common;
 
 namespace onnxruntime {
+
+static constexpr std::array cpu_supported_data_types{"tensor(float)"};
+
+static bool IsSupportedDataType(const Node& node) {
+  return node.GetExecutionProviderType() != kCpuExecutionProvider ||
+         optimizer_utils::IsSupportedDataType(node, cpu_supported_data_types);
+}
 
 /**
 Rewrite x*sigmoid(alpha*x) or x*sigmoid(x) to QuickGelu.
@@ -24,6 +33,10 @@ Status QuickGeluFusion::ApplyImpl(Graph& graph, bool& modified, int graph_level,
 
     Node& node = *p_node;
     ORT_RETURN_IF_ERROR(Recurse(node, modified, graph_level, logger));
+
+    if (!IsSupportedDataType(node)) {
+      continue;
+    }
 
     InlinedVector<std::reference_wrapper<Node>> nodes_to_fuse;
 

--- a/onnxruntime/core/optimizer/quick_gelu_fusion.cc
+++ b/onnxruntime/core/optimizer/quick_gelu_fusion.cc
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-#include <array>
-
 #include "core/optimizer/quick_gelu_fusion.h"
 
 #include "core/graph/graph_utils.h"
@@ -13,13 +11,6 @@ using namespace ONNX_NAMESPACE;
 using namespace onnxruntime::common;
 
 namespace onnxruntime {
-
-static constexpr std::array cpu_supported_data_types{"tensor(float)"};
-
-static bool IsSupportedDataType(const Node& node) {
-  return node.GetExecutionProviderType() != kCpuExecutionProvider ||
-         optimizer_utils::IsSupportedDataType(node, cpu_supported_data_types);
-}
 
 /**
 Rewrite x*sigmoid(alpha*x) or x*sigmoid(x) to QuickGelu.
@@ -33,10 +24,6 @@ Status QuickGeluFusion::ApplyImpl(Graph& graph, bool& modified, int graph_level,
 
     Node& node = *p_node;
     ORT_RETURN_IF_ERROR(Recurse(node, modified, graph_level, logger));
-
-    if (!IsSupportedDataType(node)) {
-      continue;
-    }
 
     InlinedVector<std::reference_wrapper<Node>> nodes_to_fuse;
 
@@ -98,6 +85,13 @@ Status QuickGeluFusion::ApplyImpl(Graph& graph, bool& modified, int graph_level,
       continue;
     }
     nodes_to_fuse.emplace_back(mul_node);
+
+    if (node.GetExecutionProviderType() == kCpuExecutionProvider) {
+      const auto* input_type = quick_gelu_input_arg->Type();
+      if (input_type == nullptr || *input_type != "tensor(float)") {
+        continue;
+      }
+    }
 
     NodeArg* quick_gelu_output_arg = mul_node.MutableOutputDefs()[0];
     Node& quick_gelu_node =

--- a/onnxruntime/test/optimizer/quick_gelu_fusion_test.cc
+++ b/onnxruntime/test/optimizer/quick_gelu_fusion_test.cc
@@ -1,0 +1,56 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include <vector>
+
+#include "gtest/gtest.h"
+#include "test/unittest_util/framework_test_utils.h"
+#include "test/unittest_util/graph_transform_test_builder.h"
+
+namespace onnxruntime {
+namespace test {
+
+namespace {
+
+template <typename T>
+void BuildQuickGeluGraph(ModelTestBuilder& builder) {
+  auto* input = builder.MakeInput<T>(
+      {2, 3},
+      std::vector<T>{static_cast<T>(-2.0), static_cast<T>(-1.0), static_cast<T>(-0.5),
+                     static_cast<T>(0.5), static_cast<T>(1.0), static_cast<T>(2.0)});
+  auto* alpha = builder.MakeScalarInitializer<T>(static_cast<T>(1.702));
+  auto* scaled = builder.MakeIntermediate<T>(std::vector<int64_t>{2, 3});
+  auto* sigmoid = builder.MakeIntermediate<T>(std::vector<int64_t>{2, 3});
+  auto* output = builder.MakeOutput<T>(std::vector<int64_t>{2, 3});
+
+  builder.AddNode("Mul", {input, alpha}, {scaled});
+  builder.AddNode("Sigmoid", {scaled}, {sigmoid});
+  builder.AddNode("Mul", {input, sigmoid}, {output});
+}
+
+}  // namespace
+
+TEST(QuickGeluFusionTest, CpuFloatIsFused) {
+  auto check_graph = [](InferenceSessionWrapper& session) {
+    auto op_to_count = CountOpsInGraph(session.GetGraph());
+    EXPECT_EQ(op_to_count["com.microsoft.QuickGelu"], 1);
+    EXPECT_EQ(op_to_count["Sigmoid"], 0);
+  };
+
+  TransformerTester(BuildQuickGeluGraph<float>, check_graph,
+                    TransformerLevel::Level1, TransformerLevel::Level2, 13, 1e-5);
+}
+
+TEST(QuickGeluFusionTest, CpuDoubleIsNotFused) {
+  auto check_graph = [](InferenceSessionWrapper& session) {
+    auto op_to_count = CountOpsInGraph(session.GetGraph());
+    EXPECT_EQ(op_to_count["com.microsoft.QuickGelu"], 0);
+    EXPECT_EQ(op_to_count["Sigmoid"], 1);
+  };
+
+  TransformerTester(BuildQuickGeluGraph<double>, check_graph,
+                    TransformerLevel::Level1, TransformerLevel::Level2, 13, 1e-12);
+}
+
+}  // namespace test
+}  // namespace onnxruntime

--- a/onnxruntime/test/optimizer/quick_gelu_fusion_test.cc
+++ b/onnxruntime/test/optimizer/quick_gelu_fusion_test.cc
@@ -28,6 +28,18 @@ void BuildQuickGeluGraph(ModelTestBuilder& builder) {
   builder.AddNode("Mul", {input, sigmoid}, {output});
 }
 
+void BuildResizeWithEmptyOptionalInputs(ModelTestBuilder& builder) {
+  auto* input = builder.MakeInput<float>(
+      {1, 1, 2, 2},
+      std::vector<float>{1.0f, 2.0f, 3.0f, 4.0f});
+  auto* roi = builder.MakeEmptyInput();
+  auto* scales = builder.MakeEmptyInput();
+  auto* sizes = builder.MakeInitializer<int64_t>({4}, {1, 1, 4, 4});
+  auto* output = builder.MakeOutput<float>({1, 1, 4, 4});
+
+  builder.AddNode("Resize", {input, roi, scales, sizes}, {output});
+}
+
 }  // namespace
 
 TEST(QuickGeluFusionTest, CpuFloatIsFused) {
@@ -50,6 +62,17 @@ TEST(QuickGeluFusionTest, CpuDoubleIsNotFused) {
 
   TransformerTester(BuildQuickGeluGraph<double>, check_graph,
                     TransformerLevel::Level1, TransformerLevel::Level2, 13, 1e-12);
+}
+
+TEST(QuickGeluFusionTest, CpuNodeWithEmptyOptionalInputDoesNotCrash) {
+  auto check_graph = [](InferenceSessionWrapper& session) {
+    auto op_to_count = CountOpsInGraph(session.GetGraph());
+    EXPECT_EQ(op_to_count["Resize"], 1);
+    EXPECT_EQ(op_to_count["com.microsoft.QuickGelu"], 0);
+  };
+
+  TransformerTester(BuildResizeWithEmptyOptionalInputs, check_graph,
+                    TransformerLevel::Level1, TransformerLevel::Level2, 13, 1e-5);
 }
 
 }  // namespace test

--- a/onnxruntime/test/optimizer/quick_gelu_fusion_test.cc
+++ b/onnxruntime/test/optimizer/quick_gelu_fusion_test.cc
@@ -35,7 +35,7 @@ void BuildResizeWithEmptyOptionalInputs(ModelTestBuilder& builder) {
   auto* roi = builder.MakeEmptyInput();
   auto* scales = builder.MakeEmptyInput();
   auto* sizes = builder.MakeInitializer<int64_t>({4}, {1, 1, 4, 4});
-  auto* output = builder.MakeOutput<float>({1, 1, 4, 4});
+  auto* output = builder.MakeOutput<float>(std::vector<int64_t>{1, 1, 4, 4});
 
   builder.AddNode("Resize", {input, roi, scales, sizes}, {output});
 }


### PR DESCRIPTION
### Description

Fixes #32421.

`QuickGeluFusion` can replace a valid CPU `Mul -> Sigmoid -> Mul` QuickGELU decomposition with `com.microsoft::QuickGelu` for `tensor(double)`. The CPU QuickGelu kernel is registered only for `tensor(float)`, so enabling extended graph optimizations can turn a runnable model into one that fails during session initialization.

The fusion now checks the execution provider and only creates QuickGelu for CPU inputs supported by the CPU kernel. Other execution providers keep their existing behavior; in particular, CUDA continues to support `double`.

Regression coverage verifies that CPU `float` graphs are still fused and CPU `double` graphs remain unfused.

### Motivation and Context

Graph optimizations must preserve model executability. This keeps the standard ONNX decomposition when fusing it would create a contrib op for which the selected CPU execution provider has no compatible kernel.