### PR TITLE
[Node.js] Avoid duplicate N-API cleanup hook registration

### DIFF
--- a/js/node/src/ort_instance_data.cc
+++ b/js/node/src/ort_instance_data.cc
@@ -22,13 +22,13 @@ void OrtInstanceData::InitOrt(Napi::Env env, int log_level, Napi::Function tenso
 
   data->ortTensorConstructor = Napi::Persistent(tensorConstructor);
 
-  if (data->cleanup_hook_registered) {
+  if (data->ort_singleton_referenced) {
     return;
   }
 
-  // Retain the ORT singleton and register one cleanup hook for this env.
+  // Retain one reference to the ORT singleton for this env. The cleanup hook releases it when the env is torn down.
   OrtSingletonData::InitOrtObjects(env, log_level, is_main_thread);
-  data->cleanup_hook_registered = true;
+  data->ort_singleton_referenced = true;
 }
 
 const Napi::FunctionReference& OrtInstanceData::TensorConstructor(Napi::Env env) {

--- a/js/node/src/ort_instance_data.cc
+++ b/js/node/src/ort_instance_data.cc
@@ -20,11 +20,16 @@ void OrtInstanceData::InitOrt(Napi::Env env, int log_level, Napi::Function tenso
   auto data = env.GetInstanceData<OrtInstanceData>();
   ORT_NAPI_THROW_ERROR_IF(data == nullptr, env, "OrtInstanceData not created.");
 
+  if (data->ort_initialized) {
+    return;
+  }
+
   data->ortTensorConstructor = Napi::Persistent(tensorConstructor);
 
   // Initialize ORT singleton and register cleanup hook for this env.
-  // The first call creates the OrtObjects; subsequent calls increment the ref count.
+  // The first call from each env creates or retains the OrtObjects.
   OrtSingletonData::InitOrtObjects(env, log_level, is_main_thread);
+  data->ort_initialized = true;
 }
 
 const Napi::FunctionReference& OrtInstanceData::TensorConstructor(Napi::Env env) {

--- a/js/node/src/ort_instance_data.cc
+++ b/js/node/src/ort_instance_data.cc
@@ -20,16 +20,15 @@ void OrtInstanceData::InitOrt(Napi::Env env, int log_level, Napi::Function tenso
   auto data = env.GetInstanceData<OrtInstanceData>();
   ORT_NAPI_THROW_ERROR_IF(data == nullptr, env, "OrtInstanceData not created.");
 
-  if (data->ort_initialized) {
+  data->ortTensorConstructor = Napi::Persistent(tensorConstructor);
+
+  if (data->cleanup_hook_registered) {
     return;
   }
 
-  data->ortTensorConstructor = Napi::Persistent(tensorConstructor);
-
-  // Initialize ORT singleton and register cleanup hook for this env.
-  // The first call from each env creates or retains the OrtObjects.
+  // Retain the ORT singleton and register one cleanup hook for this env.
   OrtSingletonData::InitOrtObjects(env, log_level, is_main_thread);
-  data->ort_initialized = true;
+  data->cleanup_hook_registered = true;
 }
 
 const Napi::FunctionReference& OrtInstanceData::TensorConstructor(Napi::Env env) {

--- a/js/node/src/ort_instance_data.h
+++ b/js/node/src/ort_instance_data.h
@@ -29,5 +29,5 @@ struct OrtInstanceData {
   // per env persistent constructors
   Napi::FunctionReference wrappedSessionConstructor;
   Napi::FunctionReference ortTensorConstructor;
-  bool ort_initialized{false};
+  bool cleanup_hook_registered{false};
 };

--- a/js/node/src/ort_instance_data.h
+++ b/js/node/src/ort_instance_data.h
@@ -29,4 +29,5 @@ struct OrtInstanceData {
   // per env persistent constructors
   Napi::FunctionReference wrappedSessionConstructor;
   Napi::FunctionReference ortTensorConstructor;
+  bool ort_initialized{false};
 };

--- a/js/node/src/ort_instance_data.h
+++ b/js/node/src/ort_instance_data.h
@@ -29,5 +29,5 @@ struct OrtInstanceData {
   // per env persistent constructors
   Napi::FunctionReference wrappedSessionConstructor;
   Napi::FunctionReference ortTensorConstructor;
-  bool cleanup_hook_registered{false};
+  bool ort_singleton_referenced{false};
 };

--- a/js/node/test/standalone/index.ts
+++ b/js/node/test/standalone/index.ts
@@ -6,8 +6,15 @@ import * as assert from 'assert';
 import * as path from 'path';
 
 describe('Standalone Process Tests', () => {
+  type ProcessResult = {
+    code: number | null;
+    signal: NodeJS.Signals | null;
+    stdout: string;
+    stderr: string;
+  };
+
   // Helper function to run test script in a separate process
-  const runTest = async (args: string[] = []): Promise<{ code: number; stdout: string; stderr: string }> =>
+  const runTest = async (args: string[] = []): Promise<ProcessResult> =>
     new Promise((resolve, reject) => {
       // Use the compiled main.js file from the lib directory
       const testFile = path.join(__dirname, './main.js');
@@ -20,16 +27,22 @@ describe('Standalone Process Tests', () => {
       child.stdout.on('data', (data) => (stdout += data.toString()));
       child.stderr.on('data', (data) => (stderr += data.toString()));
 
-      child.on('close', (code) => {
-        resolve({ code: code || 0, stdout, stderr });
+      child.on('close', (code, signal) => {
+        resolve({ code, signal, stdout, stderr });
       });
 
       child.on('error', reject);
     });
 
+  // Helper function to verify that the child was not terminated by a signal
+  const assertNormalExit = (result: ProcessResult) => {
+    assert.strictEqual(result.signal, null, `Child terminated by signal ${result.signal}.\n${result.stderr}`);
+    assert.strictEqual(result.code, 0, result.stderr);
+  };
+
   // Helper function to check basic success criteria
-  const assertSuccess = (result: { code: number; stdout: string; stderr: string }) => {
-    assert.strictEqual(result.code, 0);
+  const assertSuccess = (result: ProcessResult) => {
+    assertNormalExit(result);
     assert.ok(result.stdout.includes('SUCCESS: Inference completed'));
     assert.ok(!result.stderr.includes('mutex lock failed'));
   };
@@ -53,6 +66,7 @@ describe('Standalone Process Tests', () => {
   it('should handle uncaught exceptions', async () => {
     const result = await runTest(['--throw-exception']);
 
+    assert.strictEqual(result.signal, null, `Child terminated by signal ${result.signal}.\n${result.stderr}`);
     assert.notStrictEqual(result.code, 0);
     assert.ok(result.stdout.includes('SUCCESS: Inference completed'));
     assert.ok(result.stderr.includes('Test exception'));
@@ -86,7 +100,7 @@ describe('Standalone Process Tests', () => {
 
   it('should allow repeated native ORT initialization', async () => {
     const result = await runTest(['--initialize-twice']);
-    assert.strictEqual(result.code, 0, result.stderr);
+    assertNormalExit(result);
     assert.ok(result.stdout.includes('SUCCESS: ORT initialized twice'));
   });
 });

--- a/js/node/test/standalone/index.ts
+++ b/js/node/test/standalone/index.ts
@@ -83,4 +83,10 @@ describe('Standalone Process Tests', () => {
     assertSuccess(result);
     assert.ok(result.stdout.includes('Session NOT released'));
   });
+
+  it('should allow repeated native ORT initialization', async () => {
+    const result = await runTest(['--initialize-twice']);
+    assert.strictEqual(result.code, 0, result.stderr);
+    assert.ok(result.stdout.includes('SUCCESS: ORT initialized twice'));
+  });
 });

--- a/js/node/test/standalone/main.ts
+++ b/js/node/test/standalone/main.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 import * as path from 'path';
+import { isMainThread } from 'worker_threads';
 const ort = require(path.join(__dirname, '../../'));
 import * as process from 'process';
 
@@ -10,9 +11,20 @@ const modelData =
 const shouldProcessExit = process.argv.includes('--process-exit');
 const shouldThrowException = process.argv.includes('--throw-exception');
 const shouldRelease = process.argv.includes('--release');
+const shouldInitializeOrtTwice = process.argv.includes('--initialize-twice');
 
 async function main() {
   try {
+    if (shouldInitializeOrtTwice) {
+      const binding = require(
+        path.join(__dirname, `../../bin/napi-v6/${process.platform}/${process.arch}/onnxruntime_binding.node`),
+      );
+      binding.initOrtOnce(2, function Tensor() {}, isMainThread);
+      binding.initOrtOnce(2, function Tensor() {}, isMainThread);
+      console.log('SUCCESS: ORT initialized twice');
+      return;
+    }
+
     const modelBuffer = Buffer.from(modelData, 'base64');
     const session = await ort.InferenceSession.create(modelBuffer);
 

--- a/js/node/test/standalone/main.ts
+++ b/js/node/test/standalone/main.ts
@@ -3,6 +3,7 @@
 
 import * as path from 'path';
 import { isMainThread } from 'worker_threads';
+import { Tensor } from 'onnxruntime-common';
 const ort = require(path.join(__dirname, '../../'));
 import * as process from 'process';
 
@@ -19,8 +20,32 @@ async function main() {
       const binding = require(
         path.join(__dirname, `../../bin/napi-v6/${process.platform}/${process.arch}/onnxruntime_binding.node`),
       );
-      binding.initOrtOnce(2, function Tensor() {}, isMainThread);
-      binding.initOrtOnce(2, function Tensor() {}, isMainThread);
+      let lastTensorConstructor = '';
+      const createTensorConstructor = (name: string) =>
+        function (type: Tensor.Type, data: Tensor.DataType, dims?: readonly number[]) {
+          lastTensorConstructor = name;
+          return new Tensor(type, data, dims);
+        } as unknown as typeof Tensor;
+      const FirstTensor = createTensorConstructor('first');
+      const SecondTensor = createTensorConstructor('second');
+      binding.initOrtOnce(2, FirstTensor, isMainThread);
+      binding.initOrtOnce(2, SecondTensor, isMainThread);
+
+      const modelBuffer = Buffer.from(modelData, 'base64');
+      const session = new binding.InferenceSession();
+      session.loadModel(modelBuffer.buffer, modelBuffer.byteOffset, modelBuffer.byteLength, {});
+      const result = session.run(
+        {
+          a: new Tensor('float32', Float32Array.from([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]), [3, 4]),
+          b: new Tensor('float32', Float32Array.from([10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120]), [4, 3]),
+        },
+        { c: null },
+        {},
+      );
+      if (lastTensorConstructor !== 'second' || !(result.c instanceof Tensor)) {
+        throw new Error('Repeated initialization did not update the Tensor constructor.');
+      }
+      session.dispose();
       console.log('SUCCESS: ORT initialized twice');
       return;
     }


### PR DESCRIPTION
### Description

- Retain the native ORT singleton and register its N-API cleanup hook only once per `napi_env`.
- Continue refreshing the Tensor constructor on every `initOrtOnce()` call, preserving module-reload behavior.
- Keep initialization independent across Node.js worker environments.
- Add a standalone regression test that calls `initOrtOnce()` twice, verifies that the latest Tensor constructor is used, and requires a normal process exit.

### Motivation and Context

Calling the native `initOrtOnce()` export more than once in the same environment registered the same N-API cleanup hook twice. Recent Node.js versions assert on that duplicate registration and abort the process.

The guard is deliberately scoped to retaining the singleton and registering the cleanup hook. Per-environment binding state, including the Tensor constructor, is still refreshed on repeated calls.

Fixes #32464

### Testing

- Verified that the original two-call reproducer changes from exit code 134 to a normal code-0 exit.
- Ran the relevant Node API and lifecycle tests: 22 passing.
- Ran the standalone and worker tests after strengthening signal-termination detection: 9 passing.
- Ran ESLint, Prettier, clang-format, the TypeScript project checks, and `git diff --check`.
