### PR TITLE
Create a dedicated location for PCI vendor ID constants

### DIFF
--- a/include/onnxruntime/core/common/pci_vendor_ids.h
+++ b/include/onnxruntime/core/common/pci_vendor_ids.h
@@ -1,0 +1,31 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include <cstdint>
+
+// Catalog of PCI-SIG vendor ID constants for ONNX Runtime
+// (https://pcisig.com/membership/member-companies).
+// A vendor may have more than one assignment: kAmdAti (0x1002) is the former ATI assignment used
+// by AMD GPUs, while kAmd (0x1022) is the AMD assignment used by CPUs and Ryzen AI NPUs.
+// Qualcomm has two assignments: kQualcommInc (0x5143) and kQualcommTechnologies (0x17CB).
+// ORT represents the ACPI vendor identifier 'QCOM' (0x4D4F4351) for Qualcomm Snapdragon CPUs.
+// This is not a PCI vendor ID (see cpuid_info_vendor.cc and the QNN EP factory).
+namespace onnxruntime {
+namespace pci_vendor_ids {
+
+inline constexpr uint32_t kAmdAti = 0x1002;
+inline constexpr uint32_t kIbm = 0x1014;
+inline constexpr uint32_t kAmd = 0x1022;
+inline constexpr uint32_t kApple = 0x106B;
+inline constexpr uint32_t kNvidia = 0x10DE;
+inline constexpr uint32_t kArm = 0x13B5;
+inline constexpr uint32_t kMicrosoft = 0x1414;
+inline constexpr uint32_t kQualcommTechnologies = 0x17CB;
+inline constexpr uint32_t kHuawei = 0x19E5;
+inline constexpr uint32_t kQualcommInc = 0x5143;
+inline constexpr uint32_t kIntel = 0x8086;
+
+}  // namespace pci_vendor_ids
+}  // namespace onnxruntime

--- a/include/onnxruntime/core/common/pci_vendor_ids.h
+++ b/include/onnxruntime/core/common/pci_vendor_ids.h
@@ -9,9 +9,6 @@
 // (https://pcisig.com/membership/member-companies).
 // A vendor may have more than one assignment: kAmdAti (0x1002) is the former ATI assignment used
 // by AMD GPUs, while kAmd (0x1022) is the AMD assignment used by CPUs and Ryzen AI NPUs.
-// Qualcomm has two assignments: kQualcommInc (0x5143) and kQualcommTechnologies (0x17CB).
-// ORT represents the ACPI vendor identifier 'QCOM' (0x4D4F4351) for Qualcomm Snapdragon CPUs.
-// This is not a PCI vendor ID (see cpuid_info_vendor.cc and the QNN EP factory).
 namespace onnxruntime {
 namespace pci_vendor_ids {
 
@@ -22,7 +19,6 @@ inline constexpr uint32_t kApple = 0x106B;
 inline constexpr uint32_t kNvidia = 0x10DE;
 inline constexpr uint32_t kArm = 0x13B5;
 inline constexpr uint32_t kMicrosoft = 0x1414;
-inline constexpr uint32_t kQualcommTechnologies = 0x17CB;
 inline constexpr uint32_t kHuawei = 0x19E5;
 inline constexpr uint32_t kQualcommInc = 0x5143;
 inline constexpr uint32_t kIntel = 0x8086;

--- a/include/onnxruntime/core/framework/ortdevice.h
+++ b/include/onnxruntime/core/framework/ortdevice.h
@@ -6,6 +6,7 @@
 #include <sstream>
 #include "core/common/common.h"
 #include "core/common/hash_combine.h"
+#include "core/common/pci_vendor_ids.h"
 
 // fix clash with INTEL that is defined in
 // MacOSX14.2.sdk/System/Library/Frameworks/Security.framework/Headers/oidsbase.h
@@ -52,17 +53,19 @@ struct OrtDevice {
     static constexpr MemoryType HOST_ACCESSIBLE = 5;
   };
 
-  // PCI vendor ids
+  // Compatibility aliases for vendor IDs used by OrtDevice-based allocator and data transfer code.
+  // The canonical PCI vendor ID constants live in core/common/pci_vendor_ids.h.
+  // Python's OrtDeviceVendorId enum mirrors these names and values.
   enum VendorIds : VendorId {
     // No vendor ID. Valid for DeviceType::CPU + MemType::DEFAULT or for generic allocators like WebGPU.
     NONE = 0x0000,
-    AMD = 0x1002,        // MIGraphX EP
-    NVIDIA = 0x10DE,     // CUDA/TensorRT
-    ARM = 0x13B5,        // ARM GPU EP
-    MICROSOFT = 0x1414,  // DML EP
-    HUAWEI = 0x19E5,     // CANN EP
-    QUALCOMM = 0x5143,   // QNN DP
-    INTEL = 0x8086,      // OpenVINO
+    AMD = onnxruntime::pci_vendor_ids::kAmdAti,            // MIGraphX EP
+    NVIDIA = onnxruntime::pci_vendor_ids::kNvidia,         // CUDA/TensorRT
+    ARM = onnxruntime::pci_vendor_ids::kArm,               // ARM GPU EP
+    MICROSOFT = onnxruntime::pci_vendor_ids::kMicrosoft,   // DML EP
+    HUAWEI = onnxruntime::pci_vendor_ids::kHuawei,         // CANN EP
+    QUALCOMM = onnxruntime::pci_vendor_ids::kQualcommInc,  // QNN DP
+    INTEL = onnxruntime::pci_vendor_ids::kIntel,           // OpenVINO
   };
 
   constexpr OrtDevice(DeviceType device_type_, MemoryType memory_type_, VendorId vendor_id_, DeviceId device_id_,

--- a/include/onnxruntime/core/framework/ortdevice.h
+++ b/include/onnxruntime/core/framework/ortdevice.h
@@ -64,7 +64,7 @@ struct OrtDevice {
     ARM = onnxruntime::pci_vendor_ids::kArm,               // ARM GPU EP
     MICROSOFT = onnxruntime::pci_vendor_ids::kMicrosoft,   // DML EP
     HUAWEI = onnxruntime::pci_vendor_ids::kHuawei,         // CANN EP
-    QUALCOMM = onnxruntime::pci_vendor_ids::kQualcommInc,  // QNN DP
+    QUALCOMM = onnxruntime::pci_vendor_ids::kQualcommInc,  // QNN EP
     INTEL = onnxruntime::pci_vendor_ids::kIntel,           // OpenVINO
   };
 

--- a/onnxruntime/core/common/cpuid_info_vendor.cc
+++ b/onnxruntime/core/common/cpuid_info_vendor.cc
@@ -11,6 +11,8 @@
 #include "cpuinfo.h"
 #endif
 
+#include "core/common/pci_vendor_ids.h"
+
 namespace {
 
 #if !defined(CPUINFO_SUPPORTED)
@@ -192,14 +194,16 @@ struct CpuVendorInfo {
 constexpr auto kUnknownCpuVendorInfo = CpuVendorInfo{cpuinfo_vendor_unknown, "unknown", 0x0000};
 
 constexpr std::array kCpuVendorInfos{
-    CpuVendorInfo{cpuinfo_vendor_amd, "AMD", 0x1022},
-    CpuVendorInfo{cpuinfo_vendor_intel, "Intel", 0x8086},
+    CpuVendorInfo{cpuinfo_vendor_amd, "AMD", pci_vendor_ids::kAmd},  // AMD CPU/NPU ID. GPUs use kAmdAti.
+    CpuVendorInfo{cpuinfo_vendor_intel, "Intel", pci_vendor_ids::kIntel},
+    // Use the ACPI vendor identifier 'QCOM' (0x4D4F4351), not a Qualcomm PCI ID.
+    // Windows device discovery encodes VEN_QCOM the same way, and the QNN EP matches this value.
     CpuVendorInfo{cpuinfo_vendor_qualcomm, "Qualcomm", uint32_t{'Q' | ('C' << 8) | ('O' << 16) | ('M' << 24)}},
-    CpuVendorInfo{cpuinfo_vendor_nvidia, "Nvidia", 0x10DE},
-    CpuVendorInfo{cpuinfo_vendor_apple, "Apple", 0x106B},
-    CpuVendorInfo{cpuinfo_vendor_arm, "ARM", 0x13B5},
-    CpuVendorInfo{cpuinfo_vendor_ibm, "IBM", 0x1014},
-    CpuVendorInfo{cpuinfo_vendor_huawei, "HiSilicon", 0x19E5},
+    CpuVendorInfo{cpuinfo_vendor_nvidia, "Nvidia", pci_vendor_ids::kNvidia},
+    CpuVendorInfo{cpuinfo_vendor_apple, "Apple", pci_vendor_ids::kApple},
+    CpuVendorInfo{cpuinfo_vendor_arm, "ARM", pci_vendor_ids::kArm},
+    CpuVendorInfo{cpuinfo_vendor_ibm, "IBM", pci_vendor_ids::kIbm},
+    CpuVendorInfo{cpuinfo_vendor_huawei, "HiSilicon", pci_vendor_ids::kHuawei},
     // TODO add more as needed
 };
 

--- a/onnxruntime/core/platform/apple/device_discovery.cc
+++ b/onnxruntime/core/platform/apple/device_discovery.cc
@@ -7,12 +7,13 @@
 #include <TargetConditionals.h>
 
 #include "core/common/logging/logging.h"
+#include "core/common/pci_vendor_ids.h"
 
 namespace onnxruntime {
 
 namespace {
 
-constexpr auto kApplePciVendorId = 0x106B;
+constexpr auto kApplePciVendorId = pci_vendor_ids::kApple;
 constexpr auto kAppleVendorName = "Apple";
 
 std::vector<OrtHardwareDevice> GetGpuDevices() {

--- a/onnxruntime/core/platform/linux/device_discovery.cc
+++ b/onnxruntime/core/platform/linux/device_discovery.cc
@@ -16,6 +16,7 @@
 #include "core/common/common.h"
 #include "core/common/logging/logging.h"
 #include "core/common/parse_string.h"
+#include "core/common/pci_vendor_ids.h"
 #include "core/common/string_utils.h"
 
 namespace fs = std::filesystem;
@@ -122,8 +123,7 @@ std::optional<bool> IsGpuDiscrete(uint16_t vendor_id, uint16_t device_id) {
 
   // Currently, we only assume that all Nvidia GPUs are discrete.
 
-  constexpr auto kNvidiaPciId = 0x10de;
-  if (vendor_id == kNvidiaPciId) {
+  if (vendor_id == pci_vendor_ids::kNvidia) {
     return true;
   }
 

--- a/onnxruntime/core/platform/windows/device_discovery.cc
+++ b/onnxruntime/core/platform/windows/device_discovery.cc
@@ -13,6 +13,7 @@
 
 #include "core/common/cpuid_info.h"
 #include "core/common/logging/logging.h"
+#include "core/common/pci_vendor_ids.h"
 #include "core/platform/env.h"
 #include "core/session/abi_devices.h"
 
@@ -350,7 +351,8 @@ std::unordered_map<uint64_t, DeviceInfo> GetDeviceInfoD3D12(bool have_remote_dis
 
     // Microsoft Remote Display Adapter and Microsoft Hyper-V Video display adapters use the basic render driver
     // but don't set the DXGI_ADAPTER_FLAG_SOFTWARE flag. Filter them out by checking the vendor and device IDs.
-    const bool is_microsoft_basic_render_driver = desc.VendorId == 0x1414 && desc.DeviceId == 0x008c;
+    const bool is_microsoft_basic_render_driver =
+        desc.VendorId == pci_vendor_ids::kMicrosoft && desc.DeviceId == 0x008c;
     if ((desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE) != 0 ||
         (desc.Flags & DXGI_ADAPTER_FLAG_REMOTE) != 0 ||
         is_microsoft_basic_render_driver) {


### PR DESCRIPTION
### Description
OrtDevice::VendorIds, Apple device discovery, and other core call sites previously carried duplicate PCI vendor ID constants. Add include/onnxruntime/core/common/pci_vendor_ids.h to hold the shared definitions.

A vendor may have more than one PCI-SIG assignment. kAmdAti (0x1002) is the former ATI assignment used by AMD GPUs, while kAmd (0x1022) is the AMD assignment used by CPUs and Ryzen AI NPUs. Qualcomm has two assignments: kQualcommInc (0x5143) and kQualcommTechnologies (0x17CB).

Qualcomm Snapdragon CPUs use the ACPI vendor identifier 'QCOM' (0x4D4F4351), not a PCI vendor ID. This value remains local to the CPU vendor table. Windows device discovery and the QNN EP use the same encoding.