### PR TITLE
Add WebGPU MoE and expand QMoE feature support

### DIFF
--- a/docs/ContribOperators.md
+++ b/docs/ContribOperators.md
@@ -4031,6 +4031,12 @@ This version of the operator has been available since version 1 of the 'com.micr
         GLaM(https://arxiv.org/abs/2112.06905) activates top 2 FFN, Vision MOE(https://arxiv.org/pdf/2106.05974.pdf)
         usually uses top 32 experts and Mixtral(https://huggingface.co/blog/mixtral).
   
+      A 2D input is the packed token-major form used by continuous-batching engines: tokens from
+      different requests are concatenated along dimension 0 without padding. MoE is token-local,
+      so request boundaries do not affect the result and no cumulative sequence-length input is
+      required. A 3D input is the dense convenience form and is processed as batch_size *
+      sequence_length independent token rows. router_probs must contain one corresponding row per
+      token in either form.
         The SwiGLU (Swish-Gated Linear Unit) activation function is like:
            g = xW + b
            l = xV + c
@@ -4072,9 +4078,9 @@ This version of the operator has been available since version 1 of the 'com.micr
 
 <dl>
 <dt><tt>input</tt> : T</dt>
-<dd>2D input tensor with shape (num_tokens, hidden_size) or 3D input tensor with shape (batch_size, sequence_length, hidden_size)</dd>
+<dd>Packed 2D input tensor with shape (num_tokens, hidden_size), or dense 3D input tensor with shape (batch_size, sequence_length, hidden_size)</dd>
 <dt><tt>router_probs</tt> : T</dt>
-<dd>2D input tensor with shape (num_tokens, num_experts)</dd>
+<dd>2D input tensor with one row per input token and shape (num_tokens, num_experts)</dd>
 <dt><tt>fc1_experts_weights</tt> : T</dt>
 <dd>3D input tensor with shape (num_experts, fusion_size * inter_size, hidden_size), where fusion_size is 2 for fused swiglu, and 1 otherwise</dd>
 <dt><tt>fc1_experts_bias</tt> (optional) : T</dt>
@@ -4093,7 +4099,7 @@ This version of the operator has been available since version 1 of the 'com.micr
 
 <dl>
 <dt><tt>output</tt> : T</dt>
-<dd>2D input tensor with shape (num_tokens, hidden_size) or 3D input tensor with shape (batch_size, sequence_length, hidden_size)</dd>
+<dd>Tensor with the same shape as input</dd>
 </dl>
 
 #### Type Constraints
@@ -5587,6 +5593,12 @@ This version of the operator has been available since version 1 of the 'com.micr
 
   Quantized mixture of experts (MoE).
   
+  A 2D input is the packed token-major form used by continuous-batching engines: tokens from
+  different requests are concatenated along dimension 0 without padding. QMoE is token-local,
+  so request boundaries do not affect the result and no cumulative sequence-length input is
+  required. A 3D input is the dense convenience form and is processed as batch_size *
+  sequence_length independent token rows. router_probs and optional router_weights must contain
+  one corresponding row per token in either form.
         The quantized weights are stored in column major order per expert.
         The quantization block size can be specified. If not provided, column wise quantization is used.
   
@@ -5649,9 +5661,9 @@ This version of the operator has been available since version 1 of the 'com.micr
 
 <dl>
 <dt><tt>input</tt> : T</dt>
-<dd>2D tensor with shape (num_tokens, hidden_size), or 3D tensor with shape (batch_size, sequence_length, hidden_size)</dd>
+<dd>Packed 2D (num_tokens, hidden_size) or dense 3D (batch_size, sequence_length, hidden_size).</dd>
 <dt><tt>router_probs</tt> : T</dt>
-<dd>2D tensor with shape (num_tokens, num_experts)</dd>
+<dd>2D tensor with one row per input token: (num_tokens, num_experts).</dd>
 <dt><tt>fc1_experts_weights</tt> : T1</dt>
 <dd>3D tensor with shape (num_experts, fusion_size * inter_size, hidden_size / pack_size), The fusion_size is 2 for fused swiglu, or 1 otherwise. The pack_size is 8 / expert_weight_bits.</dd>
 <dt><tt>fc1_scales</tt> (optional) : T2</dt>

--- a/docs/OperatorKernels.md
+++ b/docs/OperatorKernels.md
@@ -229,8 +229,8 @@ The **OpSet Version** column uses the following notation:
 |LSTM|*in* X:**T**<br> *in* W:**T**<br> *in* R:**T**<br> *in* B:**T**<br> *in* sequence_lens:**T1**<br> *in* initial_h:**T**<br> *in* initial_c:**T**<br> *in* P:**T**<br> *out* Y:**T**<br> *out* Y_h:**T**<br> *out* Y_c:**T**|22+|**T** = tensor(double), tensor(float)<br/> **T1** = tensor(int32)|
 |||[14, 21]|**T** = tensor(double), tensor(float)<br/> **T1** = tensor(int32)|
 |||[7, 13]|**T** = tensor(double), tensor(float)<br/> **T1** = tensor(int32)|
-|LayerNormalization|*in* X:**T**<br> *in* Scale:**T**<br> *in* B:**T**<br> *out* Y:**T**<br> *out* Mean:**U**<br> *out* InvStdDev:**U**<br><br>or<br><br>*in* X:**T**<br> *in* Scale:**V**<br> *in* B:**V**<br> *out* Y:**V**<br> *out* Mean:**U**<br> *out* InvStdDev:**U**|17+|**T** = tensor(double), tensor(float), tensor(float16)<br/> **U** = tensor(float)|
-|||[1, 16]|**T** = tensor(double), tensor(float), tensor(float16)<br/> **U** = tensor(double), tensor(float), tensor(float16)<br/> **V** = tensor(double), tensor(float), tensor(float16)|
+|LayerNormalization|*in* X:**T**<br> *in* Scale:**T**<br> *in* B:**T**<br> *out* Y:**T**<br> *out* Mean:**U**<br> *out* InvStdDev:**U**<br><br>or<br><br>*in* X:**T**<br> *in* Scale:**V**<br> *in* B:**V**<br> *out* Y:**V**<br> *out* Mean:**U**<br> *out* InvStdDev:**U**|17+|**T** = tensor(bfloat16), tensor(double), tensor(float), tensor(float16)<br/> **U** = tensor(float)|
+|||[1, 16]|**T** = tensor(bfloat16), tensor(double), tensor(float), tensor(float16)<br/> **U** = tensor(float)<br/> **V** = tensor(bfloat16), tensor(double), tensor(float), tensor(float16)|
 |LeakyRelu|*in* X:**T**<br> *out* Y:**T**|16+|**T** = tensor(float)|
 |||[6, 15]|**T** = tensor(float)|
 |Less|*in* A:**T**<br> *in* B:**T**<br> *out* C:**T1**|13+|**T** = tensor(double), tensor(float), tensor(int16), tensor(int32), tensor(int64), tensor(int8), tensor(uint16), tensor(uint32), tensor(uint64), tensor(uint8)<br/> **T1** = tensor(bool)|
@@ -454,7 +454,7 @@ The **OpSet Version** column uses the following notation:
 |||[6, 12]|**T** = tensor(double), tensor(float)|
 |Sign|*in* input:**T**<br> *out* output:**T**|13+|**T** = tensor(bfloat16), tensor(double), tensor(float), tensor(float16), tensor(int16), tensor(int32), tensor(int64), tensor(int8), tensor(uint16), tensor(uint32), tensor(uint64), tensor(uint8)|
 |||[9, 12]|**T** = tensor(bfloat16), tensor(double), tensor(float), tensor(float16), tensor(int16), tensor(int32), tensor(int64), tensor(int8), tensor(uint16), tensor(uint32), tensor(uint64), tensor(uint8)|
-|SimplifiedLayerNormalization|*in* X:**T**<br> *in* scale:**V**<br> *out* Y:**V**<br> *out* inv_std_var:**U**|1+|**T** = tensor(double), tensor(float), tensor(float16)<br/> **U** = tensor(double), tensor(float), tensor(float16)<br/> **V** = tensor(double), tensor(float), tensor(float16)|
+|SimplifiedLayerNormalization|*in* X:**T**<br> *in* scale:**V**<br> *out* Y:**V**<br> *out* inv_std_var:**U**|1+|**T** = tensor(bfloat16), tensor(double), tensor(float), tensor(float16)<br/> **U** = tensor(float)<br/> **V** = tensor(bfloat16), tensor(double), tensor(float), tensor(float16)|
 |Sin|*in* input:**T**<br> *out* output:**T**|22+|**T** = tensor(double), tensor(float)|
 |||[7, 21]|**T** = tensor(double), tensor(float)|
 |Sinh|*in* input:**T**<br> *out* output:**T**|22+|**T** = tensor(float)|
@@ -630,8 +630,8 @@ The **OpSet Version** column uses the following notation:
 |RotaryEmbedding|*in* input:**T**<br> *in* position_ids:**M**<br> *in* cos_cache:**T**<br> *in* sin_cache:**T**<br> *out* output:**T**|1+|**M** = tensor(int64)<br/> **T** = tensor(float), tensor(float16)|
 |SampleOp|*in* X:**T**<br> *out* Y:**T**|1+|**T** = tensor(float)|
 |Sampling|*in* input_ids:**I**<br> *in* max_length:**I**<br> *in* min_length:**I**<br> *in* repetition_penalty:**T**<br> *in* vocab_mask:**I**<br> *in* prefix_vocab_mask:**I**<br> *in* attention_mask:**I**<br> *in* presence_mask:**I**<br> *in* seed:**I**<br> *out* sequences:**I**<br> *out* filtered_logits:**T**|1+|**T** = tensor(float)|
-|SkipLayerNormalization|*in* input:**T**<br> *in* skip:**T**<br> *in* gamma:**T**<br> *in* beta:**T**<br> *in* bias:**T**<br> *out* output:**T**<br> *out* mean:**U**<br> *out* inv_std_var:**U**<br> *out* input_skip_bias_sum:**T**|1+|**T** = tensor(double), tensor(float), tensor(float16)|
-|SkipSimplifiedLayerNormalization|*in* input:**T**<br> *in* skip:**T**<br> *in* gamma:**T**<br> *in* bias:**T**<br> *out* output:**T**<br> *out* mean:**U**<br> *out* inv_std_var:**U**<br> *out* input_skip_bias_sum:**T**|1+|**T** = tensor(double), tensor(float), tensor(float16)|
+|SkipLayerNormalization|*in* input:**T**<br> *in* skip:**T**<br> *in* gamma:**T**<br> *in* beta:**T**<br> *in* bias:**T**<br> *out* output:**T**<br> *out* mean:**U**<br> *out* inv_std_var:**U**<br> *out* input_skip_bias_sum:**T**|1+|**T** = tensor(bfloat16), tensor(double), tensor(float), tensor(float16)|
+|SkipSimplifiedLayerNormalization|*in* input:**T**<br> *in* skip:**T**<br> *in* gamma:**T**<br> *in* bias:**T**<br> *out* output:**T**<br> *out* mean:**U**<br> *out* inv_std_var:**U**<br> *out* input_skip_bias_sum:**T**|1+|**T** = tensor(bfloat16), tensor(double), tensor(float), tensor(float16)|
 |SparseAttention|*in* query:**T**<br> *in* key:**T**<br> *in* value:**T**<br> *in* past_key:**T**<br> *in* past_value:**T**<br> *in* block_row_indices:**M**<br> *in* block_col_indices:**M**<br> *in* total_sequence_length:**M**<br> *in* key_total_sequence_lengths:**M**<br> *in* cos_cache:**T**<br> *in* sin_cache:**T**<br> *out* output:**T**<br> *out* present_key:**T**<br> *out* present_value:**T**|1+|**M** = tensor(int32)<br/> **T** = tensor(float), tensor(float16)|
 |SparseToDenseMatMul|*in* A:**T**<br> *in* B:**T1**<br> *out* Y:**T1**|1+|**T** = sparse_tensor(double), sparse_tensor(float), sparse_tensor(int32), sparse_tensor(int64), sparse_tensor(uint32), sparse_tensor(uint64)<br/> **T1** = tensor(double), tensor(float), tensor(int32), tensor(int64), tensor(uint32), tensor(uint64)|
 |Tokenizer|*in* X:**T**<br> *out* Y:**T**|1+|**T** = tensor(string)|
@@ -922,8 +922,8 @@ The **OpSet Version** column uses the following notation:
 |ReduceMax|*in* data:**T**<br> *in* axes:**tensor(int64)**<br> *out* reduced:**T**<br><br>or<br><br>*in* data:**T**<br> *out* reduced:**T**|20+|**T** = tensor(double), tensor(float), tensor(float16), tensor(int32), tensor(int64), tensor(int8), tensor(uint8)|
 |||[18, 19]|**T** = tensor(double), tensor(float), tensor(float16), tensor(int32), tensor(int64), tensor(int8), tensor(uint8)|
 |||[1, 17]|**T** = tensor(double), tensor(float), tensor(float16), tensor(int32), tensor(int64), tensor(int8), tensor(uint8)|
-|ReduceMean|*in* data:**T**<br> *in* axes:**tensor(int64)**<br> *out* reduced:**T**<br><br>or<br><br>*in* data:**T**<br> *out* reduced:**T**|18+|**T** = tensor(double), tensor(float), tensor(float16), tensor(int32)|
-|||[1, 17]|**T** = tensor(double), tensor(float), tensor(float16), tensor(int32)|
+|ReduceMean|*in* data:**T**<br> *in* axes:**tensor(int64)**<br> *out* reduced:**T**<br><br>or<br><br>*in* data:**T**<br> *out* reduced:**T**|18+|**T** = tensor(bfloat16), tensor(double), tensor(float), tensor(float16), tensor(int32)|
+|||[1, 17]|**T** = tensor(bfloat16), tensor(double), tensor(float), tensor(float16), tensor(int32)|
 |ReduceMin|*in* data:**T**<br> *in* axes:**tensor(int64)**<br> *out* reduced:**T**<br><br>or<br><br>*in* data:**T**<br> *out* reduced:**T**|20+|**T** = tensor(double), tensor(float), tensor(float16), tensor(int32), tensor(int64), tensor(int8), tensor(uint8)|
 |||[18, 19]|**T** = tensor(double), tensor(float), tensor(float16), tensor(int32), tensor(int64), tensor(int8), tensor(uint8)|
 |||[1, 17]|**T** = tensor(double), tensor(float), tensor(float16), tensor(int32), tensor(int64), tensor(int8), tensor(uint8)|

--- a/onnxruntime/contrib_ops/webgpu/moe/activation.wgsl.template
+++ b/onnxruntime/contrib_ops/webgpu/moe/activation.wgsl.template
@@ -1,0 +1,52 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#use guardAgainstOutOfBoundsWorkgroupSizes
+
+#param activation
+#param swiglu_fusion
+#param has_fc3
+
+fn activate(value: f32) -> f32 {
+#if activation == 0
+  return max(value, 0.0);
+#elif activation == 1
+  return 0.5 * value * (1.0 + tanh(0.7978845608 * (value + 0.044715 * value * value * value)));
+#elif activation == 2
+  return value / (1.0 + exp(-value));
+#else
+  return value;
+#endif
+}
+
+$MAIN {
+  let total = uniforms.rows * uniforms.cols;
+  guardAgainstOutOfBoundsWorkgroupSizes(total);
+
+  let row = global_idx / uniforms.cols;
+  let col = global_idx % uniforms.cols;
+#if activation == 4
+#if has_fc3
+  var gate_value = f32(input[global_idx]);
+  var linear_value = f32(fc3_input[global_idx]);
+#elif swiglu_fusion == 1
+  let input_offset = (row * uniforms.cols + col) * 2u;
+  var gate_value = f32(input[input_offset]);
+  var linear_value = f32(input[input_offset + 1u]);
+#else
+  let input_offset = row * uniforms.cols * 2u + col;
+  var gate_value = f32(input[input_offset]);
+  var linear_value = f32(input[input_offset + uniforms.cols]);
+#endif
+  gate_value = min(gate_value, uniforms.swiglu_limit);
+  linear_value = clamp(linear_value, -uniforms.swiglu_limit, uniforms.swiglu_limit);
+  let glu = gate_value / (1.0 + exp(-uniforms.alpha * gate_value));
+  output[global_idx] = output_element_t(glu * (linear_value + uniforms.beta));
+#else
+  var value = activate(f32(input[global_idx]));
+#if has_fc3
+  value *= f32(fc3_input[global_idx]);
+#endif
+  output[global_idx] = output_element_t(value);
+#endif
+} // MAIN

--- a/onnxruntime/contrib_ops/webgpu/moe/expert_matmul.wgsl.template
+++ b/onnxruntime/contrib_ops/webgpu/moe/expert_matmul.wgsl.template
@@ -1,0 +1,23 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#use guardAgainstOutOfBoundsWorkgroupSizes
+
+#param has_bias
+
+$MAIN {
+  let total = uniforms.rows * uniforms.cols;
+  guardAgainstOutOfBoundsWorkgroupSizes(total);
+
+  let row = global_idx / uniforms.cols;
+  let col = global_idx % uniforms.cols;
+  let weight_base = (uniforms.expert_idx * uniforms.cols + col) * uniforms.inner;
+  var value = 0.0;
+  for (var inner = 0u; inner < uniforms.inner; inner++) {
+    value += f32(input[row * uniforms.inner + inner]) * f32(weights[weight_base + inner]);
+  }
+#if has_bias
+  value += f32(bias[uniforms.expert_idx * uniforms.cols + col]);
+#endif
+  output[global_idx] = output_element_t(value);
+} // MAIN

--- a/onnxruntime/contrib_ops/webgpu/moe/final_mix.wgsl.template
+++ b/onnxruntime/contrib_ops/webgpu/moe/final_mix.wgsl.template
@@ -7,17 +7,11 @@
 // out: output
 // uniform: hidden_size, num_experts, expert_idx, token_offset
 
-#param has_router_weights
-
 $MAIN {
     let token_idx = expert_tokens[workgroup_idx];
     // token_idx is the offset into hidden state while fc2_outputs is for the chunk so
     // we need to substract uniforms.token_offset
-#if has_router_weights
-    let router_value_offset = token_idx * uniforms.num_experts + uniforms.expert_idx;
-#else
     let router_value_offset = (token_idx - uniforms.token_offset) * uniforms.num_experts + uniforms.expert_idx;
-#endif
     let router_value = router_values[router_value_offset];
     let fc2_outputs_offset = workgroup_idx * uniforms.hidden_size;
     let output_offset = token_idx * uniforms.hidden_size;

--- a/onnxruntime/contrib_ops/webgpu/moe/final_mix.wgsl.template
+++ b/onnxruntime/contrib_ops/webgpu/moe/final_mix.wgsl.template
@@ -7,17 +7,21 @@
 // out: output
 // uniform: hidden_size, num_experts, expert_idx, token_offset
 
+#param has_router_weights
+
 $MAIN {
     let token_idx = expert_tokens[workgroup_idx];
-    let step = uniforms.hidden_size / workgroup_size_x;
-    let wg_offset = local_idx * step;
     // token_idx is the offset into hidden state while fc2_outputs is for the chunk so
     // we need to substract uniforms.token_offset
+#if has_router_weights
+    let router_value_offset = token_idx * uniforms.num_experts + uniforms.expert_idx;
+#else
     let router_value_offset = (token_idx - uniforms.token_offset) * uniforms.num_experts + uniforms.expert_idx;
+#endif
     let router_value = router_values[router_value_offset];
-    let fc2_outputs_offset = workgroup_idx * uniforms.hidden_size + wg_offset;
-    let output_offset = token_idx * uniforms.hidden_size + wg_offset;
-    for (var i = 0u; i < step; i++) {
+    let fc2_outputs_offset = workgroup_idx * uniforms.hidden_size;
+    let output_offset = token_idx * uniforms.hidden_size;
+    for (var i = local_idx; i < uniforms.hidden_size; i += workgroup_size_x) {
         let weight = fc2_outputs[fc2_outputs_offset + i];
         output[output_offset + i] += router_value * weight;
     }

--- a/onnxruntime/contrib_ops/webgpu/moe/gate.wgsl.template
+++ b/onnxruntime/contrib_ops/webgpu/moe/gate.wgsl.template
@@ -14,6 +14,7 @@
 
 #param is_fp16
 #param k
+#param has_router_weights
 #param normalize_routing_weights
 
 const K: u32 = k;
@@ -71,6 +72,24 @@ $MAIN {
         hiddenstate_for_expert[expert_base + target_idx] = row + uniforms.token_offset;
     }
     if (local_idx == 0u) {
+#if has_router_weights
+        var sum : f32 = 1.0;
+#if normalize_routing_weights
+        sum = 0.0;
+        for (var i = 0u; i < K; i++) {
+            sum += f32(router_weights[(row + uniforms.token_offset) * cols + shared_idxs[i]]);
+        }
+#endif
+        for (var i = 0u; i < K; i++) {
+            let expert_idx = shared_idxs[i];
+            let weight = f32(router_weights[(row + uniforms.token_offset) * cols + expert_idx]);
+            var normalized_weight = 0.0;
+            if (sum != 0.0) {
+                normalized_weight = weight / sum;
+            }
+            topk_values[output_base + expert_idx] = topk_values_value_t(normalized_weight);
+        }
+#else
         // softmax with max-subtraction for numerical stability — without it, large
         // logits (e.g. >= ~89 for f32) cause exp() to overflow to +inf and the
         // ratio inf/inf becomes NaN, propagating through the rest of the kernel.
@@ -89,5 +108,6 @@ $MAIN {
             let expert_idx = shared_idxs[i];
             topk_values[output_base + expert_idx] = topk_values_value_t(exp(f32(shared_vals[i]) - max_val) / sum);
         }
+#endif
     }
 } // MAIN

--- a/onnxruntime/contrib_ops/webgpu/moe/gate.wgsl.template
+++ b/onnxruntime/contrib_ops/webgpu/moe/gate.wgsl.template
@@ -14,6 +14,7 @@
 
 #param is_fp16
 #param k
+#param normalize_routing_weights
 
 const K: u32 = k;
 #if is_fp16
@@ -36,9 +37,6 @@ $MAIN {
     var max_val: router_logits_element_t = -MAX_FLOAT;
     var max_idx: u32 = 0u;
 
-    if (global_idx < cols) {
-        atomicStore(&tokencount_for_expert[global_idx], 0u);
-    }
     if (local_idx < cols) {
         max_val = router_logits[(row + uniforms.token_offset) * cols + local_idx];
         max_idx = local_idx;
@@ -79,7 +77,12 @@ $MAIN {
         // shared_vals is sorted in descending order, so shared_vals[0] is the max.
         let max_val = f32(shared_vals[0]);
         var sum : f32 = 0.0;
-        for (var i = 0u; i < K; i++) {
+    #if normalize_routing_weights
+        let normalization_count = K;
+    #else
+        let normalization_count = cols;
+    #endif
+        for (var i = 0u; i < normalization_count; i++) {
             sum += exp(f32(shared_vals[i]) - max_val);
         }
         for (var i = 0u; i < K; i++) {

--- a/onnxruntime/contrib_ops/webgpu/moe/gate_1token.wgsl.template
+++ b/onnxruntime/contrib_ops/webgpu/moe/gate_1token.wgsl.template
@@ -11,6 +11,7 @@
 
 #param is_fp16
 #param k
+#param normalize_routing_weights
 
 const K: u32 = k;
 #if is_fp16
@@ -66,7 +67,12 @@ $MAIN {
         // shared_vals is sorted in descending order, so shared_vals[0] is the max.
         let max_val = f32(shared_vals[0]);
         var sum : f32 = 0.0;
-        for (var i = 0u; i < K; i++) {
+    #if normalize_routing_weights
+        let normalization_count = K;
+    #else
+        let normalization_count = cols;
+    #endif
+        for (var i = 0u; i < normalization_count; i++) {
             sum += exp(f32(shared_vals[i]) - max_val);
         }
         for (var i = 0u; i < K; i++) {

--- a/onnxruntime/contrib_ops/webgpu/moe/gate_1token.wgsl.template
+++ b/onnxruntime/contrib_ops/webgpu/moe/gate_1token.wgsl.template
@@ -11,6 +11,7 @@
 
 #param is_fp16
 #param k
+#param has_router_weights
 #param normalize_routing_weights
 
 const K: u32 = k;
@@ -61,6 +62,25 @@ $MAIN {
         }
     }
     if (local_idx == 0u) {
+#if has_router_weights
+        var sum : f32 = 1.0;
+#if normalize_routing_weights
+        sum = 0.0;
+        for (var i = 0u; i < K; i++) {
+            sum += f32(router_weights[shared_idxs[i]]);
+        }
+#endif
+        for (var i = 0u; i < K; i++) {
+            let expert_idx = shared_idxs[i];
+            let weight = f32(router_weights[expert_idx]);
+            var normalized_weight = 0.0;
+            if (sum != 0.0) {
+                normalized_weight = weight / sum;
+            }
+            topk_values[output_base + expert_idx] = topk_values_value_t(normalized_weight);
+            indirect_experts[i] = expert_idx;
+        }
+#else
         // softmax with max-subtraction for numerical stability — without it, large
         // logits (e.g. >= ~89 for f32) cause exp() to overflow to +inf and the
         // ratio inf/inf becomes NaN, propagating through the rest of the kernel.
@@ -80,5 +100,6 @@ $MAIN {
             topk_values[output_base + expert_idx] = topk_values_value_t(exp(f32(shared_vals[i]) - max_val) / sum);
             indirect_experts[i] = expert_idx;
         }
+#endif
     }
 } // MAIN

--- a/onnxruntime/contrib_ops/webgpu/moe/hidden_state_gather.wgsl.template
+++ b/onnxruntime/contrib_ops/webgpu/moe/hidden_state_gather.wgsl.template
@@ -15,14 +15,9 @@ $MAIN {
     let token_idx = hiddenstate_for_expert[expert_base + workgroup_idx];
     tokens[workgroup_idx] = token_idx;
 
-    // copy hidden state for this token
-    let step = (uniforms.hidden_size + workgroup_size_x  - 1) / workgroup_size_x;
-    let wg_offset = local_idx * step;
-    let src_offset = token_idx * uniforms.hidden_size + wg_offset;
-    let dst_offset = workgroup_idx * uniforms.hidden_size + wg_offset;
-
-    for (var i = 0u; i < step; i++) {
-        let src = hidden_state[src_offset + i];
-        new_hidden_state[dst_offset + i] = src;
+    let src_offset = token_idx * uniforms.hidden_size;
+    let dst_offset = workgroup_idx * uniforms.hidden_size;
+    for (var i = local_idx; i < uniforms.hidden_size; i += workgroup_size_x) {
+        new_hidden_state[dst_offset + i] = hidden_state[src_offset + i];
     }
 } // MAIN

--- a/onnxruntime/contrib_ops/webgpu/moe/moe.cc
+++ b/onnxruntime/contrib_ops/webgpu/moe/moe.cc
@@ -1,13 +1,15 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-#include "core/providers/webgpu/shader_helper.h"
-#include "core/providers/webgpu/webgpu_utils.h"
 #include "core/providers/webgpu/webgpu_supported_types.h"
-#include "contrib_ops/webgpu/webgpu_contrib_kernels.h"
-#include "contrib_ops/webgpu/moe/moe_base.h"
-#include "contrib_ops/webgpu/moe/moe.h"
+#include "core/providers/webgpu/webgpu_utils.h"
+#include "core/providers/webgpu/shader_helper.h"
 #include "contrib_ops/cpu/moe/moe_helper.h"
+#include "contrib_ops/webgpu/moe/moe.h"
+#include "contrib_ops/webgpu/webgpu_contrib_kernels.h"
+
+#include <algorithm>
+#include <optional>
 
 namespace onnxruntime {
 namespace contrib {
@@ -16,12 +18,308 @@ namespace webgpu {
 using namespace onnxruntime::webgpu;
 using onnxruntime::webgpu::ComputeContext;
 
-Status MoEProgram::GenerateShaderCode(ShaderHelper& /*unused*/) const {
-  return Status::OK();
+namespace {
+
+class MoEGateProgram final : public Program<MoEGateProgram> {
+ public:
+  MoEGateProgram(int k, bool is_fp16, bool normalize_routing_weights)
+      : Program<MoEGateProgram>{"MoeGate"},
+        k_{k},
+        is_fp16_{is_fp16},
+        normalize_routing_weights_{normalize_routing_weights} {}
+
+  Status GenerateShaderCode(ShaderHelper& shader) const override {
+    shader.AddInput("router_logits", ShaderUsage::UseElementTypeAlias);
+    shader.AddOutput("topk_values");
+    shader.AddOutput("hiddenstate_for_expert");
+    shader.AddOutput("tokencount_for_expert");
+    return WGSL_TEMPLATE_APPLY(shader, "moe/gate.wgsl.template",
+                               WGSL_TEMPLATE_PARAMETER(is_fp16, is_fp16_),
+                               WGSL_TEMPLATE_PARAMETER(k, k_),
+                               WGSL_TEMPLATE_PARAMETER(normalize_routing_weights, normalize_routing_weights_));
+  }
+
+  WEBGPU_PROGRAM_DEFINE_UNIFORM_VARIABLES(
+      {"rows", ProgramUniformVariableDataType::Uint32},
+      {"cols", ProgramUniformVariableDataType::Uint32},
+      {"token_offset", ProgramUniformVariableDataType::Uint32});
+
+ private:
+  int k_;
+  bool is_fp16_;
+  bool normalize_routing_weights_;
+};
+
+class MoEHiddenStateGatherProgram final : public Program<MoEHiddenStateGatherProgram> {
+ public:
+  MoEHiddenStateGatherProgram() : Program<MoEHiddenStateGatherProgram>{"MoeHiddenStateGather"} {}
+
+  Status GenerateShaderCode(ShaderHelper& shader) const override {
+    shader.AddInput("hiddenstate_for_expert", ShaderUsage::UseElementTypeAlias);
+    shader.AddInput("hidden_state", ShaderUsage::UseElementTypeAlias);
+    shader.AddOutput("new_hidden_state");
+    shader.AddOutput("tokens");
+    return WGSL_TEMPLATE_APPLY(shader, "moe/hidden_state_gather.wgsl.template");
+  }
+
+  WEBGPU_PROGRAM_DEFINE_UNIFORM_VARIABLES(
+      {"expert_idx", ProgramUniformVariableDataType::Uint32},
+      {"num_experts", ProgramUniformVariableDataType::Uint32},
+      {"num_tokens", ProgramUniformVariableDataType::Uint32},
+      {"hidden_size", ProgramUniformVariableDataType::Uint32});
+};
+
+class MoEZeroTensorProgram final : public Program<MoEZeroTensorProgram> {
+ public:
+  MoEZeroTensorProgram() : Program<MoEZeroTensorProgram>{"MoeZeroTensor"} {}
+
+  Status GenerateShaderCode(ShaderHelper& shader) const override {
+    shader.AddOutput("tensor", ShaderUsage::UseElementTypeAlias);
+    return WGSL_TEMPLATE_APPLY(shader, "moe/zero_tensor.wgsl.template");
+  }
+
+  WEBGPU_PROGRAM_DEFINE_UNIFORM_VARIABLES({"size", ProgramUniformVariableDataType::Uint32});
+};
+
+class MoEZeroU32Program final : public Program<MoEZeroU32Program> {
+ public:
+  MoEZeroU32Program() : Program<MoEZeroU32Program>{"MoeZeroU32"} {}
+
+  Status GenerateShaderCode(ShaderHelper& shader) const override {
+    shader.AddOutput("output");
+    return WGSL_TEMPLATE_APPLY(shader, "moe/zero_u32.wgsl.template");
+  }
+
+  WEBGPU_PROGRAM_DEFINE_UNIFORM_VARIABLES({"size", ProgramUniformVariableDataType::Uint32});
+};
+
+class MoEExpertMatMulProgram final : public Program<MoEExpertMatMulProgram> {
+ public:
+  explicit MoEExpertMatMulProgram(bool has_bias)
+      : Program<MoEExpertMatMulProgram>{"MoeExpertMatMul"}, has_bias_{has_bias} {}
+
+  Status GenerateShaderCode(ShaderHelper& shader) const override {
+    shader.AddInput("input", ShaderUsage::UseElementTypeAlias);
+    shader.AddInput("weights", ShaderUsage::UseElementTypeAlias);
+    if (has_bias_) {
+      shader.AddInput("bias", ShaderUsage::UseElementTypeAlias);
+    }
+    shader.AddOutput("output", ShaderUsage::UseElementTypeAlias);
+    return WGSL_TEMPLATE_APPLY(shader, "moe/expert_matmul.wgsl.template",
+                               WGSL_TEMPLATE_PARAMETER(has_bias, has_bias_));
+  }
+
+  WEBGPU_PROGRAM_DEFINE_UNIFORM_VARIABLES(
+      {"rows", ProgramUniformVariableDataType::Uint32},
+      {"cols", ProgramUniformVariableDataType::Uint32},
+      {"inner", ProgramUniformVariableDataType::Uint32},
+      {"expert_idx", ProgramUniformVariableDataType::Uint32});
+
+ private:
+  bool has_bias_;
+};
+
+class MoEActivationProgram final : public Program<MoEActivationProgram> {
+ public:
+  MoEActivationProgram(MoEActivationType activation_type, int swiglu_fusion, bool has_fc3)
+      : Program<MoEActivationProgram>{"MoeActivation"},
+        activation_type_{activation_type},
+        swiglu_fusion_{swiglu_fusion},
+        has_fc3_{has_fc3} {}
+
+  Status GenerateShaderCode(ShaderHelper& shader) const override {
+    shader.AddInput("input", ShaderUsage::UseElementTypeAlias);
+    if (has_fc3_) {
+      shader.AddInput("fc3_input", ShaderUsage::UseElementTypeAlias);
+    }
+    shader.AddOutput("output", ShaderUsage::UseElementTypeAlias);
+    return WGSL_TEMPLATE_APPLY(shader, "moe/activation.wgsl.template",
+                               WGSL_TEMPLATE_PARAMETER(activation, static_cast<int>(activation_type_)),
+                               WGSL_TEMPLATE_PARAMETER(has_fc3, has_fc3_),
+                               WGSL_TEMPLATE_PARAMETER(swiglu_fusion, swiglu_fusion_));
+  }
+
+  WEBGPU_PROGRAM_DEFINE_UNIFORM_VARIABLES(
+      {"rows", ProgramUniformVariableDataType::Uint32},
+      {"cols", ProgramUniformVariableDataType::Uint32},
+      {"alpha", ProgramUniformVariableDataType::Float32},
+      {"beta", ProgramUniformVariableDataType::Float32},
+      {"swiglu_limit", ProgramUniformVariableDataType::Float32});
+
+ private:
+  MoEActivationType activation_type_;
+  int swiglu_fusion_;
+  bool has_fc3_;
+};
+
+class MoEFinalMixProgram final : public Program<MoEFinalMixProgram> {
+ public:
+  MoEFinalMixProgram() : Program<MoEFinalMixProgram>{"MoeFinalMix"} {}
+
+  Status GenerateShaderCode(ShaderHelper& shader) const override {
+    shader.AddInput("fc2_outputs", ShaderUsage::UseElementTypeAlias);
+    shader.AddInput("router_values", ShaderUsage::UseElementTypeAlias);
+    shader.AddInput("expert_tokens", ShaderUsage::UseElementTypeAlias);
+    shader.AddOutput("output", ShaderUsage::UseElementTypeAlias);
+    return WGSL_TEMPLATE_APPLY(shader, "moe/final_mix.wgsl.template",
+                               WGSL_TEMPLATE_PARAMETER(has_router_weights, false));
+  }
+
+  WEBGPU_PROGRAM_DEFINE_UNIFORM_VARIABLES(
+      {"hidden_size", ProgramUniformVariableDataType::Uint32},
+      {"num_experts", ProgramUniformVariableDataType::Uint32},
+      {"expert_idx", ProgramUniformVariableDataType::Uint32},
+      {"token_offset", ProgramUniformVariableDataType::Uint32});
+};
+
+Status RunExpertMatMul(ComputeContext& context, const Tensor* input, const Tensor* weights,
+                       const Tensor* bias, Tensor* output, uint32_t rows, uint32_t cols,
+                       uint32_t inner, uint32_t expert_idx) {
+  MoEExpertMatMulProgram matmul{bias != nullptr};
+  matmul.AddInputs({{input, ProgramTensorMetadataDependency::Type}})
+      .AddInputs({{weights, ProgramTensorMetadataDependency::Type}});
+  if (bias) {
+    matmul.AddInputs({{bias, ProgramTensorMetadataDependency::Type}});
+  }
+  matmul.AddOutput({output, ProgramTensorMetadataDependency::None})
+      .SetWorkgroupSize(64)
+      .SetDispatchGroupSize((rows * cols + 63) / 64)
+      .AddUniformVariables({rows, cols, inner, expert_idx})
+      .CacheHint(bias != nullptr);
+  return context.RunProgram(matmul);
 }
 
-Status MoE::ComputeInternal(ComputeContext& /*unused*/) const {
-  return ORT_MAKE_STATUS(ONNXRUNTIME, NOT_IMPLEMENTED, "MoE is not implemented in WebGPU");
+}  // namespace
+
+Status MoE::ComputeInternal(ComputeContext& context) const {
+  const Tensor* hidden_state = context.Input<Tensor>(0);
+  const Tensor* router_logits = context.Input<Tensor>(1);
+  const Tensor* fc1_weights = context.Input<Tensor>(2);
+  const Tensor* fc1_bias = context.Input<Tensor>(3);
+  const Tensor* fc2_weights = context.Input<Tensor>(4);
+  const Tensor* fc2_bias = context.Input<Tensor>(5);
+  const Tensor* fc3_weights = context.Input<Tensor>(6);
+  const Tensor* fc3_bias = context.Input<Tensor>(7);
+
+  int swiglu_fusion = swiglu_fusion_;
+  if (activation_type_ == MoEActivationType::SwiGLU && swiglu_fusion == 0 && fc3_weights == nullptr) {
+    swiglu_fusion = 1;
+  }
+  const bool is_fused_swiglu = activation_type_ == MoEActivationType::SwiGLU &&
+                               swiglu_fusion != 0 && fc3_weights == nullptr;
+
+  MoEParameters params;
+  ORT_RETURN_IF_ERROR(::onnxruntime::contrib::moe_helper::CheckInputs<Tensor>(
+      params, hidden_state, router_logits, fc1_weights, fc1_bias, nullptr, nullptr,
+      fc2_weights, fc2_bias, nullptr, nullptr, fc3_weights, fc3_bias, nullptr, nullptr,
+      1, is_fused_swiglu));
+  ORT_RETURN_IF_NOT(k_ > 0 && k_ <= params.num_experts,
+                    "MoE requires 0 < k <= num_experts, got k=", k_,
+                    " and num_experts=", params.num_experts);
+
+  const auto dtype = hidden_state->DataType();
+  const auto dtype_uint32 = DataTypeImpl::GetType<uint32_t>();
+  const bool is_fp16 = dtype == DataTypeImpl::GetType<MLFloat16>();
+  const uint32_t num_experts = static_cast<uint32_t>(params.num_experts);
+  const uint32_t hidden_size = static_cast<uint32_t>(params.hidden_size);
+  const uint32_t inter_size = static_cast<uint32_t>(params.inter_size);
+  const uint32_t fc1_cols = is_fused_swiglu ? 2 * inter_size : inter_size;
+  constexpr int max_tokens = 2 * 1024;
+
+  Tensor* output = context.Output(0, hidden_state->Shape());
+  if (params.num_rows == 0) {
+    return Status::OK();
+  }
+  const uint32_t output_vec4_size = static_cast<uint32_t>((hidden_state->Shape().Size() + 3) / 4);
+  MoEZeroTensorProgram zero;
+  zero.AddOutput({output, ProgramTensorMetadataDependency::Type, ProgramOutput::Flatten, 4})
+      .SetDispatchGroupSize((output_vec4_size + WORKGROUP_SIZE - 1) / WORKGROUP_SIZE)
+      .AddUniformVariables({output_vec4_size});
+  ORT_RETURN_IF_ERROR(context.RunProgram(zero));
+
+  for (int token_offset = 0; token_offset < params.num_rows; token_offset += max_tokens) {
+    const uint32_t num_tokens = static_cast<uint32_t>(
+        std::min<int64_t>(max_tokens, params.num_rows - token_offset));
+    Tensor router_values = context.CreateGPUTensor(dtype, TensorShape({num_tokens, num_experts}));
+    Tensor gate_counts = context.CreateGPUTensor(dtype_uint32, TensorShape({num_experts}));
+    Tensor gate_hidden = context.CreateGPUTensor(dtype_uint32, TensorShape({num_experts, num_tokens}));
+
+    MoEZeroU32Program zero_counts;
+    zero_counts.AddOutput({&gate_counts, ProgramTensorMetadataDependency::None})
+        .SetDispatchGroupSize((num_experts + WORKGROUP_SIZE - 1) / WORKGROUP_SIZE)
+        .AddUniformVariables({num_experts});
+    ORT_RETURN_IF_ERROR(context.RunProgram(zero_counts));
+
+    MoEGateProgram gate{k_, is_fp16, normalize_routing_weights_};
+    gate.AddInputs({{router_logits, ProgramTensorMetadataDependency::Type}})
+        .AddOutput({&router_values, ProgramTensorMetadataDependency::None})
+        .AddOutput({&gate_hidden, ProgramTensorMetadataDependency::None})
+        .AddOutput({&gate_counts, ProgramTensorMetadataDependency::None, ProgramOutput::Atomic})
+        .SetWorkgroupSize(num_experts)
+        .SetDispatchGroupSize(num_tokens)
+        .AddUniformVariables({num_tokens, num_experts, static_cast<uint32_t>(token_offset)})
+        .CacheHint(k_, is_fp16 ? "fp16" : "fp32", normalize_routing_weights_);
+    ORT_RETURN_IF_ERROR(context.RunProgram(gate));
+
+    Tensor gate_counts_cpu = context.CreateCPUTensor(dtype_uint32, TensorShape({num_experts}));
+    ORT_RETURN_IF_ERROR(Info().GetDataTransferManager().CopyTensor(gate_counts, gate_counts_cpu));
+    for (uint32_t expert_idx = 0; expert_idx < num_experts; ++expert_idx) {
+      const uint32_t used_by = gate_counts_cpu.Data<uint32_t>()[expert_idx];
+      if (used_by == 0) {
+        continue;
+      }
+
+      Tensor expert_hidden = context.CreateGPUTensor(dtype, TensorShape({used_by, hidden_size}));
+      Tensor expert_tokens = context.CreateGPUTensor(dtype_uint32, TensorShape({used_by}));
+      MoEHiddenStateGatherProgram gather;
+      gather.AddInputs({{&gate_hidden, ProgramTensorMetadataDependency::Type}})
+          .AddInputs({{hidden_state, ProgramTensorMetadataDependency::Type, 1}})
+          .AddOutput({&expert_hidden, ProgramTensorMetadataDependency::None, 1})
+          .AddOutput({&expert_tokens, ProgramTensorMetadataDependency::None})
+          .SetDispatchGroupSize(used_by)
+          .AddUniformVariables({expert_idx, num_experts, num_tokens, hidden_size});
+      ORT_RETURN_IF_ERROR(context.RunProgram(gather));
+
+      Tensor fc1_output = context.CreateGPUTensor(dtype, TensorShape({used_by, fc1_cols}));
+      ORT_RETURN_IF_ERROR(RunExpertMatMul(context, &expert_hidden, fc1_weights, fc1_bias,
+                                          &fc1_output, used_by, fc1_cols, hidden_size, expert_idx));
+
+      std::optional<Tensor> fc3_output;
+      if (fc3_weights) {
+        fc3_output.emplace(context.CreateGPUTensor(dtype, TensorShape({used_by, inter_size})));
+        ORT_RETURN_IF_ERROR(RunExpertMatMul(context, &expert_hidden, fc3_weights, fc3_bias,
+                                            &*fc3_output, used_by, inter_size, hidden_size, expert_idx));
+      }
+
+      Tensor activated = context.CreateGPUTensor(dtype, TensorShape({used_by, inter_size}));
+      MoEActivationProgram activation{activation_type_, swiglu_fusion, fc3_output.has_value()};
+      activation.AddInputs({{&fc1_output, ProgramTensorMetadataDependency::Type}});
+      if (fc3_output) {
+        activation.AddInputs({{&*fc3_output, ProgramTensorMetadataDependency::Type}});
+      }
+      activation.AddOutput({&activated, ProgramTensorMetadataDependency::None})
+          .SetWorkgroupSize(128)
+          .SetDispatchGroupSize((used_by * inter_size + 127) / 128)
+          .AddUniformVariables({used_by, inter_size, activation_alpha_, activation_beta_, swiglu_limit_})
+          .CacheHint(static_cast<int>(activation_type_), swiglu_fusion, fc3_output.has_value());
+      ORT_RETURN_IF_ERROR(context.RunProgram(activation));
+
+      Tensor fc2_output = context.CreateGPUTensor(dtype, TensorShape({used_by, hidden_size}));
+      ORT_RETURN_IF_ERROR(RunExpertMatMul(context, &activated, fc2_weights, fc2_bias,
+                                          &fc2_output, used_by, hidden_size, inter_size, expert_idx));
+
+      MoEFinalMixProgram mix;
+      mix.AddInputs({{&fc2_output, ProgramTensorMetadataDependency::Type}})
+          .AddInputs({{&router_values, ProgramTensorMetadataDependency::Type}})
+          .AddInputs({{&expert_tokens, ProgramTensorMetadataDependency::Type}})
+          .AddOutput({output, ProgramTensorMetadataDependency::None})
+          .SetDispatchGroupSize(used_by)
+          .AddUniformVariables({hidden_size, num_experts, expert_idx, static_cast<uint32_t>(token_offset)});
+      ORT_RETURN_IF_ERROR(context.RunProgram(mix));
+    }
+  }
+
+  return Status::OK();
 }
 
 ONNX_OPERATOR_KERNEL_EX(

--- a/onnxruntime/contrib_ops/webgpu/moe/moe.cc
+++ b/onnxruntime/contrib_ops/webgpu/moe/moe.cc
@@ -34,6 +34,7 @@ class MoEGateProgram final : public Program<MoEGateProgram> {
     shader.AddOutput("hiddenstate_for_expert");
     shader.AddOutput("tokencount_for_expert");
     return WGSL_TEMPLATE_APPLY(shader, "moe/gate.wgsl.template",
+                               WGSL_TEMPLATE_PARAMETER(has_router_weights, false),
                                WGSL_TEMPLATE_PARAMETER(is_fp16, is_fp16_),
                                WGSL_TEMPLATE_PARAMETER(k, k_),
                                WGSL_TEMPLATE_PARAMETER(normalize_routing_weights, normalize_routing_weights_));
@@ -161,8 +162,7 @@ class MoEFinalMixProgram final : public Program<MoEFinalMixProgram> {
     shader.AddInput("router_values", ShaderUsage::UseElementTypeAlias);
     shader.AddInput("expert_tokens", ShaderUsage::UseElementTypeAlias);
     shader.AddOutput("output", ShaderUsage::UseElementTypeAlias);
-    return WGSL_TEMPLATE_APPLY(shader, "moe/final_mix.wgsl.template",
-                               WGSL_TEMPLATE_PARAMETER(has_router_weights, false));
+    return WGSL_TEMPLATE_APPLY(shader, "moe/final_mix.wgsl.template");
   }
 
   WEBGPU_PROGRAM_DEFINE_UNIFORM_VARIABLES(
@@ -221,6 +221,12 @@ Status MoE::ComputeInternal(ComputeContext& context) const {
   const auto dtype_uint32 = DataTypeImpl::GetType<uint32_t>();
   const bool is_fp16 = dtype == DataTypeImpl::GetType<MLFloat16>();
   const uint32_t num_experts = static_cast<uint32_t>(params.num_experts);
+  const auto& device_limits = context.DeviceLimits();
+  ORT_RETURN_IF_NOT(num_experts <= device_limits.maxComputeWorkgroupSizeX &&
+                        num_experts <= device_limits.maxComputeInvocationsPerWorkgroup,
+                    "WebGPU MoE requires num_experts to fit in one workgroup; got ", num_experts,
+                    ", maxComputeWorkgroupSizeX=", device_limits.maxComputeWorkgroupSizeX,
+                    ", maxComputeInvocationsPerWorkgroup=", device_limits.maxComputeInvocationsPerWorkgroup, ".");
   const uint32_t hidden_size = static_cast<uint32_t>(params.hidden_size);
   const uint32_t inter_size = static_cast<uint32_t>(params.inter_size);
   const uint32_t fc1_cols = is_fused_swiglu ? 2 * inter_size : inter_size;

--- a/onnxruntime/contrib_ops/webgpu/moe/moe.h
+++ b/onnxruntime/contrib_ops/webgpu/moe/moe.h
@@ -7,6 +7,7 @@
 
 #include "core/providers/webgpu/program.h"
 #include "core/providers/webgpu/webgpu_kernel.h"
+#include "contrib_ops/webgpu/moe/moe_base.h"
 
 namespace onnxruntime {
 namespace contrib {
@@ -15,23 +16,11 @@ namespace webgpu {
 using namespace onnxruntime::webgpu;
 using onnxruntime::webgpu::ComputeContext;
 
-class MoEProgram final : public Program<MoEProgram> {
- public:
-  MoEProgram(TensorShape output_shape) : Program<MoEProgram>{"MoE"}, output_shape_{output_shape} {}
-
-  Status GenerateShaderCode(ShaderHelper& sh) const override;
-
-  WEBGPU_PROGRAM_DEFINE_UNIFORM_VARIABLES({"output_size", ProgramUniformVariableDataType::Uint32});
-
- private:
-  TensorShape output_shape_;
-};
-
 class MoE : public WebGpuKernel {
  public:
   MoE(const OpKernelInfo& info) : WebGpuKernel(info) {
     activation_alpha_ = static_cast<float>(info.GetAttrOrDefault<float>("activation_alpha", 1.0));
-    activation_beta_ = static_cast<float>(info.GetAttrOrDefault<float>("activation_beta", 1.0));
+    activation_beta_ = static_cast<float>(info.GetAttrOrDefault<float>("activation_beta", 0.0));
     swiglu_fusion_ = static_cast<int>(info.GetAttrOrDefault<int64_t>("swiglu_fusion", 0));
     swiglu_limit_ = info.GetAttrOrDefault<float>("swiglu_limit", std::numeric_limits<float>::infinity());
     k_ = static_cast<int>(info.GetAttrOrDefault<int64_t>("k", 4));
@@ -52,8 +41,10 @@ class MoE : public WebGpuKernel {
       ORT_THROW("Unsupported MoE activation type: ", activation_type);
     }
 
-    // for now webgpu only implements a subset of MoE features
-    // ORT_ENFORCE(normalize_routing_weights_ == 0, "normalize_routing_weights not supported");
+    ORT_ENFORCE(swiglu_fusion_ >= 0 && swiglu_fusion_ <= 2,
+                "swiglu_fusion must be 0, 1, or 2, but got ", swiglu_fusion_);
+    ORT_ENFORCE(activation_type_ == MoEActivationType::SwiGLU || swiglu_fusion_ == 0,
+                "swiglu_fusion is only valid when activation_type is 'swiglu'.");
     ORT_ENFORCE(use_sparse_mixer_ == 0, "use_sparse_mixer not supported");
   }
 

--- a/onnxruntime/contrib_ops/webgpu/moe/qmoe.cc
+++ b/onnxruntime/contrib_ops/webgpu/moe/qmoe.cc
@@ -10,6 +10,8 @@
 #include "contrib_ops/webgpu/quantization/matmul_nbits.h"
 #include "core/providers/webgpu/math/gemm_packed.h"
 
+#include <optional>
+
 namespace onnxruntime {
 namespace contrib {
 namespace webgpu {
@@ -19,7 +21,11 @@ using onnxruntime::webgpu::ComputeContext;
 
 class GateProgram final : public Program<GateProgram> {
  public:
-  GateProgram(int k, bool is_fp16) : Program<GateProgram>{"QmoeGate"}, k_{k}, is_fp16_{is_fp16} {};
+  GateProgram(int k, bool is_fp16, bool normalize_routing_weights)
+      : Program<GateProgram>{"QmoeGate"},
+        k_{k},
+        is_fp16_{is_fp16},
+        normalize_routing_weights_{normalize_routing_weights} {}
 
   Status GenerateShaderCode(ShaderHelper& shader) const override {
     shader.AddInput("router_logits", ShaderUsage::UseElementTypeAlias);
@@ -29,7 +35,8 @@ class GateProgram final : public Program<GateProgram> {
 
     return WGSL_TEMPLATE_APPLY(shader, "moe/gate.wgsl.template",
                                WGSL_TEMPLATE_PARAMETER(is_fp16, is_fp16_),
-                               WGSL_TEMPLATE_PARAMETER(k, k_));
+                               WGSL_TEMPLATE_PARAMETER(k, k_),
+                               WGSL_TEMPLATE_PARAMETER(normalize_routing_weights, normalize_routing_weights_));
   };
 
   WEBGPU_PROGRAM_DEFINE_UNIFORM_VARIABLES(
@@ -40,11 +47,16 @@ class GateProgram final : public Program<GateProgram> {
  private:
   int k_;
   bool is_fp16_;
+  bool normalize_routing_weights_;
 };
 
 class Gate1TokenProgram final : public Program<Gate1TokenProgram> {
  public:
-  Gate1TokenProgram(int k, bool is_fp16) : Program<Gate1TokenProgram>{"QmoeGate1Token"}, k_{k}, is_fp16_{is_fp16} {};
+  Gate1TokenProgram(int k, bool is_fp16, bool normalize_routing_weights)
+      : Program<Gate1TokenProgram>{"QmoeGate1Token"},
+        k_{k},
+        is_fp16_{is_fp16},
+        normalize_routing_weights_{normalize_routing_weights} {}
 
   Status GenerateShaderCode(ShaderHelper& shader) const override {
     shader.AddInput("router_logits", ShaderUsage::UseElementTypeAlias);
@@ -53,7 +65,8 @@ class Gate1TokenProgram final : public Program<Gate1TokenProgram> {
 
     return WGSL_TEMPLATE_APPLY(shader, "moe/gate_1token.wgsl.template",
                                WGSL_TEMPLATE_PARAMETER(is_fp16, is_fp16_),
-                               WGSL_TEMPLATE_PARAMETER(k, k_));
+                               WGSL_TEMPLATE_PARAMETER(k, k_),
+                               WGSL_TEMPLATE_PARAMETER(normalize_routing_weights, normalize_routing_weights_));
   };
 
   WEBGPU_PROGRAM_DEFINE_UNIFORM_VARIABLES(
@@ -63,6 +76,7 @@ class Gate1TokenProgram final : public Program<Gate1TokenProgram> {
  private:
   int k_;
   bool is_fp16_;
+  bool normalize_routing_weights_;
 };
 
 class HiddenStateGatherProgram final : public Program<HiddenStateGatherProgram> {
@@ -102,16 +116,37 @@ class ZeroTensorProgram final : public Program<ZeroTensorProgram> {
  private:
 };
 
-class SwigLuProgram final : public Program<SwigLuProgram> {
+class ZeroU32Program final : public Program<ZeroU32Program> {
  public:
-  SwigLuProgram() : Program<SwigLuProgram>{"SwigLu"} {
-                    };
+  ZeroU32Program() : Program<ZeroU32Program>{"QmoeZeroU32"} {}
+
+  Status GenerateShaderCode(ShaderHelper& shader) const override {
+    shader.AddOutput("output");
+    return WGSL_TEMPLATE_APPLY(shader, "moe/zero_u32.wgsl.template");
+  }
+
+  WEBGPU_PROGRAM_DEFINE_UNIFORM_VARIABLES({"size", ProgramUniformVariableDataType::Uint32});
+};
+
+class MoEActivationProgram final : public Program<MoEActivationProgram> {
+ public:
+  MoEActivationProgram(MoEActivationType activation_type, int swiglu_fusion, bool has_fc3)
+      : Program<MoEActivationProgram>{"MoEActivation"},
+        activation_type_{activation_type},
+        swiglu_fusion_{swiglu_fusion},
+        has_fc3_{has_fc3} {}
 
   Status GenerateShaderCode(ShaderHelper& shader) const override {
     shader.AddInput("input", ShaderUsage::UseElementTypeAlias);
+    if (has_fc3_) {
+      shader.AddInput("fc3_input", ShaderUsage::UseElementTypeAlias);
+    }
     shader.AddOutput("output", ShaderUsage::UseElementTypeAlias);
 
-    return WGSL_TEMPLATE_APPLY(shader, "moe/swiglu.wgsl.template");
+    return WGSL_TEMPLATE_APPLY(shader, "moe/activation.wgsl.template",
+                               WGSL_TEMPLATE_PARAMETER(activation, static_cast<int>(activation_type_)),
+                               WGSL_TEMPLATE_PARAMETER(has_fc3, has_fc3_),
+                               WGSL_TEMPLATE_PARAMETER(swiglu_fusion, swiglu_fusion_));
   };
 
   WEBGPU_PROGRAM_DEFINE_UNIFORM_VARIABLES(
@@ -122,6 +157,9 @@ class SwigLuProgram final : public Program<SwigLuProgram> {
       {"swiglu_limit", ProgramUniformVariableDataType::Float32});
 
  private:
+  MoEActivationType activation_type_;
+  int swiglu_fusion_;
+  bool has_fc3_;
 };
 
 class FusedFinalMix1TokenProgram final : public Program<FusedFinalMix1TokenProgram> {
@@ -143,7 +181,8 @@ class FusedFinalMix1TokenProgram final : public Program<FusedFinalMix1TokenProgr
 
 class QMoEFinalMixProgram final : public Program<QMoEFinalMixProgram> {
  public:
-  QMoEFinalMixProgram() : Program<QMoEFinalMixProgram>{"QMoEFinalMix"} {}
+  explicit QMoEFinalMixProgram(bool has_router_weights)
+      : Program<QMoEFinalMixProgram>{"QMoEFinalMix"}, has_router_weights_{has_router_weights} {}
 
   Status GenerateShaderCode(ShaderHelper& shader) const override {
     shader.AddInput("fc2_outputs", ShaderUsage::UseElementTypeAlias);
@@ -151,7 +190,8 @@ class QMoEFinalMixProgram final : public Program<QMoEFinalMixProgram> {
     shader.AddInput("expert_tokens", ShaderUsage::UseElementTypeAlias);
     shader.AddOutput("output", ShaderUsage::UseElementTypeAlias);
 
-    return WGSL_TEMPLATE_APPLY(shader, "moe/final_mix.wgsl.template");
+    return WGSL_TEMPLATE_APPLY(shader, "moe/final_mix.wgsl.template",
+                               WGSL_TEMPLATE_PARAMETER(has_router_weights, has_router_weights_));
   }
 
   WEBGPU_PROGRAM_DEFINE_UNIFORM_VARIABLES(
@@ -161,6 +201,7 @@ class QMoEFinalMixProgram final : public Program<QMoEFinalMixProgram> {
       {"token_offset", ProgramUniformVariableDataType::Uint32});
 
  private:
+  bool has_router_weights_;
 };
 
 Status QMoE::ComputeInternal(ComputeContext& context) const {
@@ -177,7 +218,6 @@ Status QMoE::ComputeInternal(ComputeContext& context) const {
   const Tensor* fc3_experts_weights_optional = context.Input<Tensor>(8);
   const Tensor* fc3_scales_optional = context.Input<Tensor>(9);
   const Tensor* fc3_experts_bias_optional = context.Input<Tensor>(10);
-  // zero points, not supported yet
   const Tensor* fc1_zero_points = context.Input<Tensor>(11);
   const Tensor* fc2_zero_points = context.Input<Tensor>(12);
   const Tensor* fc3_zero_points = context.Input<Tensor>(13);
@@ -185,39 +225,41 @@ Status QMoE::ComputeInternal(ComputeContext& context) const {
 
   MoEParameters moe_params;
 
-  if (fc1_zero_points || fc2_zero_points || fc3_zero_points) {
-    return ORT_MAKE_STATUS(ONNXRUNTIME, NOT_IMPLEMENTED,
-                           "zero_points for QMoE are not yet supported on WebGPU.");
+  int swiglu_fusion = swiglu_fusion_;
+  if (activation_type_ == MoEActivationType::SwiGLU && swiglu_fusion == 0 &&
+      fc3_experts_weights_optional == nullptr) {
+    swiglu_fusion = 1;
   }
-
-  if (router_weights) {
-    return ORT_MAKE_STATUS(ONNXRUNTIME, NOT_IMPLEMENTED,
-                           "Separate router_weights is not yet implemented on WebGPU for QMoE.");
-  }
-
+  const bool is_swiglu = activation_type_ == MoEActivationType::SwiGLU;
+  const bool is_fused_swiglu = is_swiglu && swiglu_fusion != 0 && fc3_experts_weights_optional == nullptr;
   ORT_RETURN_IF_ERROR(::onnxruntime::contrib::moe_helper::CheckInputs<Tensor>(
       moe_params, hidden_state, router_logits,
       fc1_experts_weights, fc1_experts_bias_optional, fc1_scales, fc1_zero_points,
       fc2_experts_weights, fc2_experts_bias_optional, fc2_scales, fc2_zero_points,
       fc3_experts_weights_optional, fc3_experts_bias_optional, fc3_scales_optional, fc3_zero_points,
-      expert_weight_bits_ == 4 ? 2 : 1,
-      activation_type_ == MoEActivationType::SwiGLU, block_size_));
+      8 / expert_weight_bits_, is_fused_swiglu, block_size_));
+  ORT_RETURN_IF(router_weights && router_weights->Shape() != router_logits->Shape(),
+                "router_weights must have the same shape as router_probs; got ",
+                router_weights->Shape(), " and ", router_logits->Shape());
+  ORT_RETURN_IF_NOT(k_ > 0 && k_ <= moe_params.num_experts,
+                    "QMoE requires 0 < k <= num_experts, got k=", k_,
+                    " and num_experts=", moe_params.num_experts);
+  ORT_RETURN_IF_NOT(block_size_ > 0 ||
+                        (fc1_zero_points == nullptr && fc2_zero_points == nullptr && fc3_zero_points == nullptr),
+                    "WebGPU QMoE row-wise quantization does not support explicit zero points. "
+                    "Use block-wise quantization or omit the zero-point inputs.");
+  ORT_RETURN_IF_NOT(moe_params.num_rows != 1 ||
+                        (fc1_zero_points == nullptr && fc2_zero_points == nullptr && fc3_zero_points == nullptr),
+                    "WebGPU QMoE does not support explicit zero points on the optimized single-token path.");
 
   const auto& input_shape = hidden_state->Shape();
-
-  // SwiGLU validation
-  bool is_swiglu = (activation_type_ == MoEActivationType::SwiGLU);
-  if (fc3_experts_weights_optional) {
-    return ORT_MAKE_STATUS(ONNXRUNTIME, NOT_IMPLEMENTED,
-                           "FC3 gating is not yet implemented on WebGPU.");
-  }
 
   // process tokens in chunks of max_tokens to put some cap on memory usage
   const int max_tokens = 2 * 1024;
 
   const uint32_t num_experts = static_cast<uint32_t>(moe_params.num_experts);
   const uint32_t hidden_size = static_cast<uint32_t>(moe_params.hidden_size);
-  const int64_t fc1_output_size = is_swiglu && swiglu_fusion_ > 0 ? 2 * moe_params.inter_size : moe_params.inter_size;
+  const int64_t fc1_output_size = is_fused_swiglu ? 2 * moe_params.inter_size : moe_params.inter_size;
   const bool is_fp16 = hidden_state->DataType() == DataTypeImpl::GetType<MLFloat16>();
   const auto dtype = is_fp16 ? DataTypeImpl::GetType<MLFloat16>() : DataTypeImpl::GetType<float>();
   const auto dtype_uint32 = DataTypeImpl::GetType<uint32_t>();
@@ -229,9 +271,13 @@ Status QMoE::ComputeInternal(ComputeContext& context) const {
   const int64_t accuracy_level = 4;
   const int64_t block_size_fc1 = (block_size_ != 0) ? block_size_ : K_fc1;
   const int64_t block_size_fc2 = (block_size_ != 0) ? block_size_ : K_fc2;
+  const int64_t block_size_fc3 = block_size_fc1;
   Status status;
 
   Tensor* output_tensor = context.Output(0, input_shape);
+  if (moe_params.num_rows == 0) {
+    return Status::OK();
+  }
 
   if (moe_params.num_rows == 1) {
     // Fused MoE path for 1 token: instead of looping k times with separate dispatches,
@@ -248,7 +294,7 @@ Status QMoE::ComputeInternal(ComputeContext& context) const {
     Tensor indirect_experts = context.CreateGPUTensor(dtype_uint32, indirect_experts_shape);
 
     // Step 1: Gate — select top-k experts
-    Gate1TokenProgram gate{k_, is_fp16};
+    Gate1TokenProgram gate{k_, is_fp16, normalize_routing_weights_};
     gate
         .AddInputs({{router_logits, ProgramTensorMetadataDependency::Type}})
         .AddOutput({&router_values, ProgramTensorMetadataDependency::None})
@@ -256,43 +302,49 @@ Status QMoE::ComputeInternal(ComputeContext& context) const {
         .SetWorkgroupSize(num_experts)
         .SetDispatchGroupSize(num_tokens)
         .AddUniformVariables({num_tokens, num_experts})
-        .CacheHint(k_, is_fp16 ? "fp16" : "fp32");
+        .CacheHint(k_, is_fp16 ? "fp16" : "fp32", normalize_routing_weights_);
     ORT_RETURN_IF_ERROR(context.RunProgram(gate));
 
     // Step 2: Batched fc1 MatMulNBits with M=k, per-row expert selection.
     // A is (1, hidden_size) but dispatched with override_M=k; shader broadcasts A row 0.
     TensorShape fc1_output_shape({static_cast<int64_t>(k), fc1_output_size});
     Tensor fc1_outputs = context.CreateGPUTensor(dtype, fc1_output_shape);
-    status = ApplyMatMulNBits(hidden_state, fc1_experts_weights, fc1_scales, nullptr, fc1_experts_bias_optional,
+    status = ApplyMatMulNBits(hidden_state, fc1_experts_weights, fc1_scales, fc1_zero_points, fc1_experts_bias_optional,
                               K_fc1, N_fc1, block_size_fc1, accuracy_level, expert_weight_bits_, context,
                               &fc1_outputs, 0, &indirect_experts, /*override_M=*/k);
     ORT_RETURN_IF_ERROR(status);
 
-    // Step 3: SwiGLU on all k rows at once
+    // Step 3: Apply the activation, optionally combining FC1 with a separate FC3 projection.
     TensorShape fc1_activated_shape({static_cast<int64_t>(k), moe_params.inter_size});
     Tensor fc1_activated = context.CreateGPUTensor(dtype, fc1_activated_shape);
-    if (is_swiglu) {
-      SwigLuProgram swiglu;
-      swiglu
-          .AddInputs({{&fc1_outputs, ProgramTensorMetadataDependency::Type, 2}})
-          .AddOutput({&fc1_activated, ProgramTensorMetadataDependency::None})
-          .SetWorkgroupSize(128)
-          .SetDispatchGroupSize(((k * static_cast<uint32_t>(moe_params.inter_size)) + 127) / 128)
-          .AddUniformVariables({k,
-                                static_cast<uint32_t>(moe_params.inter_size),
-                                activation_alpha_,
-                                activation_beta_,
-                                swiglu_limit_});
-      ORT_RETURN_IF_ERROR(context.RunProgram(swiglu));
-    } else {
-      ORT_THROW("only swiglu is supported for WebGPU.");
+    std::optional<Tensor> fc3_outputs;
+    if (fc3_experts_weights_optional) {
+      fc3_outputs.emplace(context.CreateGPUTensor(dtype, fc1_activated_shape));
+      ORT_RETURN_IF_ERROR(ApplyMatMulNBits(hidden_state, fc3_experts_weights_optional, fc3_scales_optional,
+                                           fc3_zero_points, fc3_experts_bias_optional,
+                                           K_fc1, moe_params.inter_size, block_size_fc3, accuracy_level,
+                                           expert_weight_bits_, context, &*fc3_outputs, 0, &indirect_experts,
+                                           /*override_M=*/k));
     }
+    MoEActivationProgram activation{activation_type_, swiglu_fusion, fc3_outputs.has_value()};
+    activation.AddInputs({{&fc1_outputs, ProgramTensorMetadataDependency::Type}});
+    if (fc3_outputs) {
+      activation.AddInputs({{&*fc3_outputs, ProgramTensorMetadataDependency::Type}});
+    }
+    activation
+        .AddOutput({&fc1_activated, ProgramTensorMetadataDependency::None})
+        .SetWorkgroupSize(128)
+        .SetDispatchGroupSize(((k * static_cast<uint32_t>(moe_params.inter_size)) + 127) / 128)
+        .AddUniformVariables({k, static_cast<uint32_t>(moe_params.inter_size), activation_alpha_,
+                              activation_beta_, swiglu_limit_})
+        .CacheHint(static_cast<int>(activation_type_), swiglu_fusion, fc3_outputs.has_value());
+    ORT_RETURN_IF_ERROR(context.RunProgram(activation));
 
     // Step 4: Batched fc2 MatMulNBits with M=k, per-row expert selection
     // fc1_activated already has k rows (one per expert), no override_M needed.
     TensorShape fc2_output_shape({static_cast<int64_t>(k), N_fc2});
     Tensor fc2_outputs = context.CreateGPUTensor(dtype, fc2_output_shape);
-    status = ApplyMatMulNBits(&fc1_activated, fc2_experts_weights, fc2_scales, nullptr, fc2_experts_bias_optional,
+    status = ApplyMatMulNBits(&fc1_activated, fc2_experts_weights, fc2_scales, fc2_zero_points, fc2_experts_bias_optional,
                               K_fc2, N_fc2, block_size_fc2, accuracy_level, expert_weight_bits_, context,
                               &fc2_outputs, 0, &indirect_experts, /*override_M=*/0);
     ORT_RETURN_IF_ERROR(status);
@@ -303,7 +355,7 @@ Status QMoE::ComputeInternal(ComputeContext& context) const {
     FusedFinalMix1TokenProgram final_mix;
     final_mix
         .AddInputs({{&fc2_outputs, ProgramTensorMetadataDependency::Type}})
-        .AddInputs({{&router_values, ProgramTensorMetadataDependency::Type}})
+        .AddInputs({{router_weights ? router_weights : &router_values, ProgramTensorMetadataDependency::Type}})
         .AddInputs({{&indirect_experts, ProgramTensorMetadataDependency::Type}})
         .AddOutput({output_tensor, ProgramTensorMetadataDependency::None})
         .SetWorkgroupSize(mix_wg_size)
@@ -345,7 +397,13 @@ Status QMoE::ComputeInternal(ComputeContext& context) const {
     //  token_idx is the global index into hidden_state
     Tensor gate_hidden = context.CreateGPUTensor(dtype_uint32, gate_hidden_shape);
 
-    GateProgram gate{k_, is_fp16};
+    ZeroU32Program zero_counts;
+    zero_counts.AddOutput({&gate_counts, ProgramTensorMetadataDependency::None})
+        .SetDispatchGroupSize((num_experts + WORKGROUP_SIZE - 1) / WORKGROUP_SIZE)
+        .AddUniformVariables({num_experts});
+    ORT_RETURN_IF_ERROR(context.RunProgram(zero_counts));
+
+    GateProgram gate{k_, is_fp16, normalize_routing_weights_};
     gate
         .AddInputs({{router_logits, ProgramTensorMetadataDependency::Type}})
         .AddOutput({&router_values, ProgramTensorMetadataDependency::None})
@@ -354,7 +412,7 @@ Status QMoE::ComputeInternal(ComputeContext& context) const {
         .SetWorkgroupSize(num_experts)
         .SetDispatchGroupSize(static_cast<uint32_t>(num_tokens))
         .AddUniformVariables({static_cast<uint32_t>(num_tokens), num_experts, static_cast<uint32_t>(token_offset)})
-        .CacheHint(k_, is_fp16 ? "fp16" : "fp32");
+        .CacheHint(k_, is_fp16 ? "fp16" : "fp32", normalize_routing_weights_);
 
     ORT_RETURN_IF_ERROR(context.RunProgram(gate));
 
@@ -400,35 +458,40 @@ Status QMoE::ComputeInternal(ComputeContext& context) const {
       //
       // Step 3: matmul the hidden_state with fc1 (gate_up) of the selected experts
       //
-      status = ApplyMatMulNBits(&expert_hidden, fc1_experts_weights, fc1_scales, nullptr, fc1_experts_bias_optional,
+      status = ApplyMatMulNBits(&expert_hidden, fc1_experts_weights, fc1_scales, fc1_zero_points, fc1_experts_bias_optional,
                                 K_fc1, N_fc1, block_size_fc1, accuracy_level, expert_weight_bits_, context,
                                 &fc1_outputs, expert_idx);
       ORT_RETURN_IF_ERROR(status);
 
       //
-      // Step 4: apply swiglu
+      // Step 4: apply the activation and optional FC3 gate.
       //
-      if (is_swiglu) {
-        SwigLuProgram swiglu;
-        swiglu
-            .AddInputs({{&fc1_outputs, ProgramTensorMetadataDependency::Type, 2}})
-            .AddOutput({&fc1_activated, ProgramTensorMetadataDependency::None})
-            .SetWorkgroupSize(128)
-            .SetDispatchGroupSize(((used_by * static_cast<uint32_t>(moe_params.inter_size)) + 127) / 128)
-            .AddUniformVariables({static_cast<uint32_t>(used_by),
-                                  static_cast<uint32_t>(moe_params.inter_size),
-                                  activation_alpha_,
-                                  activation_beta_,
-                                  swiglu_limit_});
-        ORT_RETURN_IF_ERROR(context.RunProgram(swiglu));
-      } else {
-        ORT_THROW("only swiglu is supported for WebGPU.");
+      std::optional<Tensor> fc3_outputs;
+      if (fc3_experts_weights_optional) {
+        fc3_outputs.emplace(context.CreateGPUTensor(dtype, fc1_activated_shape));
+        ORT_RETURN_IF_ERROR(ApplyMatMulNBits(&expert_hidden, fc3_experts_weights_optional, fc3_scales_optional,
+                                             fc3_zero_points, fc3_experts_bias_optional,
+                                             K_fc1, moe_params.inter_size, block_size_fc3, accuracy_level,
+                                             expert_weight_bits_, context, &*fc3_outputs, expert_idx));
       }
+      MoEActivationProgram activation{activation_type_, swiglu_fusion, fc3_outputs.has_value()};
+      activation.AddInputs({{&fc1_outputs, ProgramTensorMetadataDependency::Type}});
+      if (fc3_outputs) {
+        activation.AddInputs({{&*fc3_outputs, ProgramTensorMetadataDependency::Type}});
+      }
+      activation
+          .AddOutput({&fc1_activated, ProgramTensorMetadataDependency::None})
+          .SetWorkgroupSize(128)
+          .SetDispatchGroupSize(((used_by * static_cast<uint32_t>(moe_params.inter_size)) + 127) / 128)
+          .AddUniformVariables({used_by, static_cast<uint32_t>(moe_params.inter_size), activation_alpha_,
+                                activation_beta_, swiglu_limit_})
+          .CacheHint(static_cast<int>(activation_type_), swiglu_fusion, fc3_outputs.has_value());
+      ORT_RETURN_IF_ERROR(context.RunProgram(activation));
 
       //
       // Step 5: multiply fc1_activated with fc2 (gate_down) of the selected experts
       //
-      status = ApplyMatMulNBits(&fc1_activated, fc2_experts_weights, fc2_scales, nullptr, fc2_experts_bias_optional,
+      status = ApplyMatMulNBits(&fc1_activated, fc2_experts_weights, fc2_scales, fc2_zero_points, fc2_experts_bias_optional,
                                 K_fc2, N_fc2, block_size_fc2, accuracy_level, expert_weight_bits_, context,
                                 &fc2_outputs, expert_idx);
       ORT_RETURN_IF_ERROR(status);
@@ -436,17 +499,18 @@ Status QMoE::ComputeInternal(ComputeContext& context) const {
       //
       // Step 6: multiply fc2_outputs with router_values and accumulate
       //
-      QMoEFinalMixProgram final_mix;
+      QMoEFinalMixProgram final_mix{router_weights != nullptr};
       final_mix
           .AddInputs({{&fc2_outputs, ProgramTensorMetadataDependency::Type}})
-          .AddInputs({{&router_values, ProgramTensorMetadataDependency::Type}})
+          .AddInputs({{router_weights ? router_weights : &router_values, ProgramTensorMetadataDependency::Type}})
           .AddInputs({{&expert_tokens, ProgramTensorMetadataDependency::Type}})
           .AddOutput({output_tensor, ProgramTensorMetadataDependency::None})
           .SetDispatchGroupSize(used_by)
           .AddUniformVariables({hidden_size,
                                 num_experts,
                                 expert_idx,
-                                static_cast<uint32_t>(token_offset)});
+                                static_cast<uint32_t>(token_offset)})
+          .CacheHint(router_weights != nullptr);
 
       ORT_RETURN_IF_ERROR(context.RunProgram(final_mix));
     }

--- a/onnxruntime/contrib_ops/webgpu/moe/qmoe.cc
+++ b/onnxruntime/contrib_ops/webgpu/moe/qmoe.cc
@@ -21,19 +21,24 @@ using onnxruntime::webgpu::ComputeContext;
 
 class GateProgram final : public Program<GateProgram> {
  public:
-  GateProgram(int k, bool is_fp16, bool normalize_routing_weights)
+  GateProgram(int k, bool is_fp16, bool has_router_weights, bool normalize_routing_weights)
       : Program<GateProgram>{"QmoeGate"},
         k_{k},
         is_fp16_{is_fp16},
+        has_router_weights_{has_router_weights},
         normalize_routing_weights_{normalize_routing_weights} {}
 
   Status GenerateShaderCode(ShaderHelper& shader) const override {
     shader.AddInput("router_logits", ShaderUsage::UseElementTypeAlias);
+    if (has_router_weights_) {
+      shader.AddInput("router_weights", ShaderUsage::UseElementTypeAlias);
+    }
     shader.AddOutput("topk_values");
     shader.AddOutput("hiddenstate_for_expert");
     shader.AddOutput("tokencount_for_expert");
 
     return WGSL_TEMPLATE_APPLY(shader, "moe/gate.wgsl.template",
+                               WGSL_TEMPLATE_PARAMETER(has_router_weights, has_router_weights_),
                                WGSL_TEMPLATE_PARAMETER(is_fp16, is_fp16_),
                                WGSL_TEMPLATE_PARAMETER(k, k_),
                                WGSL_TEMPLATE_PARAMETER(normalize_routing_weights, normalize_routing_weights_));
@@ -47,23 +52,29 @@ class GateProgram final : public Program<GateProgram> {
  private:
   int k_;
   bool is_fp16_;
+  bool has_router_weights_;
   bool normalize_routing_weights_;
 };
 
 class Gate1TokenProgram final : public Program<Gate1TokenProgram> {
  public:
-  Gate1TokenProgram(int k, bool is_fp16, bool normalize_routing_weights)
+  Gate1TokenProgram(int k, bool is_fp16, bool has_router_weights, bool normalize_routing_weights)
       : Program<Gate1TokenProgram>{"QmoeGate1Token"},
         k_{k},
         is_fp16_{is_fp16},
+        has_router_weights_{has_router_weights},
         normalize_routing_weights_{normalize_routing_weights} {}
 
   Status GenerateShaderCode(ShaderHelper& shader) const override {
     shader.AddInput("router_logits", ShaderUsage::UseElementTypeAlias);
+    if (has_router_weights_) {
+      shader.AddInput("router_weights", ShaderUsage::UseElementTypeAlias);
+    }
     shader.AddOutput("topk_values");
     shader.AddOutput("indirect_experts");
 
     return WGSL_TEMPLATE_APPLY(shader, "moe/gate_1token.wgsl.template",
+                               WGSL_TEMPLATE_PARAMETER(has_router_weights, has_router_weights_),
                                WGSL_TEMPLATE_PARAMETER(is_fp16, is_fp16_),
                                WGSL_TEMPLATE_PARAMETER(k, k_),
                                WGSL_TEMPLATE_PARAMETER(normalize_routing_weights, normalize_routing_weights_));
@@ -76,6 +87,7 @@ class Gate1TokenProgram final : public Program<Gate1TokenProgram> {
  private:
   int k_;
   bool is_fp16_;
+  bool has_router_weights_;
   bool normalize_routing_weights_;
 };
 
@@ -181,8 +193,7 @@ class FusedFinalMix1TokenProgram final : public Program<FusedFinalMix1TokenProgr
 
 class QMoEFinalMixProgram final : public Program<QMoEFinalMixProgram> {
  public:
-  explicit QMoEFinalMixProgram(bool has_router_weights)
-      : Program<QMoEFinalMixProgram>{"QMoEFinalMix"}, has_router_weights_{has_router_weights} {}
+  QMoEFinalMixProgram() : Program<QMoEFinalMixProgram>{"QMoEFinalMix"} {}
 
   Status GenerateShaderCode(ShaderHelper& shader) const override {
     shader.AddInput("fc2_outputs", ShaderUsage::UseElementTypeAlias);
@@ -190,8 +201,7 @@ class QMoEFinalMixProgram final : public Program<QMoEFinalMixProgram> {
     shader.AddInput("expert_tokens", ShaderUsage::UseElementTypeAlias);
     shader.AddOutput("output", ShaderUsage::UseElementTypeAlias);
 
-    return WGSL_TEMPLATE_APPLY(shader, "moe/final_mix.wgsl.template",
-                               WGSL_TEMPLATE_PARAMETER(has_router_weights, has_router_weights_));
+    return WGSL_TEMPLATE_APPLY(shader, "moe/final_mix.wgsl.template");
   }
 
   WEBGPU_PROGRAM_DEFINE_UNIFORM_VARIABLES(
@@ -199,9 +209,6 @@ class QMoEFinalMixProgram final : public Program<QMoEFinalMixProgram> {
       {"num_experts", ProgramUniformVariableDataType::Uint32},
       {"expert_idx", ProgramUniformVariableDataType::Uint32},
       {"token_offset", ProgramUniformVariableDataType::Uint32});
-
- private:
-  bool has_router_weights_;
 };
 
 Status QMoE::ComputeInternal(ComputeContext& context) const {
@@ -258,6 +265,12 @@ Status QMoE::ComputeInternal(ComputeContext& context) const {
   const int max_tokens = 2 * 1024;
 
   const uint32_t num_experts = static_cast<uint32_t>(moe_params.num_experts);
+  const auto& device_limits = context.DeviceLimits();
+  ORT_RETURN_IF_NOT(num_experts <= device_limits.maxComputeWorkgroupSizeX &&
+                        num_experts <= device_limits.maxComputeInvocationsPerWorkgroup,
+                    "WebGPU QMoE requires num_experts to fit in one workgroup; got ", num_experts,
+                    ", maxComputeWorkgroupSizeX=", device_limits.maxComputeWorkgroupSizeX,
+                    ", maxComputeInvocationsPerWorkgroup=", device_limits.maxComputeInvocationsPerWorkgroup, ".");
   const uint32_t hidden_size = static_cast<uint32_t>(moe_params.hidden_size);
   const int64_t fc1_output_size = is_fused_swiglu ? 2 * moe_params.inter_size : moe_params.inter_size;
   const bool is_fp16 = hidden_state->DataType() == DataTypeImpl::GetType<MLFloat16>();
@@ -294,15 +307,18 @@ Status QMoE::ComputeInternal(ComputeContext& context) const {
     Tensor indirect_experts = context.CreateGPUTensor(dtype_uint32, indirect_experts_shape);
 
     // Step 1: Gate — select top-k experts
-    Gate1TokenProgram gate{k_, is_fp16, normalize_routing_weights_};
+    Gate1TokenProgram gate{k_, is_fp16, router_weights != nullptr, normalize_routing_weights_};
     gate
-        .AddInputs({{router_logits, ProgramTensorMetadataDependency::Type}})
-        .AddOutput({&router_values, ProgramTensorMetadataDependency::None})
+        .AddInputs({{router_logits, ProgramTensorMetadataDependency::Type}});
+    if (router_weights) {
+      gate.AddInputs({{router_weights, ProgramTensorMetadataDependency::Type}});
+    }
+    gate.AddOutput({&router_values, ProgramTensorMetadataDependency::None})
         .AddOutput({&indirect_experts, ProgramTensorMetadataDependency::None})
         .SetWorkgroupSize(num_experts)
         .SetDispatchGroupSize(num_tokens)
         .AddUniformVariables({num_tokens, num_experts})
-        .CacheHint(k_, is_fp16 ? "fp16" : "fp32", normalize_routing_weights_);
+        .CacheHint(k_, is_fp16 ? "fp16" : "fp32", router_weights != nullptr, normalize_routing_weights_);
     ORT_RETURN_IF_ERROR(context.RunProgram(gate));
 
     // Step 2: Batched fc1 MatMulNBits with M=k, per-row expert selection.
@@ -355,7 +371,7 @@ Status QMoE::ComputeInternal(ComputeContext& context) const {
     FusedFinalMix1TokenProgram final_mix;
     final_mix
         .AddInputs({{&fc2_outputs, ProgramTensorMetadataDependency::Type}})
-        .AddInputs({{router_weights ? router_weights : &router_values, ProgramTensorMetadataDependency::Type}})
+        .AddInputs({{&router_values, ProgramTensorMetadataDependency::Type}})
         .AddInputs({{&indirect_experts, ProgramTensorMetadataDependency::Type}})
         .AddOutput({output_tensor, ProgramTensorMetadataDependency::None})
         .SetWorkgroupSize(mix_wg_size)
@@ -403,16 +419,19 @@ Status QMoE::ComputeInternal(ComputeContext& context) const {
         .AddUniformVariables({num_experts});
     ORT_RETURN_IF_ERROR(context.RunProgram(zero_counts));
 
-    GateProgram gate{k_, is_fp16, normalize_routing_weights_};
+    GateProgram gate{k_, is_fp16, router_weights != nullptr, normalize_routing_weights_};
     gate
-        .AddInputs({{router_logits, ProgramTensorMetadataDependency::Type}})
-        .AddOutput({&router_values, ProgramTensorMetadataDependency::None})
+        .AddInputs({{router_logits, ProgramTensorMetadataDependency::Type}});
+    if (router_weights) {
+      gate.AddInputs({{router_weights, ProgramTensorMetadataDependency::Type}});
+    }
+    gate.AddOutput({&router_values, ProgramTensorMetadataDependency::None})
         .AddOutput({&gate_hidden, ProgramTensorMetadataDependency::None})
         .AddOutput({&gate_counts, ProgramTensorMetadataDependency::None, ProgramOutput::Atomic})
         .SetWorkgroupSize(num_experts)
         .SetDispatchGroupSize(static_cast<uint32_t>(num_tokens))
         .AddUniformVariables({static_cast<uint32_t>(num_tokens), num_experts, static_cast<uint32_t>(token_offset)})
-        .CacheHint(k_, is_fp16 ? "fp16" : "fp32", normalize_routing_weights_);
+        .CacheHint(k_, is_fp16 ? "fp16" : "fp32", router_weights != nullptr, normalize_routing_weights_);
 
     ORT_RETURN_IF_ERROR(context.RunProgram(gate));
 
@@ -499,10 +518,10 @@ Status QMoE::ComputeInternal(ComputeContext& context) const {
       //
       // Step 6: multiply fc2_outputs with router_values and accumulate
       //
-      QMoEFinalMixProgram final_mix{router_weights != nullptr};
+      QMoEFinalMixProgram final_mix;
       final_mix
           .AddInputs({{&fc2_outputs, ProgramTensorMetadataDependency::Type}})
-          .AddInputs({{router_weights ? router_weights : &router_values, ProgramTensorMetadataDependency::Type}})
+          .AddInputs({{&router_values, ProgramTensorMetadataDependency::Type}})
           .AddInputs({{&expert_tokens, ProgramTensorMetadataDependency::Type}})
           .AddOutput({output_tensor, ProgramTensorMetadataDependency::None})
           .SetDispatchGroupSize(used_by)
@@ -510,7 +529,7 @@ Status QMoE::ComputeInternal(ComputeContext& context) const {
                                 num_experts,
                                 expert_idx,
                                 static_cast<uint32_t>(token_offset)})
-          .CacheHint(router_weights != nullptr);
+          .CacheHint(router_weights != nullptr, normalize_routing_weights_);
 
       ORT_RETURN_IF_ERROR(context.RunProgram(final_mix));
     }

--- a/onnxruntime/contrib_ops/webgpu/moe/qmoe.h
+++ b/onnxruntime/contrib_ops/webgpu/moe/qmoe.h
@@ -23,6 +23,14 @@ class QMoE final : public MoE {
     ORT_ENFORCE(expert_weight_bits_ == 8 || expert_weight_bits_ == 4,
                 "expert_weight_bits must be 4 or 8, but got ", expert_weight_bits_);
     block_size_ = static_cast<int>(info.GetAttrOrDefault<int64_t>("block_size", 0));
+    const auto quant_type = info.GetAttrOrDefault<std::string>("quant_type", "int");
+    ORT_ENFORCE(quant_type == "int",
+                "WebGPU QMoE supports only quant_type='int'; CUDA-specific fp4, nvfp4, fp8, and "
+                "wfp4afp8 formats are not supported.");
+    const auto weights_prepacked = info.GetAttrOrDefault<int64_t>("weights_prepacked", -1);
+    ORT_ENFORCE(weights_prepacked != 1,
+                "WebGPU QMoE does not support provider-specific prepacked expert weights. "
+                "Use weights_prepacked=0 or omit the attribute.");
   }
 
   Status ComputeInternal(ComputeContext& context) const override;

--- a/onnxruntime/contrib_ops/webgpu/moe/zero_u32.wgsl.template
+++ b/onnxruntime/contrib_ops/webgpu/moe/zero_u32.wgsl.template
@@ -1,0 +1,9 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#use guardAgainstOutOfBoundsWorkgroupSizes
+
+$MAIN {
+  guardAgainstOutOfBoundsWorkgroupSizes(uniforms.size);
+  output[global_idx] = 0u;
+} // MAIN

--- a/onnxruntime/contrib_ops/webgpu/quantization/dp4a_matmul.wgsl.template
+++ b/onnxruntime/contrib_ops/webgpu/quantization/dp4a_matmul.wgsl.template
@@ -91,7 +91,7 @@ fn loadSHMA(batch:u32, a_global_base:u32, kidx_v:u32, row: u32, col: u32)
         let b_value = b.getByOffset(b_global * uniforms.K16+kidx_v + col);
 #endif
         let block_idx = kidx_v/(block_size/16);
-        let zero = mm_read_zero(b_global, block_idx, uniforms.N, uniforms.zero_blocks_per_col);
+        let zero = mm_read_zero(actual_weight_idx, b_global, block_idx, uniforms.N, uniforms.zero_blocks_per_col);
         tile_B[col][row] = DequantizedFrom4BitsTo8Bits(b_value, zero);
         if (col == 0)
         {
@@ -132,7 +132,7 @@ fn loadSHMA(batch:u32, a_global_base:u32, kidx_v:u32, row: u32, col: u32)
             let b_scale_offset = actual_weight_idx * uniforms.N * (uniforms.K/block_size);
             scale_B[row] = scales_b.getByOffset(b_scale_offset + b_global*(uniforms.K/block_size) + block_idx);
 #if has_zero_points
-            zeroes[row] = mm_read_zero(b_global, block_idx, uniforms.N, uniforms.zero_blocks_per_col);
+            zeroes[row] = mm_read_zero(actual_weight_idx, b_global, block_idx, uniforms.N, uniforms.zero_blocks_per_col);
 #endif
         }
     }
@@ -161,7 +161,7 @@ fn loadSHMA(batch:u32, a_global_base:u32, kidx_v:u32, row: u32, col: u32)
 #endif
         let block_idx = kidx_v/(block_size/16);
 #if has_zero_points
-        let zero = mm_read_zero(b_global, block_idx, uniforms.N, uniforms.zero_blocks_per_col);
+        let zero = mm_read_zero(actual_weight_idx, b_global, block_idx, uniforms.N, uniforms.zero_blocks_per_col);
         tile_B[col][row] = DequantizedFrom2BitsTo8Bits(b_value, zero);
 #else
         tile_B[col][row] = DequantizedFrom2BitsTo8Bits(b_value);

--- a/onnxruntime/contrib_ops/webgpu/quantization/dp4a_matmul_small_m.wgsl.template
+++ b/onnxruntime/contrib_ops/webgpu/quantization/dp4a_matmul_small_m.wgsl.template
@@ -68,6 +68,15 @@ $MAIN {
         return;
     }
     let a_global = u32((workgroup_idx / uniforms.num_N_tile) % uniforms.dispatch_M);
+#if has_weight_idx
+#if has_weight_idx_indirect
+    let actual_weight_idx = weight_index_indirect[a_global];
+#else
+    let actual_weight_idx = uniforms.weight_idx;
+#endif
+#else
+    const actual_weight_idx : u32 = 0;
+#endif
     // When broadcast_a_row is true, A has only 1 row but M=k for dispatch.
     // Always read from A row 0; a_global is used for output row and weight selection.
 #if broadcast_a_row
@@ -112,7 +121,7 @@ $MAIN {
     workgroupBarrier();
 #endif
 #if single_scale_weights
-    let zero = mm_read_zero(0, 0, uniforms.N, uniforms.zero_blocks_per_col);
+    let zero = mm_read_zero(actual_weight_idx, 0, 0, uniforms.N, uniforms.zero_blocks_per_col);
 #if has_weight_idx
 #if has_weight_idx_indirect
     let own_scale_b = scales_b.getByOffset(weight_index_indirect[a_global]);
@@ -158,7 +167,7 @@ $MAIN {
                 let own_scale_b = scales_b.getByOffset(b_global * uniforms.K / uniforms.block_size + block_idx);
 #endif
 #if !single_scale_weights
-                let zero = mm_read_zero(b_global, block_idx, uniforms.N, uniforms.zero_blocks_per_col);
+                let zero = mm_read_zero(actual_weight_idx, b_global, block_idx, uniforms.N, uniforms.zero_blocks_per_col);
 #endif
 #if n_bits == 4
                 let b_value = b.getByOffset(b_offset);

--- a/onnxruntime/contrib_ops/webgpu/quantization/matmul_nbits.wgsl.template
+++ b/onnxruntime/contrib_ops/webgpu/quantization/matmul_nbits.wgsl.template
@@ -73,7 +73,7 @@ $MAIN {
 #if single_scale_weights
   let block_idx = 0;
   let scale_b = scales_b.getByOffset(0 + b_scale_offset);
-  let zero = mm_read_zero(0, 0, uniforms.N, uniforms.zero_blocks_per_col);
+  let zero = mm_read_zero(actual_weight_idx, 0, 0, uniforms.N, uniforms.zero_blocks_per_col);
 #endif
 
   for (var kidx = 0u; kidx < uniforms.K; kidx += tile_size_k)
@@ -93,7 +93,7 @@ $MAIN {
 #if !single_scale_weights
         let block_idx = (kidx + idx * elements_in_value_b) / uniforms.block_size;
         let scale_b = scales_b.getByOffset(b_global * uniforms.blocks_per_col + block_idx + b_scale_offset);
-        let zero = mm_read_zero(b_global, block_idx, uniforms.N, uniforms.zero_blocks_per_col);
+        let zero = mm_read_zero(actual_weight_idx, b_global, block_idx, uniforms.N, uniforms.zero_blocks_per_col);
 #endif
         var b_value = b.getByOffset(b_global * uniforms.K_of_b + k_offset + b_base_offset);
 

--- a/onnxruntime/contrib_ops/webgpu/quantization/matmul_nbits_common.cc
+++ b/onnxruntime/contrib_ops/webgpu/quantization/matmul_nbits_common.cc
@@ -22,10 +22,10 @@ std::string GenerateZeroPointReadingCode(uint32_t nbits, bool has_zero_points,
     ss << "const elements_in_uint32 = " << (32 / nbits) << "u;\n"
        << "const bits = " << nbits << "u;\n";
     ss << R"(
-fn mm_read_zero(row : u32, col : u32, r_dim: u32, c_dim: u32) -> )"
+fn mm_read_zero(matrix_idx: u32, row : u32, col : u32, r_dim: u32, c_dim: u32) -> )"
        << output_type << R"( {
   if (row < r_dim && col < c_dim) {
-    let offset = row * c_dim + col;
+    let offset = matrix_idx * r_dim * c_dim + row * c_dim + col;
 
     // u32 holds elements_in_uint32 packed nbits.
     let array_index = offset / elements_in_uint32;
@@ -47,7 +47,7 @@ fn mm_read_zero(row : u32, col : u32, r_dim: u32, c_dim: u32) -> )"
   } else {
     ss << "const default_zero_point = " << (nbits == 4 ? 8 : 128) << ";\n";
     ss << R"(
-fn mm_read_zero(row : u32, col : u32, r_dim: u32, c_dim: u32) -> )"
+fn mm_read_zero(matrix_idx: u32, row : u32, col : u32, r_dim: u32, c_dim: u32) -> )"
        << output_type << R"( {
   return )"
        << output_type << R"((default_zero_point);

--- a/onnxruntime/contrib_ops/webgpu/quantization/matmul_nbits_zero_pt.wgsl.template
+++ b/onnxruntime/contrib_ops/webgpu/quantization/matmul_nbits_zero_pt.wgsl.template
@@ -25,10 +25,10 @@
 
 #if has_zero_points
   const elements_in_uint32:u32 = 32u / n_bits;
-  fn mm_read_zero(row : u32, col : u32, r_dim: u32, c_dim: u32) -> output_type
+  fn mm_read_zero(matrix_idx: u32, row : u32, col : u32, r_dim: u32, c_dim: u32) -> output_type
   {
     if (row < r_dim && col < c_dim) {
-      let offset = row * c_dim + col;
+      let offset = matrix_idx * r_dim * c_dim + row * c_dim + col;
 
       // u32 holds elements_in_uint32 packed nbits.
       let array_index = offset / elements_in_uint32;
@@ -44,7 +44,7 @@
     return output_type(0);
   }
 #else
-  fn mm_read_zero(row : u32, col : u32, r_dim: u32, c_dim: u32) -> output_type {
+  fn mm_read_zero(matrix_idx: u32, row : u32, col : u32, r_dim: u32, c_dim: u32) -> output_type {
     return output_type(default_zero_point);
   }
 #endif

--- a/onnxruntime/contrib_ops/webgpu/quantization/subgroup_matrix_matmul_nbits_16x16x16_128.wgsl.template
+++ b/onnxruntime/contrib_ops/webgpu/quantization/subgroup_matrix_matmul_nbits_16x16x16_128.wgsl.template
@@ -69,6 +69,7 @@ fn dequant_b_to_buf(n_base: u32, k_idx: u32, n_idx_0: u32, k_chunk: u32) {
     let weight_offset = actual_weight_idx * uniforms.K * uniforms.N;
     let scale_offset = actual_weight_idx * uniforms.N * (uniforms.K / kQuantizationBlockSize);
 #else
+    const actual_weight_idx : u32 = 0;
     const weight_offset : u32 = 0;
     const scale_offset : u32 = 0;
 #endif
@@ -83,7 +84,7 @@ fn dequant_b_to_buf(n_base: u32, k_idx: u32, n_idx_0: u32, k_chunk: u32) {
             let scale_idx = (global_n * uniforms.K + k_idx + k_offset) / kQuantizationBlockSize + scale_offset;
             let scale = f16(scales_b.getByOffset(scale_idx));
             let zero = mm_read_zero(
-                global_n, (k_idx + k_offset) / kQuantizationBlockSize, uniforms.N, uniforms.zero_blocks_per_col);
+                actual_weight_idx, global_n, (k_idx + k_offset) / kQuantizationBlockSize, uniforms.N, uniforms.zero_blocks_per_col);
             for (var step: u32 = 0; step < 2u; step++) {
                 let packed_weights = input_b.getByOffset(packed_idx + step);
                 let w_lo = (vec4<f16>(unpack4xU8(packed_weights & 0x0F0F0F0Fu)) - vec4<f16>(zero)) * scale;
@@ -110,7 +111,7 @@ fn dequant_b_to_buf(n_base: u32, k_idx: u32, n_idx_0: u32, k_chunk: u32) {
             let scale_idx = (global_n * uniforms.K + k_idx + k_offset) / kQuantizationBlockSize + scale_offset;
             let scale = f16(scales_b.getByOffset(scale_idx));
             let zero = mm_read_zero(
-                global_n, (k_idx + k_offset) / kQuantizationBlockSize, uniforms.N, uniforms.zero_blocks_per_col);
+                actual_weight_idx, global_n, (k_idx + k_offset) / kQuantizationBlockSize, uniforms.N, uniforms.zero_blocks_per_col);
             for (var step: u32 = 0; step < 2u; step++) {
                 let packed_weights = input_b.getByOffset(packed_idx + step);
                 let w_lo = (vec4<f16>(unpack4xU8(packed_weights & 0x0F0F0F0Fu)) - vec4<f16>(zero)) * scale;
@@ -142,6 +143,7 @@ fn dequant_b_to_buf(n_base: u32, k_idx: u32, n_idx_0: u32, k_chunk: u32) {
     let weight_offset = actual_weight_idx * uniforms.K * uniforms.N;
     let scale_offset = actual_weight_idx * uniforms.N * (uniforms.K / kQuantizationBlockSize);
 #else
+    const actual_weight_idx : u32 = 0;
     const weight_offset : u32 = 0;
     const scale_offset : u32 = 0;
 #endif
@@ -156,7 +158,7 @@ fn dequant_b_to_buf(n_base: u32, k_idx: u32, n_idx_0: u32, k_chunk: u32) {
             let scale_idx = (global_n * uniforms.K + k_idx + k_offset) / kQuantizationBlockSize + scale_offset;
             let scale = f16(scales_b.getByOffset(scale_idx));
             let zero = mm_read_zero(
-                global_n, (k_idx + k_offset) / kQuantizationBlockSize, uniforms.N, uniforms.zero_blocks_per_col);
+                actual_weight_idx, global_n, (k_idx + k_offset) / kQuantizationBlockSize, uniforms.N, uniforms.zero_blocks_per_col);
             for (var step: u32 = 0; step < 2u; step++) {
                 let packed_weights = input_b.getByOffset(packed_idx + step);
                 let w_lo = (vec4<f16>(unpack4xU8(packed_weights[0])) - vec4<f16>(zero)) * scale;
@@ -183,7 +185,7 @@ fn dequant_b_to_buf(n_base: u32, k_idx: u32, n_idx_0: u32, k_chunk: u32) {
             let scale_idx = (global_n * uniforms.K + k_idx + k_offset) / kQuantizationBlockSize + scale_offset;
             let scale = f16(scales_b.getByOffset(scale_idx));
             let zero = mm_read_zero(
-                global_n, (k_idx + k_offset) / kQuantizationBlockSize, uniforms.N, uniforms.zero_blocks_per_col);
+                actual_weight_idx, global_n, (k_idx + k_offset) / kQuantizationBlockSize, uniforms.N, uniforms.zero_blocks_per_col);
             for (var step: u32 = 0; step < 2u; step++) {
                 let packed_weights = input_b.getByOffset(packed_idx + step);
                 let w_lo = (vec4<f16>(unpack4xU8(packed_weights[0])) - vec4<f16>(zero)) * scale;

--- a/onnxruntime/contrib_ops/webgpu/quantization/subgroup_matrix_matmul_nbits_8x16x16.wgsl.template
+++ b/onnxruntime/contrib_ops/webgpu/quantization/subgroup_matrix_matmul_nbits_8x16x16.wgsl.template
@@ -64,6 +64,7 @@ fn dequant_b_to_tile(n_base: u32, k_idx: u32, n_idx: u32, k_chunk_idx: u32) {
     let weight_offset = actual_weight_idx * uniforms.K * uniforms.N;
     let scale_offset = actual_weight_idx * uniforms.N * (uniforms.K / kQuantizationBlockSize);
 #else
+    const actual_weight_idx : u32 = 0;
     const weight_offset : u32 = 0;
     const scale_offset : u32 = 0;
 #endif
@@ -71,7 +72,7 @@ fn dequant_b_to_tile(n_base: u32, k_idx: u32, n_idx: u32, k_chunk_idx: u32) {
     let scale_idx = (global_n * uniforms.K + k_idx + k_offset) / kQuantizationBlockSize + scale_offset;
     let scale = f16(scales_b.getByOffset(scale_idx));
     let zero = mm_read_zero(
-        global_n, (k_idx + k_offset) / kQuantizationBlockSize, uniforms.N, uniforms.zero_blocks_per_col);
+        actual_weight_idx, global_n, (k_idx + k_offset) / kQuantizationBlockSize, uniforms.N, uniforms.zero_blocks_per_col);
     let packed_weights = input_b.getByOffset(packed_idx);
     let weights_lo =
         (vec4<f16>(unpack4xU8(packed_weights & 0x0F0F0F0Fu)) - vec4<f16>(zero)) * scale;
@@ -108,6 +109,7 @@ fn dequant_b_to_tile(n_base: u32, k_idx: u32, n_idx: u32, k_chunk_idx: u32) {
     let weight_offset = actual_weight_idx * uniforms.K * uniforms.N;
     let scale_offset = actual_weight_idx * uniforms.N * (uniforms.K / kQuantizationBlockSize);
 #else
+    const actual_weight_idx : u32 = 0;
     const weight_offset : u32 = 0;
     const scale_offset : u32 = 0;
 #endif
@@ -115,7 +117,7 @@ fn dequant_b_to_tile(n_base: u32, k_idx: u32, n_idx: u32, k_chunk_idx: u32) {
     let scale_idx = (global_n * uniforms.K + k_idx + k_offset) / kQuantizationBlockSize + scale_offset;
     let scale = f16(scales_b.getByOffset(scale_idx));
     let zero = mm_read_zero(
-        global_n, (k_idx + k_offset) / kQuantizationBlockSize, uniforms.N, uniforms.zero_blocks_per_col);
+        actual_weight_idx, global_n, (k_idx + k_offset) / kQuantizationBlockSize, uniforms.N, uniforms.zero_blocks_per_col);
     let packed_weights = input_b.getByOffset(packed_idx);
     let weights_lo = (vec4<f16>(unpack4xU8(packed_weights[0])) - vec4<f16>(zero)) * scale;
     let weights_hi = (vec4<f16>(unpack4xU8(packed_weights[1])) - vec4<f16>(zero)) * scale;

--- a/onnxruntime/contrib_ops/webgpu/quantization/subgroup_matrix_matmul_nbits_8x8x8.wgsl.template
+++ b/onnxruntime/contrib_ops/webgpu/quantization/subgroup_matrix_matmul_nbits_8x8x8.wgsl.template
@@ -58,12 +58,13 @@ fn loadSHMB(tile_base: u32, k_idx: u32, row: u32, c_idx: u32) {
     let b_base_offset = actual_weight_idx * uniforms.K * uniforms.N;
     let scale_offset = actual_weight_idx * uniforms.N * (uniforms.K / quantization_block_size);
 #else
+    const actual_weight_idx : u32 = 0;
     const b_base_offset : u32 = 0;
     const scale_offset : u32 = 0;
 #endif
     let b_idx = u32((b_global*uniforms.K + k_idx + col)/8) + b_base_offset / 8;
     let scale = compute_precision(scales_b.getByOffset((b_global * uniforms.K + k_idx + col) / quantization_block_size + scale_offset));
-    let zero = mm_read_zero(b_global, (k_idx + col) / quantization_block_size, uniforms.N, uniforms.zero_blocks_per_col);
+    let zero = mm_read_zero(actual_weight_idx, b_global, (k_idx + col) / quantization_block_size, uniforms.N, uniforms.zero_blocks_per_col);
     for (var step:u32 = 0; step < 2; step++) {
       var b_value = b.getByOffset(b_idx+step);
       var b_value_lower = (vec4<compute_precision>(unpack4xU8(b_value & 0x0F0F0F0Fu)) - vec4<compute_precision>(zero)) * scale;
@@ -100,12 +101,13 @@ fn loadSHMB(tile_base: u32, k_idx: u32, row: u32, c_idx: u32) {
     let b_base_offset = actual_weight_idx * uniforms.K * uniforms.N;
     let scale_offset = actual_weight_idx * uniforms.N * (uniforms.K / quantization_block_size);
 #else
+    const actual_weight_idx : u32 = 0;
     const b_base_offset : u32 = 0;
     const scale_offset : u32 = 0;
 #endif
     let b_idx = u32((b_global*uniforms.K + k_idx + col)/8) + b_base_offset / 8;
     let scale = compute_precision(scales_b.getByOffset((b_global * uniforms.K + k_idx + col) / quantization_block_size + scale_offset));
-    let zero = mm_read_zero(b_global, (k_idx + col) / quantization_block_size, uniforms.N, uniforms.zero_blocks_per_col);
+    let zero = mm_read_zero(actual_weight_idx, b_global, (k_idx + col) / quantization_block_size, uniforms.N, uniforms.zero_blocks_per_col);
     for (var step : u32 = 0; step < 2; step++) {
       var b_value = b.getByOffset(b_idx+step);
       var b_value0 = (vec4<compute_precision>(unpack4xU8(b_value[0])) - vec4<compute_precision>(zero)) * scale;

--- a/onnxruntime/contrib_ops/webgpu/webgpu_contrib_kernels.cc
+++ b/onnxruntime/contrib_ops/webgpu/webgpu_contrib_kernels.cc
@@ -54,7 +54,7 @@ static const BuildKernelCreateInfoFn build_kernel_create_info_function_table[] =
     BuildKernelCreateInfo<class ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kWebGpuExecutionProvider, kOnnxDomain, 1, 16, LayerNormalization)>,
     BuildKernelCreateInfo<class ONNX_OPERATOR_KERNEL_CLASS_NAME(kWebGpuExecutionProvider, kOnnxDomain, 1, SimplifiedLayerNormalization)>,
     BuildKernelCreateInfo<class ONNX_OPERATOR_KERNEL_CLASS_NAME(kWebGpuExecutionProvider, kMSDomain, 1, SkipSimplifiedLayerNormalization)>,
-    // BuildKernelCreateInfo<class ONNX_OPERATOR_KERNEL_CLASS_NAME(kWebGpuExecutionProvider, kMSDomain, 1, MoE)>,
+    BuildKernelCreateInfo<class ONNX_OPERATOR_KERNEL_CLASS_NAME(kWebGpuExecutionProvider, kMSDomain, 1, MoE)>,
     BuildKernelCreateInfo<class ONNX_OPERATOR_KERNEL_CLASS_NAME(kWebGpuExecutionProvider, kMSDomain, 1, QMoE)>};
 
 Status RegisterWebGpuContribKernels(KernelRegistry& kernel_registry, bool enable_graph_capture) {

--- a/onnxruntime/core/graph/contrib_ops/contrib_defs.cc
+++ b/onnxruntime/core/graph/contrib_ops/contrib_defs.cc
@@ -1402,6 +1402,13 @@ constexpr const char* MoE_ver1_doc = R"DOC(
       GLaM(https://arxiv.org/abs/2112.06905) activates top 2 FFN, Vision MOE(https://arxiv.org/pdf/2106.05974.pdf)
       usually uses top 32 experts and Mixtral(https://huggingface.co/blog/mixtral).
 
+  A 2D input is the packed token-major form used by continuous-batching engines: tokens from
+  different requests are concatenated along dimension 0 without padding. MoE is token-local,
+  so request boundaries do not affect the result and no cumulative sequence-length input is
+  required. A 3D input is the dense convenience form and is processed as batch_size *
+  sequence_length independent token rows. router_probs must contain one corresponding row per
+  token in either form.
+
       The SwiGLU (Swish-Gated Linear Unit) activation function is like:
          g = xW + b
          l = xV + c
@@ -1426,20 +1433,31 @@ ONNX_MS_OPERATOR_SET_SCHEMA(
         .Attr("k", "Number of top experts to select from expert pool", AttributeProto::INT, static_cast<int64_t>(1))
         .Attr("normalize_routing_weights", "Whether to normalize routing weights", AttributeProto::INT, static_cast<int64_t>(0))
         .Attr("use_sparse_mixer", "Whether to use sparse mixer", AttributeProto::INT, static_cast<int64_t>(0))
-        .Input(0, "input", "2D input tensor with shape (num_tokens, hidden_size) or 3D input tensor with shape (batch_size, sequence_length, hidden_size)", "T")
-        .Input(1, "router_probs", "2D input tensor with shape (num_tokens, num_experts)", "T")
+        .Input(0, "input",
+               "Packed 2D input tensor with shape (num_tokens, hidden_size), or dense 3D input tensor with shape "
+               "(batch_size, sequence_length, hidden_size)",
+               "T")
+        .Input(1, "router_probs",
+               "2D input tensor with one row per input token and shape (num_tokens, num_experts)", "T")
         .Input(2, "fc1_experts_weights", "3D input tensor with shape (num_experts, fusion_size * inter_size, hidden_size), where fusion_size is 2 for fused swiglu, and 1 otherwise", "T")
         .Input(3, "fc1_experts_bias", "2D optional input tensor with shape (num_experts, fusion_size * inter_size)", "T", OpSchema::Optional)
         .Input(4, "fc2_experts_weights", "3D input tensor with shape (num_experts, hidden_size, inter_size)", "T")
         .Input(5, "fc2_experts_bias", "2D optional input tensor with shape (num_experts, hidden_size)", "T", OpSchema::Optional)
         .Input(6, "fc3_experts_weights", "3D optional input tensor with shape (num_experts, inter_size, hidden_size)", "T", OpSchema::Optional)
         .Input(7, "fc3_experts_bias", "2D optional input tensor with shape (num_experts, inter_size)", "T", OpSchema::Optional)
-        .Output(0, "output", "2D input tensor with shape (num_tokens, hidden_size) or 3D input tensor with shape (batch_size, sequence_length, hidden_size)", "T")
+        .Output(0, "output", "Tensor with the same shape as input", "T")
         .TypeConstraint("T", {"tensor(float)", "tensor(float16)", "tensor(bfloat16)"}, "Constrain input and output types to float tensors.")
         .TypeAndShapeInferenceFunction(ONNX_NAMESPACE::propagateShapeAndTypeFromFirstInput));
 
 constexpr const char* qMoE_ver1_doc = R"DOC(
       Quantized mixture of experts (MoE).
+
+  A 2D input is the packed token-major form used by continuous-batching engines: tokens from
+  different requests are concatenated along dimension 0 without padding. QMoE is token-local,
+  so request boundaries do not affect the result and no cumulative sequence-length input is
+  required. A 3D input is the dense convenience form and is processed as batch_size *
+  sequence_length independent token rows. router_probs and optional router_weights must contain
+  one corresponding row per token in either form.
 
       The quantized weights are stored in column major order per expert.
       The quantization block size can be specified. If not provided, column wise quantization is used.
@@ -1531,15 +1549,8 @@ ONNX_MS_OPERATOR_SET_SCHEMA(
               "un-prepacked [E, N, K/pack] tensors as produced by quantize_matmul_{4,8}bits. Defaults to -1.",
               AttributeProto::INT,
               static_cast<int64_t>(-1))
-        .Input(0,
-               "input",
-               "2D tensor with shape (num_tokens, hidden_size), or "
-               "3D tensor with shape (batch_size, sequence_length, hidden_size)",
-               "T")
-        .Input(1,
-               "router_probs",
-               "2D tensor with shape (num_tokens, num_experts)",
-               "T")
+        .Input(0, "input", "Packed 2D (num_tokens, hidden_size) or dense 3D (batch_size, sequence_length, hidden_size).", "T")
+        .Input(1, "router_probs", "2D tensor with one row per input token: (num_tokens, num_experts).", "T")
         .Input(2,
                "fc1_experts_weights",
                "3D tensor with shape (num_experts, fusion_size * inter_size, hidden_size / pack_size), "

--- a/onnxruntime/test/contrib_ops/moe_test.cc
+++ b/onnxruntime/test/contrib_ops/moe_test.cc
@@ -1494,6 +1494,76 @@ TEST(MoETest, QMoETest_Mixtral_Int4) {
 }
 
 #if defined(USE_WEBGPU)
+// Packed QMoE does not need cumulative sequence lengths: every token is routed and evaluated
+// independently. This fixture represents three requests of lengths [2, 1, 2] concatenated into a
+// single 2D token-major input. Expert-specific FC2 biases make the selected expert visible in each
+// output row, so the test also catches token reordering or accidental interaction between requests.
+TEST(MoETest, QMoETest_WebGPU_PackedRaggedBatch) {
+  constexpr int num_rows = 5;
+  constexpr int num_experts = 2;
+  constexpr int hidden_size = 64;
+  constexpr int inter_size = 64;
+
+  std::vector<float> input(num_rows * hidden_size, 0.25f);
+  const std::vector<float> router_probs = {
+      10.0f,
+      0.0f,
+      0.0f,
+      10.0f,
+      0.0f,
+      10.0f,
+      10.0f,
+      0.0f,
+      0.0f,
+      10.0f,
+  };
+
+  // 0x88 encodes two zero-valued INT4 weights. FC2 bias is therefore the expert output.
+  std::vector<uint8_t> fc1_experts_weights(num_experts * 2 * inter_size * hidden_size / 2, 0x88);
+  std::vector<uint8_t> fc2_experts_weights(num_experts * hidden_size * inter_size / 2, 0x88);
+  std::vector<float> fc1_scales(num_experts * 2 * inter_size, 0.01f);
+  std::vector<float> fc2_scales(num_experts * hidden_size, 0.01f);
+  std::vector<float> fc2_bias(hidden_size, 1.0f);
+  fc2_bias.insert(fc2_bias.end(), hidden_size, 2.0f);
+
+  std::vector<float> expected_output;
+  expected_output.reserve(num_rows * hidden_size);
+  for (float expert_value : {1.0f, 2.0f, 2.0f, 1.0f, 2.0f}) {
+    expected_output.insert(expected_output.end(), hidden_size, expert_value);
+  }
+
+  OpTester tester("QMoE", 1, onnxruntime::kMSDomain);
+  tester.AddAttribute<int64_t>("k", 1);
+  tester.AddAttribute<std::string>("activation_type", "swiglu");
+  tester.AddAttribute<int64_t>("normalize_routing_weights", 1);
+  tester.AddAttribute<int64_t>("swiglu_fusion", 1);
+  tester.AddAttribute<int64_t>("expert_weight_bits", 4);
+
+  tester.AddInput<MLFloat16>("input", {num_rows, hidden_size}, ToFloat16(input));
+  tester.AddInput<MLFloat16>("router_probs", {num_rows, num_experts}, ToFloat16(router_probs));
+  tester.AddInput<uint8_t>("fc1_experts_weights",
+                           {num_experts, 2 * inter_size, hidden_size / 2},
+                           fc1_experts_weights);
+  tester.AddInput<MLFloat16>("fc1_scales",
+                             {num_experts, 2 * inter_size},
+                             ToFloat16(fc1_scales));
+  tester.AddOptionalInputEdge<MLFloat16>();  // fc1_experts_bias
+  tester.AddInput<uint8_t>("fc2_experts_weights",
+                           {num_experts, hidden_size, inter_size / 2},
+                           fc2_experts_weights);
+  tester.AddInput<MLFloat16>("fc2_scales", {num_experts, hidden_size}, ToFloat16(fc2_scales));
+  tester.AddInput<MLFloat16>("fc2_experts_bias", {num_experts, hidden_size}, ToFloat16(fc2_bias));
+  tester.AddOptionalInputEdge<uint8_t>();    // fc3_experts_weights
+  tester.AddOptionalInputEdge<MLFloat16>();  // fc3_scales
+  tester.AddOptionalInputEdge<MLFloat16>();  // fc3_experts_bias
+  tester.AddOutput<MLFloat16>("output", {num_rows, hidden_size}, ToFloat16(expected_output));
+  tester.SetOutputTolerance(0.01f);
+
+  std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
+  execution_providers.push_back(DefaultWebGpuExecutionProvider());
+  tester.Run(OpTester::ExpectResult::kExpectSuccess, "", {}, nullptr, &execution_providers);
+}
+
 // Test QMoE with num_rows=1 on WebGPU to exercise the fused 1-token decode path.
 // Uses SwiGLU activation without FC3 (2-gate fused in FC1), which is the configuration
 // used by real MoE models on WebGPU (e.g., gpt-oss-20b).

--- a/onnxruntime/test/contrib_ops/moe_test.cc
+++ b/onnxruntime/test/contrib_ops/moe_test.cc
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+#include <cmath>
+
 #include "gtest/gtest.h"
 #include "core/session/onnxruntime_session_options_config_keys.h"
 #include "test/common/tensor_op_test_utils.h"
@@ -1690,6 +1692,260 @@ TEST(MoETest, QMoETest_WebGPU_SingleToken_LargeLogits) {
   std::vector<std::unique_ptr<IExecutionProvider>> webgpu_execution_providers;
   webgpu_execution_providers.push_back(DefaultWebGpuExecutionProvider());
   webgpu_tester.Run(OpTester::ExpectResult::kExpectSuccess, "", {}, nullptr, &webgpu_execution_providers);
+}
+
+TEST(MoETest, MoETest_WebGPU_PackedDenseActivationsAndFusion) {
+  constexpr int num_rows = 2;
+  constexpr int num_experts = 2;
+  constexpr int hidden_size = 8;
+  constexpr int inter_size = 8;
+
+  const std::vector<float> input(num_rows * hidden_size, 0.25f);
+  const std::vector<float> router_probs = {10.0f, 0.0f, 0.0f, 10.0f};
+  std::vector<float> fc2_bias(hidden_size, 1.0f);
+  fc2_bias.insert(fc2_bias.end(), hidden_size, 2.0f);
+  std::vector<float> expected(hidden_size, 1.0f);
+  expected.insert(expected.end(), hidden_size, 2.0f);
+
+  const auto run_case = [&](const std::string& activation_type, int64_t swiglu_fusion,
+                            bool has_fc3, bool use_fp16, bool dense_3d) {
+    const int fc1_size = activation_type == "swiglu" && !has_fc3 ? 2 * inter_size : inter_size;
+    const std::vector<float> fc1_weights(num_experts * fc1_size * hidden_size, 0.0f);
+    const std::vector<float> fc2_weights(num_experts * hidden_size * inter_size, 0.0f);
+    const std::vector<float> fc3_weights(num_experts * inter_size * hidden_size, 0.0f);
+    const std::vector<int64_t> input_dims = dense_3d ? std::vector<int64_t>{1, num_rows, hidden_size}
+                                                     : std::vector<int64_t>{num_rows, hidden_size};
+
+    OpTester tester("MoE", 1, onnxruntime::kMSDomain);
+    tester.AddAttribute<int64_t>("k", 1);
+    tester.AddAttribute<std::string>("activation_type", activation_type);
+    tester.AddAttribute<int64_t>("normalize_routing_weights", 1);
+    tester.AddAttribute<int64_t>("swiglu_fusion", swiglu_fusion);
+    if (use_fp16) {
+      tester.AddInput<MLFloat16>("input", input_dims, ToFloat16(input));
+      tester.AddInput<MLFloat16>("router_probs", {num_rows, num_experts}, ToFloat16(router_probs));
+      tester.AddInput<MLFloat16>("fc1_experts_weights", {num_experts, fc1_size, hidden_size},
+                                 ToFloat16(fc1_weights));
+      tester.AddOptionalInputEdge<MLFloat16>();
+      tester.AddInput<MLFloat16>("fc2_experts_weights", {num_experts, hidden_size, inter_size},
+                                 ToFloat16(fc2_weights));
+      tester.AddInput<MLFloat16>("fc2_experts_bias", {num_experts, hidden_size}, ToFloat16(fc2_bias));
+      if (has_fc3) {
+        tester.AddInput<MLFloat16>("fc3_experts_weights", {num_experts, inter_size, hidden_size},
+                                   ToFloat16(fc3_weights));
+      } else {
+        tester.AddOptionalInputEdge<MLFloat16>();
+      }
+      tester.AddOptionalInputEdge<MLFloat16>();
+      tester.AddOutput<MLFloat16>("output", input_dims, ToFloat16(expected));
+      tester.SetOutputTolerance(0.01f);
+    } else {
+      tester.AddInput<float>("input", input_dims, input);
+      tester.AddInput<float>("router_probs", {num_rows, num_experts}, router_probs);
+      tester.AddInput<float>("fc1_experts_weights", {num_experts, fc1_size, hidden_size}, fc1_weights);
+      tester.AddOptionalInputEdge<float>();
+      tester.AddInput<float>("fc2_experts_weights", {num_experts, hidden_size, inter_size}, fc2_weights);
+      tester.AddInput<float>("fc2_experts_bias", {num_experts, hidden_size}, fc2_bias);
+      if (has_fc3) {
+        tester.AddInput<float>("fc3_experts_weights", {num_experts, inter_size, hidden_size}, fc3_weights);
+      } else {
+        tester.AddOptionalInputEdge<float>();
+      }
+      tester.AddOptionalInputEdge<float>();
+      tester.AddOutput<float>("output", input_dims, expected);
+      tester.SetOutputTolerance(0.001f);
+    }
+    std::vector<std::unique_ptr<IExecutionProvider>> providers;
+    providers.push_back(DefaultWebGpuExecutionProvider());
+    tester.Run(OpTester::ExpectResult::kExpectSuccess, "", {}, nullptr, &providers);
+  };
+
+  run_case("relu", 0, false, false, false);
+  run_case("gelu", 0, false, true, true);
+  run_case("silu", 0, true, true, false);
+  run_case("identity", 0, false, false, false);
+  run_case("swiglu", 0, true, true, false);
+  run_case("swiglu", 1, false, true, false);
+  run_case("swiglu", 2, false, true, false);
+}
+
+TEST(MoETest, MoETest_WebGPU_NonzeroExpertMatMuls) {
+  constexpr int hidden_size = 8;
+  constexpr int inter_size = 8;
+  const std::vector<float> input = {1.0f, -2.0f, 3.0f, -4.0f, 5.0f, -6.0f, 7.0f, -8.0f};
+  std::vector<float> identity(hidden_size * hidden_size, 0.0f);
+  for (int i = 0; i < hidden_size; ++i) {
+    identity[i * hidden_size + i] = 1.0f;
+  }
+
+  OpTester tester("MoE", 1, onnxruntime::kMSDomain);
+  tester.AddAttribute<int64_t>("k", 1);
+  tester.AddAttribute<std::string>("activation_type", "identity");
+  tester.AddAttribute<int64_t>("normalize_routing_weights", 1);
+  tester.AddInput<float>("input", {1, hidden_size}, input);
+  tester.AddInput<float>("router_probs", {1, 1}, {0.0f});
+  tester.AddInput<float>("fc1_experts_weights", {1, inter_size, hidden_size}, identity);
+  tester.AddOptionalInputEdge<float>();
+  tester.AddInput<float>("fc2_experts_weights", {1, hidden_size, inter_size}, identity);
+  tester.AddOptionalInputEdge<float>();
+  tester.AddOptionalInputEdge<float>();
+  tester.AddOptionalInputEdge<float>();
+  tester.AddOutput<float>("output", {1, hidden_size}, input);
+  tester.SetOutputTolerance(0.001f);
+
+  std::vector<std::unique_ptr<IExecutionProvider>> providers;
+  providers.push_back(DefaultWebGpuExecutionProvider());
+  tester.Run(OpTester::ExpectResult::kExpectSuccess, "", {}, nullptr, &providers);
+}
+
+TEST(MoETest, QMoETest_WebGPU_ZeroPointsAndFC3) {
+  constexpr int num_rows = 2;
+  constexpr int num_experts = 2;
+  constexpr int hidden_size = 64;
+  constexpr int inter_size = 64;
+  constexpr int pack_size = 2;
+
+  const std::vector<float> input(num_rows * hidden_size, 0.25f);
+  const std::vector<float> router_probs = {10.0f, 0.0f, 0.0f, 10.0f};
+  const std::vector<uint8_t> fc1_weights(num_experts * inter_size * hidden_size / pack_size, 0x99);
+  const std::vector<uint8_t> fc2_weights(num_experts * hidden_size * inter_size / pack_size, 0x99);
+  const std::vector<uint8_t> fc3_weights(num_experts * inter_size * hidden_size / pack_size, 0x99);
+  const std::vector<float> fc1_scales(num_experts * inter_size * 2, 0.1f);
+  const std::vector<float> fc2_scales(num_experts * hidden_size * 2, 0.1f);
+  const std::vector<float> fc3_scales(num_experts * inter_size * 2, 0.1f);
+  const std::vector<uint8_t> fc1_zero_points(num_experts * inter_size, 0x08);
+  const std::vector<uint8_t> fc2_zero_points(num_experts * hidden_size, 0x08);
+  const std::vector<uint8_t> fc3_zero_points(num_experts * inter_size, 0x08);
+  const std::vector<float> fc2_bias(num_experts * hidden_size, 0.0f);
+  const float projection = hidden_size * 0.25f * 0.1f;
+  const float activated = projection / (1.0f + std::exp(-projection)) * projection;
+  const std::vector<float> expected(num_rows * hidden_size, inter_size * activated * 0.1f);
+
+  OpTester tester("QMoE", 1, onnxruntime::kMSDomain);
+  tester.AddAttribute<int64_t>("k", 1);
+  tester.AddAttribute<std::string>("activation_type", "silu");
+  tester.AddAttribute<int64_t>("normalize_routing_weights", 1);
+  tester.AddAttribute<int64_t>("expert_weight_bits", 4);
+  tester.AddAttribute<int64_t>("block_size", 32);
+  tester.AddAttribute<int64_t>("weights_prepacked", 0);
+  tester.AddInput<MLFloat16>("input", {num_rows, hidden_size}, ToFloat16(input));
+  tester.AddInput<MLFloat16>("router_probs", {num_rows, num_experts}, ToFloat16(router_probs));
+  tester.AddInput<uint8_t>("fc1_experts_weights", {num_experts, inter_size, hidden_size / pack_size}, fc1_weights);
+  tester.AddInput<MLFloat16>("fc1_scales", {num_experts, inter_size, 2}, ToFloat16(fc1_scales));
+  tester.AddOptionalInputEdge<MLFloat16>();
+  tester.AddInput<uint8_t>("fc2_experts_weights", {num_experts, hidden_size, inter_size / pack_size}, fc2_weights);
+  tester.AddInput<MLFloat16>("fc2_scales", {num_experts, hidden_size, 2}, ToFloat16(fc2_scales));
+  tester.AddInput<MLFloat16>("fc2_experts_bias", {num_experts, hidden_size}, ToFloat16(fc2_bias));
+  tester.AddInput<uint8_t>("fc3_experts_weights", {num_experts, inter_size, hidden_size / pack_size}, fc3_weights);
+  tester.AddInput<MLFloat16>("fc3_scales", {num_experts, inter_size, 2}, ToFloat16(fc3_scales));
+  tester.AddOptionalInputEdge<MLFloat16>();
+  tester.AddInput<uint8_t>("fc1_zero_points", {num_experts, inter_size, 1}, fc1_zero_points);
+  tester.AddInput<uint8_t>("fc2_zero_points", {num_experts, hidden_size, 1}, fc2_zero_points);
+  tester.AddInput<uint8_t>("fc3_zero_points", {num_experts, inter_size, 1}, fc3_zero_points);
+  tester.AddOptionalInputEdge<MLFloat16>();
+  tester.AddOutput<MLFloat16>("output", {num_rows, hidden_size}, ToFloat16(expected));
+  tester.SetOutputTolerance(0.05f);
+
+  std::vector<std::unique_ptr<IExecutionProvider>> providers;
+  providers.push_back(DefaultWebGpuExecutionProvider());
+  tester.Run(OpTester::ExpectResult::kExpectSuccess, "", {}, nullptr, &providers);
+}
+
+TEST(MoETest, QMoETest_WebGPU_RouterWeights) {
+  constexpr int num_rows = 2;
+  constexpr int num_experts = 2;
+  constexpr int hidden_size = 64;
+  constexpr int inter_size = 64;
+  constexpr int pack_size = 2;
+
+  const std::vector<float> input(num_rows * hidden_size, 0.25f);
+  const std::vector<float> router_probs = {10.0f, 0.0f, 0.0f, 10.0f};
+  const std::vector<float> router_weights = {0.25f, 0.75f, 0.6f, 0.4f};
+  const std::vector<uint8_t> fc1_weights(num_experts * inter_size * hidden_size / pack_size, 0x88);
+  const std::vector<uint8_t> fc2_weights(num_experts * hidden_size * inter_size / pack_size, 0x88);
+  const std::vector<float> fc1_scales(num_experts * inter_size, 0.1f);
+  const std::vector<float> fc2_scales(num_experts * hidden_size, 0.1f);
+  std::vector<float> fc2_bias(hidden_size, 4.0f);
+  fc2_bias.insert(fc2_bias.end(), hidden_size, 8.0f);
+  std::vector<float> expected(hidden_size, 1.0f);
+  expected.insert(expected.end(), hidden_size, 3.2f);
+
+  OpTester tester("QMoE", 1, onnxruntime::kMSDomain);
+  tester.AddAttribute<int64_t>("k", 1);
+  tester.AddAttribute<std::string>("activation_type", "identity");
+  tester.AddAttribute<int64_t>("expert_weight_bits", 4);
+  tester.AddInput<MLFloat16>("input", {num_rows, hidden_size}, ToFloat16(input));
+  tester.AddInput<MLFloat16>("router_probs", {num_rows, num_experts}, ToFloat16(router_probs));
+  tester.AddInput<uint8_t>("fc1_experts_weights", {num_experts, inter_size, hidden_size / pack_size}, fc1_weights);
+  tester.AddInput<MLFloat16>("fc1_scales", {num_experts, inter_size}, ToFloat16(fc1_scales));
+  tester.AddOptionalInputEdge<MLFloat16>();
+  tester.AddInput<uint8_t>("fc2_experts_weights", {num_experts, hidden_size, inter_size / pack_size}, fc2_weights);
+  tester.AddInput<MLFloat16>("fc2_scales", {num_experts, hidden_size}, ToFloat16(fc2_scales));
+  tester.AddInput<MLFloat16>("fc2_experts_bias", {num_experts, hidden_size}, ToFloat16(fc2_bias));
+  tester.AddOptionalInputEdge<uint8_t>();
+  tester.AddOptionalInputEdge<MLFloat16>();
+  tester.AddOptionalInputEdge<MLFloat16>();
+  tester.AddOptionalInputEdge<uint8_t>();
+  tester.AddOptionalInputEdge<uint8_t>();
+  tester.AddOptionalInputEdge<uint8_t>();
+  tester.AddInput<MLFloat16>("router_weights", {num_rows, num_experts}, ToFloat16(router_weights));
+  tester.AddOutput<MLFloat16>("output", {num_rows, hidden_size}, ToFloat16(expected));
+  tester.SetOutputTolerance(0.01f);
+
+  std::vector<std::unique_ptr<IExecutionProvider>> providers;
+  providers.push_back(DefaultWebGpuExecutionProvider());
+  tester.Run(OpTester::ExpectResult::kExpectSuccess, "", {}, nullptr, &providers);
+}
+
+TEST(MoETest, QMoETest_WebGPU_ActivationsAndSwiGLUFusion) {
+  constexpr int num_experts = 2;
+  constexpr int hidden_size = 64;
+  constexpr int inter_size = 64;
+  constexpr int pack_size = 2;
+  const std::vector<float> input(hidden_size, 0.25f);
+  const std::vector<float> router_probs = {10.0f, 0.0f};
+  std::vector<float> fc2_bias(hidden_size, 1.0f);
+  fc2_bias.insert(fc2_bias.end(), hidden_size, 2.0f);
+  const std::vector<float> expected(hidden_size, 1.0f);
+
+  const auto run_case = [&](const std::string& activation_type, int64_t swiglu_fusion) {
+    const int fc1_size = activation_type == "swiglu" ? 2 * inter_size : inter_size;
+    const std::vector<uint8_t> fc1_weights(num_experts * fc1_size * hidden_size / pack_size, 0x88);
+    const std::vector<uint8_t> fc2_weights(num_experts * hidden_size * inter_size / pack_size, 0x88);
+    const std::vector<float> fc1_scales(num_experts * fc1_size, 0.1f);
+    const std::vector<float> fc2_scales(num_experts * hidden_size, 0.1f);
+
+    OpTester tester("QMoE", 1, onnxruntime::kMSDomain);
+    tester.AddAttribute<int64_t>("k", 1);
+    tester.AddAttribute<std::string>("activation_type", activation_type);
+    tester.AddAttribute<int64_t>("normalize_routing_weights", 1);
+    tester.AddAttribute<int64_t>("swiglu_fusion", swiglu_fusion);
+    tester.AddAttribute<int64_t>("expert_weight_bits", 4);
+    tester.AddAttribute<int64_t>("weights_prepacked", 0);
+    tester.AddInput<MLFloat16>("input", {1, hidden_size}, ToFloat16(input));
+    tester.AddInput<MLFloat16>("router_probs", {1, num_experts}, ToFloat16(router_probs));
+    tester.AddInput<uint8_t>("fc1_experts_weights", {num_experts, fc1_size, hidden_size / pack_size}, fc1_weights);
+    tester.AddInput<MLFloat16>("fc1_scales", {num_experts, fc1_size}, ToFloat16(fc1_scales));
+    tester.AddOptionalInputEdge<MLFloat16>();
+    tester.AddInput<uint8_t>("fc2_experts_weights", {num_experts, hidden_size, inter_size / pack_size}, fc2_weights);
+    tester.AddInput<MLFloat16>("fc2_scales", {num_experts, hidden_size}, ToFloat16(fc2_scales));
+    tester.AddInput<MLFloat16>("fc2_experts_bias", {num_experts, hidden_size}, ToFloat16(fc2_bias));
+    tester.AddOptionalInputEdge<uint8_t>();
+    tester.AddOptionalInputEdge<MLFloat16>();
+    tester.AddOptionalInputEdge<MLFloat16>();
+    tester.AddOutput<MLFloat16>("output", {1, hidden_size}, ToFloat16(expected));
+    tester.SetOutputTolerance(0.01f);
+    std::vector<std::unique_ptr<IExecutionProvider>> providers;
+    providers.push_back(DefaultWebGpuExecutionProvider());
+    tester.Run(OpTester::ExpectResult::kExpectSuccess, "", {}, nullptr, &providers);
+  };
+
+  run_case("relu", 0);
+  run_case("gelu", 0);
+  run_case("silu", 0);
+  run_case("identity", 0);
+  run_case("swiglu", 1);
+  run_case("swiglu", 2);
 }
 #endif
 

--- a/onnxruntime/test/contrib_ops/moe_test.cc
+++ b/onnxruntime/test/contrib_ops/moe_test.cc
@@ -1867,28 +1867,32 @@ TEST(MoETest, QMoETest_WebGPU_ZeroPointsAndFC3) {
   tester.Run(OpTester::ExpectResult::kExpectSuccess, "", {}, nullptr, &providers);
 }
 
-TEST(MoETest, QMoETest_WebGPU_RouterWeights) {
-  constexpr int num_rows = 2;
+static void RunQMoEWebGpuNormalizedRouterWeightsTest(int64_t num_rows) {
   constexpr int num_experts = 2;
   constexpr int hidden_size = 64;
   constexpr int inter_size = 64;
   constexpr int pack_size = 2;
 
-  const std::vector<float> input(num_rows * hidden_size, 0.25f);
-  const std::vector<float> router_probs = {10.0f, 0.0f, 0.0f, 10.0f};
-  const std::vector<float> router_weights = {0.25f, 0.75f, 0.6f, 0.4f};
-  const std::vector<uint8_t> fc1_weights(num_experts * inter_size * hidden_size / pack_size, 0x88);
-  const std::vector<uint8_t> fc2_weights(num_experts * hidden_size * inter_size / pack_size, 0x88);
+  const std::vector<uint8_t> fc1_weights(num_experts * inter_size * hidden_size / pack_size, 0x99);
+  const std::vector<uint8_t> fc2_weights(num_experts * hidden_size * inter_size / pack_size, 0x99);
   const std::vector<float> fc1_scales(num_experts * inter_size, 0.1f);
   const std::vector<float> fc2_scales(num_experts * hidden_size, 0.1f);
-  std::vector<float> fc2_bias(hidden_size, 4.0f);
-  fc2_bias.insert(fc2_bias.end(), hidden_size, 8.0f);
-  std::vector<float> expected(hidden_size, 1.0f);
-  expected.insert(expected.end(), hidden_size, 3.2f);
+
+  const std::vector<float> input(static_cast<size_t>(num_rows * hidden_size), 0.25f);
+  std::vector<float> router_probs;
+  std::vector<float> router_weights;
+  for (int64_t row = 0; row < num_rows; ++row) {
+    router_probs.insert(router_probs.end(), {10.0f, 0.0f});
+    router_weights.insert(router_weights.end(), {3.0f, 1.0f});
+  }
+  const float fc1_output = hidden_size * 0.25f * 0.1f;
+  const float fc2_output = inter_size * fc1_output * 0.1f;
+  const std::vector<float> expected(static_cast<size_t>(num_rows * hidden_size), fc2_output);
 
   OpTester tester("QMoE", 1, onnxruntime::kMSDomain);
-  tester.AddAttribute<int64_t>("k", 1);
+  tester.AddAttribute<int64_t>("k", 2);
   tester.AddAttribute<std::string>("activation_type", "identity");
+  tester.AddAttribute<int64_t>("normalize_routing_weights", 1);
   tester.AddAttribute<int64_t>("expert_weight_bits", 4);
   tester.AddInput<MLFloat16>("input", {num_rows, hidden_size}, ToFloat16(input));
   tester.AddInput<MLFloat16>("router_probs", {num_rows, num_experts}, ToFloat16(router_probs));
@@ -1897,7 +1901,7 @@ TEST(MoETest, QMoETest_WebGPU_RouterWeights) {
   tester.AddOptionalInputEdge<MLFloat16>();
   tester.AddInput<uint8_t>("fc2_experts_weights", {num_experts, hidden_size, inter_size / pack_size}, fc2_weights);
   tester.AddInput<MLFloat16>("fc2_scales", {num_experts, hidden_size}, ToFloat16(fc2_scales));
-  tester.AddInput<MLFloat16>("fc2_experts_bias", {num_experts, hidden_size}, ToFloat16(fc2_bias));
+  tester.AddOptionalInputEdge<MLFloat16>();
   tester.AddOptionalInputEdge<uint8_t>();
   tester.AddOptionalInputEdge<MLFloat16>();
   tester.AddOptionalInputEdge<MLFloat16>();
@@ -1906,11 +1910,19 @@ TEST(MoETest, QMoETest_WebGPU_RouterWeights) {
   tester.AddOptionalInputEdge<uint8_t>();
   tester.AddInput<MLFloat16>("router_weights", {num_rows, num_experts}, ToFloat16(router_weights));
   tester.AddOutput<MLFloat16>("output", {num_rows, hidden_size}, ToFloat16(expected));
-  tester.SetOutputTolerance(0.01f);
+  tester.SetOutputTolerance(0.02f);
 
   std::vector<std::unique_ptr<IExecutionProvider>> providers;
   providers.push_back(DefaultWebGpuExecutionProvider());
   tester.Run(OpTester::ExpectResult::kExpectSuccess, "", {}, nullptr, &providers);
+}
+
+TEST(MoETest, QMoETest_WebGPU_RouterWeights_SingleToken) {
+  RunQMoEWebGpuNormalizedRouterWeightsTest(1);
+}
+
+TEST(MoETest, QMoETest_WebGPU_RouterWeights_MultiToken) {
+  RunQMoEWebGpuNormalizedRouterWeightsTest(2);
 }
 
 TEST(MoETest, QMoETest_WebGPU_ActivationsAndSwiGLUFusion) {

--- a/onnxruntime/test/contrib_ops/moe_test.cc
+++ b/onnxruntime/test/contrib_ops/moe_test.cc
@@ -1498,15 +1498,25 @@ TEST(MoETest, QMoETest_Mixtral_Int4) {
 #if defined(USE_WEBGPU)
 // Packed QMoE does not need cumulative sequence lengths: every token is routed and evaluated
 // independently. This fixture represents three requests of lengths [2, 1, 2] concatenated into a
-// single 2D token-major input. Expert-specific FC2 biases make the selected expert visible in each
-// output row, so the test also catches token reordering or accidental interaction between requests.
+// single 2D token-major input. Distinct token values and nonzero weights make each output depend on
+// the corresponding hidden-state row, while expert-specific biases expose the selected expert.
 TEST(MoETest, QMoETest_WebGPU_PackedRaggedBatch) {
+  auto webgpu_ep = DefaultWebGpuExecutionProvider();
+  if (!webgpu_ep) {
+    GTEST_SKIP() << "WebGPU execution provider is not available";
+  }
+
   constexpr int num_rows = 5;
   constexpr int num_experts = 2;
   constexpr int hidden_size = 64;
   constexpr int inter_size = 64;
 
-  std::vector<float> input(num_rows * hidden_size, 0.25f);
+  const std::array<float, num_rows> token_values = {0.05f, 0.1f, -0.05f, 0.2f, -0.1f};
+  std::vector<float> input;
+  input.reserve(num_rows * hidden_size);
+  for (float token_value : token_values) {
+    input.insert(input.end(), hidden_size, token_value);
+  }
   const std::vector<float> router_probs = {
       10.0f,
       0.0f,
@@ -1520,9 +1530,9 @@ TEST(MoETest, QMoETest_WebGPU_PackedRaggedBatch) {
       10.0f,
   };
 
-  // 0x88 encodes two zero-valued INT4 weights. FC2 bias is therefore the expert output.
-  std::vector<uint8_t> fc1_experts_weights(num_experts * 2 * inter_size * hidden_size / 2, 0x88);
-  std::vector<uint8_t> fc2_experts_weights(num_experts * hidden_size * inter_size / 2, 0x88);
+  // 0x99 encodes two INT4 values one above the default zero point, so both projections are nonzero.
+  std::vector<uint8_t> fc1_experts_weights(num_experts * 2 * inter_size * hidden_size / 2, 0x99);
+  std::vector<uint8_t> fc2_experts_weights(num_experts * hidden_size * inter_size / 2, 0x99);
   std::vector<float> fc1_scales(num_experts * 2 * inter_size, 0.01f);
   std::vector<float> fc2_scales(num_experts * hidden_size, 0.01f);
   std::vector<float> fc2_bias(hidden_size, 1.0f);
@@ -1530,8 +1540,12 @@ TEST(MoETest, QMoETest_WebGPU_PackedRaggedBatch) {
 
   std::vector<float> expected_output;
   expected_output.reserve(num_rows * hidden_size);
-  for (float expert_value : {1.0f, 2.0f, 2.0f, 1.0f, 2.0f}) {
-    expected_output.insert(expected_output.end(), hidden_size, expert_value);
+  const std::array<float, num_rows> expert_biases = {1.0f, 2.0f, 2.0f, 1.0f, 2.0f};
+  for (int row = 0; row < num_rows; ++row) {
+    const float projection = hidden_size * token_values[row] * 0.01f;
+    const float swiglu = projection / (1.0f + std::exp(-projection)) * projection;
+    const float expert_output = inter_size * swiglu * 0.01f + expert_biases[row];
+    expected_output.insert(expected_output.end(), hidden_size, expert_output);
   }
 
   OpTester tester("QMoE", 1, onnxruntime::kMSDomain);
@@ -1561,9 +1575,11 @@ TEST(MoETest, QMoETest_WebGPU_PackedRaggedBatch) {
   tester.AddOutput<MLFloat16>("output", {num_rows, hidden_size}, ToFloat16(expected_output));
   tester.SetOutputTolerance(0.01f);
 
+  SessionOptions session_options;
+  ASSERT_STATUS_OK(session_options.config_options.AddConfigEntry(kOrtSessionOptionsDisableCPUEPFallback, "1"));
   std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
-  execution_providers.push_back(DefaultWebGpuExecutionProvider());
-  tester.Run(OpTester::ExpectResult::kExpectSuccess, "", {}, nullptr, &execution_providers);
+  execution_providers.push_back(std::move(webgpu_ep));
+  tester.Run(session_options, OpTester::ExpectResult::kExpectSuccess, "", {}, nullptr, &execution_providers);
 }
 
 // Test QMoE with num_rows=1 on WebGPU to exercise the fused 1-token decode path.


### PR DESCRIPTION
## Description

Adds an unquantized WebGPU `MoE` kernel and expands WebGPU `QMoE` support for the configurations needed by packed token-major inference, including Qwen 3.8 Flash.

The existing operator schemas already accept both representations:

- Packed 2D input: `(num_tokens, hidden_size)`
- Dense 3D input: `(batch_size, sequence_length, hidden_size)`

`MoE` and `QMoE` are token-local, so concatenating variable-length requests does not require a separate varlen operator or a cumulative sequence-length input. Each router tensor contains one row per input token, and the output preserves the input shape.

## Changes

### WebGPU MoE

- Implements and registers the unquantized WebGPU `MoE` kernel for float and float16.
- Supports packed 2D and dense 3D inputs.
- Supports ReLU, GELU, SiLU, identity, and SwiGLU activations.
- Supports separate FC3 gating and interleaved or concatenated fused SwiGLU layouts.
- Handles empty inputs, chunked multi-token execution, and hidden sizes that are not multiples of the workgroup size.
- Uses segmented-buffer-safe tensor access throughout the WebGPU shader pipeline, including stacked expert weights and shape-preserving outputs.

### WebGPU QMoE

- Adds all schema activation types and both fused SwiGLU layouts.
- Adds separate FC3 projection and gating.
- Adds aggregation-only `router_weights` while continuing to use `router_probs` for Top-K selection, including selected Top-K normalization when `normalize_routing_weights=1`.
- Adds block-wise explicit zero-point support.
- Makes stacked `MatMulNBits` zero-point indexing follow the selected expert, matching weight and scale indexing.
- Preserves the optimized single-token decode path.
- Rejects unsupported row-wise and optimized single-token explicit-zero-point combinations with clear errors.
- Validates that `num_experts` fits the adapter's workgroup-size and invocation limits before creating the gate shader.

### Packed semantics and tests

- Clarifies packed 2D and dense 3D behavior in the authoritative schemas and generated contrib documentation.
- Adds a packed ragged-batch test representing request lengths `[2, 1, 2]`.
- Uses distinct token rows and nonzero weights so the packed test detects hidden-state reordering or cross-request interaction.
- Disables CPU fallback in every WebGPU-specific test so registration or kernel-claim regressions cannot pass through another EP.
- Adds focused coverage for float/float16 MoE, dense and packed inputs, activations, FC3, SwiGLU fusion layouts, expert-specific zero points, normalized `k > 1` router weights, non-aligned gather tails, the 2,048-token chunk boundary, adapter expert limits, empty inputs, and the optimized QMoE decode path.

## Provider-specific scope

This change targets portable WebGPU functionality. CUDA-specific `fp4`, `nvfp4`, `fp8`, and `wfp4afp8` formats, CUDA expert-weight prepacking, and sparse mixer execution remain unsupported on WebGPU and are rejected explicitly.

The normal symmetric INT4 Qwen path remains supported. Block-wise asymmetric INT4/INT8 weights, separate router weights, and FC3-based gating are now also represented by the WebGPU implementation and tests.

The official Qwen 3.8 Flash FP8 checkpoint uses 128x128 block-scaled FP8 expert weights. CUDA `QMoE` currently supports FP8 weights with one global scale per expert, while its existing block-scaled modes are `nvfp4` and `wfp4afp8`. Supporting the official block-FP8 checkpoint therefore requires a separate CUDA/schema change and is intentionally left to a focused follow-up rather than expanding this WebGPU PR.

## Validation

- Windows Release WebGPU provider and `onnxruntime_provider_test` targets build successfully with Dawn and the D3D12 Agility SDK.
- WGSL template tests pass on Windows and Linux CI.
- Deterministic nonzero WebGPU MoE and optimized single-token QMoE tests pass locally.
- `clang-format --dry-run --Werror` passes for changed C++ files.
- `git diff --check` passes.
- Editor diagnostics report no errors.
- Generated `OperatorKernels.md` content is synchronized with CI output.

Multi-token QMoE dispatch reaches the local D3D12 adapter, but repeated local runs can end in `DXGI_ERROR_DEVICE_REMOVED`; cross-adapter runtime validation is covered by WebGPU CI.
