### PR TITLE
Update pytorch/cpuinfo to 69e20fa2

### DIFF
--- a/cmake/deps.txt
+++ b/cmake/deps.txt
@@ -50,7 +50,7 @@ protoc_mac_universal;https://github.com/protocolbuffers/protobuf/releases/downlo
 psimd;https://github.com/Maratyszcza/psimd/archive/072586a71b55b7f8c584153d223e95687148a900.zip;1f5454b01f06f9656b77e4a5e2e31d7422487013
 pthreadpool;https://github.com/google/pthreadpool/archive/dcc9f28589066af0dbd4555579281230abbf74dd.zip;533a77943203ef15ca608bcd9dbe2c94da7451d2
 pybind11;https://github.com/pybind/pybind11/archive/refs/tags/v3.0.2.zip;a064e663b4d7a337ac291d1bef7337ef4e60a1ae
-pytorch_cpuinfo;https://github.com/pytorch/cpuinfo/archive/4628dc060ce4e82345dc166bbac875609db4ff69.zip;e58d4b47c16a982111c897e669ae4f1821a393d7
+pytorch_cpuinfo;https://github.com/pytorch/cpuinfo/archive/69e20fa2bb5e4d6950e431d09db028a21c8d9487.zip;7a4ea1f2bc55e4888d52079c6213209b03a8b7b4
 re2;https://github.com/google/re2/archive/refs/tags/2024-07-02.zip;646e1728269cde7fcef990bf4a8e87b047882e88
 safeint;https://github.com/dcleblanc/SafeInt/archive/refs/tags/3.0.28.zip;23f252040ff6cb9f1fd18575b32fa8fb5928daac
 tensorboard;https://github.com/tensorflow/tensorboard/archive/373eb09e4c5d2b3cc2493f0949dc4be6b6a45e81.zip;67b833913605a4f3f499894ab11528a702c2b381


### PR DESCRIPTION
### Description
Update the pytorch/cpuinfo pin by ten commits, from 4628dc06 (2026-06-12) to 69e20fa2 (2026-07-07). This includes fixes and hardware detection updates relevant to ORT:

- Initialize the vendor/uarch out-parameters in cpuinfo_arm_decode_vendor_uarch (pytorch/cpuinfo#395)
- Zero-initialize stack buffers in the ARM/Linux parsers to fix Valgrind warnings (pytorch/cpuinfo#376)
- Fix an undeclared syscall() error under stricter build options (pytorch/cpuinfo#374)
- Add Linux MIDR detection for Apple M1/M2/M3/M4 (pytorch/cpuinfo#385)
- Add Nova Lake (Coyote Cove) uarch support (pytorch/cpuinfo#393)
- Normalize AMD brand strings containing the "with Radeon Graphics" suffix (pytorch/cpuinfo#389)

The remaining four commits contain smaller cleanups (pytorch/cpuinfo#272, pytorch/cpuinfo#391, pytorch/cpuinfo#401, and pytorch/cpuinfo#410).

69e20fa2 is the last commit before pytorch/cpuinfo#411, which removes the cpuinfo_deinitialize() API that ORT began using in #28245. ORT currently calls it from cpuid_info.cc and posix/env.cc. Updating past 69e20fa2 requires replacing those calls, which is outside the scope of this update.

The three local patches in cmake/patches/cpuinfo apply cleanly to the new source tree.

