### PR TITLE
Fix DivMulFusion producer edge rewiring

### DIFF
--- a/onnxruntime/core/optimizer/div_mul_fusion.cc
+++ b/onnxruntime/core/optimizer/div_mul_fusion.cc
@@ -87,10 +87,19 @@ Status DivMulFusion::Apply(Graph& graph, Node& node, RewriteRuleEffect& rule_eff
   const auto& div_output = div_node.OutputDefs();
   auto& mul_inputs = mul_node.MutableInputDefs();
 
-  // get other input of mul
-  auto& mul_other_input = mul_inputs[0] == div_output[0] ? mul_inputs[1] : mul_inputs[0];
+  // Get the other input of Mul. If that value is produced by another node, preserve its graph edge when
+  // rewiring it to input 0 of Div. ReplaceNodeInput only updates the NodeArg and deliberately does not add edges.
+  const int mul_other_input_index = mul_inputs[0] == div_output[0] ? 1 : 0;
+  auto& mul_other_input = mul_inputs[mul_other_input_index];
+  const Node* mul_other_input_node = graph_utils::GetInputNode(mul_node, mul_other_input_index);
 
   graph_utils::ReplaceNodeInput(div_node, 0, *mul_other_input);
+  if (mul_other_input_node != nullptr) {
+    const int producer_output_index =
+        graph_utils::GetNodeOutputIndexFromOutputName(*mul_other_input_node, mul_other_input->Name());
+    graph.AddEdge(mul_other_input_node->Index(), div_node.Index(), producer_output_index, 0);
+  }
+
   // move the output definition and edges from the mul_node to the div_node and delete the mul_node
   graph_utils::FinalizeNodeFusion(graph, div_node, mul_node);
 

--- a/onnxruntime/test/optimizer/div_mul_fusion_test.cc
+++ b/onnxruntime/test/optimizer/div_mul_fusion_test.cc
@@ -1,0 +1,69 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "gtest/gtest.h"
+
+#include "core/graph/graph_utils.h"
+#include "core/graph/model.h"
+#include "core/optimizer/div_mul_fusion.h"
+#include "core/optimizer/rule_based_graph_transformer.h"
+#include "test/test_environment.h"
+#include "test/unittest_util/framework_test_utils.h"
+#include "test/unittest_util/graph_transform_test_builder.h"
+#include "test/util/include/asserts.h"
+
+namespace onnxruntime {
+namespace test {
+
+TEST(DivMulFusionTest, PreservesProducerEdgeForReplacementInput) {
+  auto& logger = DefaultLoggingManager().DefaultLogger();
+  Model model("DivMulFusionProducerEdge", false, ModelMetaData(), PathString(),
+              IOnnxRuntimeOpSchemaRegistryList(), {{kOnnxDomain, 13}}, {}, logger);
+  Graph& graph = model.MainGraph();
+  ModelTestBuilder builder(graph);
+
+  auto* input = builder.MakeInput<float>({2}, -1.0f, 1.0f);
+  auto* produced = builder.MakeIntermediate();
+  builder.AddNode("Neg", {input}, {produced});
+
+  auto* one_a = builder.MakeScalarInitializer<float>(1.0f);
+  auto* one_b = builder.MakeScalarInitializer<float>(1.0f);
+  auto* div_output = builder.MakeIntermediate();
+  builder.AddNode("Div", {one_a, one_b}, {div_output});
+
+  auto* output = builder.MakeOutput();
+  builder.AddNode("Mul", {produced, div_output}, {output});
+
+  ASSERT_STATUS_OK(graph.Resolve());
+
+  RuleBasedGraphTransformer transformer("DivMulFusionTest");
+  ASSERT_STATUS_OK(transformer.Register(std::make_unique<DivMulFusion>()));
+
+  bool modified = false;
+  ASSERT_STATUS_OK(transformer.Apply(graph, modified, logger));
+  EXPECT_TRUE(modified);
+
+  const auto op_counts = CountOpsInGraph(graph);
+  EXPECT_EQ(GetOpCount(op_counts, "Neg"), 1);
+  EXPECT_EQ(GetOpCount(op_counts, "Div"), 1);
+  EXPECT_EQ(GetOpCount(op_counts, "Mul"), 0);
+
+  const Node* fused_div = nullptr;
+  for (const auto& graph_node : graph.Nodes()) {
+    if (graph_node.OpType() == "Div") {
+      fused_div = &graph_node;
+      break;
+    }
+  }
+
+  ASSERT_NE(fused_div, nullptr);
+  EXPECT_EQ(fused_div->InputDefs()[0]->Name(), produced->Name());
+  ASSERT_NE(graph_utils::GetInputNode(*fused_div, 0), nullptr);
+  EXPECT_EQ(graph_utils::GetInputNode(*fused_div, 0)->OpType(), "Neg");
+  EXPECT_EQ(fused_div->GetInputEdgesCount(), 1);
+
+  ASSERT_STATUS_OK(graph.Resolve());
+}
+
+}  // namespace test
+}  // namespace onnxruntime

--- a/onnxruntime/test/optimizer/div_mul_fusion_test.cc
+++ b/onnxruntime/test/optimizer/div_mul_fusion_test.cc
@@ -43,10 +43,10 @@ TEST(DivMulFusionTest, PreservesProducerEdgeForReplacementInput) {
   ASSERT_STATUS_OK(transformer.Apply(graph, modified, logger));
   EXPECT_TRUE(modified);
 
-  const auto op_counts = CountOpsInGraph(graph);
-  EXPECT_EQ(GetOpCount(op_counts, "Neg"), 1);
-  EXPECT_EQ(GetOpCount(op_counts, "Div"), 1);
-  EXPECT_EQ(GetOpCount(op_counts, "Mul"), 0);
+  auto op_counts = CountOpsInGraph(graph);
+  EXPECT_EQ(op_counts["Neg"], 1);
+  EXPECT_EQ(op_counts["Div"], 1);
+  EXPECT_EQ(op_counts["Mul"], 0);
 
   const Node* fused_div = nullptr;
   for (const auto& graph_node : graph.Nodes()) {


### PR DESCRIPTION
### Description

Fixes #32413, #32414 and #32416.

`DivMulFusion` rewrites `1 / x1 * x2` to `x2 / x1` by replacing input 0 of the `Div` with the other `Mul` input. `ReplaceNodeInput()` only changes the NodeArg and intentionally does not create a graph edge.

When `x2` is produced by another node, its producer edge still targets the `Mul`. `FinalizeNodeFusion()` then removes that edge with the `Mul`, leaving the new `Div` consuming a value without a producer edge. A later producer-elimination rule can remove the producer and leave an invalid graph.

This change adds the producer edge from the replacement input to the fused `Div` whenever the replacement input is node-produced. Graph inputs and initializers retain the existing behaviour.

### Tests

Adds a regression graph with a node-produced Mul input and verifies the fused Div retains the producer connection and the graph resolves successfully.