### PR TITLE
Enable WebGPU GQA local-window flash attention

### DIFF
--- a/onnxruntime/contrib_ops/webgpu/bert/flash_attention.cc
+++ b/onnxruntime/contrib_ops/webgpu/bert/flash_attention.cc
@@ -631,7 +631,8 @@ Status ComputeFlashAttentionDecodeQKV(onnxruntime::webgpu::ComputeContext& conte
                                       const WebgpuAttentionParameters& parameters, const Tensor* indirect_buffer, uint32_t num_total_seq_length_tile, uint32_t num_present_sequence_length_tile, uint32_t tile_size, bool use_indirect_dispatch, uint32_t present_sequence_length, uint32_t m_tile, bool use_seqlen_k, const Tensor* total_seqlen,
                                       uint32_t kv_cache_quantization_bits,
                                       int compressed_head_size_u32,
-                                      bool use_seqlens_q, const Tensor* seqlens_q) {
+                                      bool use_seqlens_q, const Tensor* seqlens_q,
+                                      int local_window_size) {
   const float alpha = parameters.scale_ == 0.0f ? 1.f / sqrt(static_cast<float>(parameters.head_size_))
                                                 : parameters.scale_;
 
@@ -690,7 +691,7 @@ Status ComputeFlashAttentionDecodeQKV(onnxruntime::webgpu::ComputeContext& conte
   program.SetWorkgroupSize(workgroup_size)
       .CacheHint(tile_size, head_size_vec, has_attention_bias, use_indirect_dispatch, q_BNSH,
                  is_unidirectional, m_tile, use_seqlen_k, kv_cache_quantization_bits,
-                 compressed_head_size_u32, use_seqlens_q)
+                 compressed_head_size_u32, use_seqlens_q, local_window_size)
       .AddUniformVariables({{static_cast<uint32_t>(vectorized_head_size)},
                             {static_cast<uint32_t>(parameters.total_sequence_length_)},
                             {static_cast<float>(alpha)},
@@ -702,7 +703,8 @@ Status ComputeFlashAttentionDecodeQKV(onnxruntime::webgpu::ComputeContext& conte
                             {attn_bias_dim0},
                             {attn_bias_dim1},
                             {attn_bias_dim3},
-                            {static_cast<uint32_t>(parameters.sequence_length_)}});
+                            {static_cast<uint32_t>(parameters.sequence_length_)},
+                            {static_cast<uint32_t>(std::max(local_window_size, 0))}});
 
   return context.RunProgram(program);
 }
@@ -1221,9 +1223,8 @@ Status ApplyFlashAttention(const Tensor* Q, const Tensor* K, const Tensor* V, co
           kv_cache_quantization_bits, is_qualcomm, dense_prefill_workgroup_size,
           context.DeviceLimits().maxComputeWorkgroupStorageSize);
   const bool use_split_reduce =
-      !has_local_window &&
-      (parameters.sequence_length_ < 32 ||
-       (!use_paged_kv_cache && !dense_prefill_fits_workgroup_storage));
+      parameters.sequence_length_ < 32 ||
+      (!use_paged_kv_cache && !dense_prefill_fits_workgroup_storage);
 
   if (!use_split_reduce) {
     // Ask the shared helper whether the fused paged-prefill shader can run on
@@ -1428,7 +1429,7 @@ Status ApplyFlashAttention(const Tensor* Q, const Tensor* K, const Tensor* V, co
                                                          present_sequence_length, m_tile, use_seqlen_k, total_seqlen,
                                                          kv_cache_quantization_bits,
                                                          compressed_head_size_u32,
-                                                         use_seqlens_q, seqlens_q));
+                                                         use_seqlens_q, seqlens_q, local_window_size));
 
       ORT_RETURN_IF_ERROR(ComputeFlashAttentionDecodeVxReduce(context, &out_split_vx, &metadata, attn_output, seqlen_k, parameters,
                                                               num_total_seq_length_tile,

--- a/onnxruntime/contrib_ops/webgpu/bert/flash_attention.h
+++ b/onnxruntime/contrib_ops/webgpu/bert/flash_attention.h
@@ -230,7 +230,8 @@ class FlashAttentionDecodeQKVProgram final : public Program<FlashAttentionDecode
                                           {"attn_bias_dim0", ProgramUniformVariableDataType::Uint32},
                                           {"attn_bias_dim1", ProgramUniformVariableDataType::Uint32},
                                           {"attn_bias_dim3", ProgramUniformVariableDataType::Uint32},
-                                          {"new_sequence_length", ProgramUniformVariableDataType::Uint32});
+                                          {"new_sequence_length", ProgramUniformVariableDataType::Uint32},
+                                          {"local_window_size", ProgramUniformVariableDataType::Uint32});
 
  private:
   bool has_attention_bias_;

--- a/onnxruntime/contrib_ops/webgpu/bert/flash_attention_decode_qkv.wgsl.template
+++ b/onnxruntime/contrib_ops/webgpu/bert/flash_attention_decode_qkv.wgsl.template
@@ -107,6 +107,24 @@ $MAIN {
   #else
   let total_sequence_length = global_total_sequence_length;
   #endif
+  let window_start = select(0u,
+                            total_sequence_length - uniforms.local_window_size,
+                            uniforms.local_window_size > 0u &&
+                                total_sequence_length > uniforms.local_window_size);
+  // Whole tiles outside the window must publish a zero softmax sum. Masking every
+  // element to the finite fp16 minimum would otherwise give the tile nonzero weight.
+  if (total_seq_offset >= total_sequence_length || total_seq_offset + tile_size <= window_start) {
+    if (local_idx == 0u) {
+      for (var m = 0u; m < m_tile && q_base + m < uniforms.new_sequence_length; m++) {
+        let q_idx_local = q_base + m;
+        let meta_offset = (batch_head_idx * uniforms.new_sequence_length + q_idx_local) *
+                          uniforms.num_present_sequence_length_tile +
+                          workgroup_idx % num_total_seq_length_tile;
+        metadata.setByOffset(meta_offset, metadata_value_t(-3.4028234663852886e+38f, 0.0f));
+      }
+    }
+    return;
+  }
 
 #if kv_cache_quantization
   let kv_head_offset = (batch_head_idx / uniforms.n_reps) * uniforms.present_sequence_length * COMPRESSED_HEAD_U32;
@@ -249,6 +267,11 @@ $MAIN {
         sum = f32(-3.4028234663852886e+38f);
       }
 #endif
+      let causal_sequence_length = past_sequence_length + q_idx + 1u;
+      if (uniforms.local_window_size > 0u &&
+          total_seq_offset + local_idx + uniforms.local_window_size < causal_sequence_length) {
+        sum = q_element_t(-65504.0f);
+      }
       tile_qk[m][local_idx] = sum;
     }
     workgroupBarrier();

--- a/onnxruntime/contrib_ops/webgpu/bert/flash_attention_decode_qkv.wgsl.template
+++ b/onnxruntime/contrib_ops/webgpu/bert/flash_attention_decode_qkv.wgsl.template
@@ -107,6 +107,8 @@ $MAIN {
   #else
   let total_sequence_length = global_total_sequence_length;
   #endif
+  // Tiles beyond this batch's logical sequence publish neutral metadata so VxReduce
+  // ignores them for every query row. This applies to both quantized and dense KV caches.
   if (total_seq_offset >= total_sequence_length) {
     if (local_idx == 0u) {
       for (var m = 0u; m < m_tile && q_base + m < uniforms.new_sequence_length; m++) {
@@ -185,19 +187,6 @@ $MAIN {
 #else
   let present_key_offset = batch_head_idx / uniforms.n_reps * uniforms.present_sequence_length * uniforms.head_size_vec;
   let present_value_offset = u32(batch_head_idx / uniforms.n_reps) * v_head_size_vec * uniforms.present_sequence_length;
-
-  // If this workgroup's tile lies entirely beyond this batch's per-batch total_sequence_length,
-  // write neutral metadata so VxReduce contributes nothing for these tiles, then exit early.
-  if (total_seq_offset >= total_sequence_length) {
-    if (local_idx == 0u) {
-      for (var m = 0u; m < m_tile && q_base + m < uniforms.new_sequence_length; m++) {
-        let q_idx_local = q_base + m;
-        let meta_offset = (batch_head_idx * uniforms.new_sequence_length + q_idx_local) * uniforms.num_present_sequence_length_tile + workgroup_idx % num_total_seq_length_tile;
-        metadata.setByOffset(meta_offset, metadata_value_t(-3.4028234663852886e+38f, 0.0f));
-      }
-    }
-    return;
-  }
 
   // ============================================================
   // Phase 1: QK^T computation

--- a/onnxruntime/contrib_ops/webgpu/bert/flash_attention_decode_qkv.wgsl.template
+++ b/onnxruntime/contrib_ops/webgpu/bert/flash_attention_decode_qkv.wgsl.template
@@ -263,7 +263,7 @@ $MAIN {
       let causal_sequence_length = past_sequence_length + q_idx + 1u;
       if (uniforms.local_window_size > 0u &&
           total_seq_offset + local_idx + uniforms.local_window_size < causal_sequence_length) {
-        sum = q_element_t(-65504.0f);
+        sum = f32(-3.4028234663852886e+38f);
       }
 #endif
       tile_qk[m][local_idx] = sum;

--- a/onnxruntime/contrib_ops/webgpu/bert/flash_attention_decode_qkv.wgsl.template
+++ b/onnxruntime/contrib_ops/webgpu/bert/flash_attention_decode_qkv.wgsl.template
@@ -107,13 +107,7 @@ $MAIN {
   #else
   let total_sequence_length = global_total_sequence_length;
   #endif
-  let window_start = select(0u,
-                            total_sequence_length - uniforms.local_window_size,
-                            uniforms.local_window_size > 0u &&
-                                total_sequence_length > uniforms.local_window_size);
-  // Whole tiles outside the window must publish a zero softmax sum. Masking every
-  // element to the finite fp16 minimum would otherwise give the tile nonzero weight.
-  if (total_seq_offset >= total_sequence_length || total_seq_offset + tile_size <= window_start) {
+  if (total_seq_offset >= total_sequence_length) {
     if (local_idx == 0u) {
       for (var m = 0u; m < m_tile && q_base + m < uniforms.new_sequence_length; m++) {
         let q_idx_local = q_base + m;
@@ -280,16 +274,24 @@ $MAIN {
     if (local_idx == 0u) {
 #if is_unidirectional
       let valid_key_end = min(total_sequence_length, past_sequence_length + q_idx + 1u);
+      let valid_key_start = select(0u, valid_key_end - uniforms.local_window_size,
+                                   uniforms.local_window_size > 0u &&
+                                       valid_key_end > uniforms.local_window_size);
 #else
       let valid_key_end = total_sequence_length;
+      let valid_key_start = 0u;
 #endif
       var l_max = f32(-3.4028234663852886e+38f);
       var l_sum = f32(0);
       for (var i = 0u; i < tile_size && (total_seq_offset + i) < valid_key_end; i++) {
-        l_max = max(l_max, f32(tile_qk[m][i]));
+        if (total_seq_offset + i >= valid_key_start) {
+          l_max = max(l_max, f32(tile_qk[m][i]));
+        }
       }
       for (var i = 0u; i < tile_size && (total_seq_offset + i) < valid_key_end; i++) {
-        l_sum += exp(f32(tile_qk[m][i]) - l_max);
+        if (total_seq_offset + i >= valid_key_start) {
+          l_sum += exp(f32(tile_qk[m][i]) - l_max);
+        }
       }
       tile_max[m] = l_max;
       tile_sum[m] = l_sum;
@@ -308,10 +310,15 @@ $MAIN {
     if (local_idx < tile_size && total_seq_offset + local_idx < total_sequence_length) {
 #if is_unidirectional
       let valid_key_end = min(total_sequence_length, past_sequence_length + q_base + m + 1u);
+      let valid_key_start = select(0u, valid_key_end - uniforms.local_window_size,
+                                   uniforms.local_window_size > 0u &&
+                                       valid_key_end > uniforms.local_window_size);
 #else
       let valid_key_end = total_sequence_length;
+      let valid_key_start = 0u;
 #endif
-      if (total_seq_offset + local_idx < valid_key_end && tile_sum[m] > 0.0f) {
+      if (total_seq_offset + local_idx >= valid_key_start &&
+          total_seq_offset + local_idx < valid_key_end && tile_sum[m] > 0.0f) {
         tile_qk[m][local_idx] = exp(f32(tile_qk[m][local_idx]) - tile_max[m]) / tile_sum[m];
       } else {
         tile_qk[m][local_idx] = 0;

--- a/onnxruntime/contrib_ops/webgpu/bert/flash_attention_decode_qkv.wgsl.template
+++ b/onnxruntime/contrib_ops/webgpu/bert/flash_attention_decode_qkv.wgsl.template
@@ -266,12 +266,12 @@ $MAIN {
       if (total_seq_offset + local_idx > past_sequence_length + q_idx) {
         sum = f32(-3.4028234663852886e+38f);
       }
-#endif
       let causal_sequence_length = past_sequence_length + q_idx + 1u;
       if (uniforms.local_window_size > 0u &&
           total_seq_offset + local_idx + uniforms.local_window_size < causal_sequence_length) {
         sum = q_element_t(-65504.0f);
       }
+#endif
       tile_qk[m][local_idx] = sum;
     }
     workgroupBarrier();

--- a/onnxruntime/contrib_ops/webgpu/bert/group_query_attention.cc
+++ b/onnxruntime/contrib_ops/webgpu/bert/group_query_attention.cc
@@ -394,6 +394,7 @@ Status GroupQueryAttention::ComputeInternal(onnxruntime::webgpu::ComputeContext&
   // flash attention and apply the local window dynamically from seqlens_k in the shader.
   const bool use_dynamic_flash_window = context.IsGraphCaptureEnabled() &&
                                         parameters.sequence_length_ == 1 &&
+                                        !kv_empty &&
                                         local_window_size_ != -1;
   const int flash_local_window_size = use_dynamic_flash_window ? local_window_size_ : -1;
   bool will_use_flash_attention = false;

--- a/onnxruntime/contrib_ops/webgpu/bert/group_query_attention.cc
+++ b/onnxruntime/contrib_ops/webgpu/bert/group_query_attention.cc
@@ -395,6 +395,7 @@ Status GroupQueryAttention::ComputeInternal(onnxruntime::webgpu::ComputeContext&
   const bool use_dynamic_flash_window = context.IsGraphCaptureEnabled() &&
                                         parameters.sequence_length_ == 1 &&
                                         local_window_size_ != -1;
+  const int flash_local_window_size = use_dynamic_flash_window ? local_window_size_ : -1;
   bool will_use_flash_attention = false;
   // For kv_empty layers (shared KV), sliding window is irrelevant — there's no new KV to window
   // over, the layer reuses another layer's already-computed KV cache. Flash attention is required
@@ -438,7 +439,7 @@ Status GroupQueryAttention::ComputeInternal(onnxruntime::webgpu::ComputeContext&
       // query points to packed QKV, K and V are nullptr since they're not needed
       return ApplyFlashAttention(query, nullptr, nullptr, attention_bias, output, past_key, present_key, past_value,
                                  present_value, parameters, context, seqlen_k, cos_cache, sin_cache, head_sink,
-                                 total_seqlen_tensor, nullptr, nullptr, 0, 0, nullptr, local_window_size_);
+                                 total_seqlen_tensor, nullptr, nullptr, 0, 0, nullptr, flash_local_window_size);
     }
     // Fused: splitQKV + rotary QK
     qSplit = context.CreateGPUTensor(query->DataType(), TensorShape({parameters.batch_size_, parameters.sequence_length_, parameters.hidden_size_}));
@@ -530,7 +531,7 @@ Status GroupQueryAttention::ComputeInternal(onnxruntime::webgpu::ComputeContext&
   if (will_use_flash_attention) {
     return ApplyFlashAttention(query, key, value, attention_bias, output, past_key, present_key, past_value,
                                present_value, parameters, context, seqlen_k, nullptr, nullptr, head_sink,
-                               total_seqlen_tensor, nullptr, nullptr, 0, 0, nullptr, local_window_size_);
+                               total_seqlen_tensor, nullptr, nullptr, 0, 0, nullptr, flash_local_window_size);
   }
 
   // KV cache quantization compresses the KV cache; non-flash attention paths cannot interpret it.

--- a/onnxruntime/contrib_ops/webgpu/bert/group_query_attention.cc
+++ b/onnxruntime/contrib_ops/webgpu/bert/group_query_attention.cc
@@ -388,20 +388,9 @@ Status GroupQueryAttention::ComputeInternal(onnxruntime::webgpu::ComputeContext&
   Tensor qRotary;
   Tensor kRotary;
 
-  // Use a sliding window if the total sequence exceeds the window's length.
-  bool use_sliding_window = (local_window_size_ != -1 && local_window_size_ < parameters.total_sequence_length_);
-  // During graph capture the logical sequence length lives on the GPU. Keep decode on
-  // flash attention and apply the local window dynamically from seqlens_k in the shader.
-  const bool use_dynamic_flash_window = context.IsGraphCaptureEnabled() &&
-                                        parameters.sequence_length_ == 1 &&
-                                        !kv_empty &&
-                                        local_window_size_ != -1;
-  const int flash_local_window_size = use_dynamic_flash_window ? local_window_size_ : -1;
+  const int flash_local_window_size = kv_empty ? -1 : local_window_size_;
   bool will_use_flash_attention = false;
-  // For kv_empty layers (shared KV), sliding window is irrelevant — there's no new KV to window
-  // over, the layer reuses another layer's already-computed KV cache. Flash attention is required
-  // for these layers, so we bypass the sliding window check to allow it.
-  if (!use_smooth_softmax_ && (!use_sliding_window || kv_empty || use_dynamic_flash_window)) {
+  if (!use_smooth_softmax_) {
     // Create a temporary parameters copy with is_packed_qkv_ set to false to check if flash attention can be applied after unpacking
     WebgpuAttentionParameters temp_params = parameters;
     temp_params.is_packed_qkv_ = false;

--- a/onnxruntime/contrib_ops/webgpu/bert/group_query_attention.cc
+++ b/onnxruntime/contrib_ops/webgpu/bert/group_query_attention.cc
@@ -390,11 +390,16 @@ Status GroupQueryAttention::ComputeInternal(onnxruntime::webgpu::ComputeContext&
 
   // Use a sliding window if the total sequence exceeds the window's length.
   bool use_sliding_window = (local_window_size_ != -1 && local_window_size_ < parameters.total_sequence_length_);
+  // During graph capture the logical sequence length lives on the GPU. Keep decode on
+  // flash attention and apply the local window dynamically from seqlens_k in the shader.
+  const bool use_dynamic_flash_window = context.IsGraphCaptureEnabled() &&
+                                        parameters.sequence_length_ == 1 &&
+                                        local_window_size_ != -1;
   bool will_use_flash_attention = false;
   // For kv_empty layers (shared KV), sliding window is irrelevant — there's no new KV to window
   // over, the layer reuses another layer's already-computed KV cache. Flash attention is required
   // for these layers, so we bypass the sliding window check to allow it.
-  if (!use_smooth_softmax_ && (!use_sliding_window || kv_empty)) {
+  if (!use_smooth_softmax_ && (!use_sliding_window || kv_empty || use_dynamic_flash_window)) {
     // Create a temporary parameters copy with is_packed_qkv_ set to false to check if flash attention can be applied after unpacking
     WebgpuAttentionParameters temp_params = parameters;
     temp_params.is_packed_qkv_ = false;
@@ -433,7 +438,7 @@ Status GroupQueryAttention::ComputeInternal(onnxruntime::webgpu::ComputeContext&
       // query points to packed QKV, K and V are nullptr since they're not needed
       return ApplyFlashAttention(query, nullptr, nullptr, attention_bias, output, past_key, present_key, past_value,
                                  present_value, parameters, context, seqlen_k, cos_cache, sin_cache, head_sink,
-                                 total_seqlen_tensor);
+                                 total_seqlen_tensor, nullptr, nullptr, 0, 0, nullptr, local_window_size_);
     }
     // Fused: splitQKV + rotary QK
     qSplit = context.CreateGPUTensor(query->DataType(), TensorShape({parameters.batch_size_, parameters.sequence_length_, parameters.hidden_size_}));
@@ -525,7 +530,7 @@ Status GroupQueryAttention::ComputeInternal(onnxruntime::webgpu::ComputeContext&
   if (will_use_flash_attention) {
     return ApplyFlashAttention(query, key, value, attention_bias, output, past_key, present_key, past_value,
                                present_value, parameters, context, seqlen_k, nullptr, nullptr, head_sink,
-                               total_seqlen_tensor);
+                               total_seqlen_tensor, nullptr, nullptr, 0, 0, nullptr, local_window_size_);
   }
 
   // KV cache quantization compresses the KV cache; non-flash attention paths cannot interpret it.

--- a/onnxruntime/test/contrib_ops/group_query_attention_op_test.cc
+++ b/onnxruntime/test/contrib_ops/group_query_attention_op_test.cc
@@ -4119,6 +4119,18 @@ static void RunIndirectDispatchGraphCapture(bool do_rotary,
   RunOptions run_options;
   ORT_THROW_IF_ERROR(session.Run(run_options, *io_binding));
   auto first_output = read_output();
+  if (local_window_size != -1) {
+    auto poisoned_key = past_key_data;
+    auto poisoned_value = past_value_data;
+    const size_t batch_offset = kv_num_heads * cache_sequence_length * cache_head_size;
+    const size_t excluded_tile_size = 64 * kv_num_heads * cache_head_size;
+    std::fill_n(poisoned_key.begin() + batch_offset, excluded_tile_size, 100.0f);
+    std::fill_n(poisoned_value.begin() + batch_offset, excluded_tile_size, 100.0f);
+    update_gpu_value(past_key_value, poisoned_key.data(), DataTypeImpl::GetType<float>(), cache_shape);
+    update_gpu_value(past_value_value, poisoned_value.data(), DataTypeImpl::GetType<float>(), cache_shape);
+    ORT_THROW_IF_ERROR(session.Run(run_options, *io_binding));
+    EXPECT_EQ(first_output, read_output()) << "KV entries outside the local window affected replay";
+  }
 
   if (kv_cache_quant_bits == 8 && do_rotary && rotary_interleaved) {
     constexpr int reference_sequence_length = short_total_sequence_length;

--- a/onnxruntime/test/contrib_ops/group_query_attention_op_test.cc
+++ b/onnxruntime/test/contrib_ops/group_query_attention_op_test.cc
@@ -421,6 +421,11 @@ TEST(GroupQueryAttentionTest, LocalWindowMultiToken_WebGPU) {
 }
 
 TEST(GroupQueryAttentionTest, LocalWindowPrefill_WebGPU) {
+  auto webgpu_ep = DefaultWebGpuExecutionProvider();
+  if (!webgpu_ep) {
+    GTEST_SKIP() << "WebGPU EP not available";
+  }
+
   constexpr int sequence_length = 32;
   constexpr int head_size = 8;
   std::vector<float> value(sequence_length * head_size);
@@ -451,7 +456,7 @@ TEST(GroupQueryAttentionTest, LocalWindowPrefill_WebGPU) {
                           std::vector<float>(sequence_length * head_size, 0.0f));
   tester.AddOutput<float>("present_value", {1, 1, sequence_length, head_size}, value);
   std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
-  execution_providers.push_back(DefaultWebGpuExecutionProvider());
+  execution_providers.push_back(std::move(webgpu_ep));
   tester.Run(OpTester::ExpectResult::kExpectSuccess, "", {}, nullptr, &execution_providers);
 }
 

--- a/onnxruntime/test/contrib_ops/group_query_attention_op_test.cc
+++ b/onnxruntime/test/contrib_ops/group_query_attention_op_test.cc
@@ -413,6 +413,48 @@ TEST(GroupQueryAttentionTest, InvalidCausalValue_CUDA) {
 }
 
 #ifdef USE_WEBGPU
+TEST(GroupQueryAttentionTest, LocalWindowMultiToken_WebGPU) {
+  std::vector<float> expected(16, 1.0f);
+  std::fill(expected.begin() + 8, expected.end(), 3.0f);
+  RunGQACausalMaskTest<float>(GqaTargetEp::kWebGpu, 1, expected,
+                              OpTester::ExpectResult::kExpectSuccess, "", 1);
+}
+
+TEST(GroupQueryAttentionTest, LocalWindowPrefill_WebGPU) {
+  constexpr int sequence_length = 32;
+  constexpr int head_size = 8;
+  std::vector<float> value(sequence_length * head_size);
+  for (int s = 0; s < sequence_length; ++s) {
+    std::fill_n(value.begin() + s * head_size, head_size, static_cast<float>(s + 1));
+  }
+
+  OpTester tester("GroupQueryAttention", 1, kMSDomain);
+  tester.AddAttribute<int64_t>("num_heads", 1);
+  tester.AddAttribute<int64_t>("kv_num_heads", 1);
+  tester.AddAttribute<int64_t>("local_window_size", 1);
+  tester.AddInput<float>("query", {1, sequence_length, head_size},
+                         std::vector<float>(sequence_length * head_size, 0.0f));
+  tester.AddInput<float>("key", {1, sequence_length, head_size},
+                         std::vector<float>(sequence_length * head_size, 0.0f));
+  tester.AddInput<float>("value", {1, sequence_length, head_size}, value);
+  tester.AddOptionalInputEdge<float>();
+  tester.AddOptionalInputEdge<float>();
+  tester.AddInput<int32_t>("seqlens_k", {1}, {sequence_length - 1});
+  tester.AddInput<int32_t>("total_sequence_length", {1}, {sequence_length});
+  tester.AddOptionalInputEdge<float>();
+  tester.AddOptionalInputEdge<float>();
+  tester.AddOptionalInputEdge<int64_t>();
+  tester.AddOptionalInputEdge<float>();
+  tester.AddOptionalInputEdge<float>();
+  tester.AddOutput<float>("output", {1, sequence_length, head_size}, value);
+  tester.AddOutput<float>("present_key", {1, 1, sequence_length, head_size},
+                          std::vector<float>(sequence_length * head_size, 0.0f));
+  tester.AddOutput<float>("present_value", {1, 1, sequence_length, head_size}, value);
+  std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
+  execution_providers.push_back(DefaultWebGpuExecutionProvider());
+  tester.Run(OpTester::ExpectResult::kExpectSuccess, "", {}, nullptr, &execution_providers);
+}
+
 TEST(GroupQueryAttentionTest, BidirectionalMaskNotImplemented_WebGPU) {
   RunGQACausalMaskTest<float>(
       GqaTargetEp::kWebGpu, 0, std::vector<float>(16, 2.0f),
@@ -4119,19 +4161,6 @@ static void RunIndirectDispatchGraphCapture(bool do_rotary,
   RunOptions run_options;
   ORT_THROW_IF_ERROR(session.Run(run_options, *io_binding));
   auto first_output = read_output();
-  if (local_window_size != -1) {
-    auto poisoned_key = past_key_data;
-    auto poisoned_value = past_value_data;
-    const size_t batch_offset = kv_num_heads * cache_sequence_length * cache_head_size;
-    const size_t excluded_tile_size = 64 * kv_num_heads * cache_head_size;
-    std::fill_n(poisoned_key.begin() + batch_offset, excluded_tile_size, 100.0f);
-    std::fill_n(poisoned_value.begin() + batch_offset, excluded_tile_size, 100.0f);
-    update_gpu_value(past_key_value, poisoned_key.data(), DataTypeImpl::GetType<float>(), cache_shape);
-    update_gpu_value(past_value_value, poisoned_value.data(), DataTypeImpl::GetType<float>(), cache_shape);
-    ORT_THROW_IF_ERROR(session.Run(run_options, *io_binding));
-    EXPECT_EQ(first_output, read_output()) << "KV entries outside the local window affected replay";
-  }
-
   if (kv_cache_quant_bits == 8 && do_rotary && rotary_interleaved) {
     constexpr int reference_sequence_length = short_total_sequence_length;
     std::vector<float> reference_query(reference_sequence_length * hidden_size);

--- a/onnxruntime/test/contrib_ops/group_query_attention_op_test.cc
+++ b/onnxruntime/test/contrib_ops/group_query_attention_op_test.cc
@@ -3952,9 +3952,12 @@ static void ExpectBlockQuantInt8Close(const std::vector<float>& reference,
 static void RunIndirectDispatchGraphCapture(bool do_rotary,
                                             uint32_t kv_cache_quant_bits,
                                             bool enable_multi_rotary_cache,
-                                            bool rotary_interleaved = false) {
+                                            bool rotary_interleaved = false,
+                                            int sequence_length = 4,
+                                            int local_window_size = -1,
+                                            bool enable_graph_capture = true,
+                                            std::vector<float>* replay_output = nullptr) {
   constexpr int batch_size = 2;
-  constexpr int sequence_length = 4;
   constexpr int short_total_sequence_length = 2;
   constexpr int cache_sequence_length = 130;  // Three 64-token attention tiles.
   constexpr int num_heads = 2;
@@ -4013,6 +4016,9 @@ static void RunIndirectDispatchGraphCapture(bool do_rotary,
       node.AddAttribute("do_rotary", int64_t{1});
       node.AddAttribute("rotary_interleaved", static_cast<int64_t>(rotary_interleaved));
     }
+    if (local_window_size > 0) {
+      node.AddAttribute("local_window_size", static_cast<int64_t>(local_window_size));
+    }
     ORT_THROW_IF_ERROR(graph.Resolve());
   }
 
@@ -4022,7 +4028,7 @@ static void RunIndirectDispatchGraphCapture(bool do_rotary,
   SessionOptions session_options;
   InferenceSession session{session_options, GetEnvironment()};
   auto webgpu_ep = WebGpuEPForGqaOptions(
-      /*enable_graph_capture=*/true,
+      enable_graph_capture,
       kv_cache_quant_bits,
       enable_multi_rotary_cache ? multi_rotary_cache_concat_offset : 0);
   if (!webgpu_ep) {
@@ -4112,9 +4118,16 @@ static void RunIndirectDispatchGraphCapture(bool do_rotary,
   std::vector<int32_t> seqlens_data{short_total_sequence_length - 1, cache_sequence_length - 1};
   auto seqlens_value = make_gpu_value(seqlens_data.data(), DataTypeImpl::GetType<int32_t>(), seqlens_shape);
   std::vector<int32_t> total_sequence_length_data{cache_sequence_length};
-  auto total_sequence_length_value = make_gpu_value(total_sequence_length_data.data(),
-                                                    DataTypeImpl::GetType<int32_t>(),
-                                                    total_sequence_length_shape);
+  OrtValue total_sequence_length_value;
+  if (enable_graph_capture) {
+    total_sequence_length_value = make_gpu_value(total_sequence_length_data.data(),
+                                                 DataTypeImpl::GetType<int32_t>(),
+                                                 total_sequence_length_shape);
+  } else {
+    Tensor::InitOrtValue(DataTypeImpl::GetType<int32_t>(), total_sequence_length_shape,
+                         total_sequence_length_data.data(), cpu_allocator->Info(),
+                         total_sequence_length_value);
+  }
   auto cos_cache_value = make_gpu_value(cos_cache_data.data(), DataTypeImpl::GetType<float>(), rotary_cache_shape);
   auto sin_cache_value = make_gpu_value(sin_cache_data.data(), DataTypeImpl::GetType<float>(), rotary_cache_shape);
 
@@ -4261,6 +4274,9 @@ static void RunIndirectDispatchGraphCapture(bool do_rotary,
   update_gpu_value(seqlens_value, seqlens_data.data(), DataTypeImpl::GetType<int32_t>(), seqlens_shape);
   ORT_THROW_IF_ERROR(session.Run(run_options, *io_binding));
   auto second_output = read_output();
+  if (replay_output != nullptr) {
+    *replay_output = second_output;
+  }
 
   ASSERT_EQ(first_output.size(), second_output.size());
   EXPECT_TRUE(std::all_of(first_output.begin(), first_output.end(),
@@ -4269,7 +4285,7 @@ static void RunIndirectDispatchGraphCapture(bool do_rotary,
   EXPECT_TRUE(std::all_of(second_output.begin(), second_output.end(),
                           [](float value) { return std::isfinite(value); }))
       << "second graph-capture output contains a non-finite value";
-  constexpr size_t output_elements_per_batch = sequence_length * hidden_size;
+  const size_t output_elements_per_batch = static_cast<size_t>(sequence_length) * hidden_size;
   for (int second_batch = 0; second_batch < batch_size; ++second_batch) {
     const int first_batch = batch_size - 1 - second_batch;
     const auto* second_begin = second_output.data() + second_batch * output_elements_per_batch;
@@ -4321,6 +4337,15 @@ TEST(GroupQueryAttentionTest, WebGPU_BlockQuantInt8_IndirectDispatch_NoRotary) {
   RunIndirectDispatchGraphCapture(/*do_rotary=*/false,
                                   /*kv_cache_quant_bits=*/8,
                                   /*enable_multi_rotary_cache=*/false);
+}
+
+TEST(GroupQueryAttentionTest, WebGPU_GraphCapture_PackedRotaryLocalWindow) {
+  std::vector<float> captured_output;
+  std::vector<float> eager_output;
+  RunIndirectDispatchGraphCapture(true, 0, false, false, 1, 64, true, &captured_output);
+  RunIndirectDispatchGraphCapture(true, 0, false, false, 1, 64, false, &eager_output);
+  ExpectOutputsMatch(captured_output, eager_output, 2e-3f,
+                     "WebGPU_GraphCapture_PackedRotaryLocalWindow");
 }
 
 // The non-static packed-QKV path uses split_packed_qkv_with_rotary_embedding.


### PR DESCRIPTION
### Description

Complete WebGPU `GroupQueryAttention` local-window support in shared flash attention, including graph-captured decode.

Following the generic flash-prefill local-window support added by #32277, this change completes the split-reduce path and removes GQA's host-side sliding-window dispatch restriction. GQA now forwards `local_window_size` to flash attention whenever the configuration is otherwise supported, regardless of whether graph capture is enabled.

The split-reduce shader now:

- Reads the logical sequence length from GPU-resident `seqlens_k` during graph replay.
- Applies the local window independently for each query row, supporting single-token decode and short multi-token inputs.
- Emits neutral per-row metadata for KV tiles outside that query row's window.
- Avoids zero-sum normalization for fully excluded tiles.

Shared-KV (`kv_sequence_length == 0`) layers preserve their established no-window behavior because they reuse another layer's prepared KV cache. `smooth_softmax` and other unsupported flash-attention configurations remain independently gated.

Together with #32277, local-window GQA now uses the shared flash-attention dispatch cascade for:

- Eager and graph-captured decode through split-reduce flash attention.
- Short multi-token inputs through split-reduce flash attention.
- Prefill through generic flash attention.

Regression coverage includes:

- Packed-QKV rotary graph capture compared with eager WebGPU across the local-window boundary.
- Multi-token split-reduce with per-query-row window starts.
- Generic flash prefill with a local window.
- Existing shared-KV behavior.

### Motivation and Context

Gemma 4 uses both global-attention layers and local-attention layers with `local_window_size=512`.

WebGPU GQA previously selected between flash attention and non-flash sliding-window attention using a host-side sequence length. During graph capture, the logical sequence length is GPU-resident. If the graph was captured before reaching 512 tokens, it permanently recorded ordinary flash attention and continued attending to the full KV history after crossing the boundary.

This produced increasingly incorrect logits during long generation. Eager WebGPU remained coherent because it reevaluated the host-side path selection on every decoding step, but maintaining separate eager and captured policies left the implementations inconsistent and prevented local-window GQA prefill from using flash attention.

This change moves the remaining local-window behavior into shared split-reduce flash attention and relies on #32277 for generic flash prefill, making shader masking the source of truth instead of host-side kernel-family switching.

Observed before the fix:

| Step | Logit cosine | Maximum difference |
|---:|---:|---:|
| 300 | 1.000000 | 0.000 |
| 500 | 0.999993 | 0.250 |
| 600 | 0.975641 | 28.375 |
| 650 | 0.973550 | 42.453 |

Generation subsequently diverged and collapsed into repeated tokens.

After the fix:

| Step | Logit cosine | Maximum difference |
|---:|---:|---:|
| 300 | 1.000000 | 0.000 |
| 500 | 0.999997 | 0.125 |
| 600 | 0.999997 | 0.140625 |
| 650 | 0.999990 | 0.15625 |

Captured generation remains coherent and reaches EOS normally. The remaining small differences are expected from floating-point execution differences between attention paths.