### PR TITLE
[objectivec] expose session profiling api

### DIFF
--- a/objectivec/include/ort_session.h
+++ b/objectivec/include/ort_session.h
@@ -89,6 +89,16 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (nullable NSArray<NSString*>*)outputNamesWithError:(NSError**)error;
 
+/**
+ * Ends profiling and returns the filename of the file the profiling data was written to.
+ *
+ * Profiling is turned on through `-[ORTSessionOptions enableProfilingWithFilePrefix:error:]`.
+ *
+ * @param error Optional error information set if an error occurs.
+ * @return The profiling file name, an empty string if profiling was not enabled or nil if an error occurs.
+ */
+- (nullable NSString*)endProfilingWithError:(NSError**)error;
+
 @end
 
 /**
@@ -256,6 +266,28 @@ NS_ASSUME_NONNULL_BEGIN
  * @return Whether the ONNX Runtime Extensions custom ops were successfully registered.
  */
 - (BOOL)enableOrtExtensionsCustomOpsWithError:(NSError**)error;
+
+/**
+ * Enables profiling in sessions using this ORTSessionOptions object.
+ *
+ * The profiling results will be written into a profile file named `[filePrefix]_[timestamp].json`.
+ * Directories included in the prefix must exist.
+ * Prefix may be an absolute path or relative to current working directory.
+ *
+ * @param filePrefix The prefix for the path of the profile file.
+ * @param error Optional error information set if an error occurs.
+ * @return Whether profiling was successfully enabled.
+ */
+- (BOOL)enableProfilingWithFilePrefix:(NSString*)filePrefix
+                                error:(NSError**)error;
+
+/**
+ * Disables profiling in sessions using this ORTSessionOptions object.
+ *
+ * @param error Optional error information set if an error occurs.
+ * @return Whether profiling was successfully disabled.
+ */
+- (BOOL)disableProfilingWithError:(NSError**)error;
 
 @end
 

--- a/objectivec/ort_session.mm
+++ b/objectivec/ort_session.mm
@@ -167,6 +167,15 @@ NS_ASSUME_NONNULL_BEGIN
   return [self namesWithType:NamedValueType::Output error:error];
 }
 
+- (nullable NSString*)endProfilingWithError:(NSError**)error {
+  try {
+    Ort::AllocatorWithDefaultOptions allocator;
+    Ort::AllocatedStringPtr path = _session->EndProfilingAllocated(allocator);
+    return utils::toNSString(path.get());
+  }
+  ORT_OBJC_API_IMPL_CATCH_RETURNING_NULLABLE(error)
+}
+
 #pragma mark - Private
 
 - (nullable NSArray<NSString*>*)namesWithType:(NamedValueType)namedValueType
@@ -327,6 +336,22 @@ NS_ASSUME_NONNULL_BEGIN
 - (BOOL)enableOrtExtensionsCustomOpsWithError:(NSError**)error {
   try {
     _sessionOptions->EnableOrtCustomOps();
+    return YES;
+  }
+  ORT_OBJC_API_IMPL_CATCH_RETURNING_BOOL(error)
+}
+
+- (BOOL)enableProfilingWithFilePrefix:(NSString*)filePrefix error:(NSError**)error {
+  try {
+    _sessionOptions->EnableProfiling(filePrefix.UTF8String);
+    return YES;
+  }
+  ORT_OBJC_API_IMPL_CATCH_RETURNING_BOOL(error)
+}
+
+- (BOOL)disableProfilingWithError:(NSError**)error {
+  try {
+    _sessionOptions->DisableProfiling();
     return YES;
   }
   ORT_OBJC_API_IMPL_CATCH_RETURNING_BOOL(error)

--- a/objectivec/test/ort_session_test.mm
+++ b/objectivec/test/ort_session_test.mm
@@ -87,6 +87,16 @@ NS_ASSUME_NONNULL_BEGIN
   return runOptions;
 }
 
++ (NSDictionary<NSString*, ORTValue*>*)makeTestInput {
+  NSMutableData* aData = [ORTSessionTest dataWithScalarFloat:1.0f];
+  NSMutableData* bData = [ORTSessionTest dataWithScalarFloat:2.0f];
+
+  ORTValue* a = [ORTSessionTest ortValueWithScalarFloatData:aData];
+  ORTValue* b = [ORTSessionTest ortValueWithScalarFloatData:bData];
+
+  return @{@"A" : a, @"B" : b};
+}
+
 - (void)testInitAndRunWithPreallocatedOutputOk {
   NSMutableData* aData = [ORTSessionTest dataWithScalarFloat:1.0f];
   NSMutableData* bData = [ORTSessionTest dataWithScalarFloat:2.0f];
@@ -341,6 +351,114 @@ static OrtStatus* _Nullable DummyRegisterCustomOpsFn(OrtSessionOptions* /*sessio
   env = nil;
   // ORTSession should keep a strong reference to it.
   XCTAssertNotNil(envWeak);
+}
+
+- (void)testProfilingWithPrefixOk {
+  // Absolute path with file prefix in a temporary directory
+  NSString* prefix = [NSTemporaryDirectory() stringByAppendingPathComponent:@"profile"];
+
+  NSError* err = nil;
+  ORTSessionOptions* sessionOptions = [ORTSessionTest makeSessionOptions];
+  BOOL enableResult = [sessionOptions enableProfilingWithFilePrefix:prefix error:&err];
+  ORTAssertBoolResultSuccessful(enableResult, err);
+  ORTSession* session = [[ORTSession alloc] initWithEnv:self.ortEnv
+                                              modelPath:[ORTSessionTest getAddModelPath]
+                                         sessionOptions:sessionOptions
+                                                  error:&err];
+  ORTAssertNullableResultSuccessful(session, err);
+
+  NSDictionary<NSString*, ORTValue*>* outputs =
+      [session runWithInputs:[ORTSessionTest makeTestInput]
+                 outputNames:[NSSet setWithArray:@[ @"C" ]]
+                  runOptions:[ORTSessionTest makeRunOptions]
+                       error:&err];
+  ORTAssertNullableResultSuccessful(outputs, err);
+
+  NSString* path = [session endProfilingWithError:&err];
+  ORTAssertNullableResultSuccessful(path, err);
+  XCTAssert([path hasPrefix:prefix]);
+  XCTAssert([path hasSuffix:@".json"]);
+
+  NSFileManager* fileManager = [NSFileManager defaultManager];
+  XCTAssert([fileManager fileExistsAtPath:path]);
+  // Try cleaning up generated files after test has passed
+  [fileManager removeItemAtPath:path error:nil];
+}
+
+- (void)testProfilingWithEmptyPrefixOk {
+  // Relative path without prefix. Resolved relative to working directory (e.g. build/Debug)
+  NSString* prefix = @"";
+
+  NSError* err = nil;
+  ORTSessionOptions* sessionOptions = [ORTSessionTest makeSessionOptions];
+  BOOL enableResult = [sessionOptions enableProfilingWithFilePrefix:prefix error:&err];
+  ORTAssertBoolResultSuccessful(enableResult, err);
+  ORTSession* session = [[ORTSession alloc] initWithEnv:self.ortEnv
+                                              modelPath:[ORTSessionTest getAddModelPath]
+                                         sessionOptions:sessionOptions
+                                                  error:&err];
+  ORTAssertNullableResultSuccessful(session, err);
+
+  NSDictionary<NSString*, ORTValue*>* outputs =
+      [session runWithInputs:[ORTSessionTest makeTestInput]
+                 outputNames:[NSSet setWithArray:@[ @"C" ]]
+                  runOptions:[ORTSessionTest makeRunOptions]
+                       error:&err];
+  ORTAssertNullableResultSuccessful(outputs, err);
+
+  NSString* path = [session endProfilingWithError:&err];
+  ORTAssertNullableResultSuccessful(path, err);
+  XCTAssert([path hasSuffix:@".json"]);
+
+  NSFileManager* fileManager = [NSFileManager defaultManager];
+  XCTAssert([fileManager fileExistsAtPath:path]);
+  // Try cleaning up generated files after test has passed
+  [fileManager removeItemAtPath:path error:&err];
+}
+
+- (void)testDisableProfilingStopsProfilingInFutureSessions {
+  NSError* err = nil;
+
+  NSFileManager* fileManager = [NSFileManager defaultManager];
+  NSString* tmpFolder = [NSTemporaryDirectory() stringByAppendingPathComponent:[NSUUID UUID].UUIDString];
+  BOOL createdTmpFolder = [fileManager createDirectoryAtPath:tmpFolder
+                                 withIntermediateDirectories:NO
+                                                  attributes:nil
+                                                       error:&err];
+  ORTAssertBoolResultSuccessful(createdTmpFolder, err);
+  NSString* prefix = [tmpFolder stringByAppendingPathComponent:@"profile"];
+  ORTSessionOptions* sessionOptions = [ORTSessionTest makeSessionOptions];
+
+  BOOL enableResult = [sessionOptions enableProfilingWithFilePrefix:prefix error:&err];
+  ORTAssertBoolResultSuccessful(enableResult, err);
+  BOOL disableResult = [sessionOptions disableProfilingWithError:&err];
+  ORTAssertBoolResultSuccessful(disableResult, err);
+
+  ORTSession* session = [[ORTSession alloc] initWithEnv:self.ortEnv
+                                              modelPath:[ORTSessionTest getAddModelPath]
+                                         sessionOptions:sessionOptions
+                                                  error:&err];
+  ORTAssertNullableResultSuccessful(session, err);
+
+  NSDictionary<NSString*, ORTValue*>* outputs =
+      [session runWithInputs:[ORTSessionTest makeTestInput]
+                 outputNames:[NSSet setWithArray:@[ @"C" ]]
+                  runOptions:[ORTSessionTest makeRunOptions]
+                       error:&err];
+  ORTAssertNullableResultSuccessful(outputs, err);
+
+  NSString* path = [session endProfilingWithError:&err];
+  ORTAssertNullableResultSuccessful(path, err);
+  XCTAssert([path isEqual:@""]);
+
+  // Check no profile json files were created in folder
+  NSArray<NSString*>* tmpFiles = [fileManager contentsOfDirectoryAtPath:tmpFolder error:&err];
+  ORTAssertNullableResultSuccessful(tmpFiles, err);
+  for (NSString* filename in tmpFiles) {
+    XCTAssertFalse([filename hasSuffix:@".json"]);
+  }
+  // Try cleaning up created directory after test has passed
+  [fileManager removeItemAtPath:tmpFolder error:nil];
 }
 
 @end


### PR DESCRIPTION
Add Objective-C bindings exposing the following existing C++ API in the public Objective-C API:
* Ort::Session::EndProfilingAllocated
* Ort::SessionOptions::EnableProfiling
* Ort::SessionOptions::DisableProfiling

### Description
Makes session profiling available via official Objective-C API.

### Motivation and Context
The current implementation does not give access to profiling on the Objective-C level. Access to the underlying C++ objects is hidden behind internal headers and not possible when including onnxruntime via SwiftPackageManager.

I'm currently working on packaging the iOS / Swift Engine of [PaddleOCR](https://github.com/PaddlePaddle/PaddleOCR) as a Swift Package Manager module. This engine currently relies on installing onnxruntime via cocoapods and bypassing visibility by importing internal headers (in [ORTProfilingBridge.mm](https://github.com/PaddlePaddle/PaddleOCR/blob/main/deploy/ios_demo/PaddleOCRDemo/Engine/ORTProfilingBridge.mm)).  
Installation via SPM no longer allows these imports and requires an official api for accessing profiling functionality.

### New Objective-C API Proposed

**ORTSessionOptions**
```
- (BOOL)enableProfilingWithFilePrefix:(NSString*)filePrefix
                                error:(NSError**)error;
- (BOOL)disableProfilingWithError:(NSError**)error;
```

**ORTSession**
```
- (nullable NSString*)endProfilingWithError:(NSError**)error;
```

> [!NOTE]
> This PR proposes adding public API that is new to the language binding, but not new to the project. API for the same functionality already exists in various other language bindings of the project (C, C++, Java, Python, etc). 
> I have therefore not created a GitHub issue for this topic, but am happy to do so if necessary.
> Rel: [Contributing.md / Propose a new public API](https://github.com/microsoft/onnxruntime/blob/main/CONTRIBUTING.md#propose-a-new-public-api)

### Alternatives considered
* Vendor access to underlying C++ API by turning `objectivec/ort_session_internal.h` into a `objectivec/include/ort_session_cxx.h`
* Alternate naming:
  * `enableProfilingWithProfileFilePrefix:` instead of `enableProfilingWithFilePrefix:`
  * `enableProfilingWithPathPrefix:` instead of `enableProfilingWithFilePrefix:`