### PR TITLE
[Web] Apply extra session config before EP creation

### DIFF
--- a/js/web/lib/wasm/session-options.ts
+++ b/js/web/lib/wasm/session-options.ts
@@ -256,6 +256,14 @@ export const setSessionOptions = async (options?: InferenceSession.SessionOption
       checkLastError("Can't create session options.");
     }
 
+    // EP factories consume session config when they are appended. Apply extra
+    // settings first so ep.* entries affect provider construction.
+    if (sessionOptions.extra !== undefined) {
+      iterateExtraOptions(sessionOptions.extra, '', new WeakSet<Record<string, unknown>>(), (key, value) => {
+        appendSessionConfig(sessionOptionsHandle, key, value, allocs);
+      });
+    }
+
     if (sessionOptions.executionProviders) {
       await setExecutionProviders(sessionOptionsHandle, sessionOptions, allocs);
     }
@@ -285,12 +293,6 @@ export const setSessionOptions = async (options?: InferenceSession.SessionOption
           checkLastError(`Can't set a free dimension override: ${name} - ${value}.`);
         }
       }
-    }
-
-    if (sessionOptions.extra !== undefined) {
-      iterateExtraOptions(sessionOptions.extra, '', new WeakSet<Record<string, unknown>>(), (key, value) => {
-        appendSessionConfig(sessionOptionsHandle, key, value, allocs);
-      });
     }
 
     return [sessionOptionsHandle, allocs];

--- a/js/web/test/e2e/browser-test-webgpu-extra-options.js
+++ b/js/web/test/e2e/browser-test-webgpu-extra-options.js
@@ -1,0 +1,26 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+'use strict';
+
+it('Browser E2E testing - explicit WebGPU options override extra config', async function () {
+  await testFunction(ort, {
+    executionProviders: [{ name: 'webgpu', preferredLayout: 'NCHW' }],
+    extra: { 'ep.webgpuexecutionprovider.preferredLayout': 'invalid-extra-value' },
+  });
+});
+
+it('Browser E2E testing - WebGPU validates extra config before creating the EP', async function () {
+  let rejected = false;
+  try {
+    const session = await ort.InferenceSession.create('./model.onnx', {
+      executionProviders: ['webgpu'],
+      extra: { 'ep.webgpuexecutionprovider.enableGraphCapture': 'invalid-extra-value' },
+    });
+    await session.release();
+  } catch {
+    rejected = true;
+  }
+  // Before the fix, provider construction ignores the invalid value and succeeds.
+  assert(rejected);
+});

--- a/js/web/test/e2e/run-data.js
+++ b/js/web/test/e2e/run-data.js
@@ -67,6 +67,7 @@ const BROWSER_TEST_CASES = [
 
   [true, true, './browser-test-wasm-image-tensor-image.js', 'ort.min.js'], // pre-post-process
   [true, true, './browser-test-webgpu-custom-device.js', 'ort.webgpu.min.js'], // user-provided GPUDevice
+  [true, true, './browser-test-webgpu-extra-options.js', 'ort.webgpu.min.js'], // extra config before EP creation
   [true, true, './browser-test-webgpu-external-data.js', 'ort.webgpu.min.js'], // external data
   [true, true, './browser-test-webgpu-external-data-blob.js', 'ort.webgpu.min.js'], // external data as Blob (fallback)
   [true, true, './browser-test-webgpu-external-data-blob.js', 'ort.jspi.min.js'], // external data as Blob (on-demand)


### PR DESCRIPTION
`SessionOptions.extra` is currently appended after execution providers are constructed. WebGPU reads its `ep.webgpuexecutionprovider.*` config during factory creation, so these settings are silently ignored. For example, setting `extra['ep.webgpuexecutionprovider.enableGraphCapture'] = '1'` still logs `WebGPU EP graph capture enable: 0`.

Apply extra session config before appending providers. Explicit provider options take precedence over conflicting extra config. Add browser E2E coverage for provider-side validation of an invalid extra capture value and for explicit-option precedence.

This is a prerequisite for https://github.com/huggingface/transformers.js/pull/1765: configure capture in the C++ EP while keeping normal JS I/O binding, run prefill with `gpu_graph_id=-1`, and replay decode with stable GPU buffers.

Validation:
- Built ORT Web's pinned 1.26.0-dev.20260416-b7804b056c JS sources with this ordering change, retaining the matching, unmodified Asyncify WASM files.
- Ran both new E2E test bodies against actual ORT Web + Dawn/D3D12 on Node 24: patched runtime passes; stock runtime fails the new validation regression.
- Phi-4-mini graph-ready INT4 export on RTX 5080: native logs confirm capture enable=1 and repeated `Replaying the captured WebGpuExecutionProvider graph`. Generated tokens match capture-off exactly, including subsequent prefills.
- Five warmed-up trials, 128 prompt tokens + 128 generated tokens, fixed 2048-token KV capacity: median decode 51.46 → 128.45 tokens/sec (2.50×). Both modes use the same patched JS runtime and unchanged WASM/model assets.
- Prettier and diff whitespace checks pass. Browser automation itself was unavailable; local E2E bodies were executed with Dawn's Node WebGPU binding.
