### PR TITLE
Fix float16 QuantizeLinear rounding on CPU

### DIFF
--- a/onnxruntime/core/util/qmath.h
+++ b/onnxruntime/core/util/qmath.h
@@ -338,7 +338,7 @@ ParQuantizeLinearStd(const MLFloat16* Input,
     auto end_idx = std::min(static_cast<std::ptrdiff_t>(N), end * block_size);
     float fscale = Scale.ToFloat();
     for (; begin_idx != end_idx; ++begin_idx) {
-      int32_t ival = static_cast<int32_t>(Input[begin_idx].ToFloat() / fscale) + ZeroPoint;
+      int32_t ival = static_cast<int32_t>(std::nearbyint(Input[begin_idx].ToFloat() / fscale)) + ZeroPoint;
       Output[begin_idx] = static_cast<OutputType>(std::min(static_cast<int32_t>(std::numeric_limits<OutputType>::max()),
                                                            std::max(static_cast<int32_t>(std::numeric_limits<OutputType>::lowest()), ival)));
     }

--- a/onnxruntime/test/providers/cpu/tensor/quantize_linear_test.cc
+++ b/onnxruntime/test/providers/cpu/tensor/quantize_linear_test.cc
@@ -565,6 +565,18 @@ TEST(QuantizeLinearOpMLFloat16Test, Uint8) {
   test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider});  // TensorRT doesn't support support UINT8 for quantization
 }
 
+TEST(QuantizeLinearOpMLFloat16Test, Int8RoundsFractionalValues) {
+  OpTester test("QuantizeLinear", 19);
+  std::vector<int64_t> dims{4};
+  test.AddInput<MLFloat16>("x", dims,
+                           {MLFloat16(0.050018310546875f), MLFloat16(-0.050018310546875f),
+                            MLFloat16(0.04998779296875f), MLFloat16(-0.04998779296875f)});
+  test.AddInput<MLFloat16>("y_scale", {}, {MLFloat16(0.0999755859375f)});
+  test.AddInput<int8_t>("y_zero_point", {}, {0});
+  test.AddOutput<int8_t>("y", dims, {1, -1, 0, 0});
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {kTensorrtExecutionProvider});
+}
+
 // quantize with scalar zero point and scale
 TEST(QuantizeLinearOpTest, Int8) {
   // TODO: Unskip when fixed #41968513


### PR DESCRIPTION
## Description

Fixes the still-reproducible numerical issue reported in #18576.

The CPU `MLFloat16` overload of `ParQuantizeLinearStd` converted `x / scale` directly with `static_cast<int32_t>`, which truncates toward zero. ONNX `QuantizeLinear` requires round-to-nearest with ties to even.

This change applies `std::nearbyint` before the integer conversion, matching the ONNX contract and the nearby blocked float16 paths in the same file.

## Minimal reproduction

For opset 19:

```text
x (float16)     = [ 0.050018310546875, -0.050018310546875]
scale (float16) = 0.0999755859375
zero_point      = 0 (int8)
expected        = [ 1, -1]
ORT CPU 1.29.0  = [ 0,  0]
```

NumPy nearest-even and ONNX `ReferenceEvaluator` both return `[1, -1]`. A 4,096-value float16 differential check found 2,041 mismatches, all toward zero and by at most one quantization unit. The float32 control path matched the oracle.

## Changes

- round the scalar float16 CPU path with `std::nearbyint`;
- add a non-integral float16-to-int8 regression test.

## Testing

- reproduced on macOS ARM64 with `onnxruntime==1.29.0` and `onnx==1.22.0`;
- verified against NumPy and ONNX `ReferenceEvaluator`;
- full C++ unit suite not run locally; the new `OpTester` case is included for CI.

This is a numerical-correctness fix, not a security change.