### PR TITLE
Fix severe CPU STFT performance for batched short transforms

### DIFF
--- a/onnxruntime/core/optimizer/graph_transformer_utils.cc
+++ b/onnxruntime/core/optimizer/graph_transformer_utils.cc
@@ -221,8 +221,8 @@ InlinedVector<std::unique_ptr<GraphTransformer>> GenerateTransformers(
       session_options.config_options.GetConfigOrDefault(kOrtSessionOptionsDisableQuantQDQ, "0") == "1";
   const bool enable_cast_chain_elimination =
       session_options.config_options.GetConfigOrDefault(kOrtSessionOptionsEnableCastChainElimination, "0") == "1";
-#ifndef DISABLE_CONTRIB_OPS
   const InlinedHashSet<std::string_view> cpu_ep = {onnxruntime::kCpuExecutionProvider};
+#ifndef DISABLE_CONTRIB_OPS
   const InlinedHashSet<std::string_view> cpu_acl_eps = {onnxruntime::kCpuExecutionProvider,
                                                         onnxruntime::kAclExecutionProvider};
 #endif
@@ -280,14 +280,6 @@ InlinedVector<std::unique_ptr<GraphTransformer>> GenerateTransformers(
       transformers.emplace_back(std::make_unique<FreeDimensionOverrideTransformer>(
           session_options.free_dimension_overrides));
       transformers.emplace_back(std::make_unique<SliceConcatToSpaceToDepthFusion>());
-      // This decomposition targets CPU STFT performance. Level1 runs before EP partitioning,
-      // so only register the default transformer for CPU-only sessions.
-      const bool cpu_only_session = execution_providers == nullptr ||
-          (execution_providers->NumProviders() == 1 &&
-          execution_providers->Get(onnxruntime::kCpuExecutionProvider) != nullptr);
-      if (cpu_only_session) {
-        transformers.emplace_back(std::make_unique<STFTDecomposition>());
-      }
       transformers.emplace_back(std::make_unique<GeluFusion>());
       transformers.emplace_back(std::make_unique<LayerNormFusion>());
 
@@ -337,6 +329,7 @@ InlinedVector<std::unique_ptr<GraphTransformer>> GenerateTransformers(
       // we run TransposeOptimizer again in Level2 for some CPU EP specific optimizations that can only be
       // applied once nodes are assigned to the CPU EP (which happens between level 1 and level 2).
       transformers.emplace_back(std::make_unique<TransposeOptimizer>(std::move(cpu_allocator), kCpuExecutionProvider));
+      transformers.emplace_back(std::make_unique<STFTDecomposition>(cpu_ep));
 
       const bool enable_quant_qdq_cleanup =
           session_options.config_options.GetConfigOrDefault(kOrtSessionOptionsEnableQuantQDQCleanup, "0") == "1";

--- a/onnxruntime/core/optimizer/graph_transformer_utils.cc
+++ b/onnxruntime/core/optimizer/graph_transformer_utils.cc
@@ -280,7 +280,14 @@ InlinedVector<std::unique_ptr<GraphTransformer>> GenerateTransformers(
       transformers.emplace_back(std::make_unique<FreeDimensionOverrideTransformer>(
           session_options.free_dimension_overrides));
       transformers.emplace_back(std::make_unique<SliceConcatToSpaceToDepthFusion>());
-      transformers.emplace_back(std::make_unique<STFTDecomposition>());
+      // This decomposition targets CPU STFT performance. Level1 runs before EP partitioning,
+      // so only register the default transformer for CPU-only sessions.
+      const bool cpu_only_session = execution_providers == nullptr ||
+          (execution_providers->NumProviders() == 1 &&
+          execution_providers->Get(onnxruntime::kCpuExecutionProvider) != nullptr);
+      if (cpu_only_session) {
+        transformers.emplace_back(std::make_unique<STFTDecomposition>());
+      }
       transformers.emplace_back(std::make_unique<GeluFusion>());
       transformers.emplace_back(std::make_unique<LayerNormFusion>());
 

--- a/onnxruntime/core/optimizer/graph_transformer_utils.cc
+++ b/onnxruntime/core/optimizer/graph_transformer_utils.cc
@@ -88,6 +88,7 @@
 #include "core/optimizer/skip_layer_norm_fusion.h"
 #include "core/optimizer/slice_elimination.h"
 #include "core/optimizer/slice_concat_to_space_to_depth_fusion.h"
+#include "core/optimizer/stft_decomposition.h"
 #include "core/optimizer/transpose_optimizer.h"
 #include "core/optimizer/unsqueeze_elimination.h"
 #ifdef ENABLE_TRAINING
@@ -279,6 +280,7 @@ InlinedVector<std::unique_ptr<GraphTransformer>> GenerateTransformers(
       transformers.emplace_back(std::make_unique<FreeDimensionOverrideTransformer>(
           session_options.free_dimension_overrides));
       transformers.emplace_back(std::make_unique<SliceConcatToSpaceToDepthFusion>());
+      transformers.emplace_back(std::make_unique<STFTDecomposition>());
       transformers.emplace_back(std::make_unique<GeluFusion>());
       transformers.emplace_back(std::make_unique<LayerNormFusion>());
 

--- a/onnxruntime/core/optimizer/stft_decomposition.cc
+++ b/onnxruntime/core/optimizer/stft_decomposition.cc
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 #include <limits>
+#include <optional>
 
 #include "core/optimizer/stft_decomposition.h"
 #include "core/optimizer/initializer.h"
@@ -18,6 +19,32 @@
 using namespace onnxruntime::common;
 
 namespace onnxruntime {
+namespace {
+
+constexpr size_t kMaxSTFTConvWeightSizeInBytes = 64 * 1024 * 1024;
+
+std::optional<int64_t> ReadScalarIntegerInitializer(const Graph& graph,
+                                                    const ONNX_NAMESPACE::TensorProto* initializer) {
+  if (initializer == nullptr) {
+    return std::nullopt;
+  }
+
+  const Initializer tensor(*initializer, graph.ModelPath());
+  if (tensor.size() != 1) {
+    return std::nullopt;
+  }
+
+  switch (initializer->data_type()) {
+    case ONNX_NAMESPACE::TensorProto_DataType_INT32:
+      return static_cast<int64_t>(*tensor.data<int32_t>());
+    case ONNX_NAMESPACE::TensorProto_DataType_INT64:
+      return *tensor.data<int64_t>();
+    default:
+      return std::nullopt;
+  }
+}
+
+}  // namespace
 
 STFTDecomposition::STFTDecomposition(const InlinedHashSet<std::string_view>& compatible_execution_providers) noexcept
     : GraphTransformer("STFTDecomposition", compatible_execution_providers) {
@@ -160,7 +187,8 @@ Status STFTDecomposition::ApplyImpl(Graph& graph, bool& modified, int graph_leve
     CONTINUE_IF_NULL(node);
     ORT_RETURN_IF_ERROR(Recurse(*node, modified, graph_level, logger));
 
-    if (node->OpType() != "STFT" || !graph_utils::IsSupportedProvider(*node, compatible_eps)) {
+    if (!graph_utils::IsSupportedOptypeVersionAndDomain(*node, "STFT", {17}) ||
+        !graph_utils::IsSupportedProvider(*node, compatible_eps)) {
       continue;
     }
 
@@ -211,15 +239,19 @@ Status STFTDecomposition::ApplyImpl(Graph& graph, bool& modified, int graph_leve
       continue;
     }
 
-    auto read_int64_initializer = [](Graph& graph, const ONNX_NAMESPACE::TensorProto* initializer) {
-      return *Initializer(*initializer, graph.ModelPath()).data<int64_t>();
-    };
-    auto frame_step_value = read_int64_initializer(graph, frame_step_initializer);
+    auto frame_step_value = ReadScalarIntegerInitializer(graph, frame_step_initializer);
+    if (!frame_step_value.has_value()) {
+      continue;
+    }
 
     // Get DFT Size
     int64_t dft_size = 0;
     if (frame_length_initializer) {
-      dft_size = read_int64_initializer(graph, frame_length_initializer);
+      auto frame_length_value = ReadScalarIntegerInitializer(graph, frame_length_initializer);
+      if (!frame_length_value.has_value()) {
+        continue;
+      }
+      dft_size = *frame_length_value;
     }
     if (dft_size == 0 && window_initializer) {
       const auto* window_shape = window->Shape();
@@ -233,9 +265,9 @@ Status STFTDecomposition::ApplyImpl(Graph& graph, bool& modified, int graph_leve
 
     // Validate model-provided scalar values before using them in size calculations.
     // These come from untrusted model initializers/shapes and must be positive.
-    if (dft_size <= 0 || frame_step_value <= 0) {
+    if (dft_size <= 0 || *frame_step_value <= 0) {
       LOGS(logger, WARNING) << "STFT decomposition skipped: invalid dft_size (" << dft_size
-                            << ") or frame_step_value (" << frame_step_value << ")";
+                            << ") or frame_step_value (" << *frame_step_value << ")";
       continue;
     }
 
@@ -252,19 +284,25 @@ Status STFTDecomposition::ApplyImpl(Graph& graph, bool& modified, int graph_leve
       }
     }
 
-    const int64_t output_num_frames = ((signal_length - dft_size) / frame_step_value) + 1;
+    const int64_t output_num_frames = ((signal_length - dft_size) / *frame_step_value) + 1;
     auto dft_unique_bins = is_onesided ? ((dft_size >> 1) + 1) : dft_size;
 
     Node* signal_recipient = nullptr;
     Node* window_recipient = nullptr;
     Node* stft_producer = nullptr;
     if (is_real) {
-      size_t dft_size_sz, dft_unique_bins_sz, weight_size, conv_channels;
+      size_t dft_size_sz, dft_unique_bins_sz, weight_size, conv_channels, weight_size_in_bytes;
       if (!SafeCast(dft_unique_bins, dft_unique_bins_sz) ||
           !SafeCast(dft_size, dft_size_sz) ||
           !SafeMultiply(dft_unique_bins_sz, static_cast<size_t>(2), conv_channels) ||
-          !SafeMultiply(conv_channels, dft_size_sz, weight_size)) {
+          !SafeMultiply(conv_channels, dft_size_sz, weight_size) ||
+          !SafeMultiply(weight_size, sizeof(float), weight_size_in_bytes)) {
         LOGS(logger, WARNING) << "STFT decomposition skipped: weight size overflow";
+        continue;
+      }
+      if (weight_size_in_bytes > kMaxSTFTConvWeightSizeInBytes) {
+        LOGS(logger, VERBOSE) << "STFT decomposition skipped: generated Conv weights would require "
+                              << weight_size_in_bytes << " bytes";
         continue;
       }
 
@@ -348,7 +386,7 @@ Status STFTDecomposition::ApplyImpl(Graph& graph, bool& modified, int graph_leve
       NodeArg* conv_output = nullptr;
       std::tie(conv_node, conv_output) =
           AddNode(graph, "Conv", stft.GetExecutionProviderType(), conv_inputs, &stft);
-      conv_node->AddAttribute("strides", std::vector<int64_t>{1, frame_step_value});
+      conv_node->AddAttribute("strides", std::vector<int64_t>{1, *frame_step_value});
 
       NodeArg* output_reshape_inputs[] = {conv_output, output_shape};
       NodeArg* reshaped_output = nullptr;

--- a/onnxruntime/core/optimizer/stft_decomposition.cc
+++ b/onnxruntime/core/optimizer/stft_decomposition.cc
@@ -13,7 +13,6 @@
 #include "core/common/safeint.h"
 #include "core/framework/op_kernel.h"
 #include "core/framework/tensorprotoutils.h"
-#include "core/providers/common.h"
 #include <numbers>
 
 using namespace onnxruntime::common;
@@ -188,7 +187,8 @@ Status STFTDecomposition::ApplyImpl(Graph& graph, bool& modified, int graph_leve
     ORT_RETURN_IF_ERROR(Recurse(*node, modified, graph_level, logger));
 
     if (!graph_utils::IsSupportedOptypeVersionAndDomain(*node, "STFT", {17}) ||
-        (!node->GetExecutionProviderType().empty() && !graph_utils::IsSupportedProvider(*node, compatible_eps))) {
+        (!node->GetExecutionProviderType().empty() &&
+         !graph_utils::IsSupportedProvider(*node, compatible_eps))) {
       continue;
     }
 
@@ -275,6 +275,13 @@ Status STFTDecomposition::ApplyImpl(Graph& graph, bool& modified, int graph_leve
       continue;
     }
 
+    const auto* window_shape = window->Exists() ? window->Shape() : nullptr;
+    if (window_shape != nullptr && window_shape->dim_size() == 1 &&
+        window_shape->dim(0).has_dim_value() &&
+        window_shape->dim(0).dim_value() != dft_size) {
+      continue;
+    }
+
     bool is_onesided = true;
     auto& attrs = stft.GetAttributes();
     if (attrs.find("onesided") != attrs.end()) {
@@ -324,7 +331,8 @@ Status STFTDecomposition::ApplyImpl(Graph& graph, bool& modified, int graph_leve
         for (size_t n = 0; n < dft_size_sz; n++) {
           auto real_index = k * dft_size_sz + n;
           auto imag_index = (dft_unique_bins_sz + k) * dft_size_sz + n;
-          auto theta = -2 * std::numbers::pi_v<float> * k * n / static_cast<float>(dft_size);
+          const double theta = -2.0 * std::numbers::pi_v<double> *
+                               static_cast<double>((k * n) % dft_size_sz) / static_cast<double>(dft_size);
           auto window_scale = window_data != nullptr ? window_data[n] : 1.0f;
           weights_data[real_index] = static_cast<float>(cos(theta)) * window_scale;
           weights_data[imag_index] = static_cast<float>(sin(theta)) * window_scale;

--- a/onnxruntime/core/optimizer/stft_decomposition.cc
+++ b/onnxruntime/core/optimizer/stft_decomposition.cc
@@ -188,7 +188,7 @@ Status STFTDecomposition::ApplyImpl(Graph& graph, bool& modified, int graph_leve
     ORT_RETURN_IF_ERROR(Recurse(*node, modified, graph_level, logger));
 
     if (!graph_utils::IsSupportedOptypeVersionAndDomain(*node, "STFT", {17}) ||
-        !graph_utils::IsSupportedProvider(*node, compatible_eps)) {
+        (!node->GetExecutionProviderType().empty() && !graph_utils::IsSupportedProvider(*node, compatible_eps))) {
       continue;
     }
 
@@ -253,7 +253,7 @@ Status STFTDecomposition::ApplyImpl(Graph& graph, bool& modified, int graph_leve
       }
       dft_size = *frame_length_value;
     }
-    if (dft_size == 0 && window_initializer) {
+    if (!frame_length_initializer && window_initializer) {
       const auto* window_shape = window->Shape();
       if (window_shape == nullptr || window_shape->dim_size() != 1) {
         continue;

--- a/onnxruntime/core/optimizer/stft_decomposition.cc
+++ b/onnxruntime/core/optimizer/stft_decomposition.cc
@@ -12,6 +12,7 @@
 #include "core/common/safeint.h"
 #include "core/framework/op_kernel.h"
 #include "core/framework/tensorprotoutils.h"
+#include "core/providers/common.h"
 #include <numbers>
 
 using namespace onnxruntime::common;
@@ -124,22 +125,17 @@ std::pair<Node*, NodeArg*> AddNodeCast(Graph& graph, NodeArg* in,
               [root]--(window)------------------+||
               [root]--(frame_length) ----------+|||
                                                ||||
-                                               vvvv
+                                              vvvv
                                               [STFT]--(output)-->
-    After Fusion:
-              [root]--(signal)-------------------------+
-              [root]                                   |
-              [root]--(window)--+                      |
-              [root]            |                      |
-                                v                      v
-         (only for non-fp32) [Cast]             +--[Reshape]
-                                |               |      |
-                                v               |      v
-                            [Reshape]-->[Mul]---|-->[Conv]-------+
-                                |               |                |
-                                |               +-----|          |
-                                |                     v          v
-                                +------>[Mul]------>[Conv]-->[Concat]-->[Reshape]-->[Transpose]--(output)-->
+    After Fusion when the window is folded into the Conv weights:
+              [root]--(signal)-->[Reshape]-->[Conv]-->[Reshape]-->[Transpose]--(output)-->
+
+    After Fusion when the window remains a graph input:
+              [root]--(signal)------------------>[Reshape]------—----+
+              [root]--(window)-->[optional Cast]-->[Reshape]-->[Mul]-+
+                                                                     |
+                                                                     v
+                                                                    [Conv]-->[Reshape]-->[Transpose]--(output)-->
 
 
     Subgraph pattern 2: STFT without optional Window parameter set
@@ -151,46 +147,66 @@ std::pair<Node*, NodeArg*> AddNodeCast(Graph& graph, NodeArg* in,
                                                vvv
                                               [STFT]--(output)-->
     After Fusion:
-              [root]--(signal)-->[Reshape]-->[Conv]
-              [root]                 |         |
-              [root]                 |         v
-              [root]                 +------>[Conv]-->[Concat]-->[Reshape]-->[Transpose]--(output)-->
+              [root]--(signal)-->[Reshape]-->[Conv]-->[Reshape]-->[Transpose]--(output)-->
 */
 Status STFTDecomposition::ApplyImpl(Graph& graph, bool& modified, int graph_level, const logging::Logger& logger) const {
   GraphViewer graph_viewer(graph);
   auto& order = graph_viewer.GetNodesInTopologicalOrder();
+  const auto& compatible_eps = GetCompatibleExecutionProviders();
+  const bool may_run_on_cpu = compatible_eps.empty() || compatible_eps.find(kCpuExecutionProvider) != compatible_eps.end();
 
   for (NodeIndex i : order) {
     auto node = graph.GetNode(i);
     CONTINUE_IF_NULL(node);
     ORT_RETURN_IF_ERROR(Recurse(*node, modified, graph_level, logger));
 
-    if (node->OpType() != "STFT") {
+    if (node->OpType() != "STFT" || !graph_utils::IsSupportedProvider(*node, compatible_eps)) {
       continue;
     }
 
     Node& stft = *node;
+    if (stft.InputDefs().size() < 4 || stft.OutputDefs().empty()) {
+      continue;
+    }
+
     auto signal = stft.MutableInputDefs()[0];
     auto frame_step = stft.MutableInputDefs()[1];
     auto window = stft.MutableInputDefs()[2];
     auto frame_length = stft.MutableInputDefs()[3];
 
-    // If the signal has free dimensions, do not transform...
-    auto batch_size_dim = signal->Shape()->dim(0);
-    auto signal_length_dim = signal->Shape()->dim(1);
-    auto signal_components_dim = signal->Shape()->dim(2);
+    const auto* signal_type = signal->TypeAsProto();
+    if (signal_type == nullptr || !signal_type->has_tensor_type()) {
+      continue;
+    }
+
+    const auto* signal_shape = signal->Shape();
+    if (signal_shape == nullptr || signal_shape->dim_size() < 2 || signal_shape->dim_size() > 3) {
+      continue;
+    }
+
+    auto batch_size_dim = signal_shape->dim(0);
+    auto signal_length_dim = signal_shape->dim(1);
     CONTINUE_IF_NO_DIM_VALUE(signal_length_dim);
-    CONTINUE_IF_NO_DIM_VALUE(signal_components_dim);
 
     auto batch_size = batch_size_dim.has_dim_value() ? batch_size_dim.dim_value() : static_cast<int64_t>(-1);
     auto signal_length = signal_length_dim.dim_value();
-    auto is_real = signal_components_dim.dim_value() == 1;
-    auto data_type = static_cast<ONNX_NAMESPACE::TensorProto_DataType>(signal->TypeAsProto()->tensor_type().elem_type());
+    auto is_real = signal_shape->dim_size() == 2 ||
+                   (signal_shape->dim_size() == 3 &&
+                    signal_shape->dim(2).has_dim_value() &&
+                    signal_shape->dim(2).dim_value() == 1);
+    auto data_type = static_cast<ONNX_NAMESPACE::TensorProto_DataType>(signal_type->tensor_type().elem_type());
+    if (!is_real || (may_run_on_cpu && data_type != ONNX_NAMESPACE::TensorProto_DataType_FLOAT)) {
+      continue;
+    }
 
     auto frame_step_initializer = graph_utils::GetConstantInitializer(graph, frame_step->Name());
-    auto window_initializer = graph_utils::GetConstantInitializer(graph, window->Name());
-    auto frame_length_initializer = graph_utils::GetConstantInitializer(graph, frame_length->Name());
+    auto window_initializer = window->Exists() ? graph_utils::GetConstantInitializer(graph, window->Name()) : nullptr;
+    auto frame_length_initializer = frame_length->Exists() ? graph_utils::GetConstantInitializer(graph, frame_length->Name()) : nullptr;
     CONTINUE_IF_NULL(frame_step_initializer);
+    const auto* window_type = window->Exists() ? window->TypeAsProto() : nullptr;
+    if (window->Exists() && (window_type == nullptr || !window_type->has_tensor_type())) {
+      continue;
+    }
     if (!frame_length_initializer && !window_initializer) {
       continue;
     }
@@ -206,7 +222,11 @@ Status STFTDecomposition::ApplyImpl(Graph& graph, bool& modified, int graph_leve
       dft_size = read_int64_initializer(graph, frame_length_initializer);
     }
     if (dft_size == 0 && window_initializer) {
-      auto window_length_dim = window->Shape()->dim(0);
+      const auto* window_shape = window->Shape();
+      if (window_shape == nullptr || window_shape->dim_size() != 1) {
+        continue;
+      }
+      auto window_length_dim = window_shape->dim(0);
       CONTINUE_IF_NO_DIM_VALUE(window_length_dim);
       dft_size = window_length_dim.dim_value();
     }
@@ -219,6 +239,10 @@ Status STFTDecomposition::ApplyImpl(Graph& graph, bool& modified, int graph_leve
       continue;
     }
 
+    if (dft_size > signal_length) {
+      continue;
+    }
+
     bool is_onesided = true;
     auto& attrs = stft.GetAttributes();
     if (attrs.find("onesided") != attrs.end()) {
@@ -228,45 +252,55 @@ Status STFTDecomposition::ApplyImpl(Graph& graph, bool& modified, int graph_leve
       }
     }
 
+    const int64_t output_num_frames = ((signal_length - dft_size) / frame_step_value) + 1;
     auto dft_unique_bins = is_onesided ? ((dft_size >> 1) + 1) : dft_size;
 
     Node* signal_recipient = nullptr;
     Node* window_recipient = nullptr;
     Node* stft_producer = nullptr;
     if (is_real) {
-      auto output_num_frames = stft.MutableOutputDefs()[0]->Shape()->dim(1).dim_value();
-      auto output_frame_length = stft.MutableOutputDefs()[0]->Shape()->dim(2).dim_value();
-
-      size_t dft_size_sz, dft_unique_bins_sz, weight_size;
+      size_t dft_size_sz, dft_unique_bins_sz, weight_size, conv_channels;
       if (!SafeCast(dft_unique_bins, dft_unique_bins_sz) ||
           !SafeCast(dft_size, dft_size_sz) ||
-          !SafeMultiply(dft_unique_bins_sz, dft_size_sz, weight_size)) {
+          !SafeMultiply(dft_unique_bins_sz, static_cast<size_t>(2), conv_channels) ||
+          !SafeMultiply(conv_channels, dft_size_sz, weight_size)) {
         LOGS(logger, WARNING) << "STFT decomposition skipped: weight size overflow";
         continue;
       }
 
-      auto real_weights_data = std::vector<float>(weight_size);
-      auto imag_weights_data = std::vector<float>(weight_size);
+      auto weights_data = std::vector<float>(weight_size);
+      const float* window_data = nullptr;
+      std::unique_ptr<Initializer> window_tensor;
+      if (window_initializer != nullptr && data_type == ONNX_NAMESPACE::TensorProto_DataType_FLOAT) {
+        if (window_initializer->data_type() != ONNX_NAMESPACE::TensorProto_DataType_FLOAT ||
+            window_initializer->dims_size() != 1 ||
+            window_initializer->dims(0) != dft_size) {
+          continue;
+        }
+        window_tensor = std::make_unique<Initializer>(*window_initializer, graph.ModelPath());
+        window_data = window_tensor->data<float>();
+      }
 
       // Populate weights
       for (size_t k = 0; k < dft_unique_bins_sz; k++) {
         for (size_t n = 0; n < dft_size_sz; n++) {
-          auto index = k * dft_size_sz + n;
+          auto real_index = k * dft_size_sz + n;
+          auto imag_index = (dft_unique_bins_sz + k) * dft_size_sz + n;
           auto theta = -2 * std::numbers::pi_v<float> * k * n / static_cast<float>(dft_size);
-          real_weights_data[index] = static_cast<float>(cos(theta));
-          imag_weights_data[index] = static_cast<float>(sin(theta));
+          auto window_scale = window_data != nullptr ? window_data[n] : 1.0f;
+          weights_data[real_index] = static_cast<float>(cos(theta)) * window_scale;
+          weights_data[imag_index] = static_cast<float>(sin(theta)) * window_scale;
         }
       }
 
-      const int64_t weight_shape[] = {dft_unique_bins, 1, 1, dft_size};
-      auto* real_weights = AddInitializer<float>(graph, "stft_real_conv_weights", weight_shape, real_weights_data.data());
-      auto* imaginary_weights = AddInitializer<float>(graph, "stft_imaginary_conv_weights", weight_shape, imag_weights_data.data());
+      const int64_t weight_shape[] = {2 * dft_unique_bins, 1, 1, dft_size};
+      auto* weights = AddInitializer<float>(graph, "stft_conv_weights", weight_shape, weights_data.data());
 
       const int64_t signal_reshaped[] = {batch_size, 1, 1, signal_length};
       auto signal_shape = AddShapeInitializer(graph, "stft_signal_shape", signal_reshaped);
 
-      const int64_t unsqueezed_output_shape[] = {2, batch_size, output_frame_length, output_num_frames};
-      auto unsqueezed_shape = AddShapeInitializer(graph, "stft_output_reshaped", unsqueezed_output_shape);
+      const int64_t output_reshape_shape[] = {batch_size, 2, dft_unique_bins, output_num_frames};
+      auto output_shape = AddShapeInitializer(graph, "stft_output_reshaped", output_reshape_shape);
 
       NodeArg* signal_reshaped_inputs[] = {signal, signal_shape};
       Node* reshape_signal_node = nullptr;
@@ -274,25 +308,13 @@ Status STFTDecomposition::ApplyImpl(Graph& graph, bool& modified, int graph_leve
       std::tie(reshape_signal_node, reshape_output) =
           AddNode(graph, "Reshape", stft.GetExecutionProviderType(), signal_reshaped_inputs, &stft);
 
-      NodeArg* real_weights_final = real_weights;
-      NodeArg* imag_weights_final = imaginary_weights;
-      if (!window->Exists()) {
-        // When we are missing a window function
-        if (real_weights_final->TypeAsProto()->tensor_type().elem_type() != data_type) {
-          std::tie(std::ignore, real_weights_final) =
-              AddNodeCast(graph, real_weights_final, data_type, &stft);
-        }
-        if (imag_weights_final->TypeAsProto()->tensor_type().elem_type() != data_type) {
-          std::tie(std::ignore, imag_weights_final) =
-              AddNodeCast(graph, imag_weights_final, data_type, &stft);
-        }
-      } else {
-        // When we have a window function
+      NodeArg* weights_final = weights;
+      if (window->Exists() && window_data == nullptr) {
         const int64_t window_reshaped_shape[] = {1, 1, 1, dft_size};
         auto window_shape = AddShapeInitializer(graph, "stft_window_shape", window_reshaped_shape);
 
         auto window_final = window;
-        if (window->TypeAsProto()->tensor_type().elem_type() != GetDataType<float>()) {
+        if (window_type->tensor_type().elem_type() != GetDataType<float>()) {
           Node* window_cast_node = nullptr;
           std::tie(window_cast_node, window_final) =
               AddNodeCast(graph, window, GetDataType<float>(), &stft);
@@ -308,59 +330,37 @@ Status STFTDecomposition::ApplyImpl(Graph& graph, bool& modified, int graph_leve
           window_recipient = window_reshape_node;
         }
 
-        NodeArg* scale_real_weights_inputs[] = {real_weights, window_reshaped};
-        NodeArg* windowed_real_weights_output = nullptr;
-        std::tie(std::ignore, windowed_real_weights_output) =
-            AddNode(graph, "Mul", kCpuExecutionProvider, scale_real_weights_inputs, &stft);
+        NodeArg* scale_weights_inputs[] = {weights, window_reshaped};
+        NodeArg* windowed_weights_output = nullptr;
+        std::tie(std::ignore, windowed_weights_output) =
+            AddNode(graph, "Mul", kCpuExecutionProvider, scale_weights_inputs, &stft);
 
-        NodeArg* scale_imag_weights_inputs[] = {imaginary_weights, window_reshaped};
-        NodeArg* windowed_imag_weights_output = nullptr;
-        std::tie(std::ignore, windowed_imag_weights_output) =
-            AddNode(graph, "Mul", kCpuExecutionProvider, scale_imag_weights_inputs, &stft);
-
-        std::tie(std::ignore, real_weights_final) =
-            AddNodeCast(graph, windowed_real_weights_output, data_type, &stft);
-        std::tie(std::ignore, imag_weights_final) =
-            AddNodeCast(graph, windowed_imag_weights_output, data_type, &stft);
+        weights_final = windowed_weights_output;
       }
 
-      // Add Convolution (reals)
-      NodeArg* conv_real_inputs[] = {reshape_output, real_weights_final};
-      Node* real_conv_node = nullptr;
-      NodeArg* real_conv_output = nullptr;
-      std::tie(real_conv_node, real_conv_output) =
-          AddNode(graph, "Conv", stft.GetExecutionProviderType(), conv_real_inputs, &stft);
-      real_conv_node->AddAttribute("strides", std::vector<int64_t>{1, frame_step_value});
+      if (data_type != ONNX_NAMESPACE::TensorProto_DataType_FLOAT) {
+        std::tie(std::ignore, weights_final) =
+            AddNodeCast(graph, weights_final, data_type, &stft);
+      }
 
-      // Add Convolution (imaginary)
-      NodeArg* conv_imag_inputs[] = {reshape_output, imag_weights_final};
-      Node* imag_conv_node = nullptr;
-      NodeArg* imag_conv_output = nullptr;
-      std::tie(imag_conv_node, imag_conv_output) =
-          AddNode(graph, "Conv", stft.GetExecutionProviderType(), conv_imag_inputs, &stft);
-      imag_conv_node->AddAttribute("strides", std::vector<int64_t>{1, frame_step_value});
+      NodeArg* conv_inputs[] = {reshape_output, weights_final};
+      Node* conv_node = nullptr;
+      NodeArg* conv_output = nullptr;
+      std::tie(conv_node, conv_output) =
+          AddNode(graph, "Conv", stft.GetExecutionProviderType(), conv_inputs, &stft);
+      conv_node->AddAttribute("strides", std::vector<int64_t>{1, frame_step_value});
 
-      // Concatenate
-      NodeArg* concatenate_inputs[] = {real_conv_output, imag_conv_output};
-      Node* concat_node = nullptr;
-      NodeArg* concatenated_conv_output = nullptr;
-      std::tie(concat_node, concatenated_conv_output) =
-          AddNode(graph, "Concat", stft.GetExecutionProviderType(), concatenate_inputs, &stft);
-      concat_node->AddAttribute("axis", static_cast<int64_t>(0));
+      NodeArg* output_reshape_inputs[] = {conv_output, output_shape};
+      NodeArg* reshaped_output = nullptr;
+      std::tie(std::ignore, reshaped_output) =
+          AddNode(graph, "Reshape", stft.GetExecutionProviderType(), output_reshape_inputs, &stft);
 
-      // Unsqueeze Reshape
-      NodeArg* unsqueeze_reshape_inputs[] = {concatenated_conv_output, unsqueezed_shape};
-      NodeArg* unsqueezed_output = nullptr;
-      std::tie(std::ignore, unsqueezed_output) =
-          AddNode(graph, "Reshape", stft.GetExecutionProviderType(), unsqueeze_reshape_inputs, &stft);
-
-      // Transpose
-      NodeArg* transpose_inputs[] = {unsqueezed_output};
+      NodeArg* transpose_inputs[] = {reshaped_output};
       Node* transpose_node = nullptr;
       NodeArg* transpose_output = nullptr;
       std::tie(transpose_node, transpose_output) =
           AddNode(graph, "Transpose", stft.GetExecutionProviderType(), transpose_inputs, &stft);
-      transpose_node->AddAttribute("perm", std::vector<int64_t>{1, 3, 2, 0});
+      transpose_node->AddAttribute("perm", std::vector<int64_t>{0, 3, 2, 1});
 
       signal_recipient = reshape_signal_node;
       stft_producer = transpose_node;

--- a/onnxruntime/test/optimizer/graph_transform_test.cc
+++ b/onnxruntime/test/optimizer/graph_transform_test.cc
@@ -12981,6 +12981,214 @@ TEST_F(GraphTransformationTests, DivMulFusion_MultiElementInitializer) {
 // `dropout_elimination.cc` remains as pure defense-in-depth against future
 // internal callers that may bypass shape inference.
 
+TEST_F(GraphTransformationTests, STFTDecomposition_Float3DWithWindow) {
+  constexpr int64_t batch_size = 3;
+  constexpr int64_t signal_length = 20;
+  constexpr int64_t dft_size = 10;
+  constexpr int64_t frame_step = 3;
+  constexpr int64_t output_num_frames = 4;
+  constexpr int64_t dft_unique_bins = 6;
+
+  auto build_test_case = [&](ModelTestBuilder& builder) {
+    std::vector<float> signal_data(batch_size * signal_length);
+    for (size_t i = 0; i < signal_data.size(); ++i) {
+      signal_data[i] = static_cast<float>((static_cast<int>(i % 17) - 8) * 0.125f);
+    }
+
+    auto* signal = builder.MakeInput<float>({batch_size, signal_length, 1}, signal_data);
+    auto* frame_step_arg = builder.MakeScalarInitializer<int64_t>(frame_step);
+    auto* window = builder.Make1DInitializer<float>({0.0f, 0.25f, 0.75f, 1.0f, 0.75f,
+                                                     0.25f, 0.125f, 0.5f, 0.875f, 1.0f});
+    auto* frame_length = builder.MakeScalarInitializer<int64_t>(dft_size);
+    auto* output = builder.MakeOutput<float>({{batch_size, output_num_frames, dft_unique_bins, 2}});
+
+    builder.AddNode("STFT", {signal, frame_step_arg, window, frame_length}, {output})
+        .AddAttribute("onesided", static_cast<int64_t>(1));
+  };
+
+  auto check_transformed_graph = [&](InferenceSessionWrapper& session) {
+    const auto op_to_count = CountOpsInGraph(session.GetGraph());
+    ASSERT_EQ(op_to_count.count("STFT"), 0);
+    ASSERT_EQ(op_to_count.at("Conv"), 1);
+    ASSERT_EQ(op_to_count.at("Reshape"), 2);
+    ASSERT_EQ(op_to_count.at("Transpose"), 1);
+    ASSERT_EQ(op_to_count.count("Concat"), 0);
+  };
+
+  TransformerTester(build_test_case,
+                    check_transformed_graph,
+                    TransformerLevel::Default,
+                    TransformerLevel::Level1,
+                    17,
+                    3e-4,
+                    3e-4,
+                    std::make_unique<STFTDecomposition>());
+}
+
+TEST_F(GraphTransformationTests, STFTDecomposition_Float3DWithRuntimeWindow) {
+  constexpr int64_t batch_size = 3;
+  constexpr int64_t signal_length = 20;
+  constexpr int64_t dft_size = 10;
+  constexpr int64_t frame_step = 3;
+  constexpr int64_t output_num_frames = 4;
+  constexpr int64_t dft_unique_bins = 6;
+
+  auto build_test_case = [&](ModelTestBuilder& builder) {
+    std::vector<float> signal_data(batch_size * signal_length);
+    for (size_t i = 0; i < signal_data.size(); ++i) {
+      signal_data[i] = static_cast<float>((static_cast<int>(i % 17) - 8) * 0.125f);
+    }
+
+    auto* signal = builder.MakeInput<float>({batch_size, signal_length, 1}, signal_data);
+    auto* frame_step_arg = builder.MakeScalarInitializer<int64_t>(frame_step);
+    auto* window = builder.MakeInput<float>({dft_size}, {0.0f, 0.25f, 0.75f, 1.0f, 0.75f,
+                                                         0.25f, 0.125f, 0.5f, 0.875f, 1.0f});
+    auto* frame_length = builder.MakeScalarInitializer<int64_t>(dft_size);
+    auto* output = builder.MakeOutput<float>({{batch_size, output_num_frames, dft_unique_bins, 2}});
+
+    builder.AddNode("STFT", {signal, frame_step_arg, window, frame_length}, {output})
+        .AddAttribute("onesided", static_cast<int64_t>(1));
+  };
+
+  auto check_transformed_graph = [&](InferenceSessionWrapper& session) {
+    const auto op_to_count = CountOpsInGraph(session.GetGraph());
+    ASSERT_EQ(op_to_count.count("STFT"), 0);
+    ASSERT_EQ(op_to_count.at("Conv"), 1);
+    ASSERT_EQ(op_to_count.at("Mul"), 1);
+    ASSERT_EQ(op_to_count.at("Reshape"), 3);
+    ASSERT_EQ(op_to_count.at("Transpose"), 1);
+  };
+
+  TransformerTester(build_test_case,
+                    check_transformed_graph,
+                    TransformerLevel::Default,
+                    TransformerLevel::Level1,
+                    17,
+                    3e-4,
+                    3e-4,
+                    std::make_unique<STFTDecomposition>());
+}
+
+TEST_F(GraphTransformationTests, STFTDecomposition_Float2DNoWindow) {
+  constexpr int64_t batch_size = 2;
+  constexpr int64_t signal_length = 12;
+  constexpr int64_t dft_size = 5;
+  constexpr int64_t frame_step = 2;
+  constexpr int64_t output_num_frames = 4;
+  constexpr int64_t dft_unique_bins = 3;
+
+  auto build_test_case = [&](ModelTestBuilder& builder) {
+    std::vector<float> signal_data(batch_size * signal_length);
+    for (size_t i = 0; i < signal_data.size(); ++i) {
+      signal_data[i] = static_cast<float>((static_cast<int>(i % 11) - 5) * 0.2f);
+    }
+
+    auto* signal = builder.MakeInput<float>({batch_size, signal_length}, signal_data);
+    auto* frame_step_arg = builder.MakeScalarInitializer<int64_t>(frame_step);
+    auto* frame_length = builder.MakeScalarInitializer<int64_t>(dft_size);
+    auto* output = builder.MakeOutput<float>({{batch_size, output_num_frames, dft_unique_bins, 2}});
+
+    builder.AddNode("STFT", {signal, frame_step_arg, builder.MakeEmptyInput(), frame_length}, {output})
+        .AddAttribute("onesided", static_cast<int64_t>(1));
+  };
+
+  auto check_transformed_graph = [&](InferenceSessionWrapper& session) {
+    const auto op_to_count = CountOpsInGraph(session.GetGraph());
+    ASSERT_EQ(op_to_count.count("STFT"), 0);
+    ASSERT_EQ(op_to_count.at("Conv"), 1);
+    ASSERT_EQ(op_to_count.at("Reshape"), 2);
+    ASSERT_EQ(op_to_count.at("Transpose"), 1);
+  };
+
+  TransformerTester(build_test_case,
+                    check_transformed_graph,
+                    TransformerLevel::Default,
+                    TransformerLevel::Level1,
+                    17,
+                    3e-4,
+                    3e-4,
+                    std::make_unique<STFTDecomposition>());
+}
+
+TEST_F(GraphTransformationTests, STFTDecomposition_RunsAtLevel1ByDefault) {
+  constexpr int64_t batch_size = 2;
+  constexpr int64_t signal_length = 12;
+  constexpr int64_t dft_size = 5;
+  constexpr int64_t frame_step = 2;
+  constexpr int64_t output_num_frames = 4;
+  constexpr int64_t dft_unique_bins = 3;
+
+  auto build_test_case = [&](ModelTestBuilder& builder) {
+    std::vector<float> signal_data(batch_size * signal_length);
+    for (size_t i = 0; i < signal_data.size(); ++i) {
+      signal_data[i] = static_cast<float>((static_cast<int>(i % 11) - 5) * 0.2f);
+    }
+
+    auto* signal = builder.MakeInput<float>({batch_size, signal_length}, signal_data);
+    auto* frame_step_arg = builder.MakeScalarInitializer<int64_t>(frame_step);
+    auto* frame_length = builder.MakeScalarInitializer<int64_t>(dft_size);
+    auto* output = builder.MakeOutput<float>({{batch_size, output_num_frames, dft_unique_bins, 2}});
+
+    builder.AddNode("STFT", {signal, frame_step_arg, builder.MakeEmptyInput(), frame_length}, {output})
+        .AddAttribute("onesided", static_cast<int64_t>(1));
+  };
+
+  auto check_transformed_graph = [&](InferenceSessionWrapper& session) {
+    const auto op_to_count = CountOpsInGraph(session.GetGraph());
+    ASSERT_EQ(op_to_count.count("STFT"), 0);
+    ASSERT_EQ(op_to_count.at("Conv"), 1);
+    ASSERT_EQ(op_to_count.at("Reshape"), 2);
+    ASSERT_EQ(op_to_count.at("Transpose"), 1);
+  };
+
+  TransformerTester(build_test_case,
+                    check_transformed_graph,
+                    TransformerLevel::Default,
+                    TransformerLevel::Level1,
+                    17,
+                    3e-4,
+                    3e-4);
+}
+
+TEST_F(GraphTransformationTests, STFTDecomposition_DoubleSkippedForCpu) {
+  constexpr int64_t batch_size = 2;
+  constexpr int64_t signal_length = 12;
+  constexpr int64_t dft_size = 5;
+  constexpr int64_t frame_step = 2;
+  constexpr int64_t output_num_frames = 4;
+  constexpr int64_t dft_unique_bins = 3;
+
+  auto build_test_case = [&](ModelTestBuilder& builder) {
+    std::vector<double> signal_data(batch_size * signal_length);
+    for (size_t i = 0; i < signal_data.size(); ++i) {
+      signal_data[i] = static_cast<double>((static_cast<int>(i % 11) - 5) * 0.2);
+    }
+
+    auto* signal = builder.MakeInput<double>({batch_size, signal_length}, signal_data);
+    auto* frame_step_arg = builder.MakeScalarInitializer<int64_t>(frame_step);
+    auto* frame_length = builder.MakeScalarInitializer<int64_t>(dft_size);
+    auto* output = builder.MakeOutput<double>({{batch_size, output_num_frames, dft_unique_bins, 2}});
+
+    builder.AddNode("STFT", {signal, frame_step_arg, builder.MakeEmptyInput(), frame_length}, {output})
+        .AddAttribute("onesided", static_cast<int64_t>(1));
+  };
+
+  auto check_transformed_graph = [&](InferenceSessionWrapper& session) {
+    const auto op_to_count = CountOpsInGraph(session.GetGraph());
+    ASSERT_EQ(op_to_count.at("STFT"), 1);
+    ASSERT_EQ(op_to_count.count("Conv"), 0);
+  };
+
+  TransformerTester(build_test_case,
+                    check_transformed_graph,
+                    TransformerLevel::Default,
+                    TransformerLevel::Level1,
+                    17,
+                    0.0,
+                    0.0,
+                    std::make_unique<STFTDecomposition>());
+}
+
 // These tests verify that STFTDecomposition skips malformed models
 // instead of crashing with OOB writes from negative initializer values.
 TEST_F(GraphTransformationTests, STFTDecomposition_NegativeFrameLength) {

--- a/onnxruntime/test/optimizer/graph_transform_test.cc
+++ b/onnxruntime/test/optimizer/graph_transform_test.cc
@@ -13192,7 +13192,48 @@ TEST_F(GraphTransformationTests, STFTDecomposition_OnesidedFalse) {
                     std::make_unique<STFTDecomposition>());
 }
 
-TEST_F(GraphTransformationTests, STFTDecomposition_RunsAtLevel1ByDefault) {
+TEST_F(GraphTransformationTests, STFTDecomposition_LargeDftSizeNumericalAccuracy) {
+  constexpr int64_t batch_size = 2;
+  constexpr int64_t signal_length = 768;
+  constexpr int64_t dft_size = 512;
+  constexpr int64_t frame_step = 128;
+  constexpr int64_t output_num_frames = 3;
+  constexpr int64_t dft_unique_bins = 257;
+
+  auto build_test_case = [&](ModelTestBuilder& builder) {
+    std::vector<float> signal_data(batch_size * signal_length);
+    for (size_t i = 0; i < signal_data.size(); ++i) {
+      signal_data[i] = static_cast<float>((static_cast<int>(i % 97) - 48) * 0.01f);
+    }
+
+    auto* signal = builder.MakeInput<float>({batch_size, signal_length}, signal_data);
+    auto* frame_step_arg = builder.MakeScalarInitializer<int64_t>(frame_step);
+    auto* frame_length = builder.MakeScalarInitializer<int64_t>(dft_size);
+    auto* output = builder.MakeOutput<float>({{batch_size, output_num_frames, dft_unique_bins, 2}});
+
+    builder.AddNode("STFT", {signal, frame_step_arg, builder.MakeEmptyInput(), frame_length}, {output})
+        .AddAttribute("onesided", static_cast<int64_t>(1));
+  };
+
+  auto check_transformed_graph = [&](InferenceSessionWrapper& session) {
+    const auto op_to_count = CountOpsInGraph(session.GetGraph());
+    ASSERT_EQ(op_to_count.count("STFT"), 0);
+    ASSERT_EQ(op_to_count.at("Conv"), 1);
+    ASSERT_EQ(op_to_count.at("Reshape"), 2);
+    ASSERT_EQ(op_to_count.at("Transpose"), 1);
+  };
+
+  TransformerTester(build_test_case,
+                    check_transformed_graph,
+                    TransformerLevel::Default,
+                    TransformerLevel::Level1,
+                    17,
+                    1e-5,
+                    1e-5,
+                    std::make_unique<STFTDecomposition>());
+}
+
+TEST_F(GraphTransformationTests, STFTDecomposition_RunsAtLevel2ByDefault) {
   constexpr int64_t batch_size = 2;
   constexpr int64_t signal_length = 12;
   constexpr int64_t dft_size = 5;
@@ -13226,7 +13267,7 @@ TEST_F(GraphTransformationTests, STFTDecomposition_RunsAtLevel1ByDefault) {
   TransformerTester(build_test_case,
                     check_transformed_graph,
                     TransformerLevel::Default,
-                    TransformerLevel::Level1,
+                    TransformerLevel::Level2,
                     17,
                     3e-4,
                     3e-4);
@@ -13270,6 +13311,74 @@ TEST_F(GraphTransformationTests, STFTDecomposition_SkipsLargeConvWeight) {
                                         TransformerLevel::Level1,
                                         1,
                                         pre_graph_checker,
+                                        post_graph_checker));
+}
+
+TEST_F(GraphTransformationTests, STFTDecomposition_SkipsDftSizeGreaterThanSignalLength) {
+  constexpr int64_t batch_size = 1;
+  constexpr int64_t signal_length = 8;
+  constexpr int64_t dft_size = 16;
+  constexpr int64_t frame_step = 2;
+
+  auto build_test_case = [&](ModelTestBuilder& builder) {
+    auto* signal = builder.MakeInput<float>(std::vector<int64_t>{batch_size, signal_length});
+    auto* frame_step_arg = builder.MakeScalarInitializer<int64_t>(frame_step);
+    auto* frame_length = builder.MakeScalarInitializer<int64_t>(dft_size);
+    auto* output = builder.MakeOutput<float>(std::nullopt);
+
+    builder.AddNode("STFT", {signal, frame_step_arg, builder.MakeEmptyInput(), frame_length}, {output})
+        .AddAttribute("onesided", static_cast<int64_t>(1));
+  };
+
+  auto post_graph_checker = [](Graph& graph) -> Status {
+    const auto op_to_count = CountOpsInGraph(graph);
+    TEST_RETURN_IF_NOT(op_to_count.at("STFT") == 1);
+    TEST_RETURN_IF_NOT(op_to_count.count("Conv") == 0);
+    return Status::OK();
+  };
+
+  ASSERT_STATUS_OK(TestGraphTransformer(build_test_case,
+                                        17,
+                                        *logger_,
+                                        std::make_unique<STFTDecomposition>(),
+                                        TransformerLevel::Level1,
+                                        1,
+                                        nullptr,
+                                        post_graph_checker));
+}
+
+TEST_F(GraphTransformationTests, STFTDecomposition_SkipsNonConstantFrameStep) {
+  constexpr int64_t batch_size = 2;
+  constexpr int64_t signal_length = 12;
+  constexpr int64_t dft_size = 5;
+  constexpr int64_t frame_step = 2;
+  constexpr int64_t output_num_frames = 4;
+  constexpr int64_t dft_unique_bins = 3;
+
+  auto build_test_case = [&](ModelTestBuilder& builder) {
+    auto* signal = builder.MakeInput<float>(std::vector<int64_t>{batch_size, signal_length});
+    auto* frame_step_arg = builder.MakeInput<int64_t>(std::vector<int64_t>{}, std::vector<int64_t>{frame_step});
+    auto* frame_length = builder.MakeScalarInitializer<int64_t>(dft_size);
+    auto* output = builder.MakeOutput<float>({{batch_size, output_num_frames, dft_unique_bins, 2}});
+
+    builder.AddNode("STFT", {signal, frame_step_arg, builder.MakeEmptyInput(), frame_length}, {output})
+        .AddAttribute("onesided", static_cast<int64_t>(1));
+  };
+
+  auto post_graph_checker = [](Graph& graph) -> Status {
+    const auto op_to_count = CountOpsInGraph(graph);
+    TEST_RETURN_IF_NOT(op_to_count.at("STFT") == 1);
+    TEST_RETURN_IF_NOT(op_to_count.count("Conv") == 0);
+    return Status::OK();
+  };
+
+  ASSERT_STATUS_OK(TestGraphTransformer(build_test_case,
+                                        17,
+                                        *logger_,
+                                        std::make_unique<STFTDecomposition>(),
+                                        TransformerLevel::Level1,
+                                        1,
+                                        nullptr,
                                         post_graph_checker));
 }
 

--- a/onnxruntime/test/optimizer/graph_transform_test.cc
+++ b/onnxruntime/test/optimizer/graph_transform_test.cc
@@ -13273,6 +13273,79 @@ TEST_F(GraphTransformationTests, STFTDecomposition_SkipsLargeConvWeight) {
                                         post_graph_checker));
 }
 
+TEST_F(GraphTransformationTests, STFTDecomposition_DmlTransformerAcceptsUnassignedNode) {
+  constexpr int64_t batch_size = 2;
+  constexpr int64_t signal_length = 12;
+  constexpr int64_t dft_size = 5;
+  constexpr int64_t frame_step = 2;
+  constexpr int64_t output_num_frames = 4;
+  constexpr int64_t dft_unique_bins = 3;
+
+  auto build_test_case = [&](ModelTestBuilder& builder) {
+    auto* signal = builder.MakeInput<float>(std::vector<int64_t>{batch_size, signal_length});
+    auto* frame_step_arg = builder.MakeScalarInitializer<int64_t>(frame_step);
+    auto* frame_length = builder.MakeScalarInitializer<int64_t>(dft_size);
+    auto* output = builder.MakeOutput<float>({{batch_size, output_num_frames, dft_unique_bins, 2}});
+
+    builder.AddNode("STFT", {signal, frame_step_arg, builder.MakeEmptyInput(), frame_length}, {output})
+        .AddAttribute("onesided", static_cast<int64_t>(1));
+  };
+
+  auto post_graph_checker = [](Graph& graph) -> Status {
+    const auto op_to_count = CountOpsInGraph(graph);
+    TEST_RETURN_IF_NOT(op_to_count.count("STFT") == 0);
+    TEST_RETURN_IF_NOT(op_to_count.at("Conv") == 1);
+    return Status::OK();
+  };
+
+  const InlinedHashSet<std::string_view> dml_ep = {kDmlExecutionProvider};
+  ASSERT_STATUS_OK(TestGraphTransformer(build_test_case,
+                                        17,
+                                        *logger_,
+                                        std::make_unique<STFTDecomposition>(dml_ep),
+                                        TransformerLevel::Level1,
+                                        1,
+                                        nullptr,
+                                        post_graph_checker));
+}
+
+TEST_F(GraphTransformationTests, STFTDecomposition_DmlTransformerSkipsAssignedCpuNode) {
+  constexpr int64_t batch_size = 2;
+  constexpr int64_t signal_length = 12;
+  constexpr int64_t dft_size = 5;
+  constexpr int64_t frame_step = 2;
+  constexpr int64_t output_num_frames = 4;
+  constexpr int64_t dft_unique_bins = 3;
+
+  auto build_test_case = [&](ModelTestBuilder& builder) {
+    auto* signal = builder.MakeInput<float>(std::vector<int64_t>{batch_size, signal_length});
+    auto* frame_step_arg = builder.MakeScalarInitializer<int64_t>(frame_step);
+    auto* frame_length = builder.MakeScalarInitializer<int64_t>(dft_size);
+    auto* output = builder.MakeOutput<float>({{batch_size, output_num_frames, dft_unique_bins, 2}});
+
+    auto& stft = builder.AddNode("STFT", {signal, frame_step_arg, builder.MakeEmptyInput(), frame_length}, {output});
+    stft.AddAttribute("onesided", static_cast<int64_t>(1));
+    stft.SetExecutionProviderType(kCpuExecutionProvider);
+  };
+
+  auto post_graph_checker = [](Graph& graph) -> Status {
+    const auto op_to_count = CountOpsInGraph(graph);
+    TEST_RETURN_IF_NOT(op_to_count.at("STFT") == 1);
+    TEST_RETURN_IF_NOT(op_to_count.count("Conv") == 0);
+    return Status::OK();
+  };
+
+  const InlinedHashSet<std::string_view> dml_ep = {kDmlExecutionProvider};
+  ASSERT_STATUS_OK(TestGraphTransformer(build_test_case,
+                                        17,
+                                        *logger_,
+                                        std::make_unique<STFTDecomposition>(dml_ep),
+                                        TransformerLevel::Level1,
+                                        1,
+                                        nullptr,
+                                        post_graph_checker));
+}
+
 TEST_F(GraphTransformationTests, STFTDecomposition_DoubleSkippedForCpu) {
   constexpr int64_t batch_size = 2;
   constexpr int64_t signal_length = 12;

--- a/onnxruntime/test/optimizer/graph_transform_test.cc
+++ b/onnxruntime/test/optimizer/graph_transform_test.cc
@@ -13110,6 +13110,88 @@ TEST_F(GraphTransformationTests, STFTDecomposition_Float2DNoWindow) {
                     std::make_unique<STFTDecomposition>());
 }
 
+TEST_F(GraphTransformationTests, STFTDecomposition_Int32FrameStepAndFrameLength) {
+  constexpr int64_t batch_size = 2;
+  constexpr int64_t signal_length = 12;
+  constexpr int32_t dft_size = 5;
+  constexpr int32_t frame_step = 2;
+  constexpr int64_t output_num_frames = 4;
+  constexpr int64_t dft_unique_bins = 3;
+
+  auto build_test_case = [&](ModelTestBuilder& builder) {
+    std::vector<float> signal_data(batch_size * signal_length);
+    for (size_t i = 0; i < signal_data.size(); ++i) {
+      signal_data[i] = static_cast<float>((static_cast<int>(i % 11) - 5) * 0.2f);
+    }
+
+    auto* signal = builder.MakeInput<float>({batch_size, signal_length}, signal_data);
+    auto* frame_step_arg = builder.MakeScalarInitializer<int32_t>(frame_step);
+    auto* frame_length = builder.MakeScalarInitializer<int32_t>(dft_size);
+    auto* output = builder.MakeOutput<float>({{batch_size, output_num_frames, dft_unique_bins, 2}});
+
+    builder.AddNode("STFT", {signal, frame_step_arg, builder.MakeEmptyInput(), frame_length}, {output})
+        .AddAttribute("onesided", static_cast<int64_t>(1));
+  };
+
+  auto check_transformed_graph = [&](InferenceSessionWrapper& session) {
+    const auto op_to_count = CountOpsInGraph(session.GetGraph());
+    ASSERT_EQ(op_to_count.count("STFT"), 0);
+    ASSERT_EQ(op_to_count.at("Conv"), 1);
+    ASSERT_EQ(op_to_count.at("Reshape"), 2);
+    ASSERT_EQ(op_to_count.at("Transpose"), 1);
+  };
+
+  TransformerTester(build_test_case,
+                    check_transformed_graph,
+                    TransformerLevel::Default,
+                    TransformerLevel::Level1,
+                    17,
+                    3e-4,
+                    3e-4,
+                    std::make_unique<STFTDecomposition>());
+}
+
+TEST_F(GraphTransformationTests, STFTDecomposition_OnesidedFalse) {
+  constexpr int64_t batch_size = 2;
+  constexpr int64_t signal_length = 12;
+  constexpr int64_t dft_size = 5;
+  constexpr int64_t frame_step = 2;
+  constexpr int64_t output_num_frames = 4;
+  constexpr int64_t dft_unique_bins = dft_size;
+
+  auto build_test_case = [&](ModelTestBuilder& builder) {
+    std::vector<float> signal_data(batch_size * signal_length);
+    for (size_t i = 0; i < signal_data.size(); ++i) {
+      signal_data[i] = static_cast<float>((static_cast<int>(i % 11) - 5) * 0.2f);
+    }
+
+    auto* signal = builder.MakeInput<float>({batch_size, signal_length}, signal_data);
+    auto* frame_step_arg = builder.MakeScalarInitializer<int64_t>(frame_step);
+    auto* frame_length = builder.MakeScalarInitializer<int64_t>(dft_size);
+    auto* output = builder.MakeOutput<float>({{batch_size, output_num_frames, dft_unique_bins, 2}});
+
+    builder.AddNode("STFT", {signal, frame_step_arg, builder.MakeEmptyInput(), frame_length}, {output})
+        .AddAttribute("onesided", static_cast<int64_t>(0));
+  };
+
+  auto check_transformed_graph = [&](InferenceSessionWrapper& session) {
+    const auto op_to_count = CountOpsInGraph(session.GetGraph());
+    ASSERT_EQ(op_to_count.count("STFT"), 0);
+    ASSERT_EQ(op_to_count.at("Conv"), 1);
+    ASSERT_EQ(op_to_count.at("Reshape"), 2);
+    ASSERT_EQ(op_to_count.at("Transpose"), 1);
+  };
+
+  TransformerTester(build_test_case,
+                    check_transformed_graph,
+                    TransformerLevel::Default,
+                    TransformerLevel::Level1,
+                    17,
+                    3e-4,
+                    3e-4,
+                    std::make_unique<STFTDecomposition>());
+}
+
 TEST_F(GraphTransformationTests, STFTDecomposition_RunsAtLevel1ByDefault) {
   constexpr int64_t batch_size = 2;
   constexpr int64_t signal_length = 12;
@@ -13148,6 +13230,47 @@ TEST_F(GraphTransformationTests, STFTDecomposition_RunsAtLevel1ByDefault) {
                     17,
                     3e-4,
                     3e-4);
+}
+
+TEST_F(GraphTransformationTests, STFTDecomposition_SkipsLargeConvWeight) {
+  constexpr int64_t batch_size = 1;
+  constexpr int64_t signal_length = 8192;
+  constexpr int64_t dft_size = 8192;
+  constexpr int64_t frame_step = 1;
+  constexpr int64_t output_num_frames = 1;
+  constexpr int64_t dft_unique_bins = 4097;
+
+  auto build_test_case = [&](ModelTestBuilder& builder) {
+    auto* signal = builder.MakeInput<float>(std::vector<int64_t>{batch_size, signal_length});
+    auto* frame_step_arg = builder.MakeScalarInitializer<int64_t>(frame_step);
+    auto* frame_length = builder.MakeScalarInitializer<int64_t>(dft_size);
+    auto* output = builder.MakeOutput<float>({{batch_size, output_num_frames, dft_unique_bins, 2}});
+
+    builder.AddNode("STFT", {signal, frame_step_arg, builder.MakeEmptyInput(), frame_length}, {output})
+        .AddAttribute("onesided", static_cast<int64_t>(1));
+  };
+
+  auto pre_graph_checker = [](Graph& graph) -> Status {
+    const auto op_to_count = CountOpsInGraph(graph);
+    TEST_RETURN_IF_NOT(op_to_count.at("STFT") == 1);
+    return Status::OK();
+  };
+
+  auto post_graph_checker = [](Graph& graph) -> Status {
+    const auto op_to_count = CountOpsInGraph(graph);
+    TEST_RETURN_IF_NOT(op_to_count.at("STFT") == 1);
+    TEST_RETURN_IF_NOT(op_to_count.count("Conv") == 0);
+    return Status::OK();
+  };
+
+  ASSERT_STATUS_OK(TestGraphTransformer(build_test_case,
+                                        17,
+                                        *logger_,
+                                        std::make_unique<STFTDecomposition>(),
+                                        TransformerLevel::Level1,
+                                        1,
+                                        pre_graph_checker,
+                                        post_graph_checker));
 }
 
 TEST_F(GraphTransformationTests, STFTDecomposition_DoubleSkippedForCpu) {


### PR DESCRIPTION
Fix #32403.

## Description

The CPU `STFT` kernel currently computes each frame independently. This is slow for batched short transforms, especially for non-power-of-two DFT sizes where the DFT path uses Bluestein internally.

We already have an `STFTDecomposition` transformer that can express real-valued STFT as standard ONNX ops, but it was not registered in the default CPU graph optimization path. This PR makes that decomposition available at Level2 with a CPU EP filter, so it runs after EP partitioning and only rewrites STFT nodes assigned or fallbacked to CPU.

The rewrite is:

```text
STFT
=> Reshape -> Conv -> Reshape -> Transpose
```

For constant float windows, the window is pre-multiplied into the generated Conv weights. Large generated Conv weights are capped at 64 MiB so large transforms remain as native STFT nodes instead of materializing an O(N^2) initializer.

## Local benchmark

Environment:

```text
Fedora 44
CPU: 11th Gen Intel(R) Core(TM) i5-11260H @ 2.60GHz
Build: Debug
Provider: CPUExecutionProvider
Threads: intra-op=1, inter-op=1
```

Benchmark compares the same STFT model with graph optimizations disabled versus STFT decomposition enabled.

| Model | Optimization | Avg latency | P50 latency | Throughput |
|---|---:|---:|---:|---:|
| `nfft=100`, `hop=10`, `signal_length=1000`, `batch=100` | disabled | 2492.61 ms | 2420.96 ms | 0.40/s |
| `nfft=100`, `hop=10`, `signal_length=1000`, `batch=100` | STFTDecomposition | 29.36 ms | 28.41 ms | 34.05/s |
| `nfft=128`, `hop=8`, `signal_length=1024`, `batch=100` | disabled | 574.96 ms | 570.40 ms | 1.74/s |
| `nfft=128`, `hop=8`, `signal_length=1024`, `batch=100` | STFTDecomposition | 48.00 ms | 46.38 ms | 20.83/s |
| `nfft=1024`, `hop=256`, `signal_length=8192`, `batch=64` | disabled (`-o 0`) | 1093.18 ms | 1076.51 ms | 0.91/s |
| `nfft=1024`, `hop=256`, `signal_length=8192`, `batch=64` | Level2 (`-o 2`) | 94.27 ms | 93.84 ms | 10.61/s |
| `nfft=2048`, `hop=512`, `signal_length=16384`, `batch=64` | disabled (`-o 0`) | 2327.06 ms | 2307.76 ms | 0.43/s |
| `nfft=2048`, `hop=512`, `signal_length=16384`, `batch=64` | Level2 (`-o 2`) | 304.03 ms | 298.09 ms | 3.29/s |

Observed local speedups:

- `nfft=100`: about `84.9x`
- `nfft=128`: about `12.0x`
- `nfft=1024`: about `11.6x`
- `nfft=2048`: about `7.7x`

The `nfft=1024/2048` data points show that the decomposition still helps beyond very small transforms, while the generated-weight cap keeps larger O(N^2) cases on the native STFT path.

The optimized graph contains:

```text
{'Reshape': 2, 'Conv': 1, 'Transpose': 1}
```

instead of retaining an `STFT` node.