### PR TITLE
[CUDA] Pin FP8 GEMV residency for grids just past two blocks per SM

### DIFF
--- a/onnxruntime/contrib_ops/cuda/bert/group_query_attention_impl.cu
+++ b/onnxruntime/contrib_ops/cuda/bert/group_query_attention_impl.cu
@@ -799,9 +799,9 @@ static void KvRowCopyLaunchConfig(const int vec_count,
                                   const int batch_size,
                                   dim3& grid,
                                   dim3& block) {
-  constexpr int kThreadsPerBlock = 256;
+  constexpr int kRowCopyThreadsPerBlock = 256;
   const int threads_x = vec_count < 32 ? vec_count : 32;
-  const int threads_y = kThreadsPerBlock / threads_x > 0 ? kThreadsPerBlock / threads_x : 1;
+  const int threads_y = kRowCopyThreadsPerBlock / threads_x > 0 ? kRowCopyThreadsPerBlock / threads_x : 1;
   block = dim3(threads_x, threads_y);
   grid = dim3((rows + threads_y - 1) / threads_y, kv_num_heads, batch_size);
 }

--- a/onnxruntime/contrib_ops/cuda/bert/paged_attention_impl.cu
+++ b/onnxruntime/contrib_ops/cuda/bert/paged_attention_impl.cu
@@ -1777,7 +1777,7 @@ Status EfficientAttention(
     float scale) {
   const int max_threads_per_block = device_prop.maxThreadsPerBlock;
   const int batch_size = parameters.batch_size;
-  const int token_count = parameters.token_count;
+  [[maybe_unused]] const int token_count = parameters.token_count;
   const int num_heads = parameters.num_heads;
   const int kv_num_heads = parameters.kv_num_heads;
   const int head_size = parameters.head_size;

--- a/onnxruntime/contrib_ops/cuda/math/matmul_block_scaled_fp8.cu
+++ b/onnxruntime/contrib_ops/cuda/math/matmul_block_scaled_fp8.cu
@@ -978,7 +978,8 @@ static Status LaunchMatMulBlockScaledFp8GemvImpl(void* y,
     const int k_split = ApplyFp8MmaKSplitOverride(selected_k_split, m, n, k);
     const int mtiles = (m > 16) ? 4 : ((m > 8) ? 2 : 1);
     const dim3 mma_blocks{static_cast<unsigned int>((n + 15) / 16)};
-    const bool pin_residency = Fp8MmaGemvPinsResidency(n, k_split, mtiles, device_prop.multiProcessorCount);
+    const bool pin_residency = Fp8MmaGemvPinsResidency(
+        n, k_split, mtiles, device_prop.multiProcessorCount, device_prop.major, device_prop.minor);
     const auto launch_mma = [&]<int KSplit, int MTiles>() {
       const dim3 mma_threads{32, KSplit};
 #define ORT_FP8_LAUNCH_MMA(kernel_name)                                                      \

--- a/onnxruntime/contrib_ops/cuda/math/matmul_block_scaled_fp8.cu
+++ b/onnxruntime/contrib_ops/cuda/math/matmul_block_scaled_fp8.cu
@@ -515,17 +515,17 @@ struct Fp8GemvMma<__nv_bfloat16> {
 };
 
 template <int KSplit, int MTiles, typename AType>
-__global__ void MatMulBlockScaledFp8MmaGemvKernel(AType* __restrict__ output,
-                                                  const AType* __restrict__ input_a,
-                                                  const __nv_fp8_e4m3* __restrict__ input_b,
-                                                  const float* __restrict__ weight_scale,
-                                                  const AType* __restrict__ bias,
-                                                  const float* __restrict__ act_scale,
-                                                  int m,
-                                                  int n,
-                                                  int k,
-                                                  int block_size,
-                                                  int k_blocks) {
+__device__ __forceinline__ void Fp8MmaGemvBody(AType* __restrict__ output,
+                                               const AType* __restrict__ input_a,
+                                               const __nv_fp8_e4m3* __restrict__ input_b,
+                                               const float* __restrict__ weight_scale,
+                                               const AType* __restrict__ bias,
+                                               const float* __restrict__ act_scale,
+                                               int m,
+                                               int n,
+                                               int k,
+                                               int block_size,
+                                               int k_blocks) {
   using Mma = Fp8GemvMma<AType>;
 
   const bool act_qdq = act_scale != nullptr;
@@ -692,10 +692,47 @@ __global__ void MatMulBlockScaledFp8MmaGemvKernel(AType* __restrict__ output,
   }
 }
 
+// Two entry points over one body. The pinned one carries a residency hint; see
+// `Fp8MmaGemvPinsResidency` for when the launcher picks it and why the plain one has to stay.
+// clang-format off
+#define ORT_FP8_MMA_GEMV_PARAMS                  \
+  AType* __restrict__ output,                    \
+      const AType* __restrict__ input_a,         \
+      const __nv_fp8_e4m3* __restrict__ input_b, \
+      const float* __restrict__ weight_scale,    \
+      const AType* __restrict__ bias,            \
+      const float* __restrict__ act_scale,       \
+      int m, int n, int k, int block_size, int k_blocks
+
+#define ORT_FP8_MMA_GEMV_ARGS \
+  output, input_a, input_b, weight_scale, bias, act_scale, m, n, k, block_size, k_blocks
+// clang-format on
+
+template <int KSplit, int MTiles, typename AType>
+__global__ void MatMulBlockScaledFp8MmaGemvKernel(ORT_FP8_MMA_GEMV_PARAMS) {
+  Fp8MmaGemvBody<KSplit, MTiles, AType>(ORT_FP8_MMA_GEMV_ARGS);
+}
+
+template <int KSplit, int MTiles, typename AType>
+__global__ __launch_bounds__(32 * KSplit, 3) void MatMulBlockScaledFp8MmaGemvKernelPinned(ORT_FP8_MMA_GEMV_PARAMS) {
+  Fp8MmaGemvBody<KSplit, MTiles, AType>(ORT_FP8_MMA_GEMV_ARGS);
+}
+
+#undef ORT_FP8_MMA_GEMV_ARGS
+#undef ORT_FP8_MMA_GEMV_PARAMS
+
 // Kill switch for A/B testing the tensor-core path against the FMA path in the same binary.
 bool Fp8GemvMmaEnabled() {
   static bool const enabled = onnxruntime::ParseEnvironmentVariableWithDefault<bool>("ORT_FP8_GEMV_MMA", true);
   return enabled;
+}
+
+// Tiling override for A/B sweeps; 0 keeps the heuristic.
+int Fp8GemvKSplitOverride() {
+  static int const k_split = onnxruntime::ParseEnvironmentVariableWithDefault<int>("ORT_FP8_GEMV_KSPLIT", 0);
+  ORT_ENFORCE(k_split == 0 || k_split == 4 || k_split == 8 || k_split == 16 || k_split == 32,
+              "ORT_FP8_GEMV_KSPLIT must be 0, 4, 8, 16, or 32.");
+  return k_split;
 }
 
 // Largest M each sub-path accepts. One mma launch unrolls 4 tiles of the mma's 8-row N extent.
@@ -949,17 +986,31 @@ static Status LaunchMatMulBlockScaledFp8GemvImpl(void* y,
     const int k_split = ApplyFp8MmaKSplitOverride(selected_k_split, m, n, k);
     const int mtiles = (m > 16) ? 4 : ((m > 8) ? 2 : 1);
     const dim3 mma_blocks{static_cast<unsigned int>((n + 15) / 16)};
+    const bool pin_residency = Fp8MmaGemvPinsResidency(n, k_split, mtiles, device_prop.multiProcessorCount);
     const auto launch_mma = [&]<int KSplit, int MTiles>() {
       const dim3 mma_threads{32, KSplit};
-      if (is_bf16) {
-        MatMulBlockScaledFp8MmaGemvKernel<KSplit, MTiles><<<mma_blocks, mma_threads, 0, stream>>>(
-            reinterpret_cast<__nv_bfloat16*>(y), reinterpret_cast<const __nv_bfloat16*>(a), b,
-            weight_scale, reinterpret_cast<const __nv_bfloat16*>(bias), act_scale, m, n, k, block_size, k_blocks);
-      } else {
-        MatMulBlockScaledFp8MmaGemvKernel<KSplit, MTiles><<<mma_blocks, mma_threads, 0, stream>>>(
-            reinterpret_cast<half*>(y), reinterpret_cast<const half*>(a), b,
-            weight_scale, reinterpret_cast<const half*>(bias), act_scale, m, n, k, block_size, k_blocks);
+#define ORT_FP8_LAUNCH_MMA(kernel_name)                                                      \
+  do {                                                                                       \
+    if (is_bf16) {                                                                           \
+      kernel_name<KSplit, MTiles><<<mma_blocks, mma_threads, 0, stream>>>(                   \
+          reinterpret_cast<__nv_bfloat16*>(y), reinterpret_cast<const __nv_bfloat16*>(a), b, \
+          weight_scale, reinterpret_cast<const __nv_bfloat16*>(bias), act_scale, m, n, k,    \
+          block_size, k_blocks);                                                             \
+    } else {                                                                                 \
+      kernel_name<KSplit, MTiles><<<mma_blocks, mma_threads, 0, stream>>>(                   \
+          reinterpret_cast<half*>(y), reinterpret_cast<const half*>(a), b,                   \
+          weight_scale, reinterpret_cast<const half*>(bias), act_scale, m, n, k,             \
+          block_size, k_blocks);                                                             \
+    }                                                                                        \
+  } while (0)
+      if constexpr (KSplit == 16 && MTiles == 1) {
+        if (pin_residency) {
+          ORT_FP8_LAUNCH_MMA(MatMulBlockScaledFp8MmaGemvKernelPinned);
+          return;
+        }
       }
+      ORT_FP8_LAUNCH_MMA(MatMulBlockScaledFp8MmaGemvKernel);
+#undef ORT_FP8_LAUNCH_MMA
     };
     // Only 1, 2 and 4 row tiles are instantiated; an M of 17..24 rounds up to 4 and masks the
     // remainder, which costs nothing next to the weight traffic it shares.

--- a/onnxruntime/contrib_ops/cuda/math/matmul_block_scaled_fp8.cu
+++ b/onnxruntime/contrib_ops/cuda/math/matmul_block_scaled_fp8.cu
@@ -727,14 +727,6 @@ bool Fp8GemvMmaEnabled() {
   return enabled;
 }
 
-// Tiling override for A/B sweeps; 0 keeps the heuristic.
-int Fp8GemvKSplitOverride() {
-  static int const k_split = onnxruntime::ParseEnvironmentVariableWithDefault<int>("ORT_FP8_GEMV_KSPLIT", 0);
-  ORT_ENFORCE(k_split == 0 || k_split == 4 || k_split == 8 || k_split == 16 || k_split == 32,
-              "ORT_FP8_GEMV_KSPLIT must be 0, 4, 8, 16, or 32.");
-  return k_split;
-}
-
 // Largest M each sub-path accepts. One mma launch unrolls 4 tiles of the mma's 8-row N extent.
 // Larger speculative batches are split into two launches so they keep the same per-row arithmetic
 // instead of switching to the dequantize + cuBLAS path.

--- a/onnxruntime/contrib_ops/cuda/math/matmul_block_scaled_fp8_tiling.h
+++ b/onnxruntime/contrib_ops/cuda/math/matmul_block_scaled_fp8_tiling.h
@@ -40,4 +40,26 @@ inline int PickFp8MmaKSplit(int n, int m, int windows, int sm_count,
   return k_split;
 }
 
+// True when the tensor-core GEMV should launch the entry point that carries a residency hint.
+//
+// The mma grid is ceil(N / 16) blocks. A 16-warp block only fits twice per SM, so N just above
+// 32 * sm_count spills into a second, nearly empty wave: on H200 N = 5120 launches 1.21 waves
+// and ncu measures 66% active cycles. __launch_bounds__(threads, 3) makes those shapes a single
+// wave, worth 1.21-1.35x. Outside that window it only costs registers, so:
+//
+//   * a grid at or below 2 blocks per SM is already one wave and must stay on the plain kernel;
+//   * a grid above 3 blocks per SM stays multi-wave either way;
+//   * 8-warp blocks (KSplit 8, taken from N >= 8192) must not carry the attribute at all --
+//     declaring it replaces nvcc's implicit bounds and costs 1.05-1.08x even when the register
+//     cap is unchanged, and KSplit 32 cannot host 3 blocks per SM at all;
+//   * only one row tile fits the 40-register cap that 3 blocks per SM imply. M = 16 (two tiles)
+//     measures 0.74x and M = 32 (four tiles) 0.24x, both from spills.
+inline bool Fp8MmaGemvPinsResidency(int n, int k_split, int m_tiles, int sm_count) {
+  if (k_split != 16 || m_tiles != 1) {
+    return false;
+  }
+  const int col_blocks = (n + 15) / 16;
+  return col_blocks > 2 * sm_count && col_blocks <= 3 * sm_count;
+}
+
 }  // namespace onnxruntime::contrib::cuda

--- a/onnxruntime/contrib_ops/cuda/math/matmul_block_scaled_fp8_tiling.h
+++ b/onnxruntime/contrib_ops/cuda/math/matmul_block_scaled_fp8_tiling.h
@@ -49,13 +49,18 @@ inline int PickFp8MmaKSplit(int n, int m, int windows, int sm_count,
 //
 //   * a grid at or below 2 blocks per SM is already one wave and must stay on the plain kernel;
 //   * a grid above 3 blocks per SM stays multi-wave either way;
+//   * pre-SM89 devices lack native FP8 tensor-core support and lose about 1% from the register
+//     cap even inside the target grid window;
 //   * 8-warp blocks (KSplit 8, taken from N >= 8192) must not carry the attribute at all --
 //     declaring it replaces nvcc's implicit bounds and costs 1.05-1.08x even when the register
 //     cap is unchanged, and KSplit 32 cannot host 3 blocks per SM at all;
 //   * only one row tile fits the 40-register cap that 3 blocks per SM imply. M = 16 (two tiles)
 //     measures 0.74x and M = 32 (four tiles) 0.24x, both from spills.
-inline bool Fp8MmaGemvPinsResidency(int n, int k_split, int m_tiles, int sm_count) {
-  if (k_split != 16 || m_tiles != 1) {
+inline bool Fp8MmaGemvPinsResidency(int n, int k_split, int m_tiles, int sm_count,
+                                    int compute_capability_major, int compute_capability_minor) {
+  if (compute_capability_major < 8 ||
+      (compute_capability_major == 8 && compute_capability_minor < 9) ||
+      k_split != 16 || m_tiles != 1) {
     return false;
   }
   const int col_blocks = (n + 15) / 16;

--- a/onnxruntime/contrib_ops/cuda/moe/qmoe_kernels.cu
+++ b/onnxruntime/contrib_ops/cuda/moe/qmoe_kernels.cu
@@ -3,14 +3,18 @@
 // Licensed under the MIT License.
 
 #include "contrib_ops/cuda/moe/qmoe_kernels.h"
-#include "core/common/narrow.h"
-#include "core/providers/cuda/cuda_common.h"
-#include "core/providers/cuda/cu_inc/cub.cuh"
-#include "core/providers/cuda/cu_inc/topk_warp_sort.cuh"
-#include "contrib_ops/cuda/llm/moe_gemm/moe_kernels.h"
+
 #include <cuda_bf16.h>
+#include <cuda_fp8.h>
+
 #include <algorithm>
 #include <cfloat>
+
+#include "contrib_ops/cuda/llm/moe_gemm/moe_kernels.h"
+#include "core/common/narrow.h"
+#include "core/providers/cuda/cu_inc/cub.cuh"
+#include "core/providers/cuda/cu_inc/topk_warp_sort.cuh"
+#include "core/providers/cuda/cuda_common.h"
 
 namespace onnxruntime {
 namespace contrib {
@@ -363,8 +367,9 @@ __global__ void SoftmaxTopKWarpMergeKernel(const T* logits, float* topk_scales, 
   }
   const float inv_sum = SafeInvSum(WarpReduceSum(local_sum));
 
-  __syncwarp();
+  // Each lane reads back only the slots it wrote above, so the sort needs no barrier before it.
   WarpMergeSorter::Sort(s_scores, s_indices, temp_storage, num_experts);
+  // Sort's blocked write-back must be visible to the strided reads below.
   __syncwarp();
 
   // s_scores[r]/s_indices[r] now hold the rank-r logit/expert index.
@@ -1214,6 +1219,158 @@ void LaunchQMoEDequantizeFp4Weights(
     int k,
     cudaStream_t stream) {
   LaunchQMoEDequantizeFp4WeightsImpl(packed_weights, block_scales, global_scales, output, num_experts, n, k, stream);
+}
+
+// ---------------------------------------------------------------------------
+// MXFP4 -> FP8 (e4m3) weight conversion for the QMoE DeepGEMM path.
+//
+// The FP8 GEMM scales B by one fp32 factor per [128 N, 128 K] block. Factoring the arbitrary
+// per-expert global scale out of the FP8 value and rounding the remaining block scale to a
+// *power of two* makes the conversion bit-exact: an E2M1 code carries at most two significant
+// bits, e4m3 carries four, and a power-of-two scale only shifts exponents. The conventional
+// amax/448 scale would give every weight a full mantissa before rounding it to three bits
+// (measured 4.76% max relative error).
+//
+// Losslessness still needs the quantized magnitudes to stay inside e4m3's range, i.e. the
+// per-block spread of the MXFP4 group exponents must be at most 14. It is 6 for this model, but
+// the second pass verifies the round trip element-by-element rather than assuming it.
+// ---------------------------------------------------------------------------
+constexpr int kQMoEFp8BlockN = 128;
+constexpr int kQMoEFp8BlockK = 128;
+constexpr int kQMoEFp8ScaleThreads = 256;
+constexpr int kQMoEFp8VecK = 16;
+constexpr int kQMoEFp8TileN = 64;
+constexpr int kQMoEFp8TileK = 128;
+constexpr float kQMoEFp8Max = 448.0f;
+
+// One CUDA block per [128 N, 128 K] weight block, emitting sfb[expert][n / 128][k / 128].
+__global__ void QMoEFp4ToFp8BlockScaleKernel(
+    const uint8_t* __restrict__ packed_weights,
+    const uint8_t* __restrict__ block_scales,
+    const float* __restrict__ global_scales,
+    float* __restrict__ output_scales,
+    int n,
+    int k) {
+  using BlockReduce = cub::BlockReduce<float, kQMoEFp8ScaleThreads>;
+  __shared__ typename BlockReduce::TempStorage temp_storage;
+
+  const int n_block = static_cast<int>(blockIdx.x);
+  const int k_block = static_cast<int>(blockIdx.y);
+  const int expert = static_cast<int>(blockIdx.z);
+  const int packed_n = n >> 1;
+  const int scale_k = k >> 5;  // MXFP4 group size is 32
+  constexpr int kHalfRows = kQMoEFp8BlockN / 2;
+
+  float local_max = 0.0f;
+  for (int i = static_cast<int>(threadIdx.x); i < kQMoEFp8BlockK * kHalfRows; i += kQMoEFp8ScaleThreads) {
+    const int col = k_block * kQMoEFp8BlockK + i / kHalfRows;
+    const int half = i % kHalfRows;
+    const uint8_t packed = packed_weights[(static_cast<int64_t>(expert) * k + col) * packed_n +
+                                          n_block * kHalfRows + half];
+    const int row = n_block * kQMoEFp8BlockN + 2 * half;
+    const int64_t scale_base = (static_cast<int64_t>(expert) * n + row) * scale_k + (col >> 5);
+    const float even = DecodeFp4E2M1(static_cast<uint8_t>(packed & 0x0F)) * DecodeUE8M0(block_scales[scale_base]);
+    const float odd = DecodeFp4E2M1(static_cast<uint8_t>(packed >> 4)) * DecodeUE8M0(block_scales[scale_base + scale_k]);
+    local_max = fmaxf(local_max, fmaxf(fabsf(even), fabsf(odd)));
+  }
+  const float amax = BlockReduceMax<BlockReduce>(local_max, temp_storage);
+
+  if (threadIdx.x == 0) {
+    // Preserve the arbitrary fp32 global scale and round only the MXFP4 exponent component.
+    // frexpf gives amax/448 = m * 2^e with m in [0.5, 1).
+    float scale = 1.0f;
+    const float global_scale = fabsf(global_scales[expert]);
+    if (amax > 0.0f && global_scale > 0.0f) {
+      int exponent = 0;
+      const float mantissa = frexpf(amax * (1.0f / kQMoEFp8Max), &exponent);
+      exponent -= mantissa == 0.5f;
+      scale = ldexpf(global_scale, exponent);
+    }
+    output_scales[(static_cast<int64_t>(expert) * (n / kQMoEFp8BlockN) + n_block) * (k / kQMoEFp8BlockK) + k_block] =
+        scale;
+  }
+}
+
+// Second pass: quantize with the power-of-two block scale from above. Tiling matches
+// QMoEDequantizeFp4WeightsVecKernel (8 lanes of one row, 16 bytes each = one 128-byte store).
+__global__ void QMoEFp4ToFp8WeightsKernel(
+    const uint8_t* __restrict__ packed_weights,
+    const uint8_t* __restrict__ block_scales,
+    const float* __restrict__ global_scales,
+    const float* __restrict__ output_scales,
+    uint8_t* __restrict__ output,
+    int* __restrict__ inexact,
+    int n,
+    int k) {
+  const int row = static_cast<int>(blockIdx.x) * kQMoEFp8TileN + static_cast<int>(threadIdx.y);
+  if (row >= n) {
+    return;
+  }
+  const int k_base = static_cast<int>(blockIdx.y) * kQMoEFp8TileK + static_cast<int>(threadIdx.x) * kQMoEFp8VecK;
+  const int expert = static_cast<int>(blockIdx.z);
+
+  const int packed_n = n >> 1;
+  const int shift = (row & 1) ? 4 : 0;
+  const int64_t weight_base = (static_cast<int64_t>(expert) * k + k_base) * packed_n + (row >> 1);
+
+  const int scale_k = k >> 5;
+  const float group_scale =
+      DecodeUE8M0(block_scales[(static_cast<int64_t>(expert) * n + row) * scale_k + (k_base >> 5)]);
+  const float block_scale =
+      output_scales[(static_cast<int64_t>(expert) * (n / kQMoEFp8BlockN) + row / kQMoEFp8BlockN) *
+                        (k / kQMoEFp8BlockK) +
+                    k_base / kQMoEFp8BlockK];
+  const float scaled_global = global_scales[expert] / block_scale;
+
+  union {
+    uint4 vec;
+    uint8_t bytes[kQMoEFp8VecK];
+  } staged;
+  bool exact = true;
+#pragma unroll
+  for (int j = 0; j < kQMoEFp8VecK; ++j) {
+    const uint8_t packed = packed_weights[weight_base + static_cast<int64_t>(j) * packed_n];
+    const float fp4_value = DecodeFp4E2M1(static_cast<uint8_t>((packed >> shift) & 0x0F));
+    const float value = fp4_value * group_scale * global_scales[expert];
+    const __nv_fp8_e4m3 quantized(fp4_value * group_scale * scaled_global);
+    staged.bytes[j] = quantized.__x;
+    exact = exact && (static_cast<float>(quantized) * block_scale == value);
+  }
+  *reinterpret_cast<uint4*>(output + (static_cast<int64_t>(expert) * n + row) * k + k_base) = staged.vec;
+  if (!exact) {
+    *inexact = 1;
+  }
+}
+
+void LaunchQMoEQuantizeFp4WeightsToFp8(
+    const uint8_t* packed_weights,
+    const uint8_t* block_scales,
+    const float* global_scales,
+    uint8_t* output,
+    float* output_scales,
+    int* inexact_flag,
+    int num_experts,
+    int n,
+    int k,
+    cudaStream_t stream) {
+  ORT_ENFORCE(n % kQMoEFp8BlockN == 0 && k % kQMoEFp8BlockK == 0 && (n % kQMoEFp8TileN) == 0,
+              "QMoE MXFP4->FP8 conversion requires n a multiple of ", kQMoEFp8BlockN,
+              " and k a multiple of ", kQMoEFp8BlockK, ", got n=", n, " k=", k);
+  static_assert(kQMoEFp8VecK * sizeof(uint8_t) == sizeof(uint4), "vector store must be 16 bytes");
+  // 32 is the MXFP4 group size; a thread's kQMoEFp8VecK values must share one group scale.
+  static_assert(32 % kQMoEFp8VecK == 0);
+  static_assert(kQMoEFp8TileK % kQMoEFp8VecK == 0);
+
+  const dim3 scale_grid(n / kQMoEFp8BlockN, k / kQMoEFp8BlockK, num_experts);
+  QMoEFp4ToFp8BlockScaleKernel<<<scale_grid, kQMoEFp8ScaleThreads, 0, stream>>>(
+      packed_weights, block_scales, global_scales, output_scales, n, k);
+  CUDA_CALL_THROW(cudaGetLastError());
+
+  const dim3 grid(n / kQMoEFp8TileN, k / kQMoEFp8TileK, num_experts);
+  const dim3 block(kQMoEFp8TileK / kQMoEFp8VecK, kQMoEFp8TileN);
+  QMoEFp4ToFp8WeightsKernel<<<grid, block, 0, stream>>>(
+      packed_weights, block_scales, global_scales, output_scales, output, inexact_flag, n, k);
+  CUDA_CALL_THROW(cudaGetLastError());
 }
 
 template <typename T>

--- a/onnxruntime/contrib_ops/cuda/moe/qmoe_kernels.cu
+++ b/onnxruntime/contrib_ops/cuda/moe/qmoe_kernels.cu
@@ -3,18 +3,14 @@
 // Licensed under the MIT License.
 
 #include "contrib_ops/cuda/moe/qmoe_kernels.h"
-
-#include <cuda_bf16.h>
-#include <cuda_fp8.h>
-
-#include <algorithm>
-#include <cfloat>
-
-#include "contrib_ops/cuda/llm/moe_gemm/moe_kernels.h"
 #include "core/common/narrow.h"
+#include "core/providers/cuda/cuda_common.h"
 #include "core/providers/cuda/cu_inc/cub.cuh"
 #include "core/providers/cuda/cu_inc/topk_warp_sort.cuh"
-#include "core/providers/cuda/cuda_common.h"
+#include "contrib_ops/cuda/llm/moe_gemm/moe_kernels.h"
+#include <cuda_bf16.h>
+#include <algorithm>
+#include <cfloat>
 
 namespace onnxruntime {
 namespace contrib {
@@ -367,9 +363,8 @@ __global__ void SoftmaxTopKWarpMergeKernel(const T* logits, float* topk_scales, 
   }
   const float inv_sum = SafeInvSum(WarpReduceSum(local_sum));
 
-  // Each lane reads back only the slots it wrote above, so the sort needs no barrier before it.
+  __syncwarp();
   WarpMergeSorter::Sort(s_scores, s_indices, temp_storage, num_experts);
-  // Sort's blocked write-back must be visible to the strided reads below.
   __syncwarp();
 
   // s_scores[r]/s_indices[r] now hold the rank-r logit/expert index.
@@ -1219,158 +1214,6 @@ void LaunchQMoEDequantizeFp4Weights(
     int k,
     cudaStream_t stream) {
   LaunchQMoEDequantizeFp4WeightsImpl(packed_weights, block_scales, global_scales, output, num_experts, n, k, stream);
-}
-
-// ---------------------------------------------------------------------------
-// MXFP4 -> FP8 (e4m3) weight conversion for the QMoE DeepGEMM path.
-//
-// The FP8 GEMM scales B by one fp32 factor per [128 N, 128 K] block. Factoring the arbitrary
-// per-expert global scale out of the FP8 value and rounding the remaining block scale to a
-// *power of two* makes the conversion bit-exact: an E2M1 code carries at most two significant
-// bits, e4m3 carries four, and a power-of-two scale only shifts exponents. The conventional
-// amax/448 scale would give every weight a full mantissa before rounding it to three bits
-// (measured 4.76% max relative error).
-//
-// Losslessness still needs the quantized magnitudes to stay inside e4m3's range, i.e. the
-// per-block spread of the MXFP4 group exponents must be at most 14. It is 6 for this model, but
-// the second pass verifies the round trip element-by-element rather than assuming it.
-// ---------------------------------------------------------------------------
-constexpr int kQMoEFp8BlockN = 128;
-constexpr int kQMoEFp8BlockK = 128;
-constexpr int kQMoEFp8ScaleThreads = 256;
-constexpr int kQMoEFp8VecK = 16;
-constexpr int kQMoEFp8TileN = 64;
-constexpr int kQMoEFp8TileK = 128;
-constexpr float kQMoEFp8Max = 448.0f;
-
-// One CUDA block per [128 N, 128 K] weight block, emitting sfb[expert][n / 128][k / 128].
-__global__ void QMoEFp4ToFp8BlockScaleKernel(
-    const uint8_t* __restrict__ packed_weights,
-    const uint8_t* __restrict__ block_scales,
-    const float* __restrict__ global_scales,
-    float* __restrict__ output_scales,
-    int n,
-    int k) {
-  using BlockReduce = cub::BlockReduce<float, kQMoEFp8ScaleThreads>;
-  __shared__ typename BlockReduce::TempStorage temp_storage;
-
-  const int n_block = static_cast<int>(blockIdx.x);
-  const int k_block = static_cast<int>(blockIdx.y);
-  const int expert = static_cast<int>(blockIdx.z);
-  const int packed_n = n >> 1;
-  const int scale_k = k >> 5;  // MXFP4 group size is 32
-  constexpr int kHalfRows = kQMoEFp8BlockN / 2;
-
-  float local_max = 0.0f;
-  for (int i = static_cast<int>(threadIdx.x); i < kQMoEFp8BlockK * kHalfRows; i += kQMoEFp8ScaleThreads) {
-    const int col = k_block * kQMoEFp8BlockK + i / kHalfRows;
-    const int half = i % kHalfRows;
-    const uint8_t packed = packed_weights[(static_cast<int64_t>(expert) * k + col) * packed_n +
-                                          n_block * kHalfRows + half];
-    const int row = n_block * kQMoEFp8BlockN + 2 * half;
-    const int64_t scale_base = (static_cast<int64_t>(expert) * n + row) * scale_k + (col >> 5);
-    const float even = DecodeFp4E2M1(static_cast<uint8_t>(packed & 0x0F)) * DecodeUE8M0(block_scales[scale_base]);
-    const float odd = DecodeFp4E2M1(static_cast<uint8_t>(packed >> 4)) * DecodeUE8M0(block_scales[scale_base + scale_k]);
-    local_max = fmaxf(local_max, fmaxf(fabsf(even), fabsf(odd)));
-  }
-  const float amax = BlockReduceMax<BlockReduce>(local_max, temp_storage);
-
-  if (threadIdx.x == 0) {
-    // Preserve the arbitrary fp32 global scale and round only the MXFP4 exponent component.
-    // frexpf gives amax/448 = m * 2^e with m in [0.5, 1).
-    float scale = 1.0f;
-    const float global_scale = fabsf(global_scales[expert]);
-    if (amax > 0.0f && global_scale > 0.0f) {
-      int exponent = 0;
-      const float mantissa = frexpf(amax * (1.0f / kQMoEFp8Max), &exponent);
-      exponent -= mantissa == 0.5f;
-      scale = ldexpf(global_scale, exponent);
-    }
-    output_scales[(static_cast<int64_t>(expert) * (n / kQMoEFp8BlockN) + n_block) * (k / kQMoEFp8BlockK) + k_block] =
-        scale;
-  }
-}
-
-// Second pass: quantize with the power-of-two block scale from above. Tiling matches
-// QMoEDequantizeFp4WeightsVecKernel (8 lanes of one row, 16 bytes each = one 128-byte store).
-__global__ void QMoEFp4ToFp8WeightsKernel(
-    const uint8_t* __restrict__ packed_weights,
-    const uint8_t* __restrict__ block_scales,
-    const float* __restrict__ global_scales,
-    const float* __restrict__ output_scales,
-    uint8_t* __restrict__ output,
-    int* __restrict__ inexact,
-    int n,
-    int k) {
-  const int row = static_cast<int>(blockIdx.x) * kQMoEFp8TileN + static_cast<int>(threadIdx.y);
-  if (row >= n) {
-    return;
-  }
-  const int k_base = static_cast<int>(blockIdx.y) * kQMoEFp8TileK + static_cast<int>(threadIdx.x) * kQMoEFp8VecK;
-  const int expert = static_cast<int>(blockIdx.z);
-
-  const int packed_n = n >> 1;
-  const int shift = (row & 1) ? 4 : 0;
-  const int64_t weight_base = (static_cast<int64_t>(expert) * k + k_base) * packed_n + (row >> 1);
-
-  const int scale_k = k >> 5;
-  const float group_scale =
-      DecodeUE8M0(block_scales[(static_cast<int64_t>(expert) * n + row) * scale_k + (k_base >> 5)]);
-  const float block_scale =
-      output_scales[(static_cast<int64_t>(expert) * (n / kQMoEFp8BlockN) + row / kQMoEFp8BlockN) *
-                        (k / kQMoEFp8BlockK) +
-                    k_base / kQMoEFp8BlockK];
-  const float scaled_global = global_scales[expert] / block_scale;
-
-  union {
-    uint4 vec;
-    uint8_t bytes[kQMoEFp8VecK];
-  } staged;
-  bool exact = true;
-#pragma unroll
-  for (int j = 0; j < kQMoEFp8VecK; ++j) {
-    const uint8_t packed = packed_weights[weight_base + static_cast<int64_t>(j) * packed_n];
-    const float fp4_value = DecodeFp4E2M1(static_cast<uint8_t>((packed >> shift) & 0x0F));
-    const float value = fp4_value * group_scale * global_scales[expert];
-    const __nv_fp8_e4m3 quantized(fp4_value * group_scale * scaled_global);
-    staged.bytes[j] = quantized.__x;
-    exact = exact && (static_cast<float>(quantized) * block_scale == value);
-  }
-  *reinterpret_cast<uint4*>(output + (static_cast<int64_t>(expert) * n + row) * k + k_base) = staged.vec;
-  if (!exact) {
-    *inexact = 1;
-  }
-}
-
-void LaunchQMoEQuantizeFp4WeightsToFp8(
-    const uint8_t* packed_weights,
-    const uint8_t* block_scales,
-    const float* global_scales,
-    uint8_t* output,
-    float* output_scales,
-    int* inexact_flag,
-    int num_experts,
-    int n,
-    int k,
-    cudaStream_t stream) {
-  ORT_ENFORCE(n % kQMoEFp8BlockN == 0 && k % kQMoEFp8BlockK == 0 && (n % kQMoEFp8TileN) == 0,
-              "QMoE MXFP4->FP8 conversion requires n a multiple of ", kQMoEFp8BlockN,
-              " and k a multiple of ", kQMoEFp8BlockK, ", got n=", n, " k=", k);
-  static_assert(kQMoEFp8VecK * sizeof(uint8_t) == sizeof(uint4), "vector store must be 16 bytes");
-  // 32 is the MXFP4 group size; a thread's kQMoEFp8VecK values must share one group scale.
-  static_assert(32 % kQMoEFp8VecK == 0);
-  static_assert(kQMoEFp8TileK % kQMoEFp8VecK == 0);
-
-  const dim3 scale_grid(n / kQMoEFp8BlockN, k / kQMoEFp8BlockK, num_experts);
-  QMoEFp4ToFp8BlockScaleKernel<<<scale_grid, kQMoEFp8ScaleThreads, 0, stream>>>(
-      packed_weights, block_scales, global_scales, output_scales, n, k);
-  CUDA_CALL_THROW(cudaGetLastError());
-
-  const dim3 grid(n / kQMoEFp8TileN, k / kQMoEFp8TileK, num_experts);
-  const dim3 block(kQMoEFp8TileK / kQMoEFp8VecK, kQMoEFp8TileN);
-  QMoEFp4ToFp8WeightsKernel<<<grid, block, 0, stream>>>(
-      packed_weights, block_scales, global_scales, output_scales, output, inexact_flag, n, k);
-  CUDA_CALL_THROW(cudaGetLastError());
 }
 
 template <typename T>

--- a/onnxruntime/test/contrib_ops/matmul_block_scaled_fp8_test.cc
+++ b/onnxruntime/test/contrib_ops/matmul_block_scaled_fp8_test.cc
@@ -637,10 +637,30 @@ TEST(MatMulBlockQuantizedFp8WeightOpTest, GemvTensorCorePinnedResidencyBoundarie
 
 // Runs the residency-hinted kernel. It is a second instantiation of the same body, so what is
 // under test is the dispatch: nothing above reaches it, because which N selects it depends on the
-// device's SM count (N = 4098 is 257 column blocks, already one wave on anything from 86 SMs up).
-TEST(MatMulBlockQuantizedFp8WeightOpTest, GemvTensorCorePinnedResidencyFp16) {
+// device's SM count.
+TEST(MatMulBlockQuantizedFp8WeightOpTest, GemvTensorCorePinnedResidency) {
+  constexpr const char* kChildProcessVariable = "ORT_FP8_GEMV_PINNED_TEST_CHILD";
+  const bool is_child_process = !Env::Default().GetEnvironmentVar(kChildProcessVariable).empty();
   if (!HasCudaEnvironment(800)) {
     GTEST_SKIP() << "CUDA device is required for MatMulBlockQuantizedFp8Weight.";
+  }
+
+  ScopedEnvironmentVariables scoped_env_vars{EnvVarMap{
+      {"ORT_DISABLE_FUSED_FP8_ACT_QDQ", "0"},
+      {"ORT_FP8_GEMV_MMA", "1"},
+      {"ORT_FP8_GEMV_MAX_M", "32"},
+      {"ORT_FP8_GEMV_KSPLIT", "0"},
+      {"ORT_FP8_GEMV_MATCH_N", "0"},
+      {"ORT_FP8_GEMV_MATCH_K", "0"},
+      {"ORT_FP8_GEMV_DISABLE_GB10_TUNING", "0"},
+      {kChildProcessVariable, "1"},
+  }};
+  if (!is_child_process) {
+    const std::string command =
+        "\"" + CurrentExecutablePath() +
+        "\" --gtest_filter=MatMulBlockQuantizedFp8WeightOpTest.GemvTensorCorePinnedResidency --gtest_color=no";
+    ASSERT_EQ(std::system(command.c_str()), 0);
+    return;
   }
 
   cudaDeviceProp device_prop{};
@@ -700,17 +720,48 @@ TEST(MatMulBlockQuantizedFp8WeightOpTest, GemvTensorCorePinnedResidencyFp16) {
         }
       }
 
-      OpTester test("MatMulBlockQuantizedFp8Weight", 1, onnxruntime::kMSDomain);
-      test.AddAttribute<int64_t>("block_size", block_size);
-      test.AddInput<MLFloat16>("A", {m, k}, FloatsToMLFloat16s(a));
-      test.AddInput<Float8E4M3FN>("B", {n, k}, b);
-      test.AddInput<float>("b_scale", {n, k_blocks}, b_scale);
-      test.AddOutput<MLFloat16>("Y", {m, n}, FloatsToMLFloat16s(expected));
-      test.SetOutputTolerance(0.005f);
+      std::vector<float> bias(static_cast<size_t>(n));
+      for (int64_t col = 0; col < n; ++col) {
+        bias[static_cast<size_t>(col)] = static_cast<float>(col % 5) - 2.0f;
+      }
+      for (const bool with_optional_inputs : {false, true}) {
+        SCOPED_TRACE("with_optional_inputs = " + std::to_string(with_optional_inputs));
+        std::vector<float> expected_output = expected;
+        if (with_optional_inputs) {
+          for (int64_t row = 0; row < m; ++row) {
+            for (int64_t col = 0; col < n; ++col) {
+              expected_output[static_cast<size_t>(row * n + col)] += bias[static_cast<size_t>(col)];
+            }
+          }
+        }
+        for (const bool is_bf16 : {false, true}) {
+          SCOPED_TRACE("is_bf16 = " + std::to_string(is_bf16));
+          OpTester test("MatMulBlockQuantizedFp8Weight", 1, onnxruntime::kMSDomain);
+          test.AddAttribute<int64_t>("block_size", block_size);
+          if (is_bf16) {
+            test.AddInput<BFloat16>("A", {m, k}, FloatsToBFloat16s(a));
+            test.AddOutput<BFloat16>("Y", {m, n}, FloatsToBFloat16s(expected_output));
+          } else {
+            test.AddInput<MLFloat16>("A", {m, k}, FloatsToMLFloat16s(a));
+            test.AddOutput<MLFloat16>("Y", {m, n}, FloatsToMLFloat16s(expected_output));
+          }
+          test.AddInput<Float8E4M3FN>("B", {n, k}, b);
+          test.AddInput<float>("b_scale", {n, k_blocks}, b_scale);
+          if (with_optional_inputs) {
+            test.AddInput<float>("a_scale", {}, {1.0f});
+            if (is_bf16) {
+              test.AddInput<BFloat16>("bias", {n}, FloatsToBFloat16s(bias));
+            } else {
+              test.AddInput<MLFloat16>("bias", {n}, FloatsToMLFloat16s(bias));
+            }
+          }
+          test.SetOutputTolerance(is_bf16 ? 0.02f : 0.005f);
 
-      std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
-      execution_providers.push_back(DefaultCudaExecutionProvider());
-      test.Run(OpTester::ExpectResult::kExpectSuccess, "", {}, nullptr, &execution_providers);
+          std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
+          execution_providers.push_back(DefaultCudaExecutionProvider());
+          test.Run(OpTester::ExpectResult::kExpectSuccess, "", {}, nullptr, &execution_providers);
+        }
+      }
     }
   }
 }

--- a/onnxruntime/test/contrib_ops/matmul_block_scaled_fp8_test.cc
+++ b/onnxruntime/test/contrib_ops/matmul_block_scaled_fp8_test.cc
@@ -664,7 +664,7 @@ TEST(MatMulBlockQuantizedFp8WeightOpTest, GemvTensorCorePinnedResidencyFp16) {
   // A ragged width in the same window leaves the last 16-column tile partly out of range.
   for (const int64_t n : {n_pinned, n_pinned + 5}) {
     const int k_split = onnxruntime::contrib::cuda::PickFp8MmaKSplit(
-      static_cast<int>(n), 1, static_cast<int>(k / 64), sm_count, device_prop.major, device_prop.minor);
+        static_cast<int>(n), 1, static_cast<int>(k / 64), sm_count, device_prop.major, device_prop.minor);
     ASSERT_TRUE(onnxruntime::contrib::cuda::Fp8MmaGemvPinsResidency(static_cast<int>(n), k_split, 1, sm_count))
         << "N = " << n << " should take the hinted entry point on this device";
 

--- a/onnxruntime/test/contrib_ops/matmul_block_scaled_fp8_test.cc
+++ b/onnxruntime/test/contrib_ops/matmul_block_scaled_fp8_test.cc
@@ -21,6 +21,7 @@
 // CUDA_VERSION comes from cuda.h. Without this include the guard below silently
 // evaluates to false and every test in this file is compiled out.
 #include <cuda.h>
+#include <cuda_runtime_api.h>
 
 #include "contrib_ops/cuda/math/matmul_block_scaled_fp8_tiling.h"
 #include "core/providers/cuda/cuda_provider_options.h"
@@ -612,6 +613,105 @@ TEST(MatMulBlockQuantizedFp8WeightOpTest, GemvTensorCoreTilesBf16) {
     std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
     execution_providers.push_back(DefaultCudaExecutionProvider());
     test.Run(OpTester::ExpectResult::kExpectSuccess, "", {}, nullptr, &execution_providers);
+  }
+}
+
+// Selection boundaries for the residency-hinted entry point, at a fixed device size so the
+// expectations do not move with the test machine.
+TEST(MatMulBlockQuantizedFp8WeightOpTest, GemvTensorCorePinnedResidencyBoundaries) {
+  constexpr int sm_count = 132;
+  using onnxruntime::contrib::cuda::Fp8MmaGemvPinsResidency;
+
+  // ceil(N / 16) has to land in (2 * sm_count, 3 * sm_count] == (264, 396].
+  EXPECT_FALSE(Fp8MmaGemvPinsResidency(16 * 264, 16, 1, sm_count));
+  EXPECT_TRUE(Fp8MmaGemvPinsResidency(16 * 264 + 1, 16, 1, sm_count));
+  EXPECT_TRUE(Fp8MmaGemvPinsResidency(16 * 396, 16, 1, sm_count));
+  EXPECT_FALSE(Fp8MmaGemvPinsResidency(16 * 396 + 1, 16, 1, sm_count));
+  // 8-warp blocks regress under any explicit bounds, 32-warp blocks cannot host 3 blocks per SM,
+  // and 2 or 4 row tiles spill at the register cap that 3 resident blocks imply.
+  EXPECT_FALSE(Fp8MmaGemvPinsResidency(16 * 300, 8, 1, sm_count));
+  EXPECT_FALSE(Fp8MmaGemvPinsResidency(16 * 300, 32, 1, sm_count));
+  EXPECT_FALSE(Fp8MmaGemvPinsResidency(16 * 300, 16, 2, sm_count));
+  EXPECT_FALSE(Fp8MmaGemvPinsResidency(16 * 300, 16, 4, sm_count));
+}
+
+// Runs the residency-hinted kernel. It is a second instantiation of the same body, so what is
+// under test is the dispatch: nothing above reaches it, because which N selects it depends on the
+// device's SM count (N = 4098 is 257 column blocks, already one wave on anything from 86 SMs up).
+TEST(MatMulBlockQuantizedFp8WeightOpTest, GemvTensorCorePinnedResidencyFp16) {
+  if (!HasCudaEnvironment(800)) {
+    GTEST_SKIP() << "CUDA device is required for MatMulBlockQuantizedFp8Weight.";
+  }
+
+  cudaDeviceProp device_prop{};
+  int device_id = 0;
+  ASSERT_EQ(cudaGetDevice(&device_id), cudaSuccess);
+  ASSERT_EQ(cudaGetDeviceProperties(&device_prop, device_id), cudaSuccess);
+  const int sm_count = device_prop.multiProcessorCount;
+
+  constexpr int64_t k = 1024;  // 16 K windows, so KSplit stays at its full 16
+  constexpr int64_t block_size = 256;
+  constexpr int64_t k_blocks = k / block_size;
+  // Narrowest N above 2 blocks per SM. Past N = 8192 the launcher drops to 8 warps per block and
+  // stops hinting at all, so a device that large has no shape to test here.
+  const int64_t n_pinned = 16 * (2 * sm_count + 1);
+  if (n_pinned >= 8192) {
+    GTEST_SKIP() << "Device has " << sm_count << " SMs; the hinted window is above N = 8192.";
+  }
+
+  static const float kWeightValues[] = {1.0f, 2.0f, -1.0f};      // exact in E4M3
+  static const float kActValues[] = {1.0f, -1.0f, 0.5f, -0.5f};  // exact in FP16
+  // A ragged width in the same window leaves the last 16-column tile partly out of range.
+  for (const int64_t n : {n_pinned, n_pinned + 5}) {
+    const int k_split = onnxruntime::contrib::cuda::PickFp8MmaKSplit(
+      static_cast<int>(n), 1, static_cast<int>(k / 64), sm_count, device_prop.major, device_prop.minor);
+    ASSERT_TRUE(onnxruntime::contrib::cuda::Fp8MmaGemvPinsResidency(static_cast<int>(n), k_split, 1, sm_count))
+        << "N = " << n << " should take the hinted entry point on this device";
+
+    std::vector<Float8E4M3FN> b(static_cast<size_t>(n * k));
+    std::vector<float> b_scale(static_cast<size_t>(n * k_blocks));
+    for (int64_t col = 0; col < n; ++col) {
+      for (int64_t i = 0; i < k; ++i) {
+        b[static_cast<size_t>(col * k + i)] = Float8E4M3FN(kWeightValues[(col + i) % 3]);
+      }
+      for (int64_t kb = 0; kb < k_blocks; ++kb) {
+        b_scale[static_cast<size_t>(col * k_blocks + kb)] = static_cast<float>(1 + (col + kb) % 3) / 4.0f;
+      }
+    }
+
+    // Only one row tile is hinted, so M stops at 8.
+    for (const int64_t m : {1, 3, 8}) {
+      SCOPED_TRACE("N = " + std::to_string(n) + ", M = " + std::to_string(m));
+      std::vector<float> a(static_cast<size_t>(m * k));
+      for (int64_t row = 0; row < m; ++row) {
+        for (int64_t i = 0; i < k; ++i) {
+          a[static_cast<size_t>(row * k + i)] = kActValues[(row + i) % 4];
+        }
+      }
+      std::vector<float> expected(static_cast<size_t>(m * n));
+      for (int64_t row = 0; row < m; ++row) {
+        for (int64_t col = 0; col < n; ++col) {
+          float acc = 0.0f;
+          for (int64_t i = 0; i < k; ++i) {
+            acc += a[static_cast<size_t>(row * k + i)] * kWeightValues[(col + i) % 3] *
+                   b_scale[static_cast<size_t>(col * k_blocks + i / block_size)];
+          }
+          expected[static_cast<size_t>(row * n + col)] = acc;
+        }
+      }
+
+      OpTester test("MatMulBlockQuantizedFp8Weight", 1, onnxruntime::kMSDomain);
+      test.AddAttribute<int64_t>("block_size", block_size);
+      test.AddInput<MLFloat16>("A", {m, k}, FloatsToMLFloat16s(a));
+      test.AddInput<Float8E4M3FN>("B", {n, k}, b);
+      test.AddInput<float>("b_scale", {n, k_blocks}, b_scale);
+      test.AddOutput<MLFloat16>("Y", {m, n}, FloatsToMLFloat16s(expected));
+      test.SetOutputTolerance(0.005f);
+
+      std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
+      execution_providers.push_back(DefaultCudaExecutionProvider());
+      test.Run(OpTester::ExpectResult::kExpectSuccess, "", {}, nullptr, &execution_providers);
+    }
   }
 }
 

--- a/onnxruntime/test/contrib_ops/matmul_block_scaled_fp8_test.cc
+++ b/onnxruntime/test/contrib_ops/matmul_block_scaled_fp8_test.cc
@@ -620,19 +620,31 @@ TEST(MatMulBlockQuantizedFp8WeightOpTest, GemvTensorCoreTilesBf16) {
 // expectations do not move with the test machine.
 TEST(MatMulBlockQuantizedFp8WeightOpTest, GemvTensorCorePinnedResidencyBoundaries) {
   constexpr int sm_count = 132;
+  constexpr int compute_capability_major = 9;
+  constexpr int compute_capability_minor = 0;
   using onnxruntime::contrib::cuda::Fp8MmaGemvPinsResidency;
 
   // ceil(N / 16) has to land in (2 * sm_count, 3 * sm_count] == (264, 396].
-  EXPECT_FALSE(Fp8MmaGemvPinsResidency(16 * 264, 16, 1, sm_count));
-  EXPECT_TRUE(Fp8MmaGemvPinsResidency(16 * 264 + 1, 16, 1, sm_count));
-  EXPECT_TRUE(Fp8MmaGemvPinsResidency(16 * 396, 16, 1, sm_count));
-  EXPECT_FALSE(Fp8MmaGemvPinsResidency(16 * 396 + 1, 16, 1, sm_count));
+  EXPECT_FALSE(Fp8MmaGemvPinsResidency(
+      16 * 264, 16, 1, sm_count, compute_capability_major, compute_capability_minor));
+  EXPECT_TRUE(Fp8MmaGemvPinsResidency(
+      16 * 264 + 1, 16, 1, sm_count, compute_capability_major, compute_capability_minor));
+  EXPECT_TRUE(Fp8MmaGemvPinsResidency(
+      16 * 396, 16, 1, sm_count, compute_capability_major, compute_capability_minor));
+  EXPECT_FALSE(Fp8MmaGemvPinsResidency(
+      16 * 396 + 1, 16, 1, sm_count, compute_capability_major, compute_capability_minor));
+  EXPECT_FALSE(Fp8MmaGemvPinsResidency(16 * 300, 16, 1, sm_count, 8, 6));
+  EXPECT_TRUE(Fp8MmaGemvPinsResidency(16 * 300, 16, 1, sm_count, 8, 9));
   // 8-warp blocks regress under any explicit bounds, 32-warp blocks cannot host 3 blocks per SM,
   // and 2 or 4 row tiles spill at the register cap that 3 resident blocks imply.
-  EXPECT_FALSE(Fp8MmaGemvPinsResidency(16 * 300, 8, 1, sm_count));
-  EXPECT_FALSE(Fp8MmaGemvPinsResidency(16 * 300, 32, 1, sm_count));
-  EXPECT_FALSE(Fp8MmaGemvPinsResidency(16 * 300, 16, 2, sm_count));
-  EXPECT_FALSE(Fp8MmaGemvPinsResidency(16 * 300, 16, 4, sm_count));
+  EXPECT_FALSE(Fp8MmaGemvPinsResidency(
+      16 * 300, 8, 1, sm_count, compute_capability_major, compute_capability_minor));
+  EXPECT_FALSE(Fp8MmaGemvPinsResidency(
+      16 * 300, 32, 1, sm_count, compute_capability_major, compute_capability_minor));
+  EXPECT_FALSE(Fp8MmaGemvPinsResidency(
+      16 * 300, 16, 2, sm_count, compute_capability_major, compute_capability_minor));
+  EXPECT_FALSE(Fp8MmaGemvPinsResidency(
+      16 * 300, 16, 4, sm_count, compute_capability_major, compute_capability_minor));
 }
 
 // Runs the residency-hinted kernel. It is a second instantiation of the same body, so what is
@@ -667,6 +679,9 @@ TEST(MatMulBlockQuantizedFp8WeightOpTest, GemvTensorCorePinnedResidency) {
   int device_id = 0;
   ASSERT_EQ(cudaGetDevice(&device_id), cudaSuccess);
   ASSERT_EQ(cudaGetDeviceProperties(&device_prop, device_id), cudaSuccess);
+  if (device_prop.major < 8 || (device_prop.major == 8 && device_prop.minor < 9)) {
+    GTEST_SKIP() << "The residency hint requires native FP8 tensor-core support on SM89 or newer devices.";
+  }
   const int sm_count = device_prop.multiProcessorCount;
 
   constexpr int64_t k = 1024;  // 16 K windows, so KSplit stays at its full 16
@@ -685,7 +700,8 @@ TEST(MatMulBlockQuantizedFp8WeightOpTest, GemvTensorCorePinnedResidency) {
   for (const int64_t n : {n_pinned, n_pinned + 5}) {
     const int k_split = onnxruntime::contrib::cuda::PickFp8MmaKSplit(
         static_cast<int>(n), 1, static_cast<int>(k / 64), sm_count, device_prop.major, device_prop.minor);
-    ASSERT_TRUE(onnxruntime::contrib::cuda::Fp8MmaGemvPinsResidency(static_cast<int>(n), k_split, 1, sm_count))
+    ASSERT_TRUE(onnxruntime::contrib::cuda::Fp8MmaGemvPinsResidency(
+        static_cast<int>(n), k_split, 1, sm_count, device_prop.major, device_prop.minor))
         << "N = " << n << " should take the hinted entry point on this device";
 
     std::vector<Float8E4M3FN> b(static_cast<size_t>(n * k));


### PR DESCRIPTION
### Description

Stacked on #32409. That PR's commit is the first commit here; **only the second commit (`Pin FP8 GEMV residency ...`) belongs to this PR.** Please merge #32409 first ??? GitHub will then collapse this diff to the residency change alone.

The tensor-core FP8 GEMV launches `ceil(N / 16)` blocks. A 16-warp block only fits twice per SM, so an `N` just above `32 * sm_count` spills into a second, nearly empty wave: on H200 `N = 5120` launches 1.21 waves and `ncu` measures 66% active cycles.

This adds a second `__global__` entry point over the same kernel body carrying `__launch_bounds__(32 * KSplit, 3)`, and routes the shapes in that window to it. The hint caps registers at 40, which makes three blocks resident and collapses those shapes to a single wave. `cuobjdump -res-usage` confirms the new entry point at `REG:40 SHARED:9216`, so `40 * 512 * 3 = 61440` registers and `27 KiB` of shared memory per SM ??? three blocks fit.

The window is narrow and the hint is a pessimization outside it, so `Fp8MmaGemvPinsResidency` in `matmul_block_scaled_fp8_tiling.h` gates on the conditions that measurement showed matter:

* a grid at or below 2 blocks per SM is already one wave (`N = 1024`, 64 blocks, measured 0.96x);
* a grid above 3 blocks per SM stays multi-wave either way;
* the residency hint requires SM89 or newer, where FP8 tensor-core support is native. SM86 measurements below show a repeatable ~1% regression from the register cap;
* 8-warp blocks (`KSplit` 8, taken from `N >= 8192`) lose 1.05-1.08x from *any* explicit `__launch_bounds__` ??? declaring it replaces nvcc's implicit bounds even when the register cap is unchanged. 32-warp blocks (the `KSplit` 32 arm from #32409) cannot host 3 blocks per SM at all;
* only one row tile meets the 40-register cap. `M = 16` (two tiles) measures 0.74x and `M = 32` (four tiles) 0.24x, both from spills.

The plain kernel is unchanged and stays the default for everything outside the window, so no currently-selected shape changes code path.

Also adds `ORT_FP8_GEMV_KSPLIT` to override the K-split heuristic for A/B sweeps, matching the override already present in the FP4 GEMV.

### Measurements (H200, sm_90, 132 SMs, CUDA 13.0)

Kernel time, FP16 activations, `block_size` 128:

| N | K | before | after | speedup |
|---|---|---|---|---|
| 5120 | 6144 | 13.25 us | 11.04 us | 1.20x |
| 6144 | 5120 | 13.18 us | 9.63 us | 1.37x |
| 5120 | 17408 | 52.00 us | 36.51 us | 1.42x |

On a Qwen3 27B NVFP4 weights + FP8 KV decode workload the FP8 GEMV total drops from 12150 to 11712 us per forward. End-to-end decode throughput (median of repeats, both arms built as real binaries):

| config | speedup |
|---|---|
| batch 1, speculative | 1.030 - 1.036x |
| batch 1, non-speculative | ~1.04x |
| batch 4, speculative (`M = 32`, gated out) | ~1.00x |

Acceptance rate is identical to four decimals in every cell.

### Measurements (GeForce RTX 5060 Ti, sm_120, 36 SMs, CUDA 13.0)

Kernel medians from Nsight Systems CUDA activity traces, FP16 activations, `M = 8`, `block_size` 128. Each trace contains 100 measured launches after warmup; `before` and `after` select the plain and residency-pinned entry points from the same binary.

| N | K | grid | before | after | speedup |
|---|---|---|---|---|---|
| 1168 | 5120 | 73 | 9.088 us | 7.936 us | 1.15x |
| 1440 | 5120 | 90 | 10.928 us | 8.480 us | 1.29x |
| 1440 | 6144 | 90 | 12.896 us | 10.016 us | 1.29x |
| 1440 | 17408 | 90 | 34.704 us | 26.816 us | 1.29x |
| 1728 | 5120 | 108 | 11.872 us | 9.264 us | 1.28x |

The predicate boundaries behave as intended: `N = 1152` (exactly 2 blocks/SM), `N = 1744` (just above 3 blocks/SM), and `M = 16` all stay on the plain kernel and measure within 1% between A/B arms. A ragged in-window `N = 1169` produces bitwise-identical output (`max_abs_diff = 0`).

### Measurements (GeForce RTX 3060, sm_86, 28 SMs, CUDA 13.0)

The same methodology shows that applying the hint on SM86 is a small but repeatable pessimization, which motivates the SM89 minimum:

| N | K | grid | before | after | speedup |
|---|---|---|---|---|---|
| 912 | 5120 | 57 | 71.648 us | 72.608 us | 0.987x |
| 1024 | 5120 | 64 | 72.096 us | 72.959 us | 0.988x |
| 1120 | 5120 | 70 | 72.576 us | 73.183 us | 0.992x |
| 1344 | 5120 | 84 | 73.760 us | 74.352 us | 0.992x |
| 1024 | 17408 | 64 | 236.814 us | 239.135 us | 0.990x |

Three independent `N = 1024`, `K = 5120` traces with alternating arm order reproduce a 0.988-0.991x speedup. `cuobjdump -res-usage` shows that SM86 moves from `REG:56 STACK:0` for the plain FP16 kernel to `REG:40 STACK:8` for the pinned kernel. Boundary and `M = 16` controls remain neutral, and a ragged in-window correctness case is bitwise identical. The final dispatch therefore leaves pre-SM89 devices on the plain kernel.

### Measurements (GeForce RTX 4090, sm_89, 128 SMs, CUDA 13.3)

Kernel time measured with Nsight Systems CUDA traces, FP16 activations, `block_size` 128. The baseline and pinned arms are separate provider binaries built from the same merged PR head; the baseline changes only the residency dispatch to select the plain entry point.

| M | N | K | Grid | Plain | Pinned | Speedup |
|---:|---:|---:|---:|---:|---:|---:|
| 8 | 5120 | 6144 | 320 | 18.43 us | 14.56 us | **1.27x** |
| 8 | 6144 | 5120 | 384 | 16.45 us | 13.76 us | **1.20x** |
| 8 | 5120 | 17408 | 320 | 101.83 us | 98.11 us | **1.04x** |

Controls outside the pinned dispatch remain neutral within run-to-run variance:

| Control | Plain | PR | Ratio |
|---|---:|---:|---:|
| `M = 8, N = 1024, K = 5120` (grid below 2 blocks/SM) | 5.76 us | 5.92 us | 0.97x |
| `M = 16, N = 5120, K = 6144` (`MTiles = 2`) | 31.36 us | 30.78 us | 1.02x |

Using the occurrence counts in the Qwen3.8 workload microbenchmark, the three affected shapes save about 407 us per forward. A reverse-order repeat reproduced the main gains (1.24x, 1.22x, and 1.04x respectively).
### Tests

`onnxruntime_provider_test --gtest_filter='*MatMulBlockQuantizedFp8Weight*'` ??? 14/14 pass.

Two new tests:

* `GemvTensorCorePinnedResidencyBoundaries` ??? pure predicate test at a fixed `sm_count` of 132, asserting the `(264, 396]` column-block window, SM86 exclusion, SM89 inclusion, and the `KSplit` / `MTiles` exclusions, so the expectations do not move with the test machine.
* `GemvTensorCorePinnedResidency` ??? runs the hinted kernel. Which `N` selects it depends on the device's SM count, so the shape is derived from `cudaGetDeviceProperties` (`N = 16 * (2 * sm_count + 1)`, plus a ragged `+ 5`) and cross-checked against `PickFp8MmaKSplit`. Skips on pre-SM89 devices and devices whose window lands above `N = 8192`, where the launcher drops to 8 warps and stops hinting.

### Note for #32409

`cuobjdump -res-usage` shows `MatMulBlockScaledFp8MmaGemvKernel<32, 4, ...>` at `SHARED:66560` (65 KiB). `PickFp8MmaKSplit` only returns 32 when `m <= 8`, so `MTiles` is always 1 there and that instantiation can never be launched ??? but it is still compiled and emitted. Calling `launch_mma.template operator()<32, 1>()` directly instead of going through `launch_for_ksplit<32>()` would drop it. Not changed here since it belongs to #32409.

