### PR TITLE
Fix GeluFusion for unsupported CPU dtypes

### DIFF
--- a/onnxruntime/core/optimizer/gelu_fusion.cc
+++ b/onnxruntime/core/optimizer/gelu_fusion.cc
@@ -8,6 +8,7 @@
 #include "float.h"
 #include <deque>
 #include <numbers>
+#include <string_view>
 
 using namespace ONNX_NAMESPACE;
 using namespace onnxruntime::common;
@@ -23,6 +24,30 @@ static bool IsSupportedDataType(const Node& node) {
       return false;
     }
   }
+  return true;
+}
+
+static bool IsSupportedCpuGeluTargetDataType(const Node& node, std::string_view target_domain) {
+  if (node.GetExecutionProviderType() != kCpuExecutionProvider) {
+    return true;
+  }
+
+  const auto* input_type = node.InputDefs()[0]->Type();
+  if (input_type == nullptr) {
+    return false;
+  }
+
+  // com.microsoft.Gelu(1) has a CPU kernel only for float. The official ONNX Gelu(20)
+  // CPU kernel also supports float16. Do not create a fused CPU node that the selected
+  // target operator cannot execute.
+  if (target_domain == kMSDomain) {
+    return *input_type == "tensor(float)";
+  }
+
+  if (target_domain == kOnnxDomain) {
+    return *input_type == "tensor(float)" || *input_type == "tensor(float16)";
+  }
+
   return true;
 }
 /*
@@ -75,7 +100,8 @@ Status GeluFusion::ApplyImpl(Graph& graph, bool& modified, int graph_level, cons
     if (!graph_utils::IsSupportedOptypeVersionAndDomain(div, "Div", {7, 13, 14}) ||
         !graph_utils::IsSupportedProvider(div, GetCompatibleExecutionProviders()) ||
         !optimizer_utils::CheckOutputEdges(graph, div, 1) ||
-        !IsSupportedDataType(div)) {
+        !IsSupportedDataType(div) ||
+        !IsSupportedCpuGeluTargetDataType(div, op_domain)) {
       continue;
     }
 

--- a/onnxruntime/core/optimizer/gelu_fusion.cc
+++ b/onnxruntime/core/optimizer/gelu_fusion.cc
@@ -28,7 +28,8 @@ static bool IsSupportedDataType(const Node& node) {
 }
 
 static bool IsSupportedCpuGeluTargetDataType(const Node& node, std::string_view target_domain) {
-  if (node.GetExecutionProviderType() != kCpuExecutionProvider) {
+  const auto& provider_type = node.GetExecutionProviderType();
+  if (!provider_type.empty() && provider_type != kCpuExecutionProvider) {
     return true;
   }
 
@@ -37,9 +38,10 @@ static bool IsSupportedCpuGeluTargetDataType(const Node& node, std::string_view 
     return false;
   }
 
+  // An empty provider means Level 1 is running before partitioning, so preserve CPU fallback.
   // com.microsoft.Gelu(1) has a CPU kernel only for float. The official ONNX Gelu(20)
-  // CPU kernel also supports float16. Do not create a fused CPU node that the selected
-  // target operator cannot execute.
+  // CPU kernel also supports float16. Explicitly assigned non-CPU providers retain their
+  // provider-specific dtype support.
   if (target_domain == kMSDomain) {
     return *input_type == "tensor(float)";
   }

--- a/onnxruntime/test/optimizer/gelu_fusion_dtype_test.cc
+++ b/onnxruntime/test/optimizer/gelu_fusion_dtype_test.cc
@@ -1,0 +1,89 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "gtest/gtest.h"
+
+#include "core/optimizer/gelu_fusion.h"
+#include "test/test_environment.h"
+#include "test/unittest_util/graph_transform_test_builder.h"
+#include "test/util/include/asserts.h"
+
+namespace onnxruntime {
+namespace test {
+namespace {
+
+template <typename T>
+void BuildCpuErfGeluPattern(ModelTestBuilder& builder) {
+  auto* input = builder.MakeInput<T>(
+      {1, 4}, std::vector<T>{T(-1.0f), T(-0.25f), T(0.5f), T(1.0f)});
+  auto* sqrt_two = builder.MakeScalarInitializer<T>(T(1.4142099618911743f));
+  auto* one = builder.MakeScalarInitializer<T>(T(1.0f));
+  auto* half = builder.MakeScalarInitializer<T>(T(0.5f));
+
+  auto* div_output = builder.MakeIntermediate();
+  Node& div = builder.AddNode("Div", {input, sqrt_two}, {div_output});
+  div.SetExecutionProviderType(kCpuExecutionProvider);
+
+  auto* erf_output = builder.MakeIntermediate();
+  Node& erf = builder.AddNode("Erf", {div_output}, {erf_output});
+  erf.SetExecutionProviderType(kCpuExecutionProvider);
+
+  auto* add_output = builder.MakeIntermediate();
+  Node& add = builder.AddNode("Add", {erf_output, one}, {add_output});
+  add.SetExecutionProviderType(kCpuExecutionProvider);
+
+  auto* mul_output = builder.MakeIntermediate();
+  Node& mul = builder.AddNode("Mul", {input, add_output}, {mul_output});
+  mul.SetExecutionProviderType(kCpuExecutionProvider);
+
+  auto* output = builder.MakeOutput();
+  Node& final_mul = builder.AddNode("Mul", {mul_output, half}, {output});
+  final_mul.SetExecutionProviderType(kCpuExecutionProvider);
+}
+
+Status CheckCpuGeluFusion(Graph& graph, bool expect_fusion) {
+  int contrib_gelu_count = 0;
+  int div_count = 0;
+  for (const auto& node : graph.Nodes()) {
+    if (node.OpType() == "Gelu" && node.Domain() == kMSDomain) {
+      ++contrib_gelu_count;
+    } else if (node.OpType() == "Div") {
+      ++div_count;
+    }
+  }
+
+  ORT_RETURN_IF_NOT(contrib_gelu_count == (expect_fusion ? 1 : 0),
+                    "Unexpected com.microsoft.Gelu count");
+  ORT_RETURN_IF_NOT(div_count == (expect_fusion ? 0 : 1),
+                    "Unexpected Div count after GeluFusion");
+  return Status::OK();
+}
+
+template <typename T>
+void RunCpuContribGeluFusionTest(bool expect_fusion) {
+  auto build = [](ModelTestBuilder& builder) { BuildCpuErfGeluPattern<T>(builder); };
+  auto post_check = [expect_fusion](Graph& graph) { return CheckCpuGeluFusion(graph, expect_fusion); };
+
+  ASSERT_STATUS_OK(TestGraphTransformer(
+      build,
+      /*opset_version=*/17,
+      DefaultLoggingManager().DefaultLogger(),
+      std::make_unique<GeluFusion>(InlinedHashSet<std::string_view>{}, TransformerLevel::Level2),
+      TransformerLevel::Level2,
+      /*steps=*/1,
+      /*pre_graph_checker=*/{},
+      post_check));
+}
+
+}  // namespace
+
+TEST(GeluFusionDtypeTest, CpuFloatContribGeluIsFused) {
+  RunCpuContribGeluFusionTest<float>(true);
+}
+
+TEST(GeluFusionDtypeTest, CpuFloat16ContribGeluIsNotFused) {
+  RunCpuContribGeluFusionTest<MLFloat16>(false);
+}
+
+}  // namespace test
+}  // namespace onnxruntime

--- a/onnxruntime/test/optimizer/gelu_fusion_dtype_test.cc
+++ b/onnxruntime/test/optimizer/gelu_fusion_dtype_test.cc
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+#include <string>
+
 #include "gtest/gtest.h"
 
 #include "core/optimizer/gelu_fusion.h"
@@ -41,6 +43,41 @@ void BuildCpuErfGeluPattern(ModelTestBuilder& builder) {
   final_mul.SetExecutionProviderType(kCpuExecutionProvider);
 }
 
+template <typename T>
+void BuildErfGeluPattern(ModelTestBuilder& builder, const std::string& provider_type) {
+  auto* input = builder.MakeInput<T>(
+      {1, 4}, std::vector<T>{T(-1.0f), T(-0.25f), T(0.5f), T(1.0f)});
+  auto* sqrt_two = builder.MakeScalarInitializer<T>(T(1.4142099618911743f));
+  auto* one = builder.MakeScalarInitializer<T>(T(1.0f));
+  auto* half = builder.MakeScalarInitializer<T>(T(0.5f));
+
+  auto set_provider = [&provider_type](Node& node) {
+    if (!provider_type.empty()) {
+      node.SetExecutionProviderType(provider_type);
+    }
+  };
+
+  auto* div_output = builder.MakeIntermediate();
+  Node& div = builder.AddNode("Div", {input, sqrt_two}, {div_output});
+  set_provider(div);
+
+  auto* erf_output = builder.MakeIntermediate();
+  Node& erf = builder.AddNode("Erf", {div_output}, {erf_output});
+  set_provider(erf);
+
+  auto* add_output = builder.MakeIntermediate();
+  Node& add = builder.AddNode("Add", {erf_output, one}, {add_output});
+  set_provider(add);
+
+  auto* mul_output = builder.MakeIntermediate();
+  Node& mul = builder.AddNode("Mul", {input, add_output}, {mul_output});
+  set_provider(mul);
+
+  auto* output = builder.MakeOutput();
+  Node& final_mul = builder.AddNode("Mul", {mul_output, half}, {output});
+  set_provider(final_mul);
+}
+
 Status CheckCpuGeluFusion(Graph& graph, bool expect_fusion) {
   int contrib_gelu_count = 0;
   int div_count = 0;
@@ -75,6 +112,44 @@ void RunCpuContribGeluFusionTest(bool expect_fusion) {
       post_check));
 }
 
+Status CheckOnnxGeluFusion(Graph& graph, bool expect_fusion) {
+  int onnx_gelu_count = 0;
+  int div_count = 0;
+  for (const auto& node : graph.Nodes()) {
+    if (node.OpType() == "Gelu" && node.Domain() == kOnnxDomain) {
+      ++onnx_gelu_count;
+    } else if (node.OpType() == "Div") {
+      ++div_count;
+    }
+  }
+
+  ORT_RETURN_IF_NOT(onnx_gelu_count == (expect_fusion ? 1 : 0),
+                    "Unexpected ONNX Gelu count");
+  ORT_RETURN_IF_NOT(div_count == (expect_fusion ? 0 : 1),
+                    "Unexpected Div count after GeluFusion");
+  return Status::OK();
+}
+
+template <typename T>
+void RunLevel1OnnxGeluFusionTest(const std::string& provider_type, bool expect_fusion) {
+  auto build = [&provider_type](ModelTestBuilder& builder) {
+    BuildErfGeluPattern<T>(builder, provider_type);
+  };
+  auto post_check = [expect_fusion](Graph& graph) {
+    return CheckOnnxGeluFusion(graph, expect_fusion);
+  };
+
+  ASSERT_STATUS_OK(TestGraphTransformer(
+      build,
+      /*opset_version=*/20,
+      DefaultLoggingManager().DefaultLogger(),
+      std::make_unique<GeluFusion>(InlinedHashSet<std::string_view>{}, TransformerLevel::Level1),
+      TransformerLevel::Level1,
+      /*steps=*/1,
+      /*pre_graph_checker=*/{},
+      post_check));
+}
+
 }  // namespace
 
 TEST(GeluFusionDtypeTest, CpuFloatContribGeluIsFused) {
@@ -83,6 +158,18 @@ TEST(GeluFusionDtypeTest, CpuFloatContribGeluIsFused) {
 
 TEST(GeluFusionDtypeTest, CpuFloat16ContribGeluIsNotFused) {
   RunCpuContribGeluFusionTest<MLFloat16>(false);
+}
+
+TEST(GeluFusionDtypeTest, UnassignedDoubleOnnxGeluIsNotFused) {
+  RunLevel1OnnxGeluFusionTest<double>("", false);
+}
+
+TEST(GeluFusionDtypeTest, UnassignedFloat16OnnxGeluIsFused) {
+  RunLevel1OnnxGeluFusionTest<MLFloat16>("", true);
+}
+
+TEST(GeluFusionDtypeTest, AssignedNonCpuDoubleOnnxGeluIsFused) {
+  RunLevel1OnnxGeluFusionTest<double>("TestExecutionProvider", true);
 }
 
 }  // namespace test


### PR DESCRIPTION
### Description

Fixes #32386.

For opsets below 20, `GeluFusion` replaces the standard Erf-based GELU decomposition with `com.microsoft::Gelu(1)`. On CPU that contrib kernel is registered only for `tensor(float)`, but the fusion currently accepts `tensor(float16)` and `tensor(double)`. On Linux ARM64 an fp16 graph can therefore become a fused node with no compatible CPU kernel and session initialization fails.

This change makes `GeluFusion` validate the CPU dtype against the operator domain it will emit:

- `com.microsoft::Gelu` CPU fusion is limited to `float`.
- ONNX `Gelu(20)` CPU fusion continues to support `float` and `float16`.
- Other execution providers retain their existing behavior.

### Tests

Adds graph-level regression coverage confirming that an opset-17 CPU float graph still fuses while the same CPU float16 graph remains as the valid standard ONNX decomposition.