### PR TITLE
Fix XNNPACK EP std::terminate on Resize with empty scales initializer

### DIFF
--- a/onnxruntime/core/providers/xnnpack/tensor/resize.cc
+++ b/onnxruntime/core/providers/xnnpack/tensor/resize.cc
@@ -100,9 +100,10 @@ bool Resize::IsOnnxNodeSupported(const NodeUnit& node_unit,
     if (size_tensor) {
       const Initializer size_val(graph_viewer.GetGraph(), *size_tensor, node_unit.ModelPath());
       const auto sizes = size_val.DataAsSpan<int64_t>();
-      // As with `scales` above, `sizes` must be the rank-4 NCHW vector. Guard the length before
-      // indexing so a malformed/empty `sizes` initializer is rejected here instead of tripping the
-      // gsl::span bounds check and std::terminate()ing the process (issue #32298).
+      // As with `scales` above, `sizes` must be the rank-4 NCHW vector. ONNX requires
+      // len(sizes) == rank(X) so a valid model always satisfies this, but guard the length anyway:
+      // an out-of-range index here is an uncatchable std::terminate() rather than an error status
+      // (issue #32298). Defense in depth against a malformed model.
       if (sizes.size() != 4 || sizes[1] != x_shape->dim(1).dim_value()) {
         break;
       }

--- a/onnxruntime/core/providers/xnnpack/tensor/resize.cc
+++ b/onnxruntime/core/providers/xnnpack/tensor/resize.cc
@@ -67,6 +67,14 @@ bool Resize::IsOnnxNodeSupported(const NodeUnit& node_unit,
     if (scale_tensor) {
       const Initializer scale_val(graph_viewer.GetGraph(), *scale_tensor, node_unit.ModelPath());
       const auto scales = scale_val.DataAsSpan<float>();
+      // This checker only handles the rank-4 NCHW case (see the dim_size() != 4 check above), so
+      // `scales` must have exactly 4 elements. tf2onnx (opset 11) exports Resize with a zero-length
+      // `scales` initializer passed positionally alongside a real `sizes` input; without this guard
+      // the indexing below reads past the end of the span and std::terminate()s the process during
+      // graph partitioning (issue #32298). Anything else: let the node fall back to CPU.
+      if (scales.size() != 4) {
+        break;
+      }
       if (scales[1] != 1.0F) {
         break;
       }
@@ -91,7 +99,11 @@ bool Resize::IsOnnxNodeSupported(const NodeUnit& node_unit,
 
     if (size_tensor) {
       const Initializer size_val(graph_viewer.GetGraph(), *size_tensor, node_unit.ModelPath());
-      if (size_val.DataAsSpan<int64_t>()[1] != x_shape->dim(1).dim_value()) {
+      const auto sizes = size_val.DataAsSpan<int64_t>();
+      // As with `scales` above, `sizes` must be the rank-4 NCHW vector. Guard the length before
+      // indexing so a malformed/empty `sizes` initializer is rejected here instead of tripping the
+      // gsl::span bounds check and std::terminate()ing the process (issue #32298).
+      if (sizes.size() != 4 || sizes[1] != x_shape->dim(1).dim_value()) {
         break;
       }
     }

--- a/onnxruntime/test/providers/xnnpack/xnnpack_basic_test.cc
+++ b/onnxruntime/test/providers/xnnpack/xnnpack_basic_test.cc
@@ -743,9 +743,11 @@ TEST(XnnpackEP, TestResize_EmptyScales_NoTerminate) {
     resize_node.AddAttribute("mode", "linear");
     resize_node.AddAttribute("coordinate_transformation_mode", "asymmetric");
   };
-  // ExpectedEPNodeAssignment::None asserts both that the session initialized without aborting AND
-  // that XNNPACK rejected the malformed Resize. RunModelTest also compares the run against the pure
-  // CPU baseline, verifying the fallback is numerically correct.
+  // The Resize itself is valid ONNX: the empty scales initializer is the positional placeholder for
+  // the populated sizes input. ExpectedEPNodeAssignment::None asserts both that the session
+  // initialized without aborting AND that XNNPACK declined to take the node (it does not support
+  // this form) rather than crashing. RunModelTest also compares the run against the pure CPU
+  // baseline, verifying the fallback is numerically correct.
   RunModelTest(modelBuilder, "xnnpack_test_graph_resize_empty_scales",
                {
                    ExpectedEPNodeAssignment::None,

--- a/onnxruntime/test/providers/xnnpack/xnnpack_basic_test.cc
+++ b/onnxruntime/test/providers/xnnpack/xnnpack_basic_test.cc
@@ -753,30 +753,6 @@ TEST(XnnpackEP, TestResize_EmptyScales_NoTerminate) {
                });
 }
 
-// Companion to TestResize_EmptyScales_NoTerminate for the `sizes` branch of
-// Resize::IsOnnxNodeSupported (issue #32298). A conformant Resize supplies `scales` and passes an
-// empty `sizes` initializer for the omitted input. Before the length guard, size_val.DataAsSpan
-// <int64_t>()[1] on that zero-length span tripped the GSL bounds check -> std::terminate() during
-// GetCapability. The checker must reject it and fall back to the CPU EP instead.
-TEST(XnnpackEP, TestResize_EmptySizes_NoTerminate) {
-  const std::vector<int64_t> input_shape = {1, 3, 32, 32};
-  auto modelBuilder = [&](ModelTestBuilder& builder) {
-    auto* input = builder.MakeInput<float>(input_shape, -1.f, 1.f);
-    auto* roi = builder.MakeInitializer<float>({0}, {});
-    auto* scales = builder.MakeInitializer<float>({4}, {1.0f, 1.0f, 2.0f, 2.0f});
-    auto* sizes = builder.MakeInitializer<int64_t>({0}, {});  // empty -> the trigger
-    auto* output_arg = builder.MakeOutput();
-    auto& resize_node = builder.AddNode("Resize", {input, roi, scales, sizes}, {output_arg});
-    resize_node.AddAttribute("mode", "linear");
-    resize_node.AddAttribute("coordinate_transformation_mode", "asymmetric");
-  };
-  RunModelTest(modelBuilder, "xnnpack_test_graph_resize_empty_sizes",
-               {
-                   ExpectedEPNodeAssignment::None,
-                   1e-4f /* fp32_abs_err */,
-               });
-}
-
 #endif
 
 }  // namespace test

--- a/onnxruntime/test/providers/xnnpack/xnnpack_basic_test.cc
+++ b/onnxruntime/test/providers/xnnpack/xnnpack_basic_test.cc
@@ -725,6 +725,34 @@ TEST(XnnpackEP, TestGemm_DynamicM) {
                });
 }
 
+// Regression test for https://github.com/microsoft/onnxruntime/issues/32298.
+// tf2onnx (opset 11) exports Resize with a zero-length `scales` initializer passed positionally
+// alongside a real `sizes` input. GetConstantInitializer returns a non-null but empty tensor, and
+// Resize::IsOnnxNodeSupported indexed the resulting zero-length gsl::span (scales[1]), tripping the
+// GSL bounds check -> std::terminate() during GetCapability graph partitioning, before any kernel
+// ran. The support check must reject the node cleanly so it falls back to the CPU EP.
+TEST(XnnpackEP, TestResize_EmptyScales_NoTerminate) {
+  const std::vector<int64_t> input_shape = {1, 3, 32, 32};
+  auto modelBuilder = [&](ModelTestBuilder& builder) {
+    auto* input = builder.MakeInput<float>(input_shape, -1.f, 1.f);
+    auto* roi = builder.MakeInitializer<float>({0}, {});     // empty optional input
+    auto* scales = builder.MakeInitializer<float>({0}, {});  // empty -> the trigger
+    auto* sizes = builder.Make1DInitializer<int64_t>({1, 3, 16, 16});
+    auto* output_arg = builder.MakeOutput();
+    auto& resize_node = builder.AddNode("Resize", {input, roi, scales, sizes}, {output_arg});
+    resize_node.AddAttribute("mode", "linear");
+    resize_node.AddAttribute("coordinate_transformation_mode", "asymmetric");
+  };
+  // ExpectedEPNodeAssignment::None asserts both that the session initialized without aborting AND
+  // that XNNPACK rejected the malformed Resize. RunModelTest also compares the run against the pure
+  // CPU baseline, verifying the fallback is numerically correct.
+  RunModelTest(modelBuilder, "xnnpack_test_graph_resize_empty_scales",
+               {
+                   ExpectedEPNodeAssignment::None,
+                   1e-4f /* fp32_abs_err */,
+               });
+}
+
 #endif
 
 }  // namespace test

--- a/onnxruntime/test/providers/xnnpack/xnnpack_basic_test.cc
+++ b/onnxruntime/test/providers/xnnpack/xnnpack_basic_test.cc
@@ -753,6 +753,30 @@ TEST(XnnpackEP, TestResize_EmptyScales_NoTerminate) {
                });
 }
 
+// Companion to TestResize_EmptyScales_NoTerminate for the `sizes` branch of
+// Resize::IsOnnxNodeSupported (issue #32298). A conformant Resize supplies `scales` and passes an
+// empty `sizes` initializer for the omitted input. Before the length guard, size_val.DataAsSpan
+// <int64_t>()[1] on that zero-length span tripped the GSL bounds check -> std::terminate() during
+// GetCapability. The checker must reject it and fall back to the CPU EP instead.
+TEST(XnnpackEP, TestResize_EmptySizes_NoTerminate) {
+  const std::vector<int64_t> input_shape = {1, 3, 32, 32};
+  auto modelBuilder = [&](ModelTestBuilder& builder) {
+    auto* input = builder.MakeInput<float>(input_shape, -1.f, 1.f);
+    auto* roi = builder.MakeInitializer<float>({0}, {});
+    auto* scales = builder.MakeInitializer<float>({4}, {1.0f, 1.0f, 2.0f, 2.0f});
+    auto* sizes = builder.MakeInitializer<int64_t>({0}, {});  // empty -> the trigger
+    auto* output_arg = builder.MakeOutput();
+    auto& resize_node = builder.AddNode("Resize", {input, roi, scales, sizes}, {output_arg});
+    resize_node.AddAttribute("mode", "linear");
+    resize_node.AddAttribute("coordinate_transformation_mode", "asymmetric");
+  };
+  RunModelTest(modelBuilder, "xnnpack_test_graph_resize_empty_sizes",
+               {
+                   ExpectedEPNodeAssignment::None,
+                   1e-4f /* fp32_abs_err */,
+               });
+}
+
 #endif
 
 }  // namespace test


### PR DESCRIPTION
### Description

`Resize::IsOnnxNodeSupported` in the XNNPACK EP read `scales` / `sizes` initializer data without
first checking the span length, which aborted the process on a valid model. This adds the two
missing length guards and a pair of regression tests.

The checker already restricts itself to the rank-4 NCHW case (it rejects anything where
`x_shape->dim_size() != 4`), and ONNX requires `len(scales) == len(sizes) == rank(X)`, so both
vectors must have exactly 4 elements. Guard the span length before indexing; anything else — notably
a zero-length initializer — is rejected here and the node falls back to the CPU EP.

This strictly converts a crash into the already-existing "unsupported -> CPU" behaviour. No `Resize`
that is accepted today changes, and nothing new reaches the `Resize` kernel constructor or
`Compute`.

### Motivation and Context

`tf2onnx` exports opset-11 `Resize` nodes with four inputs (`X`, `roi`, `scales`, `sizes`) where
`scales` is a **zero-length** float initializer passed positionally alongside a real `sizes` input
(e.g. MoveNet SinglePose Lightning v4, which has three such nodes). This is valid ONNX and runs fine
on the CPU EP.

With the XNNPACK EP registered, the process **aborts with `std::terminate`** during
`InferenceSession::Initialize()`, so callers cannot catch it and fall back:

- `Resize::IsOnnxNodeSupported` fetches the `scales` initializer. `Graph::GetConstantInitializer`
  has no length check, so it returns a non-null but **empty** `TensorProto`.
- `Initializer::DataAsSpan<float>()` performs only a *type* check and returns a clean **zero-length**
  `gsl::span`.
- Indexing `scales[1]` then trips `gsl::span::operator[]`'s `Expects(idx < size())`. ONNX Runtime
  builds against Microsoft GSL (v4.2.1 via `cmake/deps.txt`, v4.2.2 via the vcpkg path) and never
  defines `GSL_THROW_ON_CONTRACT_VIOLATION`, so the default `GSL_TERMINATE_ON_CONTRACT_VIOLATION`
  handler calls `std::terminate()` — not a C++ exception, so it escapes the `ORT_TRY`/`ORT_CATCH`
  in `Initialize()`.
- This runs during `GetCapability` graph partitioning, before any kernel is constructed. It is also
  reached *before* the `mode != "linear"` check, so it fires regardless of the resize mode.

The identical unguarded pattern existed for the `sizes` initializer further down the same function.

### Testing

`XnnpackEP.TestResize_EmptyScales_NoTerminate` is added next to the existing
`TestGemm_*_NoSegfault` family in `onnxruntime/test/providers/xnnpack/xnnpack_basic_test.cc`, which
covers the same class of capability-check crash. It asserts `ExpectedEPNodeAssignment::None` (the
node is cleanly rejected and the session initializes without aborting) and compares against the
pure-CPU baseline, so the fallback is verified numerically too.

I verified this as a before/after pair on a macOS arm64 Debug build with `--use_xnnpack`
(`MacOS CI Pipeline`, `xnnpack` job) — the same configuration this repo already runs.

**Without the `resize.cc` change**, the test binary aborts on entry, taking the whole
`onnxruntime_provider_test` process with it (`1 tests failed out of 13`,
`3 - onnxruntime_provider_test (Subprocess aborted)`):

```
[       OK ] XnnpackEP.TestGemm_DynamicM (5 ms)
[ RUN      ] XnnpackEP.TestResize_EmptyScales_NoTerminate
libc++abi: terminating
```

**With the change**, it passes and the rest of the suite is unaffected:

```
[ RUN      ] XnnpackEP.TestResize_EmptyScales_NoTerminate
[       OK ] XnnpackEP.TestResize_EmptyScales_NoTerminate (5 ms)
```

Note this is a reintroduction guard: pre-fix the binary aborts rather than failing an assertion, so
it cannot be written as a death test that passes on the unfixed tree.

#### On the `sizes` guard

The second guard has no dedicated test, deliberately. I tried to add one and it turned out to be
unconstructible: ONNX requires `len(sizes) == rank(X)`, and the empty-`sizes` variant is rejected
earlier by ORT's own CPU kernel — `upsample.cc` does
`ORT_RETURN_IF_NOT(sizes == nullptr, "Only one of scales or sizes must be provided as input.")`,
which tests the input pointer rather than emptiness. So no model ORT will execute can reach that
index.

I kept the guard anyway because an out-of-range index there is an uncatchable `std::terminate()`
rather than an error status, and the comment says as much. Happy to drop it if you'd rather not
carry unreachable defensive code.

### Out of scope

Pre-existing issues found while investigating, deliberately not changed here to keep the fix
minimal:

- `Resize::Resize` indexes `output_dims_[1]`/`[2]`, which can be empty when the input H/W are
  dynamic. Reachable only through the already-supported `sizes` path, unchanged by this PR.
- The later `node_unit.Outputs()[0].node_arg.Shape()` dereference in the same checker is not
  null-guarded.
- `onnxruntime/core/providers/xnnpack/math/softmax.cc` has the same unguarded
  `DataAsSpan<...>()[0]` pattern. Lower risk — those are QDQ scale/zero-point operands, which the op
  schema guarantees are scalars.

Happy to fold any of these in here or as a follow-up if preferred.

Fixes #32298

🤖 Generated with [Claude Code](https://claude.com/claude-code)
