### PR TITLE
[WebGPU] Add GroupNorm and SkipGroupNorm contrib kernels

### DIFF
--- a/onnxruntime/contrib_ops/webgpu/diffusion/group_norm.cc
+++ b/onnxruntime/contrib_ops/webgpu/diffusion/group_norm.cc
@@ -1,0 +1,246 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "contrib_ops/webgpu/diffusion/group_norm.h"
+#include "contrib_ops/webgpu/webgpu_contrib_kernels.h"
+#include "core/providers/webgpu/shader_helper.h"
+#include "core/providers/webgpu/webgpu_supported_types.h"
+#include "core/providers/webgpu/webgpu_utils.h"
+
+namespace onnxruntime {
+namespace contrib {
+namespace webgpu {
+
+using onnxruntime::webgpu::ProgramTensorMetadataDependency;
+using onnxruntime::webgpu::ShaderUsage;
+using onnxruntime::webgpu::ShaderVariableHelper;
+using onnxruntime::webgpu::SumVector;
+using onnxruntime::webgpu::WebGpuSupportedFloatTypes;
+using onnxruntime::webgpu::WORKGROUP_SIZE;
+
+Status GroupNormStatsProgram::GenerateShaderCode(ShaderHelper& shader) const {
+  const auto& x = shader.AddInput("x", ShaderUsage::UseUniform);
+  const ShaderVariableHelper* skip = has_skip_ ? &shader.AddInput("skip", ShaderUsage::UseUniform) : nullptr;
+  const ShaderVariableHelper* bias = has_bias_ ? &shader.AddInput("bias", ShaderUsage::UseUniform) : nullptr;
+  const auto& output = shader.AddOutput("output", ShaderUsage::UseUniform | ShaderUsage::UseValueTypeAlias);
+
+  shader.AdditionalImplementation() << "alias f32_val_t = " << (components_ == 4 ? "vec4<f32>" : (components_ == 2 ? "vec2<f32>" : "f32")) << ";\n"
+                                    << "var<workgroup> workgroup_shared_sum : array<f32_val_t, " << workgroup_size_ << ">;\n"
+                                    << "var<workgroup> workgroup_shared_squared_sum : array<f32_val_t, " << workgroup_size_ << ">;\n"
+                                    << "const workgroup_size = " << workgroup_size_ << "u;\n";
+
+  shader.MainFunctionBody() << "  let n = workgroup_idx / uniforms.groups;\n"
+                            << "  let g = workgroup_idx % uniforms.groups;\n"
+                            << "  let count = uniforms.hw * uniforms.cg_comp;\n"
+                            << "  var sum = f32_val_t(0);\n"
+                            << "  var squared_sum = f32_val_t(0);\n"
+                            << "  for (var i = local_idx; i < count; i += workgroup_size) {\n"
+                            << "    let hw = i / uniforms.cg_comp;\n"
+                            << "    let k = i % uniforms.cg_comp;\n"
+                            << "    let c_idx = g * uniforms.cg_comp + k;\n"
+                            << "    let offset = (n * uniforms.hw + hw) * uniforms.c_comp + c_idx;\n"
+                            << "    var value = f32_val_t(" << x.GetByOffset("offset") << ");\n";
+  if (has_skip_) {
+    shader.MainFunctionBody() << "    value += f32_val_t("
+                              << skip->GetByOffset(skip_broadcast_ ? "n * uniforms.c_comp + c_idx" : "offset") << ");\n";
+  }
+  if (has_bias_) {
+    shader.MainFunctionBody() << "    value += f32_val_t(" << bias->GetByOffset("c_idx") << ");\n";
+  }
+  shader.MainFunctionBody() << "    sum += value;\n"
+                            << "    squared_sum += value * value;\n"
+                            << "  }\n"
+                            << "  workgroup_shared_sum[local_idx] = sum;\n"
+                            << "  workgroup_shared_squared_sum[local_idx] = squared_sum;\n"
+                            << "  workgroupBarrier();\n"
+                            << "  for (var curr_size = workgroup_size >> 1; curr_size > 0; curr_size = curr_size >> 1) {\n"
+                            << "    if (local_idx < curr_size) {\n"
+                            << "      workgroup_shared_sum[local_idx] = workgroup_shared_sum[local_idx] + workgroup_shared_sum[local_idx + curr_size];\n"
+                            << "      workgroup_shared_squared_sum[local_idx] = workgroup_shared_squared_sum[local_idx] + workgroup_shared_squared_sum[local_idx + curr_size];\n"
+                            << "    }\n"
+                            << "    workgroupBarrier();\n"
+                            << "  }\n"
+                            << "  if (local_idx == 0) {\n"
+                            << "    let element_count = f32(count * " << components_ << "u);\n"
+                            << "    let mean = " << SumVector("workgroup_shared_sum[0]", components_) << " / element_count;\n"
+                            << "    let squared_mean = " << SumVector("workgroup_shared_squared_sum[0]", components_) << " / element_count;\n"
+                            << "    let inv_std_dev = inverseSqrt(squared_mean - mean * mean + uniforms.epsilon);\n"
+                            << "    " << output.SetByOffset("workgroup_idx", "output_value_t(mean, inv_std_dev)") << ";\n"
+                            << "  }\n";
+  return Status::OK();
+}
+
+Status GroupNormApplyProgram::GenerateShaderCode(ShaderHelper& shader) const {
+  const auto& x = shader.AddInput("x", ShaderUsage::UseUniform);
+  const ShaderVariableHelper* skip = has_skip_ ? &shader.AddInput("skip", ShaderUsage::UseUniform) : nullptr;
+  const ShaderVariableHelper* bias = has_bias_ ? &shader.AddInput("bias", ShaderUsage::UseUniform) : nullptr;
+  const auto& stats = shader.AddInput("stats", ShaderUsage::UseUniform);
+  const auto& gamma = shader.AddInput("gamma", ShaderUsage::UseUniform);
+  const auto& beta = shader.AddInput("beta", ShaderUsage::UseUniform);
+  const auto& output = shader.AddOutput("output", ShaderUsage::UseUniform | ShaderUsage::UseValueTypeAlias);
+  const ShaderVariableHelper* sum_output = has_sum_output_ ? &shader.AddOutput("sum_output", ShaderUsage::UseUniform | ShaderUsage::UseValueTypeAlias) : nullptr;
+
+  shader.AdditionalImplementation() << "alias f32_val_t = " << (components_ == 4 ? "vec4<f32>" : (components_ == 2 ? "vec2<f32>" : "f32")) << ";\n";
+
+  shader.MainFunctionBody() << shader.GuardAgainstOutOfBoundsWorkgroupSizes("uniforms.output_size")
+                            << "  let hwc = uniforms.hw * uniforms.c_comp;\n"
+                            << "  let n = global_idx / hwc;\n"
+                            << "  let c_idx = global_idx % uniforms.c_comp;\n"
+                            << "  let g = c_idx / uniforms.cg_comp;\n"
+                            << "  let mean_inv_std = " << stats.GetByOffset("n * uniforms.groups + g") << ";\n"
+                            << "  let gamma_v = f32_val_t(" << gamma.GetByOffset("c_idx") << ");\n"
+                            << "  let beta_v = f32_val_t(" << beta.GetByOffset("c_idx") << ");\n"
+                            << "  var value = f32_val_t(" << x.GetByOffset("global_idx") << ");\n";
+  if (has_skip_) {
+    shader.MainFunctionBody() << "  value += f32_val_t("
+                              << skip->GetByOffset(skip_broadcast_ ? "n * uniforms.c_comp + c_idx" : "global_idx") << ");\n";
+  }
+  if (has_bias_) {
+    shader.MainFunctionBody() << "  value += f32_val_t(" << bias->GetByOffset("c_idx") << ");\n";
+  }
+  if (has_sum_output_) {
+    shader.MainFunctionBody() << "  " << sum_output->SetByOffset("global_idx", "sum_output_value_t(value)") << ";\n";
+  }
+  shader.MainFunctionBody() << "  var result = (value - mean_inv_std.x) * mean_inv_std.y * gamma_v + beta_v;\n";
+  if (use_silu_) {
+    shader.MainFunctionBody() << "  result = result * (f32_val_t(1) / (f32_val_t(1) + exp(-result)));\n";
+  }
+  shader.MainFunctionBody() << "  " << output.SetByOffset("global_idx", "output_value_t(result)") << ";\n";
+  return Status::OK();
+}
+
+Status GroupNorm::ComputeInternal(ComputeContext& context) const {
+  const auto* x = context.Input<Tensor>(0);
+  const auto* gamma = context.Input<Tensor>(1);
+  const auto* beta = context.Input<Tensor>(2);
+  const auto* skip = context.Input<Tensor>(3);  // SkipGroupNorm only
+  const auto* bias = context.Input<Tensor>(4);  // SkipGroupNorm only
+
+  ORT_RETURN_IF_NOT(channels_last_ == 1, "WebGPU GroupNorm only supports channels_last=1.");
+
+  const auto& x_shape = x->Shape();
+  const auto rank = x_shape.NumDimensions();
+  ORT_RETURN_IF_NOT(rank >= 3, "GroupNorm input must have rank >= 3 (N, spatial..., C).");
+
+  const bool has_skip = skip != nullptr;
+  const bool has_bias = bias != nullptr;
+  Tensor* y = context.Output(0, x_shape);
+  Tensor* sum_output = has_skip ? context.Output(1, x_shape) : nullptr;
+  const bool has_sum_output = sum_output != nullptr;
+
+  if (x_shape.Size() == 0) {
+    return Status::OK();
+  }
+
+  const int64_t batch = x_shape[0];
+  const int64_t channels = x_shape[rank - 1];
+  const int64_t hw = x_shape.SizeFromDimension(1) / channels;
+  const int64_t groups = groups_;
+  ORT_RETURN_IF_NOT(channels % groups == 0, "Number of channels must be divisible by groups.");
+  const int64_t channels_per_group = channels / groups;
+
+  ORT_RETURN_IF_NOT(gamma->Shape().Size() == channels && beta->Shape().Size() == channels,
+                    "gamma and beta must have size equal to number of channels.");
+  // skip is either the same shape as X, or per-(batch, channel) broadcast: (N, C) or (N, 1, 1, C).
+  bool skip_broadcast = false;
+  if (has_skip) {
+    const auto& skip_shape = skip->Shape();
+    if (skip_shape == x_shape) {
+      skip_broadcast = false;
+    } else {
+      const auto skip_rank = skip_shape.NumDimensions();
+      // Check the rank first so the short-circuit protects the indexing below.
+      const bool valid_broadcast =
+          (skip_rank == 2 || skip_rank == rank) &&
+          skip_shape[0] == batch && skip_shape[skip_rank - 1] == channels &&
+          skip_shape.Size() == batch * channels;
+      ORT_RETURN_IF_NOT(valid_broadcast,
+                        "SkipGroupNorm skip must have the same shape as X, or be broadcastable as (N, C) or (N, 1, ..., 1, C).");
+      skip_broadcast = true;
+    }
+  }
+  ORT_RETURN_IF_NOT(!has_bias || bias->Shape().Size() == channels,
+                    "SkipGroupNorm bias must be a 1D tensor with size equal to number of channels.");
+
+  const int components = channels_per_group % 4 == 0 ? 4 : (channels_per_group % 2 == 0 ? 2 : 1);
+  const int64_t c_comp = channels / components;
+  const int64_t cg_comp = channels_per_group / components;
+
+  // Pass 1: per-(batch, group) mean / inv_std, f32, shape [N * G, 2] accessed with 2 components.
+  TensorShape stats_shape{batch * groups, 2};
+  Tensor stats = context.CreateGPUTensor(DataTypeImpl::GetType<float>(), stats_shape);
+  const uint32_t stats_workgroup_size = 256;
+  const TensorShape x_flat_shape{batch * hw * c_comp};
+  const TensorShape skip_flat_shape{skip_broadcast ? batch * c_comp : batch * hw * c_comp};
+  const TensorShape channel_flat_shape{c_comp};
+
+  GroupNormStatsProgram stats_program{components, stats_workgroup_size, has_skip, skip_broadcast, has_bias};
+  stats_program.CacheHint(components, stats_workgroup_size, has_skip, skip_broadcast, has_bias)
+      .AddInput({x, ProgramTensorMetadataDependency::Type, x_flat_shape, components})
+      .AddOutput({&stats, ProgramTensorMetadataDependency::None, TensorShape{batch * groups, 1}, 2})
+      .SetDispatchGroupSize(static_cast<uint32_t>(batch * groups))
+      .SetWorkgroupSize(stats_workgroup_size)
+      .AddUniformVariables({{static_cast<uint32_t>(hw)},
+                            {static_cast<uint32_t>(c_comp)},
+                            {static_cast<uint32_t>(cg_comp)},
+                            {static_cast<uint32_t>(groups)},
+                            {epsilon_}});
+  if (has_skip) {
+    stats_program.AddInput({skip, ProgramTensorMetadataDependency::Type, skip_flat_shape, components});
+  }
+  if (has_bias) {
+    stats_program.AddInput({bias, ProgramTensorMetadataDependency::Type, channel_flat_shape, components});
+  }
+  ORT_RETURN_IF_ERROR(context.RunProgram(stats_program));
+
+  // Pass 2: normalize + affine + optional SiLU, elementwise; optionally writes x + skip + bias to S.
+  const bool use_silu = activation_ == 1;
+  const int64_t output_size = batch * hw * c_comp;
+  GroupNormApplyProgram apply_program{components, use_silu, has_skip, skip_broadcast, has_bias, has_sum_output};
+  apply_program.CacheHint(components, use_silu, has_skip, skip_broadcast, has_bias, has_sum_output)
+      .AddInputs({{x, ProgramTensorMetadataDependency::Type, x_flat_shape, components}})
+      .SetDispatchGroupSize(static_cast<uint32_t>((output_size + WORKGROUP_SIZE - 1) / WORKGROUP_SIZE))
+      .AddUniformVariables({{static_cast<uint32_t>(output_size)},
+                            {static_cast<uint32_t>(hw)},
+                            {static_cast<uint32_t>(c_comp)},
+                            {static_cast<uint32_t>(cg_comp)},
+                            {static_cast<uint32_t>(groups)}});
+  if (has_skip) {
+    apply_program.AddInput({skip, ProgramTensorMetadataDependency::Type, skip_flat_shape, components});
+  }
+  if (has_bias) {
+    apply_program.AddInput({bias, ProgramTensorMetadataDependency::Type, channel_flat_shape, components});
+  }
+  apply_program.AddInputs({{&stats, ProgramTensorMetadataDependency::None, TensorShape{batch * groups, 1}, 2},
+                           {gamma, ProgramTensorMetadataDependency::Type, TensorShape{c_comp}, components},
+                           {beta, ProgramTensorMetadataDependency::Type, TensorShape{c_comp}, components}});
+  apply_program.AddOutput({y, ProgramTensorMetadataDependency::None, x_flat_shape, components});
+  if (has_sum_output) {
+    apply_program.AddOutput({sum_output, ProgramTensorMetadataDependency::None, x_flat_shape, components});
+  }
+  return context.RunProgram(apply_program);
+}
+
+ONNX_OPERATOR_KERNEL_EX(
+    GroupNorm,
+    kMSDomain,
+    1,
+    kWebGpuExecutionProvider,
+    (*KernelDefBuilder::Create())
+        .TypeConstraint("T", WebGpuSupportedFloatTypes())
+        .TypeConstraint("M", WebGpuSupportedFloatTypes()),
+    GroupNorm);
+
+ONNX_OPERATOR_KERNEL_EX(
+    SkipGroupNorm,
+    kMSDomain,
+    1,
+    kWebGpuExecutionProvider,
+    (*KernelDefBuilder::Create())
+        .TypeConstraint("T", WebGpuSupportedFloatTypes())
+        .TypeConstraint("M", WebGpuSupportedFloatTypes()),
+    GroupNorm);
+
+}  // namespace webgpu
+}  // namespace contrib
+}  // namespace onnxruntime

--- a/onnxruntime/contrib_ops/webgpu/diffusion/group_norm.h
+++ b/onnxruntime/contrib_ops/webgpu/diffusion/group_norm.h
@@ -1,0 +1,106 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include "core/providers/webgpu/program.h"
+#include "core/providers/webgpu/webgpu_kernel.h"
+
+namespace onnxruntime {
+namespace contrib {
+namespace webgpu {
+
+using onnxruntime::webgpu::ComputeContext;
+using onnxruntime::webgpu::Program;
+using onnxruntime::webgpu::ProgramUniformVariableDataType;
+using onnxruntime::webgpu::ShaderHelper;
+using onnxruntime::webgpu::WebGpuKernel;
+
+// Computes per-(batch, group) mean and inverse standard deviation of x (+ skip + bias).
+// One workgroup per (batch, group); output is [N * G] with 2 components (mean, inv_std) in f32.
+class GroupNormStatsProgram final : public Program<GroupNormStatsProgram> {
+ public:
+  GroupNormStatsProgram(int components, uint32_t workgroup_size, bool has_skip, bool skip_broadcast, bool has_bias)
+      : Program{"GroupNormStats"},
+        components_{components},
+        workgroup_size_{workgroup_size},
+        has_skip_{has_skip},
+        skip_broadcast_{skip_broadcast},
+        has_bias_{has_bias} {}
+
+  Status GenerateShaderCode(ShaderHelper& shader) const override;
+
+  WEBGPU_PROGRAM_DEFINE_UNIFORM_VARIABLES(
+      {"hw", ProgramUniformVariableDataType::Uint32},
+      {"c_comp", ProgramUniformVariableDataType::Uint32},
+      {"cg_comp", ProgramUniformVariableDataType::Uint32},
+      {"groups", ProgramUniformVariableDataType::Uint32},
+      {"epsilon", ProgramUniformVariableDataType::Float32});
+
+ private:
+  int components_;
+  uint32_t workgroup_size_;
+  bool has_skip_;
+  bool skip_broadcast_;
+  bool has_bias_;
+};
+
+// Applies normalization with per-channel affine (gamma, beta) and optional SiLU activation.
+// With skip: normalizes (x + skip + bias) and optionally writes the sum to the S output.
+class GroupNormApplyProgram final : public Program<GroupNormApplyProgram> {
+ public:
+  GroupNormApplyProgram(int components, bool use_silu, bool has_skip, bool skip_broadcast, bool has_bias, bool has_sum_output)
+      : Program{"GroupNormApply"},
+        components_{components},
+        use_silu_{use_silu},
+        has_skip_{has_skip},
+        skip_broadcast_{skip_broadcast},
+        has_bias_{has_bias},
+        has_sum_output_{has_sum_output} {}
+
+  Status GenerateShaderCode(ShaderHelper& shader) const override;
+
+  WEBGPU_PROGRAM_DEFINE_UNIFORM_VARIABLES(
+      {"output_size", ProgramUniformVariableDataType::Uint32},
+      {"hw", ProgramUniformVariableDataType::Uint32},
+      {"c_comp", ProgramUniformVariableDataType::Uint32},
+      {"cg_comp", ProgramUniformVariableDataType::Uint32},
+      {"groups", ProgramUniformVariableDataType::Uint32});
+
+ private:
+  int components_;
+  bool use_silu_;
+  bool has_skip_;
+  bool skip_broadcast_;
+  bool has_bias_;
+  bool has_sum_output_;
+};
+
+// Handles both com.microsoft.GroupNorm and com.microsoft.SkipGroupNorm (channels_last only).
+class GroupNorm final : public WebGpuKernel {
+ public:
+  GroupNorm(const OpKernelInfo& info) : WebGpuKernel(info) {
+    epsilon_ = info.GetAttrOrDefault<float>("epsilon", 1e-5f);
+    ORT_ENFORCE(epsilon_ >= 0.0f, "epsilon must be non-negative, got ", epsilon_);
+
+    ORT_ENFORCE(info.GetAttr("groups", &groups_).IsOK(), "groups attribute is required");
+    ORT_ENFORCE(groups_ > 0, "groups must be positive, got ", groups_);
+
+    ORT_ENFORCE(info.GetAttr("activation", &activation_).IsOK(), "activation attribute is required");
+    ORT_ENFORCE(activation_ == 0 || activation_ == 1, "activation must be 0 (None) or 1 (SiLU), got ", activation_);
+
+    channels_last_ = info.GetAttrOrDefault<int64_t>("channels_last", 1);
+  }
+
+  Status ComputeInternal(ComputeContext& context) const override;
+
+ private:
+  float epsilon_;
+  int64_t groups_;
+  int64_t activation_;
+  int64_t channels_last_;
+};
+
+}  // namespace webgpu
+}  // namespace contrib
+}  // namespace onnxruntime

--- a/onnxruntime/contrib_ops/webgpu/webgpu_contrib_kernels.cc
+++ b/onnxruntime/contrib_ops/webgpu/webgpu_contrib_kernels.cc
@@ -38,6 +38,7 @@ static const BuildKernelCreateInfoFn build_kernel_create_info_function_table[] =
     BuildKernelCreateInfo<class ONNX_OPERATOR_KERNEL_CLASS_NAME(kWebGpuExecutionProvider, kMSDomain, 1, EngramGate)>,
     BuildKernelCreateInfo<class ONNX_OPERATOR_KERNEL_CLASS_NAME(kWebGpuExecutionProvider, kMSDomain, 1, NGramHashMapping)>,
     BuildKernelCreateInfo<class ONNX_OPERATOR_KERNEL_CLASS_NAME(kWebGpuExecutionProvider, kMSDomain, 1, Gelu)>,
+    BuildKernelCreateInfo<class ONNX_OPERATOR_KERNEL_CLASS_NAME(kWebGpuExecutionProvider, kMSDomain, 1, GroupNorm)>,
     BuildKernelCreateInfo<class ONNX_OPERATOR_KERNEL_CLASS_NAME(kWebGpuExecutionProvider, kMSDomain, 1, LinearAttention)>,
     BuildKernelCreateInfo<class ONNX_OPERATOR_KERNEL_CLASS_NAME(kWebGpuExecutionProvider, kMSDomain, 1, LinearAttentionGate)>,
     BuildKernelCreateInfo<class ONNX_OPERATOR_KERNEL_CLASS_NAME(kWebGpuExecutionProvider, kMSDomain, 1, MatMulBnb4)>,
@@ -49,6 +50,7 @@ static const BuildKernelCreateInfoFn build_kernel_create_info_function_table[] =
     BuildKernelCreateInfo<class ONNX_OPERATOR_KERNEL_CLASS_NAME(kWebGpuExecutionProvider, kMSDomain, 1, PagedAttention)>,
     BuildKernelCreateInfo<class ONNX_OPERATOR_KERNEL_CLASS_NAME(kWebGpuExecutionProvider, kMSDomain, 1, QuickGelu)>,
     BuildKernelCreateInfo<class ONNX_OPERATOR_KERNEL_CLASS_NAME(kWebGpuExecutionProvider, kMSDomain, 1, RotaryEmbedding)>,
+    BuildKernelCreateInfo<class ONNX_OPERATOR_KERNEL_CLASS_NAME(kWebGpuExecutionProvider, kMSDomain, 1, SkipGroupNorm)>,
     BuildKernelCreateInfo<class ONNX_OPERATOR_KERNEL_CLASS_NAME(kWebGpuExecutionProvider, kMSDomain, 1, SkipLayerNormalization)>,
     // LayerNormalization used to be a contrib op that (incorrectly) used kOnnxDomain so we need to version it
     BuildKernelCreateInfo<class ONNX_OPERATOR_VERSIONED_KERNEL_CLASS_NAME(kWebGpuExecutionProvider, kOnnxDomain, 1, 16, LayerNormalization)>,

--- a/onnxruntime/test/contrib_ops/group_norm_op_test.cc
+++ b/onnxruntime/test/contrib_ops/group_norm_op_test.cc
@@ -1,7 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+#include <cmath>
 #include <random>
+#include <type_traits>
+#include <utility>
 #include "test/common/tensor_op_test_utils.h"
 #include "test/common/cuda_op_test_utils.h"
 #include "test/unittest_util/framework_test_utils.h"
@@ -731,11 +734,12 @@ TEST(GroupNormTest, GroupNorm_128) {
   int min_cuda_architecture = 530;
   bool enable_cuda = HasCudaEnvironment(min_cuda_architecture);
   bool enable_dml = (nullptr != DefaultDmlExecutionProvider().get());
+  bool enable_webgpu = (nullptr != DefaultWebGpuExecutionProvider().get());
 
   std::array<int, 3> channels_last_values = {-1, 0, 1};
 
   for (const int channels_last : channels_last_values) {
-    if (enable_cuda || enable_dml) {
+    if (enable_cuda || enable_dml || enable_webgpu) {
       std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
       if (enable_cuda && channels_last != 0) {
         execution_providers.push_back(DefaultCudaExecutionProvider());
@@ -743,6 +747,11 @@ TEST(GroupNormTest, GroupNorm_128) {
 
       if (enable_dml) {
         execution_providers.push_back(DefaultDmlExecutionProvider());
+      }
+
+      // WebGPU only supports the channels_last layout
+      if (enable_webgpu && channels_last != 0) {
+        execution_providers.push_back(DefaultWebGpuExecutionProvider());
       }
 
       // Don't run the test if no providers are supported
@@ -781,7 +790,7 @@ TEST(GroupNormTest, GroupNorm_128) {
 
     // Test float32, with activation
     enable_cuda = HasCudaEnvironment(0);
-    if (enable_cuda || enable_dml) {
+    if (enable_cuda || enable_dml || enable_webgpu) {
       std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
       if (enable_cuda && channels_last != 0) {
         execution_providers.push_back(DefaultCudaExecutionProvider());
@@ -789,6 +798,11 @@ TEST(GroupNormTest, GroupNorm_128) {
 
       if (enable_dml) {
         execution_providers.push_back(DefaultDmlExecutionProvider());
+      }
+
+      // WebGPU only supports the channels_last layout
+      if (enable_webgpu && channels_last != 0) {
+        execution_providers.push_back(DefaultWebGpuExecutionProvider());
       }
 
       // Don't run the test if no providers are supported
@@ -823,6 +837,113 @@ TEST(GroupNormTest, GroupNorm_128) {
       test.AddInput<float>("gamma", {C}, gamma_data);
       test.AddInput<float>("beta", {C}, beta_data);
       test.Run(OpTester::ExpectResult::kExpectSuccess, "", {}, nullptr, &execution_providers);
+    }
+  }
+}
+
+namespace {
+
+// Double-precision GroupNorm reference in NHWC layout with per-channel gamma/beta.
+std::vector<float> GroupNormReference(const std::vector<float>& x, const std::vector<float>& gamma,
+                                      const std::vector<float>& beta, int64_t batch, int64_t hw,
+                                      int64_t channels, int64_t groups, float epsilon, bool silu) {
+  const int64_t channels_per_group = channels / groups;
+  std::vector<float> y(x.size());
+  for (int64_t n = 0; n < batch; ++n) {
+    for (int64_t g = 0; g < groups; ++g) {
+      double sum = 0.0;
+      double squared_sum = 0.0;
+      for (int64_t p = 0; p < hw; ++p) {
+        for (int64_t k = 0; k < channels_per_group; ++k) {
+          const double v = x[(n * hw + p) * channels + g * channels_per_group + k];
+          sum += v;
+          squared_sum += v * v;
+        }
+      }
+      const double count = static_cast<double>(hw * channels_per_group);
+      const double mean = sum / count;
+      const double inv_std = 1.0 / std::sqrt(squared_sum / count - mean * mean + epsilon);
+      for (int64_t p = 0; p < hw; ++p) {
+        for (int64_t k = 0; k < channels_per_group; ++k) {
+          const int64_t c = g * channels_per_group + k;
+          const int64_t idx = (n * hw + p) * channels + c;
+          double v = (x[idx] - mean) * inv_std * gamma[c] + beta[c];
+          if (silu) {
+            v = v / (1.0 + std::exp(-v));
+          }
+          y[idx] = static_cast<float>(v);
+        }
+      }
+    }
+  }
+  return y;
+}
+
+// Rounds values through the storage type T so the reference sees exactly what the kernel reads.
+template <typename T>
+std::vector<float> RoundTripThrough(const std::vector<float>& values) {
+  if constexpr (std::is_same_v<T, MLFloat16>) {
+    std::vector<float> result;
+    result.reserve(values.size());
+    for (float v : values) {
+      result.push_back(MLFloat16(v).ToFloat());
+    }
+    return result;
+  } else {
+    return values;
+  }
+}
+
+// TX: type of X and Y (schema type T). TM: type of gamma and beta (schema type M).
+template <typename TX, typename TM>
+void RunGroupNormWebGpu(int64_t channels, int64_t groups, bool silu) {
+  constexpr int64_t B = 2;
+  constexpr int64_t H = 3;
+  constexpr int64_t W = 2;
+  constexpr float epsilon = 1e-5f;
+  const std::vector<int64_t> dims{B, H, W, channels};
+  const std::vector<int64_t> channel_dims{channels};
+
+  RandomValueGenerator random{1234};
+  const auto x = RoundTripThrough<TX>(random.Uniform<float>(dims, -1.0f, 1.0f));
+  const auto gamma = RoundTripThrough<TM>(random.Uniform<float>(channel_dims, 0.5f, 1.5f));
+  const auto beta = RoundTripThrough<TM>(random.Uniform<float>(channel_dims, -0.5f, 0.5f));
+  const auto y = GroupNormReference(x, gamma, beta, B, H * W, channels, groups, epsilon, silu);
+
+  OpTester test("GroupNorm", 1, onnxruntime::kMSDomain);
+  test.AddAttribute<float>("epsilon", epsilon);
+  test.AddAttribute<int64_t>("groups", groups);
+  test.AddAttribute<int64_t>("activation", silu ? 1 : 0);
+  test.AddAttribute<int64_t>("channels_last", 1);
+  test.AddInput<TX>("X", dims, GetTypedArray<TX>(x));
+  test.AddInput<TM>("gamma", channel_dims, GetTypedArray<TM>(gamma));
+  test.AddInput<TM>("beta", channel_dims, GetTypedArray<TM>(beta));
+
+  constexpr float rel_error = 0.0f;
+  constexpr float abs_error = std::is_same_v<TX, MLFloat16> ? 0.02f : 1e-4f;
+  test.AddOutput<TX>("Y", dims, GetTypedArray<TX>(y), false, rel_error, abs_error);
+
+  std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
+  execution_providers.push_back(DefaultWebGpuExecutionProvider());
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {}, nullptr, &execution_providers);
+}
+
+}  // namespace
+
+// Covers the vec2 (channels_per_group == 2) and scalar (channels_per_group == 1) variants,
+// fp16 gamma/beta (type M), and all four T/M combinations, with and without SiLU.
+TEST(GroupNormTest, GroupNorm_WebGpu_SmallChannelsPerGroup) {
+  if (DefaultWebGpuExecutionProvider().get() == nullptr) {
+    GTEST_SKIP() << "WebGPU EP is not available";
+  }
+
+  const std::vector<std::pair<int64_t, int64_t>> configs = {{6, 3}, {4, 4}};
+  for (const auto& [channels, groups] : configs) {
+    for (const bool silu : {false, true}) {
+      RunGroupNormWebGpu<float, float>(channels, groups, silu);
+      RunGroupNormWebGpu<float, MLFloat16>(channels, groups, silu);
+      RunGroupNormWebGpu<MLFloat16, float>(channels, groups, silu);
+      RunGroupNormWebGpu<MLFloat16, MLFloat16>(channels, groups, silu);
     }
   }
 }

--- a/onnxruntime/test/contrib_ops/skip_group_norm_op_test.cc
+++ b/onnxruntime/test/contrib_ops/skip_group_norm_op_test.cc
@@ -1,7 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+#include <cmath>
 #include <random>
+#include <type_traits>
+#include <utility>
 #include "test/common/tensor_op_test_utils.h"
 #include "test/common/cuda_op_test_utils.h"
 #include "test/unittest_util/framework_test_utils.h"
@@ -114,14 +117,20 @@ TEST(SkipGroupNormTest, SkipGroupNorm_with_bias) {
 
   int min_cuda_architecture = 530;
   bool enable_cuda = HasCudaEnvironment(min_cuda_architecture);
+  bool enable_webgpu = (nullptr != DefaultWebGpuExecutionProvider().get());
 
   std::array<int, 2> channels_last_values = {-1, 1};
 
   for (const int channels_last : channels_last_values) {
-    if (enable_cuda) {
+    if (enable_cuda || enable_webgpu) {
       std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
       if (enable_cuda && channels_last != 0) {
         execution_providers.push_back(DefaultCudaExecutionProvider());
+      }
+
+      // WebGPU only supports the channels_last layout
+      if (enable_webgpu && channels_last != 0) {
+        execution_providers.push_back(DefaultWebGpuExecutionProvider());
       }
 
       // Don't run the test if no providers are supported
@@ -230,6 +239,7 @@ TEST(SkipGroupNormTest, SkipGroupNorm_no_bias_broadcast_skip) {
 
   int min_cuda_architecture = 530;
   bool enable_cuda = HasCudaEnvironment(min_cuda_architecture);
+  bool enable_webgpu = (nullptr != DefaultWebGpuExecutionProvider().get());
 
   std::array<bool, 2> has_add_out_values = {true, false};
   std::array<int, 2> skip_dims = {2, 4};
@@ -237,10 +247,15 @@ TEST(SkipGroupNormTest, SkipGroupNorm_no_bias_broadcast_skip) {
   constexpr int channels_last = 1;
   for (const int skip_dim : skip_dims) {
     for (const bool has_add_out : has_add_out_values) {
-      if (enable_cuda) {
+      if (enable_cuda || enable_webgpu) {
         std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
         if (enable_cuda && channels_last != 0) {
           execution_providers.push_back(DefaultCudaExecutionProvider());
+        }
+
+        // WebGPU only supports the channels_last layout
+        if (enable_webgpu && channels_last != 0) {
+          execution_providers.push_back(DefaultWebGpuExecutionProvider());
         }
 
         // Don't run the test if no providers are supported
@@ -277,6 +292,163 @@ TEST(SkipGroupNormTest, SkipGroupNorm_no_bias_broadcast_skip) {
         }
 
         test.Run(OpTester::ExpectResult::kExpectSuccess, "", {}, nullptr, &execution_providers);
+      }
+    }
+  }
+}
+
+namespace {
+
+enum class SkipLayout {
+  kFull,  // (N, H, W, C), same shape as X
+  kNC,    // (N, C), broadcast over H and W
+  kN11C,  // (N, 1, 1, C), broadcast over H and W
+};
+
+// Double-precision SkipGroupNorm reference in NHWC layout:
+//   s = x + skip + bias;  y = gamma * (s - mean) / sqrt(var + epsilon) + beta
+// skip is indexed as (n, c) when broadcast, otherwise like x. bias may be null.
+void SkipGroupNormReference(const std::vector<float>& x, const std::vector<float>& skip, bool skip_broadcast,
+                            const std::vector<float>* bias, const std::vector<float>& gamma,
+                            const std::vector<float>& beta, int64_t batch, int64_t hw, int64_t channels,
+                            int64_t groups, float epsilon, std::vector<float>& y, std::vector<float>& s) {
+  const int64_t channels_per_group = channels / groups;
+  std::vector<double> sum_data(x.size());
+  for (int64_t n = 0; n < batch; ++n) {
+    for (int64_t p = 0; p < hw; ++p) {
+      for (int64_t c = 0; c < channels; ++c) {
+        const int64_t idx = (n * hw + p) * channels + c;
+        double v = x[idx] + (skip_broadcast ? skip[n * channels + c] : skip[idx]);
+        if (bias != nullptr) {
+          v += (*bias)[c];
+        }
+        sum_data[idx] = v;
+      }
+    }
+  }
+
+  y.resize(x.size());
+  s.resize(x.size());
+  for (int64_t n = 0; n < batch; ++n) {
+    for (int64_t g = 0; g < groups; ++g) {
+      double sum = 0.0;
+      double squared_sum = 0.0;
+      for (int64_t p = 0; p < hw; ++p) {
+        for (int64_t k = 0; k < channels_per_group; ++k) {
+          const double v = sum_data[(n * hw + p) * channels + g * channels_per_group + k];
+          sum += v;
+          squared_sum += v * v;
+        }
+      }
+      const double count = static_cast<double>(hw * channels_per_group);
+      const double mean = sum / count;
+      const double inv_std = 1.0 / std::sqrt(squared_sum / count - mean * mean + epsilon);
+      for (int64_t p = 0; p < hw; ++p) {
+        for (int64_t k = 0; k < channels_per_group; ++k) {
+          const int64_t c = g * channels_per_group + k;
+          const int64_t idx = (n * hw + p) * channels + c;
+          y[idx] = static_cast<float>((sum_data[idx] - mean) * inv_std * gamma[c] + beta[c]);
+          s[idx] = static_cast<float>(sum_data[idx]);
+        }
+      }
+    }
+  }
+}
+
+// Rounds values through the storage type T so the reference sees exactly what the kernel reads.
+template <typename T>
+std::vector<float> RoundTripThrough(const std::vector<float>& values) {
+  if constexpr (std::is_same_v<T, MLFloat16>) {
+    std::vector<float> result;
+    result.reserve(values.size());
+    for (float v : values) {
+      result.push_back(MLFloat16(v).ToFloat());
+    }
+    return result;
+  } else {
+    return values;
+  }
+}
+
+// TX: type of X, skip, bias, Y and S (schema type T). TM: type of gamma and beta (schema type M).
+template <typename TX, typename TM>
+void RunSkipGroupNormWebGpu(int64_t channels, int64_t groups, SkipLayout skip_layout, bool has_bias,
+                            bool has_sum_output) {
+  constexpr int64_t B = 2;
+  constexpr int64_t H = 3;
+  constexpr int64_t W = 2;
+  constexpr float epsilon = 1e-5f;
+  const std::vector<int64_t> dims{B, H, W, channels};
+  const std::vector<int64_t> channel_dims{channels};
+
+  std::vector<int64_t> skip_dims;
+  switch (skip_layout) {
+    case SkipLayout::kFull:
+      skip_dims = dims;
+      break;
+    case SkipLayout::kNC:
+      skip_dims = {B, channels};
+      break;
+    case SkipLayout::kN11C:
+      skip_dims = {B, 1, 1, channels};
+      break;
+  }
+  const bool skip_broadcast = skip_layout != SkipLayout::kFull;
+
+  RandomValueGenerator random{1234};
+  const auto x = RoundTripThrough<TX>(random.Uniform<float>(dims, -1.0f, 1.0f));
+  const auto skip = RoundTripThrough<TX>(random.Uniform<float>(skip_dims, -1.0f, 1.0f));
+  const auto bias = RoundTripThrough<TX>(random.Uniform<float>(channel_dims, -0.5f, 0.5f));
+  const auto gamma = RoundTripThrough<TM>(random.Uniform<float>(channel_dims, 0.5f, 1.5f));
+  const auto beta = RoundTripThrough<TM>(random.Uniform<float>(channel_dims, -0.5f, 0.5f));
+
+  std::vector<float> y;
+  std::vector<float> s;
+  SkipGroupNormReference(x, skip, skip_broadcast, has_bias ? &bias : nullptr, gamma, beta,
+                         B, H * W, channels, groups, epsilon, y, s);
+
+  OpTester test("SkipGroupNorm", 1, onnxruntime::kMSDomain);
+  test.AddAttribute<float>("epsilon", epsilon);
+  test.AddAttribute<int64_t>("groups", groups);
+  test.AddAttribute<int64_t>("activation", 0);
+  test.AddAttribute<int64_t>("channels_last", 1);
+  test.AddInput<TX>("X", dims, GetTypedArray<TX>(x));
+  test.AddInput<TM>("gamma", channel_dims, GetTypedArray<TM>(gamma));
+  test.AddInput<TM>("beta", channel_dims, GetTypedArray<TM>(beta));
+  test.AddInput<TX>("skip", skip_dims, GetTypedArray<TX>(skip));
+  if (has_bias) {
+    test.AddInput<TX>("bias", channel_dims, GetTypedArray<TX>(bias));
+  }
+
+  constexpr float rel_error = 0.0f;
+  constexpr float abs_error = std::is_same_v<TX, MLFloat16> ? 0.02f : 1e-4f;
+  test.AddOutput<TX>("Y", dims, GetTypedArray<TX>(y), false, rel_error, abs_error);
+  if (has_sum_output) {
+    test.AddOutput<TX>("S", dims, GetTypedArray<TX>(s), false, rel_error, abs_error);
+  }
+
+  std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
+  execution_providers.push_back(DefaultWebGpuExecutionProvider());
+  test.Run(OpTester::ExpectResult::kExpectSuccess, "", {}, nullptr, &execution_providers);
+}
+
+}  // namespace
+
+// Uses H = 3, W = 2 so a kernel that fails to repeat skip values across spatial positions produces wrong
+// results, and also exercises the vec4 and vec2 variants with bias and S.
+TEST(SkipGroupNormTest, SkipGroupNorm_WebGpu_BroadcastSkipSpatial) {
+  if (DefaultWebGpuExecutionProvider().get() == nullptr) {
+    GTEST_SKIP() << "WebGPU EP is not available";
+  }
+
+  const std::vector<std::pair<int64_t, int64_t>> configs = {{8, 2}, {6, 3}};
+  for (const auto& [channels, groups] : configs) {
+    for (const SkipLayout skip_layout : {SkipLayout::kFull, SkipLayout::kNC, SkipLayout::kN11C}) {
+      for (const bool has_bias : {false, true}) {
+        for (const bool has_sum_output : {false, true}) {
+          RunSkipGroupNormWebGpu<MLFloat16, float>(channels, groups, skip_layout, has_bias, has_sum_output);
+          RunSkipGroupNormWebGpu<float, float>(channels, groups, skip_layout, has_bias, has_sum_output);
+        }
       }
     }
   }


### PR DESCRIPTION
### Description

Followed contrib [schema](https://github.com/microsoft/onnxruntime/blob/main/docs/ContribOperators.md), adds WebGPU EP kernels for `com.microsoft.GroupNorm` and
`com.microsoft.SkipGroupNorm`.

Implementation is a two-pass program shared by both ops:
- Stats pass: one workgroup per (batch, group) computes mean and
  inverse standard deviation in f32.
- Apply pass: elementwise normalize + per-channel affine + optional SiLU.
  For `SkipGroupNorm ` also adds skip and bias before normalization and
  optionally writes the sum to the output.

Covers the full schema: fp16/fp32 inputs with independent gamma/beta
type (M), skip broadcast as (N, C) or (N, 1, 1, C), optional bias and
optional S output.

`channels_last=0` is rejected, matching the CUDA kernel.

Tests: enables the existing GroupNormTest and SkipGroupNormTest
contrib-op tests for the WebGPU EP.

### Motivation and Context

The schema, the CUDA/DML kernels and the offline fusions in
`onnxruntime.transformers` all exist upstream,  but the WebGPU EP had no
kernel, so optimized diffusion models (SD/SDXL-style UNet and VAE) could
not run on WebGPU without falling back to the decomposed graph.

On a Stable-Diffusion-style VAE decoder at 1024x1024 (Intel Arc B390), fusing the decomposed `Reshape/InstanceNormalization/Mul/Add` pattern into these kernels reduced the 
end-to-end decode from ~9.1 s to ~4.5 s.

