### PR TITLE
Clarify external initializer and EP context path interaction

### DIFF
--- a/include/onnxruntime/core/session/onnxruntime_session_options_config_keys.h
+++ b/include/onnxruntime/core/session/onnxruntime_session_options_config_keys.h
@@ -369,6 +369,8 @@ static const char* const kOrtSessionOptionsOptimizedModelExternalInitializersMin
 // file path or from a memory buffer/stream. All external data files must be in the same folder.
 // Typical uses include loading models with external data from memory, sharing a weights file
 // across models, and weightless/cache models whose weights live outside the model directory.
+// For EPContext workflows, also set kOrtSessionOptionEpContextFilePath so the EPContext
+// model location remains available for resolving an external EP context binary.
 static const char* const kOrtSessionOptionsModelExternalInitializersFileFolderPath =
     "session.model_external_initializers_file_folder_path";
 
@@ -470,9 +472,14 @@ static const char* const kOrtSessionOptionsMaxShapeOverride = "session.max_shape
 // "1": enable.
 static const char* const kOrtSessionOptionEpContextEnable = "ep.context_enable";
 
-// Specify the file path for the Onnx model which has EP context.
-// Default to original_file_name_ctx.onnx if not specified
-// Folder is not a valid option
+// Specify the file path for the ONNX model containing EP context.
+// For EP context generation, defaults to original_file_name_ctx.onnx if not specified.
+// During inference, EPs use this path to resolve an external EP context binary whose
+// relative path is stored in an EPContext node's ep_cache_context attribute.
+// To resolve an external EP context binary, set this option when the model path is
+// unavailable or when kOrtSessionOptionsModelExternalInitializersFileFolderPath overrides
+// it with a different directory. Specifying both paths is recommended for EPContext workflows.
+// A folder is not a valid value.
 static const char* const kOrtSessionOptionEpContextFilePath = "ep.context_file_path";
 
 // Flag to specify whether to dump the EP context into the Onnx model.

--- a/onnxruntime/core/providers/openvino/onnx_ctx_model_helper.cc
+++ b/onnxruntime/core/providers/openvino/onnx_ctx_model_helper.cc
@@ -117,7 +117,11 @@ std::unique_ptr<ModelBlobWrapper> EPCtxHandler::GetModelBlobStream(const std::fi
     }
     ORT_THROW_IF_ERROR(utils::ValidateExternalDataPath(blob_filepath, std::filesystem::path(ep_cache_context)));
     blob_filepath = blob_filepath.parent_path() / ep_cache_context;
-    ORT_ENFORCE(std::filesystem::exists(blob_filepath), "Blob file not found: ", blob_filepath.string());
+    ORT_ENFORCE(
+        std::filesystem::exists(blob_filepath),
+        "External EP context file not found: ", blob_filepath.string(),
+        ". If session.model_external_initializers_file_folder_path is set, set ep.context_file_path to the "
+        "EPContext model path so relative ep_cache_context paths are resolved from the EPContext model directory.");
     result.reset((std::istream*)new std::ifstream(blob_filepath, std::ios_base::binary | std::ios_base::in));
   }
 

--- a/onnxruntime/core/providers/openvino/onnx_ctx_model_helper.cc
+++ b/onnxruntime/core/providers/openvino/onnx_ctx_model_helper.cc
@@ -115,13 +115,16 @@ std::unique_ptr<ModelBlobWrapper> EPCtxHandler::GetModelBlobStream(const std::fi
     if (blob_filepath.empty() && !graph_viewer.ModelPath().empty()) {
       blob_filepath = graph_viewer.ModelPath();
     }
-    ORT_THROW_IF_ERROR(utils::ValidateExternalDataPath(blob_filepath, std::filesystem::path(ep_cache_context)));
+    constexpr const char* path_resolution_guidance =
+        ". If session.model_external_initializers_file_folder_path is set, set ep.context_file_path to the "
+        "EPContext model path so relative ep_cache_context paths are resolved from the EPContext model directory.";
+    const auto validate_status =
+        utils::ValidateExternalDataPath(blob_filepath, std::filesystem::path(ep_cache_context));
+    ORT_ENFORCE(validate_status.IsOK(), validate_status.ErrorMessage(), path_resolution_guidance);
     blob_filepath = blob_filepath.parent_path() / ep_cache_context;
     ORT_ENFORCE(
         std::filesystem::exists(blob_filepath),
-        "External EP context file not found: ", blob_filepath.string(),
-        ". If session.model_external_initializers_file_folder_path is set, set ep.context_file_path to the "
-        "EPContext model path so relative ep_cache_context paths are resolved from the EPContext model directory.");
+        "External EP context file not found: ", blob_filepath.string(), path_resolution_guidance);
     result.reset((std::istream*)new std::ifstream(blob_filepath, std::ios_base::binary | std::ios_base::in));
   }
 

--- a/onnxruntime/core/providers/openvino/onnx_ctx_model_helper.cc
+++ b/onnxruntime/core/providers/openvino/onnx_ctx_model_helper.cc
@@ -120,7 +120,10 @@ std::unique_ptr<ModelBlobWrapper> EPCtxHandler::GetModelBlobStream(const std::fi
         "EPContext model path so relative ep_cache_context paths are resolved from the EPContext model directory.";
     const auto validate_status =
         utils::ValidateExternalDataPath(blob_filepath, std::filesystem::path(ep_cache_context));
-    ORT_ENFORCE(validate_status.IsOK(), validate_status.ErrorMessage(), path_resolution_guidance);
+    if (!validate_status.IsOK()) {
+      ORT_THROW_IF_ERROR(Status(validate_status.Category(), validate_status.Code(),
+                                validate_status.ErrorMessage() + path_resolution_guidance));
+    }
     blob_filepath = blob_filepath.parent_path() / ep_cache_context;
     ORT_ENFORCE(
         std::filesystem::exists(blob_filepath),

--- a/onnxruntime/core/providers/qnn/builder/onnx_ctx_model_helper.cc
+++ b/onnxruntime/core/providers/qnn/builder/onnx_ctx_model_helper.cc
@@ -107,19 +107,20 @@ Status GetEpContextFromMainNode(const onnxruntime::Node& main_context_node,
 
   // Validate that the cache path does not escape the model directory.
   // Rejects absolute paths, ".." traversal, and symlink-based escapes.
+  constexpr const char* path_resolution_guidance =
+      ". If session.model_external_initializers_file_folder_path is set, set ep.context_file_path to the "
+      "EPContext model path so relative ep_cache_context paths are resolved from the EPContext model directory.";
   auto validate_status = ::onnxruntime::utils::ValidateExternalDataPath(
       std::filesystem::path(ctx_onnx_model_path), std::filesystem::path(external_qnn_ctx_binary_file_name));
   if (!validate_status.IsOK()) {
-    return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_GRAPH, validate_status.ErrorMessage());
+    return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_GRAPH, validate_status.ErrorMessage(), path_resolution_guidance);
   }
 
   std::filesystem::path context_binary_path = folder_path / external_qnn_ctx_binary_file_name;
   if (!std::filesystem::is_regular_file(context_binary_path)) {
     return ORT_MAKE_STATUS(
         ONNXRUNTIME, INVALID_GRAPH, "The external EP context file '", context_binary_path.string(),
-        "' does not exist or is not accessible. If session.model_external_initializers_file_folder_path is set, "
-        "set ep.context_file_path to the EPContext model path so relative ep_cache_context paths are resolved from "
-        "the EPContext model directory.");
+        "' does not exist or is not accessible", path_resolution_guidance);
   }
 
   std::string context_binary_path_str = context_binary_path.string();

--- a/onnxruntime/core/providers/qnn/builder/onnx_ctx_model_helper.cc
+++ b/onnxruntime/core/providers/qnn/builder/onnx_ctx_model_helper.cc
@@ -115,7 +115,11 @@ Status GetEpContextFromMainNode(const onnxruntime::Node& main_context_node,
 
   std::filesystem::path context_binary_path = folder_path / external_qnn_ctx_binary_file_name;
   if (!std::filesystem::is_regular_file(context_binary_path)) {
-    return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_GRAPH, "The file path in ep_cache_context does not exist or is not accessible.");
+    return ORT_MAKE_STATUS(
+        ONNXRUNTIME, INVALID_GRAPH, "The external EP context file '", context_binary_path.string(),
+        "' does not exist or is not accessible. If session.model_external_initializers_file_folder_path is set, "
+        "set ep.context_file_path to the EPContext model path so relative ep_cache_context paths are resolved from "
+        "the EPContext model directory.");
   }
 
   std::string context_binary_path_str = context_binary_path.string();

--- a/onnxruntime/test/providers/openvino/openvino_ep_context_test.cc
+++ b/onnxruntime/test/providers/openvino/openvino_ep_context_test.cc
@@ -398,6 +398,39 @@ TEST_P(OVEPOVIRModelsExportEPContextTests, ExportEpCtxFromOVIRModel) {
     RunAndValidate(session);
   }
 
+  if (!embed_mode) {
+    const std::filesystem::path external_initializers_dir = out_dir / "external_initializers";
+    std::filesystem::create_directories(external_initializers_dir);
+
+    {
+      Ort::SessionOptions session_options;
+      session_options.AddConfigEntry(kOrtSessionOptionsModelExternalInitializersFileFolderPath,
+                                     external_initializers_dir.string().c_str());
+      std::unordered_map<std::string, std::string> ov_options = {{"device_type", kDevice}};
+      session_options.AppendExecutionProvider_OpenVINO_V2(ov_options);
+
+      try {
+        Ort::Session session(*ort_env, epctx_model.c_str(), session_options);
+        FAIL() << "Session creation should fail when the EP context binary is resolved from the initializer folder.";
+      } catch (const Ort::Exception& ex) {
+        EXPECT_THAT(ex.what(), ::testing::HasSubstr("session.model_external_initializers_file_folder_path"));
+        EXPECT_THAT(ex.what(), ::testing::HasSubstr("ep.context_file_path"));
+      }
+    }
+
+    {
+      Ort::SessionOptions session_options;
+      session_options.AddConfigEntry(kOrtSessionOptionsModelExternalInitializersFileFolderPath,
+                                     external_initializers_dir.string().c_str());
+      session_options.AddConfigEntry(kOrtSessionOptionEpContextFilePath, epctx_model.string().c_str());
+      std::unordered_map<std::string, std::string> ov_options = {{"device_type", kDevice}};
+      session_options.AppendExecutionProvider_OpenVINO_V2(ov_options);
+
+      Ort::Session session(*ort_env, epctx_model.c_str(), session_options);
+      RunAndValidate(session);
+    }
+  }
+
   std::filesystem::remove_all(out_dir);
 }
 

--- a/onnxruntime/test/providers/openvino/openvino_ep_context_test.cc
+++ b/onnxruntime/test/providers/openvino/openvino_ep_context_test.cc
@@ -413,6 +413,8 @@ TEST_P(OVEPOVIRModelsExportEPContextTests, ExportEpCtxFromOVIRModel) {
         Ort::Session session(*ort_env, epctx_model.c_str(), session_options);
         FAIL() << "Session creation should fail when the EP context binary is resolved from the initializer folder.";
       } catch (const Ort::Exception& ex) {
+        EXPECT_THAT(ex.what(), ::testing::HasSubstr("External data path does not exist"));
+        EXPECT_THAT(ex.what(), ::testing::Not(::testing::HasSubstr("validate_status.IsOK()")));
         EXPECT_THAT(ex.what(), ::testing::HasSubstr("session.model_external_initializers_file_folder_path"));
         EXPECT_THAT(ex.what(), ::testing::HasSubstr("ep.context_file_path"));
       }

--- a/onnxruntime/test/providers/qnn/qnn_ep_context_test.cc
+++ b/onnxruntime/test/providers/qnn/qnn_ep_context_test.cc
@@ -1453,8 +1453,10 @@ TEST_F(QnnHTPBackendTests, QnnContextBinaryFileNotExistTest) {
 
   ASSERT_STATUS_OK(session_object.RegisterExecutionProvider(QnnExecutionProviderWithOptions(provider_options, &so)));
   ASSERT_STATUS_OK(session_object.Load(model_data.data(), static_cast<int>(model_data.size())));
-  // Verify the return status with code INVALID_GRAPH
-  ASSERT_TRUE(session_object.Initialize().Code() == common::StatusCode::INVALID_GRAPH);
+  const auto status = session_object.Initialize();
+  ASSERT_EQ(status.Code(), common::StatusCode::INVALID_GRAPH);
+  EXPECT_THAT(status.ErrorMessage(), testing::HasSubstr("session.model_external_initializers_file_folder_path"));
+  EXPECT_THAT(status.ErrorMessage(), testing::HasSubstr("ep.context_file_path"));
 }
 
 // Create a model with EPContext node. Set the node property ep_cache_context to empty string


### PR DESCRIPTION
## Description

- Clarify how `session.model_external_initializers_file_folder_path` interacts with `ep.context_file_path`.
- Add actionable OpenVINO and QNN errors when an external EP context binary is resolved from the external-initializer directory.
- Add OpenVINO failure/recovery coverage and strengthen the existing QNN missing-context-file assertion.
- Preserve the existing file-path support and option semantics.

## Motivation

`session.model_external_initializers_file_folder_path` overrides the model directory used internally to resolve ONNX external initializer data. For an `EPContext` model with `embed_mode = 0`, an EP can consequently search that directory for the external context binary unless `ep.context_file_path` identifies the EPContext model location. The previous errors reported only the unresolved file path and did not explain the option interaction.

## Testing

- `lintrunner -a` on all changed files
- Built `onnxruntime_test_all` and `onnxruntime_shared_lib_test` in the available CPU configuration
- `onnxruntime_shared_lib_test --gtest_filter=CApiTest.TestLoadModelFromPathWithExternalInitializersViaSetExternalDataPath` (1 test passed)

The local build has OpenVINO and QNN disabled, so the provider-specific tests were added but could not be executed locally.