### PR TITLE
MultiThreading Optimization: Reduce intra-op threading overhead: spin backoff and cost scale

### DIFF
--- a/onnxruntime/core/common/threadpool.cc
+++ b/onnxruntime/core/common/threadpool.cc
@@ -635,7 +635,7 @@ static ptrdiff_t CalculateParallelForBlock(const ptrdiff_t n, const Eigen::Tenso
 #endif
 
 static double ParallelForCostScale() {
-  static const double kScale = []() -> double {
+  static const double kScale = []() {
     double value = ORT_DEFAULT_PARALLEL_COST_SCALE;
 #if defined(_MSC_VER)
     char* buffer = nullptr;

--- a/onnxruntime/core/common/threadpool.cc
+++ b/onnxruntime/core/common/threadpool.cc
@@ -616,14 +616,56 @@ static ptrdiff_t CalculateParallelForBlock(const ptrdiff_t n, const Eigen::Tenso
   return block_size;
 }
 
+// Scales the cost estimate used only for the go/no-go parallelization decision.
+//
+// Eigen's cost model charges a flat kStartupCycles = 100000 cycles (~30 us at
+// current clocks) before a loop is considered worth splitting. That is far more
+// than this pool's measured fork-join cost, so loops that would benefit from
+// two or three threads are kept on the calling thread instead. Keeping them
+// serial is not free: profiling short CNN graphs shows the ops that stay on the
+// calling thread running ~80% slower once the pool has four threads, because
+// their inputs were just scattered across the other cores' private caches by
+// the neighbouring parallel ops. Lowering the threshold lets those ops recover
+// that cost.
+//
+// Block sizing deliberately continues to use the unscaled cost, so this only
+// changes whether a loop is split, never how finely.
+#if !defined(ORT_DEFAULT_PARALLEL_COST_SCALE)
+#define ORT_DEFAULT_PARALLEL_COST_SCALE 8.0
+#endif
+
+static double ParallelForCostScale() {
+  static const double kScale = []() -> double {
+    double value = ORT_DEFAULT_PARALLEL_COST_SCALE;
+#if defined(_MSC_VER)
+    char* buffer = nullptr;
+    size_t buffer_size = 0;
+    if (_dupenv_s(&buffer, &buffer_size, "ORT_PARALLEL_COST_SCALE") == 0 && buffer != nullptr) {
+      value = atof(buffer);
+      free(buffer);
+    }
+#else
+    if (const char* env = getenv("ORT_PARALLEL_COST_SCALE")) {
+      value = atof(env);
+    }
+#endif
+    return value > 0.0 ? value : 1.0;
+  }();
+  return kScale;
+}
+
 void ThreadPool::ParallelFor(std::ptrdiff_t n, const TensorOpCost& c,
                              const std::function<void(std::ptrdiff_t first, std::ptrdiff_t)>& f) {
   ORT_ENFORCE(n >= 0);
   Eigen::TensorOpCost cost{c.bytes_loaded, c.bytes_stored, c.compute_cycles};
   auto d_of_p = DegreeOfParallelism(this);
+  const double cost_scale = ParallelForCostScale();
+  Eigen::TensorOpCost decision_cost{c.bytes_loaded * cost_scale,
+                                    c.bytes_stored * cost_scale,
+                                    c.compute_cycles * cost_scale};
   // Compute small problems directly in the caller thread.
   if ((!ShouldParallelizeLoop(n)) ||
-      CostModel::numThreads(static_cast<double>(n), cost, d_of_p) == 1) {
+      CostModel::numThreads(static_cast<double>(n), decision_cost, d_of_p) == 1) {
     f(0, n);
     return;
   }

--- a/onnxruntime/core/session/inference_session.cc
+++ b/onnxruntime/core/session/inference_session.cc
@@ -145,7 +145,7 @@ PathString GetExternalInitializersFolderModelPath(const ConfigOptions& config_op
 #endif  // !defined(ORT_MINIMAL_BUILD)
 
 // Parse a spin backoff max config value (exponential-backoff cap). Defaults to
-// 1 (no backoff, one SpinPause() per iteration). Values >= 2 enable backoff.
+// 2 (one level of exponential backoff). Values >= 2 enable backoff; 1 = no backoff.
 unsigned int ParseSpinBackoffMax(std::string_view str, const char* config_key,
                                  const logging::Logger& logger) {
   unsigned int backoff = 1U;
@@ -564,11 +564,11 @@ void InferenceSession::ConstructorCommon(const SessionOptions& session_options,
               session_options_.config_options.GetConfigOrDefault(kOrtSessionOptionsConfigIntraOpSpinDurationUs, "-1"),
               kOrtSessionOptionsConfigIntraOpSpinDurationUs, *session_logger_);
           to.spin_backoff_max = ParseSpinBackoffMax(
-              session_options_.config_options.GetConfigOrDefault(kOrtSessionOptionsConfigIntraOpSpinBackoffMax, "1"),
+              session_options_.config_options.GetConfigOrDefault(kOrtSessionOptionsConfigIntraOpSpinBackoffMax, "2"),
               kOrtSessionOptionsConfigIntraOpSpinBackoffMax, *session_logger_);
         } else {
           to.spin_duration_us = concurrency::kSpinDurationDefault;
-          to.spin_backoff_max = 1U;
+          to.spin_backoff_max = 2U;
         }
         to.dynamic_block_base_ = std::stoi(session_options_.config_options.GetConfigOrDefault(kOrtSessionOptionsConfigDynamicBlockBase, "0"));
         LOGS(*session_logger_, INFO) << "Dynamic block base set to " << to.dynamic_block_base_;
@@ -622,11 +622,11 @@ void InferenceSession::ConstructorCommon(const SessionOptions& session_options,
               session_options_.config_options.GetConfigOrDefault(kOrtSessionOptionsConfigInterOpSpinDurationUs, "-1"),
               kOrtSessionOptionsConfigInterOpSpinDurationUs, *session_logger_);
           to.spin_backoff_max = ParseSpinBackoffMax(
-              session_options_.config_options.GetConfigOrDefault(kOrtSessionOptionsConfigInterOpSpinBackoffMax, "1"),
+              session_options_.config_options.GetConfigOrDefault(kOrtSessionOptionsConfigInterOpSpinBackoffMax, "2"),
               kOrtSessionOptionsConfigInterOpSpinBackoffMax, *session_logger_);
         } else {
           to.spin_duration_us = concurrency::kSpinDurationDefault;
-          to.spin_backoff_max = 1U;
+          to.spin_backoff_max = 2U;
         }
         to.dynamic_block_base_ = std::stoi(session_options_.config_options.GetConfigOrDefault(kOrtSessionOptionsConfigDynamicBlockBase, "0"));
 

--- a/onnxruntime/core/util/thread_utils.h
+++ b/onnxruntime/core/util/thread_utils.h
@@ -45,7 +45,14 @@ struct OrtThreadPoolParams {
   //                 tracks spin_duration_us.
   // Values above concurrency::kSpinBackoffMaxLimit are clamped to that limit.
   // Ignored when spinning is disabled or when spin_count is forced to zero.
-  unsigned int spin_backoff_max = 1;
+  //
+  // Defaults to 2. An idle worker re-polls its RunQueue about three times per
+  // spin iteration, so at backoff 1 the spinners keep the whole package at
+  // all-core clocks and contend with the ops that run on the calling thread.
+  // Halving that duty cycle measurably speeds up short inference graphs and,
+  // unlike disabling spinning, keeps the workers unparked so they still pick up
+  // the next dispatch without a kernel wake.
+  unsigned int spin_backoff_max = 2;
 
   // It it is non-negative, thread pool will split a task by a decreasing block size
   // of remaining_of_total_iterations / (num_of_threads * dynamic_block_base_)

--- a/onnxruntime/core/util/thread_utils.h
+++ b/onnxruntime/core/util/thread_utils.h
@@ -38,7 +38,7 @@ struct OrtThreadPoolParams {
   int spin_duration_us = onnxruntime::concurrency::kSpinDurationDefault;
 
   // Maximum exponential-backoff cap for the thread pool spin loop.
-  //   1 (default) = no backoff, one SpinPause() per iteration (original behavior).
+  //   1           = no backoff, one SpinPause() per iteration (original behavior).
   //   >= 2        = enable exponential backoff: each iteration emits 1, 2, 4, ...
   //                 SpinPause() calls, capped at this value. The iteration count
   //                 is scaled internally so the wall-clock spin window still

--- a/onnxruntime/test/framework/intra_op_threading_accuracy_test.cc
+++ b/onnxruntime/test/framework/intra_op_threading_accuracy_test.cc
@@ -1,0 +1,281 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+// End-to-end accuracy guards for the intra-op threading tuning:
+//   * OrtThreadPoolParams::spin_backoff_max default 1 -> 2
+//   * the ParallelFor go/no-go cost scale (ORT_PARALLEL_COST_SCALE,
+//     ORT_DEFAULT_PARALLEL_COST_SCALE, see threadpool.cc)
+//
+// Both are latency/power tunings that must not move a single output value. The
+// cost scale is the risky one: by lowering the threshold it makes ParallelFor
+// split loops that previously ran whole on the calling thread, so any kernel
+// whose result depends on how its loop was carved up would start drifting.
+//
+// These tests take one model, run it once with a single-threaded intra-op pool
+// (no ParallelFor splitting at all - the reference), then re-run it across a
+// range of intra-op thread counts and spin_backoff_max values, and compare every
+// output against that reference.
+//
+// The tests live in onnxruntime_test_all, so a normal
+//   build.py --build --test
+// verifies accuracy as part of the build. To also cover the pre-change decision
+// point, run the binary a second time with ORT_PARALLEL_COST_SCALE=1:
+//   onnxruntime_test_all --gtest_filter=IntraOpThreadingAccuracy.*
+// (threadpool.cc caches that lookup in a function-local static, so the scale is
+// fixed for the lifetime of a process and cannot be varied from inside a test.)
+
+#include <algorithm>
+#include <cmath>
+#include <functional>
+#include <memory>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include "gtest/gtest.h"
+
+#include "core/framework/tensor.h"
+#include "core/graph/model.h"
+#include "core/graph/onnx_protobuf.h"
+#include "core/session/inference_session.h"
+#include "core/session/onnxruntime_session_options_config_keys.h"
+#include "test/test_environment.h"
+#include "test/unittest_util/graph_transform_test_builder.h"
+#include "test/util/include/asserts.h"
+#include "test/util/include/inference_session_wrapper.h"
+
+namespace onnxruntime {
+namespace test {
+namespace {
+
+constexpr int kOpsetVersion = 13;
+
+// How a run's intra-op thread pool is configured.
+struct ThreadingConfig {
+  int intra_op_num_threads = 1;
+  // nullptr leaves session.intra_op.spin_backoff_max unset, i.e. exercises
+  // whatever OrtThreadPoolParams::spin_backoff_max currently defaults to.
+  const char* spin_backoff_max = nullptr;
+
+  std::string Describe() const {
+    std::ostringstream out;
+    out << "intra_op_num_threads=" << intra_op_num_threads
+        << " spin_backoff_max=" << (spin_backoff_max == nullptr ? "<default>" : spin_backoff_max);
+    return out.str();
+  }
+};
+
+// The reference: a single-threaded intra-op pool. CreateThreadPoolHelper returns
+// no pool for a size of 1, so every ParallelFor runs whole on the calling thread
+// and the cost scale cannot influence the result.
+const ThreadingConfig kReferenceConfig{/*intra_op_num_threads*/ 1, /*spin_backoff_max*/ nullptr};
+
+std::vector<ThreadingConfig> ThreadingConfigsUnderTest() {
+  std::vector<ThreadingConfig> configs;
+  for (int num_threads : {2, 4, 8}) {
+    // <default> pins the shipped default (2); 1 is the pre-change value; 8 and
+    // the clamped-above-limit value cover the rest of the range.
+    for (const char* backoff : {static_cast<const char*>(nullptr), "1", "2", "8", "1024"}) {
+      configs.push_back(ThreadingConfig{num_threads, backoff});
+    }
+  }
+  return configs;
+}
+
+// Builds the model once and serializes it, so every run below sees byte-identical
+// input. ModelTestBuilder seeds its value generator deterministically, so the
+// feeds are reproducible too.
+class ThreadingAccuracyModel {
+ public:
+  explicit ThreadingAccuracyModel(const std::function<void(ModelTestBuilder&)>& build_graph) {
+    std::unordered_map<std::string, int> domain_to_version;
+    domain_to_version[kOnnxDomain] = kOpsetVersion;
+    Model model("IntraOpThreadingAccuracy", false, ModelMetaData(), PathString(),
+                IOnnxRuntimeOpSchemaRegistryList(), domain_to_version, {},
+                DefaultLoggingManager().DefaultLogger());
+    ModelTestBuilder helper(model.MainGraph());
+    build_graph(helper);
+    helper.SetGraphOutputs();
+    ASSERT_STATUS_OK(model.MainGraph().Resolve());
+    model.ToProto().SerializeToString(&model_data_);
+    feeds_ = helper.feeds_;
+    output_names_ = helper.output_names_;
+  }
+
+  void Run(const ThreadingConfig& config, std::vector<OrtValue>& fetches) const {
+    SessionOptions session_options;
+    // Pin everything except the threading knobs so the runs differ only in
+    // how work is partitioned.
+    session_options.graph_optimization_level = TransformerLevel::Level2;
+    session_options.execution_mode = ExecutionMode::ORT_SEQUENTIAL;
+    session_options.use_per_session_threads = true;
+    session_options.intra_op_param.thread_pool_size = config.intra_op_num_threads;
+    if (config.spin_backoff_max != nullptr) {
+      ASSERT_STATUS_OK(session_options.config_options.AddConfigEntry(
+          kOrtSessionOptionsConfigIntraOpSpinBackoffMax, config.spin_backoff_max));
+    }
+
+    InferenceSessionWrapper session{session_options, GetEnvironment()};
+    std::istringstream model_istream(model_data_);
+    ASSERT_STATUS_OK(session.Load(model_istream));
+    ASSERT_STATUS_OK(session.Initialize());
+
+    RunOptions run_options;
+    ASSERT_STATUS_OK(session.Run(run_options, feeds_, output_names_, &fetches));
+    ASSERT_EQ(fetches.size(), output_names_.size());
+  }
+
+  const std::vector<std::string>& output_names() const { return output_names_; }
+
+ private:
+  std::string model_data_;
+  NameMLValMap feeds_;
+  std::vector<std::string> output_names_;
+};
+
+// Compares one float output. tolerance == 0 means bit-identical.
+void ExpectFloatOutputsMatch(const OrtValue& actual, const OrtValue& expected,
+                             double relative_tolerance, const std::string& context) {
+  ASSERT_TRUE(actual.IsTensor()) << context;
+  ASSERT_TRUE(expected.IsTensor()) << context;
+  const Tensor& actual_tensor = actual.Get<Tensor>();
+  const Tensor& expected_tensor = expected.Get<Tensor>();
+  ASSERT_EQ(actual_tensor.DataType(), DataTypeImpl::GetType<float>()) << context;
+  ASSERT_EQ(actual_tensor.Shape(), expected_tensor.Shape()) << context;
+
+  const auto actual_data = actual_tensor.DataAsSpan<float>();
+  const auto expected_data = expected_tensor.DataAsSpan<float>();
+  ASSERT_EQ(actual_data.size(), expected_data.size()) << context;
+
+  size_t mismatches = 0;
+  double worst_relative_diff = 0.0;
+  size_t worst_index = 0;
+  for (size_t i = 0; i < actual_data.size(); ++i) {
+    const float a = actual_data[i];
+    const float e = expected_data[i];
+    if (a == e) {
+      continue;
+    }
+    ++mismatches;
+    // Both values are finite and O(1) for these graphs; guard the divide anyway.
+    const double denominator = std::max(std::abs(static_cast<double>(e)), 1e-30);
+    const double relative_diff = std::abs(static_cast<double>(a) - static_cast<double>(e)) / denominator;
+    if (relative_diff > worst_relative_diff) {
+      worst_relative_diff = relative_diff;
+      worst_index = i;
+    }
+  }
+
+  if (relative_tolerance == 0.0) {
+    EXPECT_EQ(mismatches, 0u)
+        << context << ": " << mismatches << " of " << actual_data.size()
+        << " values changed; worst at index " << worst_index << " (" << actual_data[worst_index]
+        << " vs " << expected_data[worst_index] << ", relative " << worst_relative_diff << ")";
+  } else {
+    EXPECT_LE(worst_relative_diff, relative_tolerance)
+        << context << ": " << mismatches << " of " << actual_data.size()
+        << " values differ; worst at index " << worst_index << " (" << actual_data[worst_index]
+        << " vs " << expected_data[worst_index] << ")";
+  }
+}
+
+void ExpectAccuracyAcrossThreadingConfigs(const std::function<void(ModelTestBuilder&)>& build_graph,
+                                          double relative_tolerance) {
+  ThreadingAccuracyModel model(build_graph);
+  ASSERT_FALSE(::testing::Test::HasFatalFailure());
+
+  std::vector<OrtValue> reference_fetches;
+  ASSERT_NO_FATAL_FAILURE(model.Run(kReferenceConfig, reference_fetches));
+
+  for (const ThreadingConfig& config : ThreadingConfigsUnderTest()) {
+    std::vector<OrtValue> fetches;
+    ASSERT_NO_FATAL_FAILURE(model.Run(config, fetches));
+    ASSERT_EQ(fetches.size(), reference_fetches.size()) << config.Describe();
+    for (size_t i = 0; i < fetches.size(); ++i) {
+      const std::string context = config.Describe() + " output=" + model.output_names()[i];
+      ASSERT_NO_FATAL_FAILURE(
+          ExpectFloatOutputsMatch(fetches[i], reference_fetches[i], relative_tolerance, context));
+    }
+  }
+}
+
+// An elementwise/shape-only graph. Every op here computes each output element
+// from a fixed set of input elements, independent of the loop partitioning, so
+// the results must be bit-identical no matter how ParallelFor splits the work.
+// Shapes are large enough (32768 elements) that the cost model genuinely has a
+// parallelize/serialize choice to make.
+void BuildElementwiseGraph(ModelTestBuilder& builder) {
+  auto* x = builder.MakeInput<float>({64, 512}, -1.0f, 1.0f);
+  auto* w = builder.MakeInitializer<float>({64, 512}, -1.0f, 1.0f);
+
+  auto* sum = builder.MakeIntermediate();
+  builder.AddNode("Add", {x, w}, {sum});
+  auto* squared = builder.MakeIntermediate();
+  builder.AddNode("Mul", {sum, sum}, {squared});
+  auto* shifted = builder.MakeIntermediate();
+  builder.AddNode("Sub", {squared, w}, {shifted});
+  auto* relu = builder.MakeIntermediate();
+  builder.AddNode("Relu", {shifted}, {relu});
+  auto* sigmoid = builder.MakeIntermediate();
+  builder.AddNode("Sigmoid", {relu}, {sigmoid});
+  auto* tanh = builder.MakeIntermediate();
+  builder.AddNode("Tanh", {sigmoid}, {tanh});
+  auto* absolute = builder.MakeIntermediate();
+  builder.AddNode("Abs", {tanh}, {absolute});
+  auto* root = builder.MakeIntermediate();
+  builder.AddNode("Sqrt", {absolute}, {root});
+  auto* erf = builder.MakeIntermediate();
+  builder.AddNode("Erf", {root}, {erf});
+
+  // Two outputs: a divide (sigmoid is strictly positive, so no inf/nan can
+  // creep in and turn a bitwise comparison into a NaN != NaN false positive)
+  // and a transposed copy, so the layout pass through Transpose is covered too.
+  builder.AddNode("Div", {erf, sigmoid}, {builder.MakeOutput()});
+  builder.AddNode("Transpose", {erf}, {builder.MakeOutput()});
+}
+
+// A graph with the reduction-bearing ops that actually dominate inference time:
+// MatMul and Gemm (MLAS, which shards over M/N) plus Softmax (per-row
+// reductions). These are compared with a tolerance rather than bit-exactly,
+// because splitting a reduction across threads is allowed to reassociate the
+// float adds.
+void BuildComputeGraph(ModelTestBuilder& builder) {
+  auto* x = builder.MakeInput<float>({128, 256}, -1.0f, 1.0f);
+  auto* w1 = builder.MakeInitializer<float>({256, 512}, -0.5f, 0.5f);
+  auto* w2 = builder.MakeInitializer<float>({512, 256}, -0.5f, 0.5f);
+  auto* bias = builder.MakeInitializer<float>({512}, -0.5f, 0.5f);
+
+  auto* matmul1 = builder.MakeIntermediate();
+  builder.AddNode("MatMul", {x, w1}, {matmul1});
+  auto* biased = builder.MakeIntermediate();
+  builder.AddNode("Add", {matmul1, bias}, {biased});
+  auto* activated = builder.MakeIntermediate();
+  builder.AddNode("Relu", {biased}, {activated});
+  auto* matmul2 = builder.MakeIntermediate();
+  builder.AddNode("MatMul", {activated, w2}, {matmul2});
+  builder.AddNode("Softmax", {matmul2}, {builder.MakeOutput()});
+
+  auto* gemm = builder.MakeIntermediate();
+  builder.AddNode("Gemm", {x, w1, bias}, {gemm});
+  builder.AddNode("Sigmoid", {gemm}, {builder.MakeOutput()});
+}
+
+}  // namespace
+
+// Elementwise kernels have no cross-iteration dependency, so re-partitioning
+// their loops - which is exactly what the lowered cost threshold causes - must
+// leave every output bit-identical to the single-threaded run.
+TEST(IntraOpThreadingAccuracy, ElementwiseGraphIsBitIdenticalAcrossThreadingConfigs) {
+  ExpectAccuracyAcrossThreadingConfigs(BuildElementwiseGraph, /*relative_tolerance*/ 0.0);
+}
+
+// MatMul/Gemm/Softmax may legitimately reassociate their reductions when the
+// work is spread over more threads, so hold them to a tight relative tolerance
+// instead. A real accuracy regression (a mis-split range, a dropped tail block)
+// blows past 1e-5 by orders of magnitude.
+TEST(IntraOpThreadingAccuracy, ComputeGraphMatchesSingleThreadWithinTolerance) {
+  ExpectAccuracyAcrossThreadingConfigs(BuildComputeGraph, /*relative_tolerance*/ 1e-5);
+}
+
+}  // namespace test
+}  // namespace onnxruntime

--- a/onnxruntime/test/framework/intra_op_threading_accuracy_test.cc
+++ b/onnxruntime/test/framework/intra_op_threading_accuracy_test.cc
@@ -25,6 +25,7 @@
 // fixed for the lifetime of a process and cannot be varied from inside a test.)
 
 #include <algorithm>
+#include <array>
 #include <cmath>
 #include <functional>
 #include <memory>
@@ -70,13 +71,17 @@ struct ThreadingConfig {
 // and the cost scale cannot influence the result.
 const ThreadingConfig kReferenceConfig{/*intra_op_num_threads*/ 1, /*spin_backoff_max*/ nullptr};
 
+constexpr std::array<int, 3> kThreadCounts{2, 4, 8};
+// <default> pins the shipped default (2); 1 is the pre-change value; 8 and the
+// clamped-above-limit value cover the rest of the range.
+constexpr std::array<const char*, 5> kSpinBackoffMaxValues{nullptr, "1", "2", "8", "1024"};
+
 std::vector<ThreadingConfig> ThreadingConfigsUnderTest() {
   std::vector<ThreadingConfig> configs;
-  for (int num_threads : {2, 4, 8}) {
-    // <default> pins the shipped default (2); 1 is the pre-change value; 8 and
-    // the clamped-above-limit value cover the rest of the range.
-    for (const char* backoff : {static_cast<const char*>(nullptr), "1", "2", "8", "1024"}) {
-      configs.push_back(ThreadingConfig{num_threads, backoff});
+  configs.reserve(kThreadCounts.size() * kSpinBackoffMaxValues.size());
+  for (int num_threads : kThreadCounts) {
+    for (const char* backoff : kSpinBackoffMaxValues) {
+      configs.emplace_back(ThreadingConfig{num_threads, backoff});
     }
   }
   return configs;
@@ -87,7 +92,10 @@ std::vector<ThreadingConfig> ThreadingConfigsUnderTest() {
 // feeds are reproducible too.
 class ThreadingAccuracyModel {
  public:
-  explicit ThreadingAccuracyModel(const std::function<void(ModelTestBuilder&)>& build_graph) {
+  // Two-phase construction: the gtest ASSERT_* macros expand to a `return`
+  // statement, which a constructor is not allowed to use, so the fallible part
+  // of the setup lives here. Callers wrap this in ASSERT_NO_FATAL_FAILURE.
+  void Build(const std::function<void(ModelTestBuilder&)>& build_graph) {
     std::unordered_map<std::string, int> domain_to_version;
     domain_to_version[kOnnxDomain] = kOpsetVersion;
     Model model("IntraOpThreadingAccuracy", false, ModelMetaData(), PathString(),
@@ -181,8 +189,8 @@ void ExpectFloatOutputsMatch(const OrtValue& actual, const OrtValue& expected,
 
 void ExpectAccuracyAcrossThreadingConfigs(const std::function<void(ModelTestBuilder&)>& build_graph,
                                           double relative_tolerance) {
-  ThreadingAccuracyModel model(build_graph);
-  ASSERT_FALSE(::testing::Test::HasFatalFailure());
+  ThreadingAccuracyModel model;
+  ASSERT_NO_FATAL_FAILURE(model.Build(build_graph));
 
   std::vector<OrtValue> reference_fetches;
   ASSERT_NO_FATAL_FAILURE(model.Run(kReferenceConfig, reference_fetches));

--- a/onnxruntime/test/framework/intra_op_threading_accuracy_test.cc
+++ b/onnxruntime/test/framework/intra_op_threading_accuracy_test.cc
@@ -165,9 +165,12 @@ void ExpectFloatOutputsMatch(const OrtValue& actual, const OrtValue& expected,
       continue;
     }
     ++mismatches;
-    // Both values are finite and O(1) for these graphs; guard the divide anyway.
+    // The reference graphs produce finite values; any non-finite actual value is a failure.
     const double denominator = std::max(std::abs(static_cast<double>(e)), 1e-30);
-    const double relative_diff = std::abs(static_cast<double>(a) - static_cast<double>(e)) / denominator;
+    const double relative_diff =
+        std::isfinite(a)
+            ? std::abs(static_cast<double>(a) - static_cast<double>(e)) / denominator
+            : relative_tolerance + 1.0;
     if (relative_diff > worst_relative_diff) {
       worst_relative_diff = relative_diff;
       worst_index = i;

--- a/onnxruntime/test/platform/threadpool_test.cc
+++ b/onnxruntime/test/platform/threadpool_test.cc
@@ -1156,20 +1156,35 @@ using Block = std::pair<std::ptrdiff_t, std::ptrdiff_t>;
 // Runs the kernel over [0, n) through TryParallelFor with the given per-unit
 // cost, filling `out` and returning the block boundaries ParallelFor handed out,
 // sorted by start index.
+//
+// The blocks are recorded without a lock by giving each one a slot it owns
+// outright: its start index. There are at most n blocks and their starts are
+// distinct, so a vector sized n upfront gives every block a private destination
+// and no two threads ever touch the same element. A block's end index is never
+// negative, so kUnclaimed marks a slot no block wrote to. Compacting the
+// claimed slots in index order then yields exactly the sorted block list,
+// without a separate sort.
 std::vector<Block> RunElementwise(ThreadPool* tp, std::ptrdiff_t n,
                                   const onnxruntime::TensorOpCost& cost,
                                   std::vector<float>& out) {
+  constexpr std::ptrdiff_t kUnclaimed = -1;
   out.assign(static_cast<size_t>(n), 0.0f);
-  std::vector<Block> blocks;
-  std::mutex blocks_mutex;
+  std::vector<Block> blocks(static_cast<size_t>(n), Block{0, kUnclaimed});
   ThreadPool::TryParallelFor(tp, n, cost, [&](std::ptrdiff_t first, std::ptrdiff_t last) {
     for (std::ptrdiff_t i = first; i < last; ++i) {
       out[static_cast<size_t>(i)] = ElementKernel(i);
     }
-    std::lock_guard<std::mutex> guard(blocks_mutex);
-    blocks.emplace_back(first, last);
+    blocks[static_cast<size_t>(first)] = Block{first, last};
   });
-  std::sort(blocks.begin(), blocks.end());
+  // TryParallelFor joins every block before returning, so those writes are
+  // visible here.
+  size_t claimed = 0;
+  for (size_t i = 0; i < blocks.size(); ++i) {
+    if (blocks[i].second != kUnclaimed) {
+      blocks[claimed++] = blocks[i];
+    }
+  }
+  blocks.resize(claimed);
   return blocks;
 }
 

--- a/onnxruntime/test/platform/threadpool_test.cc
+++ b/onnxruntime/test/platform/threadpool_test.cc
@@ -15,6 +15,9 @@
 #include <algorithm>
 #include <memory>
 #include <functional>
+#include <string>
+#include <utility>
+#include <vector>
 
 #ifdef _WIN32
 #include <Windows.h>
@@ -1100,5 +1103,223 @@ TEST(ThreadPoolTest, InvalidOrtEnvVarValueThrows) {
                OnnxRuntimeException);
 }
 #endif
+
+// -------------------------------------------------------------------
+// Accuracy guards for the intra-op threading tuning: the spin_backoff_max
+// default and the ParallelFor go/no-go cost scale.
+//
+// Neither knob is meant to change a single numeric result. The cost scale only
+// moves the point at which ParallelFor decides a loop is worth splitting (block
+// sizing keeps using the unscaled cost), and spin_backoff_max only changes how
+// an idle worker waits. Both, though, change *how* - and whether - a loop is
+// carved into blocks, so a loop body that is not invariant under
+// re-partitioning would start drifting silently. These tests pin that
+// invariance down across the whole space of partitionings ParallelFor can hand
+// out: thread count, dynamic_block_base_, per-iteration cost and backoff cap.
+//
+// Note on the cost scale itself: ParallelForCostScale() in threadpool.cc caches
+// the ORT_PARALLEL_COST_SCALE lookup in a function-local static, so its value is
+// fixed for the lifetime of the process and cannot be varied from inside a
+// single test binary. Rather than assert on one scale, these tests assert the
+// property that has to hold at *every* scale, and CostBasedSplitDecisionIsAThreshold
+// checks that the scale in force behaves as a clean threshold. Running the
+// binary a second time with ORT_PARALLEL_COST_SCALE=1 exercises the pre-change
+// decision point against the same assertions.
+// -------------------------------------------------------------------
+namespace {
+
+// Per-iteration body. Strongly index-dependent, so an index that is skipped,
+// visited twice, or handed to the wrong block shows up immediately - but built
+// only from exactly-representable float arithmetic (integers below 2^24 scaled
+// by powers of two), so every operation is exact. That keeps the expected
+// result independent of vectorization and of whether the compiler contracts a
+// multiply-add into an FMA, which would otherwise make a bitwise comparison
+// between the serial and parallel code paths flaky rather than meaningful.
+float ElementKernel(std::ptrdiff_t i) {
+  float acc = static_cast<float>(i % 97);
+  for (int k = 0; k < 8; ++k) {
+    acc = acc * 2.0f + static_cast<float>((i + k) % 13);
+  }
+  return acc * 0.25f;
+}
+
+std::vector<float> SerialReference(std::ptrdiff_t n) {
+  std::vector<float> out(static_cast<size_t>(n));
+  for (std::ptrdiff_t i = 0; i < n; ++i) {
+    out[static_cast<size_t>(i)] = ElementKernel(i);
+  }
+  return out;
+}
+
+using Block = std::pair<std::ptrdiff_t, std::ptrdiff_t>;
+
+// Runs the kernel over [0, n) through TryParallelFor with the given per-unit
+// cost, filling `out` and returning the block boundaries ParallelFor handed out,
+// sorted by start index.
+std::vector<Block> RunElementwise(ThreadPool* tp, std::ptrdiff_t n,
+                                  const onnxruntime::TensorOpCost& cost,
+                                  std::vector<float>& out) {
+  out.assign(static_cast<size_t>(n), 0.0f);
+  std::vector<Block> blocks;
+  std::mutex blocks_mutex;
+  ThreadPool::TryParallelFor(tp, n, cost, [&](std::ptrdiff_t first, std::ptrdiff_t last) {
+    for (std::ptrdiff_t i = first; i < last; ++i) {
+      out[static_cast<size_t>(i)] = ElementKernel(i);
+    }
+    std::lock_guard<std::mutex> guard(blocks_mutex);
+    blocks.emplace_back(first, last);
+  });
+  std::sort(blocks.begin(), blocks.end());
+  return blocks;
+}
+
+// The contract every ParallelFor caller relies on: the blocks tile [0, n)
+// exactly once, in increasing order, with no gap and no overlap.
+void ExpectBlocksTileRange(const std::vector<Block>& blocks, std::ptrdiff_t n,
+                           const std::string& context) {
+  ASSERT_FALSE(blocks.empty()) << context;
+  std::ptrdiff_t expected_start = 0;
+  for (const auto& block : blocks) {
+    ASSERT_EQ(block.first, expected_start) << context;
+    ASSERT_GT(block.second, block.first) << context;
+    expected_start = block.second;
+  }
+  ASSERT_EQ(expected_start, n) << context;
+}
+
+// Reports the first differing index rather than dumping both vectors, which
+// would be tens of thousands of values wide for the larger loop sizes.
+void ExpectSameValues(const std::vector<float>& actual, const std::vector<float>& expected,
+                      const std::string& context) {
+  ASSERT_EQ(actual.size(), expected.size()) << context;
+  size_t mismatches = 0;
+  size_t first_mismatch = 0;
+  for (size_t i = 0; i < actual.size(); ++i) {
+    if (actual[i] != expected[i]) {
+      if (mismatches == 0) {
+        first_mismatch = i;
+      }
+      ++mismatches;
+    }
+  }
+  ASSERT_EQ(mismatches, 0u) << context << ": " << mismatches << " of " << actual.size()
+                            << " values differ; first at index " << first_mismatch << " ("
+                            << actual[first_mismatch] << " vs " << expected[first_mismatch] << ")";
+}
+
+std::unique_ptr<ThreadPool> MakePool(int num_threads, int dynamic_block_base = 0,
+                                     unsigned int spin_backoff_max = 1U) {
+  if (num_threads <= 0) {
+    return nullptr;  // exercises the no-pool path
+  }
+  onnxruntime::ThreadOptions thread_options;
+  thread_options.dynamic_block_base_ = dynamic_block_base;
+  return std::make_unique<ThreadPool>(&onnxruntime::Env::Default(),
+                                      thread_options,
+                                      nullptr,
+                                      num_threads,
+                                      onnxruntime::concurrency::kSpinDurationDefault,
+                                      /*force_hybrid*/ false,
+                                      spin_backoff_max);
+}
+
+// Per-iteration costs spanning both sides of Eigen's parallelization threshold
+// (kStartupCycles = 100000) for the loop sizes used below, at any cost scale
+// between 1 and a few hundred.
+const std::vector<double> kCostSweep{0.0, 1.0, 4.0, 16.0, 20.0, 64.0, 256.0,
+                                     1024.0, 4096.0, 16384.0, 262144.0};
+
+}  // namespace
+
+// The new default. Guards against a rebase or a merge quietly restoring 1.
+TEST(ThreadPoolTest, SpinBackoffMaxDefaultIsTwo) {
+  const OrtThreadPoolParams defaults;
+  EXPECT_EQ(defaults.spin_backoff_max, 2U);
+  EXPECT_LE(defaults.spin_backoff_max, concurrency::kSpinBackoffMaxLimit);
+}
+
+// Core accuracy guard for the cost-scale change: whatever the scale decides,
+// the values produced must be bit-identical to the serial computation. Sweeping
+// thread count x dynamic_block_base_ x per-iteration cost covers both the
+// "stayed serial" and the "got split" outcomes, and every block size the
+// scheduler can pick in between.
+TEST(ThreadPoolTest, ParallelForResultsAreBitIdenticalUnderAllPartitionings) {
+  for (std::ptrdiff_t n : {std::ptrdiff_t{1}, std::ptrdiff_t{2}, std::ptrdiff_t{97},
+                           std::ptrdiff_t{1024}, std::ptrdiff_t{4096}, std::ptrdiff_t{65537}}) {
+    const std::vector<float> reference = SerialReference(n);
+    for (int num_threads : {0, 1, 2, 4, 8}) {
+      for (int dynamic_block_base : {0, 1, 4}) {
+        auto tp = MakePool(num_threads, dynamic_block_base);
+        for (double compute_cycles : kCostSweep) {
+          const onnxruntime::TensorOpCost cost{0.0, 0.0, compute_cycles};
+          std::vector<float> actual;
+          const auto blocks = RunElementwise(tp.get(), n, cost, actual);
+
+          const std::string context = "n=" + std::to_string(n) +
+                                      " threads=" + std::to_string(num_threads) +
+                                      " dynamic_block_base=" + std::to_string(dynamic_block_base) +
+                                      " compute_cycles=" + std::to_string(compute_cycles);
+          ASSERT_NO_FATAL_FAILURE(ExpectBlocksTileRange(blocks, n, context));
+          // Bit-identical, not merely close: re-partitioning an elementwise loop
+          // must not perturb a single result.
+          ASSERT_NO_FATAL_FAILURE(ExpectSameValues(actual, reference, context));
+        }
+      }
+    }
+  }
+}
+
+// Same guard for the spin_backoff_max change. Backoff only affects how idle
+// workers wait, so results must be identical for every legal value, including
+// values above kSpinBackoffMaxLimit (which are clamped, not rejected).
+TEST(ThreadPoolTest, SpinBackoffDoesNotChangeParallelForResults) {
+  constexpr std::ptrdiff_t n = 4096;
+  const std::vector<float> reference = SerialReference(n);
+  for (unsigned int spin_backoff_max : {1U, 2U, 4U, 8U,
+                                        concurrency::kSpinBackoffMaxLimit,
+                                        concurrency::kSpinBackoffMaxLimit * 4U}) {
+    for (int num_threads : {1, 2, 4}) {
+      auto tp = MakePool(num_threads, /*dynamic_block_base*/ 0, spin_backoff_max);
+      for (double compute_cycles : {0.0, 20.0, 4096.0}) {
+        std::vector<float> actual;
+        const auto blocks = RunElementwise(tp.get(), n,
+                                           onnxruntime::TensorOpCost{0.0, 0.0, compute_cycles},
+                                           actual);
+        const std::string context = "spin_backoff_max=" + std::to_string(spin_backoff_max) +
+                                    " threads=" + std::to_string(num_threads) +
+                                    " compute_cycles=" + std::to_string(compute_cycles);
+        ASSERT_NO_FATAL_FAILURE(ExpectBlocksTileRange(blocks, n, context));
+        ASSERT_NO_FATAL_FAILURE(ExpectSameValues(actual, reference, context));
+      }
+    }
+  }
+}
+
+// The scaled cost is only allowed to move the go/no-go point, so the decision
+// must stay a monotone threshold in the per-iteration cost: once a loop of a
+// given size is worth splitting, a more expensive one is too. Holds at any
+// ORT_PARALLEL_COST_SCALE, and would catch the scale leaking into the block
+// sizing (which still uses the unscaled cost) as a non-monotone block count.
+TEST(ThreadPoolTest, CostBasedSplitDecisionIsAThreshold) {
+  constexpr std::ptrdiff_t n = 65537;
+  auto tp = MakePool(4);
+  bool seen_split = false;
+  for (double compute_cycles : kCostSweep) {
+    std::vector<float> actual;
+    const auto blocks = RunElementwise(tp.get(), n,
+                                       onnxruntime::TensorOpCost{0.0, 0.0, compute_cycles},
+                                       actual);
+    const bool split = blocks.size() > 1;
+    const std::string context = "compute_cycles=" + std::to_string(compute_cycles);
+    if (seen_split) {
+      EXPECT_TRUE(split) << "split decision is not monotone in cost at " << context;
+    }
+    seen_split = seen_split || split;
+  }
+  // The sweep spans several orders of magnitude either side of Eigen's
+  // threshold, so at least the top of it has to parallelize on a 4-thread pool.
+  EXPECT_TRUE(seen_split) << "no cost in the sweep parallelized; the cost model or "
+                             "ORT_PARALLEL_COST_SCALE is not doing anything";
+}
 
 }  // namespace onnxruntime

--- a/onnxruntime/test/platform/threadpool_test.cc
+++ b/onnxruntime/test/platform/threadpool_test.cc
@@ -1337,4 +1337,23 @@ TEST(ThreadPoolTest, CostBasedSplitDecisionIsAThreshold) {
                              "ORT_PARALLEL_COST_SCALE is not doing anything";
 }
 
+// Pins ORT_DEFAULT_PARALLEL_COST_SCALE=8 and verifies it causes a different
+// split decision than scale=1 at a known boundary.
+//
+// With n=65537 and compute_cycles=1.0 on a 4-thread pool:
+//   scale=1 : n * cost =     65,537 < Eigen kStartupCycles (100,000) → serial
+//   scale=8 : n * cost * 8 = 524,296 > kStartupCycles               → split
+//
+// If this fails, ORT_DEFAULT_PARALLEL_COST_SCALE was reverted to 1 or the
+// scale is not reaching the split decision in ParallelFor.
+TEST(ThreadPoolTest, CostScaleDefaultSplitsAtKnownBoundary) {
+  constexpr std::ptrdiff_t n = 65537;
+  auto tp = MakePool(4);
+  std::vector<float> actual;
+  const auto blocks = RunElementwise(tp.get(), n, onnxruntime::TensorOpCost{0.0, 0.0, 1.0}, actual);
+  EXPECT_GT(blocks.size(), 1u)
+      << "n=" << n << " compute_cycles=1.0 must split at ORT_DEFAULT_PARALLEL_COST_SCALE=8 "
+         "(would stay serial at scale=1); constant was reverted or scale is being bypassed";
+}
+
 }  // namespace onnxruntime


### PR DESCRIPTION
### Description
spin_backoff_max 1->2: halves idle-worker poll duty cycle, cuts SpinPause

ParallelForCostScale x8: lowers Eigen's parallelization threshold so borderline loops get split across threads instead of running serial on the main thread with cold cache. Block sizing unchanged.

Observation:

The optimization shows meaningful gains in MobileNetV3_large (4T, +6.12%), MobileNetV3_small (2T, +7.38%; 4T, +4.98%), and Mobileclip_s0 (1T, +4.78%). All YOLOX variants fail to show a qualifying gain and regress at 4T for yolox_small

<img width="361" height="347" alt="mt_mtspin" src="https://github.com/user-attachments/assets/f445dfe2-28d9-457a-b03c-c8be93664a80" />