### PR TITLE
[WebAssembly] Expose GetAvailableProviders on the wasm API

### DIFF
--- a/js/web/lib/wasm/wasm-types.ts
+++ b/js/web/lib/wasm/wasm-types.ts
@@ -343,6 +343,9 @@ export interface OrtInferenceAPIs {
 
   _OrtGetLastError(errorCodeOffset: number, errorMessageOffset: number): number;
 
+  _OrtGetAvailableProviders(providersOffset: number, providersLengthOffset: number): number;
+  _OrtReleaseAvailableProviders(providersOffset: number, providersLength: number): number;
+
   _OrtCreateSession(dataOffset: number, dataLength: number, sessionOptionsHandle: number): Promise<number>;
   _OrtReleaseSession(sessionHandle: number): number;
   _OrtGetInputOutputCount(sessionHandle: number, inputCountOffset: number, outputCountOffset: number): number;

--- a/js/web/test/unittests/backends/wasm/test-available-providers.ts
+++ b/js/web/test/unittests/backends/wasm/test-available-providers.ts
@@ -1,0 +1,58 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { expect } from 'chai';
+import { InferenceSession } from 'onnxruntime-common';
+
+import { getInstance } from '../../../../lib/wasm/wasm-factory';
+
+const ONNX_MODEL_TEST_ABS_STATIC = Uint8Array.from([
+  8, 9, 58, 83, 10, 31, 10, 7, 105, 110, 112, 117, 116, 95, 48, 18, 8, 111, 117, 116, 112, 117, 116, 95, 48, 26, 3, 65,
+  98, 115, 34, 3, 65, 98, 115, 58, 0, 18, 3, 97, 98, 115, 90, 25, 10, 7, 105, 110, 112, 117, 116, 95, 48, 18, 14, 10,
+  12, 8, 1, 18, 8, 10, 2, 8, 2, 10, 2, 8, 4, 98, 16, 10, 8, 111, 117, 116, 112, 117, 116, 95, 48, 18, 4, 10, 2, 8, 1,
+  66, 4, 10, 0, 16, 21,
+]);
+
+// Calls the exports directly rather than through a higher level API, because what needs covering is that the symbols
+// survive into the emitted module and are callable with this signature.
+const getAvailableProviders = (): string[] => {
+  const wasm = getInstance();
+  const ptrSize = wasm.PTR_SIZE;
+
+  const stack = wasm.stackSave();
+  try {
+    const providersOffset = wasm.stackAlloc(ptrSize);
+    const lengthOffset = wasm.stackAlloc(4);
+
+    expect(wasm._OrtGetAvailableProviders(providersOffset, lengthOffset)).to.equal(0);
+
+    const buffer = Number(wasm.getValue(providersOffset, '*'));
+    const length = Number(wasm.getValue(lengthOffset, 'i32'));
+    expect(buffer).to.not.equal(0);
+
+    const providers: string[] = [];
+    for (let i = 0; i < length; i++) {
+      providers.push(wasm.UTF8ToString(Number(wasm.getValue(buffer + i * ptrSize, '*'))));
+    }
+
+    expect(wasm._OrtReleaseAvailableProviders(buffer, length)).to.equal(0);
+    return providers;
+  } finally {
+    wasm.stackRestore(stack);
+  }
+};
+
+const testAvailableProviders = async (model: Uint8Array, expectedProviders: string[]) => {
+  // Loading a model first, so that the WebAssembly module is initialized before the exports are called.
+  await InferenceSession.create(model);
+
+  const providers = getAvailableProviders();
+  expect(providers).to.include.members(expectedProviders);
+  providers.forEach((provider) => expect(provider.length).to.be.greaterThan(0));
+};
+
+describe('#UnitTest# - wasm - test available providers', () => {
+  it('providers the build was compiled with', async () => {
+    await testAvailableProviders(ONNX_MODEL_TEST_ABS_STATIC, ['CPUExecutionProvider']);
+  });
+});

--- a/js/web/test/unittests/index.ts
+++ b/js/web/test/unittests/index.ts
@@ -12,6 +12,7 @@ if (typeof window !== 'undefined') {
 }
 
 require('./backends/wasm/test-model-metadata');
+require('./backends/wasm/test-available-providers');
 
 require('./pool-output-shape');
 

--- a/onnxruntime/wasm/api.cc
+++ b/onnxruntime/wasm/api.cc
@@ -110,6 +110,14 @@ int OrtGetLastError(int* error_code, const char** error_message) {
   return ORT_OK;
 }
 
+int OrtGetAvailableProviders(char*** out_ptr, int* providers_length) {
+  return CHECK_STATUS(GetAvailableProviders, out_ptr, providers_length);
+}
+
+int OrtReleaseAvailableProviders(char** ptr, int providers_length) {
+  return CHECK_STATUS(ReleaseAvailableProviders, ptr, providers_length);
+}
+
 OrtSessionOptions* OrtCreateSessionOptions(size_t graph_optimization_level,
                                            bool enable_cpu_mem_arena,
                                            bool enable_mem_pattern,

--- a/onnxruntime/wasm/api.h
+++ b/onnxruntime/wasm/api.h
@@ -57,6 +57,24 @@ int EMSCRIPTEN_KEEPALIVE OrtInit(int num_threads, int logging_level);
 int EMSCRIPTEN_KEEPALIVE OrtGetLastError(int* error_code, const char** error_message);
 
 /**
+ * get the list of execution providers that this build was compiled with.
+ * @param out_ptr [out] a pointer to accept the buffer of provider names. The buffer contains `providers_length`
+ *                      C-style string pointers, followed by the string data they point into. Caller must release it
+ *                      after use by calling OrtReleaseAvailableProviders().
+ * @param providers_length [out] a pointer to accept the number of provider names.
+ * @returns ORT error code. If not zero, call OrtGetLastError() to get detailed error message.
+ */
+int EMSCRIPTEN_KEEPALIVE OrtGetAvailableProviders(char*** out_ptr, int* providers_length);
+
+/**
+ * release the buffer returned by OrtGetAvailableProviders().
+ * @param ptr the buffer returned as `out_ptr` by OrtGetAvailableProviders().
+ * @param providers_length the count returned as `providers_length` by OrtGetAvailableProviders().
+ * @returns ORT error code. If not zero, call OrtGetLastError() to get detailed error message.
+ */
+int EMSCRIPTEN_KEEPALIVE OrtReleaseAvailableProviders(char** ptr, int providers_length);
+
+/**
  * create an instance of ORT session options.
  * assume that all enum type parameters, such as graph_optimization_level, execution_mode, and log_severity_level,
  * are checked and set properly at JavaScript.


### PR DESCRIPTION
The wasm build compiles its providers in, so there are separate artifacts for XNNPACK, WebGPU and WebNN and nothing exported says which one you got. Native has GetAvailableProviders, Python has get_available_providers().

This just wraps it. GetAvailableExecutionProviderNames() already gates the web providers on USE_JSEP, USE_WEBNN, USE_WEBGPU and USE_XNNPACK, so only the export was missing. No cmake change, EMSCRIPTEN_KEEPALIVE handles it.
