### PR TITLE
Fix virtual-only CUDA architecture normalization

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -97,6 +97,15 @@ option(onnxruntime_USE_ARM_NEON_NCHWC "Build with ARM Neon NCHWc kernels in MLAS
 option(onnxruntime_USE_KLEIDIAI "Build with KleidiAI integration in MLAS" OFF)
 option(onnxruntime_USE_QMX_KLEIDIAI_COEXIST "Build with QMX and Arm KLEIDIAI libraries" OFF)
 option(onnxruntime_BUILD_UNIT_TESTS "Build ONNXRuntime unit tests" ON)
+if(onnxruntime_BUILD_UNIT_TESTS)
+  add_test(
+    NAME onnxruntime_test_cuda_architecture_virtual_only
+    COMMAND ${CMAKE_COMMAND}
+      -S "${CMAKE_CURRENT_SOURCE_DIR}/tests/cuda_architectures"
+      -B "${CMAKE_CURRENT_BINARY_DIR}/tests/cuda_architectures/virtual_only"
+      "-DTEST_CUDA_ARCHITECTURES=75-virtual"
+      "-DEXPECTED_CUDA_ARCHITECTURES=75-virtual")
+endif()
 # Materialize the ONNX node-test corpus from ONNX's Python generators into the build tree at
 # configure/build time, instead of depending on the on-disk corpus shipped in the ONNX source
 # archive. This detaches ORT from ONNX PR #7959 (which deletes onnx/backend/test/data/node).

--- a/cmake/external/cuda_configuration.cmake
+++ b/cmake/external/cuda_configuration.cmake
@@ -172,7 +172,9 @@ macro(setup_cuda_architectures)
     endif()
   endforeach()
   list(REMOVE_DUPLICATES CMAKE_CUDA_ARCHITECTURES_CLEAN)
-  set(CMAKE_CUDA_ARCHITECTURES ${CMAKE_CUDA_ARCHITECTURES_CLEAN})
+  # Keep the normal variable defined when the input contains only a virtual architecture.
+  # Otherwise, the original cache value becomes visible again and is normalized as a real architecture.
+  set(CMAKE_CUDA_ARCHITECTURES "${CMAKE_CUDA_ARCHITECTURES_CLEAN}")
 
   # CMAKE_CUDA_ARCHITECTURES_ORIG contains all architectures enabled, without automatically added -real or -a suffix.
   set(CMAKE_CUDA_ARCHITECTURES_ORIG "${CMAKE_CUDA_ARCHITECTURES}")

--- a/cmake/tests/cuda_architectures/CMakeLists.txt
+++ b/cmake/tests/cuda_architectures/CMakeLists.txt
@@ -1,0 +1,21 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+cmake_minimum_required(VERSION 3.28)
+project(cuda_architectures_test NONE)
+
+if(NOT DEFINED TEST_CUDA_ARCHITECTURES OR NOT DEFINED EXPECTED_CUDA_ARCHITECTURES)
+  message(FATAL_ERROR "TEST_CUDA_ARCHITECTURES and EXPECTED_CUDA_ARCHITECTURES are required")
+endif()
+
+set(CMAKE_CUDA_ARCHITECTURES "${TEST_CUDA_ARCHITECTURES}" CACHE STRING "CUDA architectures to test")
+set(CMAKE_CUDA_COMPILER_VERSION 13.0)
+
+include("${CMAKE_CURRENT_LIST_DIR}/../../external/cuda_configuration.cmake")
+setup_cuda_architectures()
+
+if(NOT CMAKE_CUDA_ARCHITECTURES STREQUAL "${EXPECTED_CUDA_ARCHITECTURES}")
+  message(
+    FATAL_ERROR
+      "Expected CUDA architectures '${EXPECTED_CUDA_ARCHITECTURES}', got '${CMAKE_CUDA_ARCHITECTURES}'")
+endif()


### PR DESCRIPTION
### Description

Fixes https://github.com/microsoft/onnxruntime/issues/32436.

Preserve an empty normal `CMAKE_CUDA_ARCHITECTURES` value while normalizing an input that contains only a virtual architecture. This prevents the command-line cache value from becoming visible again and incorrectly producing `75-virtual-real;75-virtual`.

This also adds a configuration-level regression test for the virtual-only case.

### Motivation and Context

Passing `-DCMAKE_CUDA_ARCHITECTURES=75-virtual` should retain that valid CMake architecture unchanged. The previous normalization cleared the normal variable, exposed the original cache entry, and then treated it as a real architecture before appending the intended virtual target.

Validation performed:

- Confirmed the regression test fails against the base revision with `75-virtual-real;75-virtual`.
- Confirmed it passes with the change and produces only `75-virtual`.
- Confirmed real-only `75` still normalizes to `75-real`.
- Confirmed mixed `75;80-virtual` still normalizes to `75-real;80-virtual`.
- Ran `git diff --check` and `git show --check`.

Known limitations: a full CUDA build was not run because this host has no CUDA toolchain. The affected normalization path is exercised through a standalone CMake configure test that does not require CUDA hardware or a compiler.
