### PR TITLE
Fix duplicated subgraph initializers when saving a model with external data

### DIFF
--- a/onnxruntime/core/graph/graph.cc
+++ b/onnxruntime/core/graph/graph.cc
@@ -5195,6 +5195,15 @@ Status Graph::AddExternalInitializersToGraphProtoImpl(
     for (SubgraphWithMutableProto& subgraph_and_proto : subgraphs) {
       gsl::not_null<const Graph*> subgraph = subgraph_and_proto.subgraph;
       gsl::not_null<ONNX_NAMESPACE::GraphProto*> subgraph_proto = subgraph_and_proto.subgraph_proto;
+
+      // Clear pre-existing initializers from the subgraph proto. The subgraph proto was populated by
+      // Node::ToProto -> Graph::ToGraphProto() const, which already inlined in-memory data.
+      // The recursive Impl call below re-adds all initializers, so we must clear to avoid duplicates.
+      subgraph_proto->clear_initializer();
+#if !defined(DISABLE_SPARSE_TENSORS)
+      subgraph_proto->clear_sparse_initializer();
+#endif
+
       ORT_RETURN_IF_ERROR(subgraph->AddExternalInitializersToGraphProtoImpl(
           model_path, external_file_path,
           model_external_file_path, model_saving_options,

--- a/onnxruntime/test/framework/save_model_with_external_initializers.cc
+++ b/onnxruntime/test/framework/save_model_with_external_initializers.cc
@@ -1,6 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+#include <fstream>
+#include <map>
+
 #include "core/common/common.h"
 #include "core/common/status.h"
 #include "core/common/path_string.h"
@@ -127,6 +130,154 @@ TEST(SaveWithExternalInitializers, ModelWithOriginalExternalDataAlignOffset) {
       ORT_TSTR("model_with_orig_ext_data.onnx.data"),
       ORT_TSTR("testdata/model_with_new_external_initializers.onnx"),
       ORT_TSTR("model_with_new_external_initializers.bin"), model_saving_options));
+}
+
+
+namespace {
+
+// Builds a model whose If branches own their initializers. The optimized-model
+// saving path used to emit each of those twice: Node::ToProto had already placed
+// them in the subgraph proto and the recursion added them again.
+void AddSubgraphInitializer(GraphProto& graph, const std::string& name, int64_t rows, int64_t cols) {
+  TensorProto* tensor = graph.add_initializer();
+  tensor->set_name(name);
+  tensor->set_data_type(TensorProto_DataType_FLOAT);
+  tensor->add_dims(rows);
+  tensor->add_dims(cols);
+  tensor->set_raw_data(std::string(static_cast<size_t>(rows * cols * sizeof(float)), '\1'));
+}
+
+void MakeIfBranch(GraphProto& graph, const std::string& graph_name, const std::string& weight_name,
+                  const std::string& output_name, int64_t rows, int64_t cols) {
+  graph.set_name(graph_name);
+  AddSubgraphInitializer(graph, weight_name, rows, cols);
+
+  NodeProto* node = graph.add_node();
+  node->set_op_type("MatMul");
+  node->add_input("x");
+  node->add_input(weight_name);
+  node->add_output(output_name);
+
+  ValueInfoProto* output = graph.add_output();
+  output->set_name(output_name);
+  auto* tensor_type = output->mutable_type()->mutable_tensor_type();
+  tensor_type->set_elem_type(TensorProto_DataType_FLOAT);
+  tensor_type->mutable_shape()->add_dim()->set_dim_param("N");
+  tensor_type->mutable_shape()->add_dim()->set_dim_value(cols);
+}
+
+ModelProto MakeModelWithSubgraphInitializers(int64_t rows, int64_t cols) {
+  ModelProto model;
+  model.set_ir_version(8);
+  OperatorSetIdProto* opset = model.add_opset_import();
+  opset->set_domain("");
+  opset->set_version(13);
+
+  GraphProto* graph = model.mutable_graph();
+  graph->set_name("main");
+
+  ValueInfoProto* x = graph->add_input();
+  x->set_name("x");
+  auto* x_type = x->mutable_type()->mutable_tensor_type();
+  x_type->set_elem_type(TensorProto_DataType_FLOAT);
+  x_type->mutable_shape()->add_dim()->set_dim_param("N");
+  x_type->mutable_shape()->add_dim()->set_dim_value(rows);
+
+  ValueInfoProto* cond = graph->add_input();
+  cond->set_name("cond");
+  cond->mutable_type()->mutable_tensor_type()->set_elem_type(TensorProto_DataType_BOOL);
+  cond->mutable_type()->mutable_tensor_type()->mutable_shape();
+
+  NodeProto* if_node = graph->add_node();
+  if_node->set_op_type("If");
+  if_node->add_input("cond");
+  if_node->add_output("y");
+
+  AttributeProto* then_attr = if_node->add_attribute();
+  then_attr->set_name("then_branch");
+  then_attr->set_type(AttributeProto_AttributeType_GRAPH);
+  MakeIfBranch(*then_attr->mutable_g(), "then", "Wa", "then_out", rows, cols);
+
+  AttributeProto* else_attr = if_node->add_attribute();
+  else_attr->set_name("else_branch");
+  else_attr->set_type(AttributeProto_AttributeType_GRAPH);
+  MakeIfBranch(*else_attr->mutable_g(), "else", "Wb", "else_out", rows, cols);
+
+  ValueInfoProto* y = graph->add_output();
+  y->set_name("y");
+  auto* y_type = y->mutable_type()->mutable_tensor_type();
+  y_type->set_elem_type(TensorProto_DataType_FLOAT);
+  y_type->mutable_shape()->add_dim()->set_dim_param("N");
+  y_type->mutable_shape()->add_dim()->set_dim_value(cols);
+  return model;
+}
+
+void CountSubgraphInitializers(const GraphProto& graph, std::map<std::string, int>& counts, int depth) {
+  if (depth > 0) {
+    for (const auto& tensor : graph.initializer()) {
+      counts[tensor.name()]++;
+    }
+  }
+  for (const auto& node : graph.node()) {
+    for (const auto& attribute : node.attribute()) {
+      if (attribute.has_g()) {
+        CountSubgraphInitializers(attribute.g(), counts, depth + 1);
+      }
+      for (const auto& subgraph : attribute.graphs()) {
+        CountSubgraphInitializers(subgraph, counts, depth + 1);
+      }
+    }
+  }
+}
+
+// Saves a model whose subgraphs own initializers and checks that each of them is
+// declared exactly once, and that the saved model can be loaded back.
+void SaveAndCheckSubgraphInitializers(int64_t rows, int64_t cols, size_t size_threshold) {
+  auto logger = DefaultLoggingManager().CreateLogger("SaveWithExternalInitializers");
+
+  const auto output_onnx = std::filesystem::temp_directory_path() / "subgraph_initializers.onnx";
+  const std::filesystem::path output_external{"subgraph_initializers.onnx.data"};
+  std::filesystem::remove(output_onnx);
+  std::filesystem::remove(output_onnx.parent_path() / output_external);
+
+  std::shared_ptr<Model> model;
+  ASSERT_STATUS_OK(Model::Load(MakeModelWithSubgraphInitializers(rows, cols), model, nullptr, *logger));
+
+  ModelSavingOptions saving_options{size_threshold};
+  saving_options.align_offset = true;
+  ASSERT_STATUS_OK(Model::SaveWithExternalInitializers(*model, output_onnx, output_external, saving_options));
+
+  ModelProto saved;
+  {
+    std::ifstream saved_stream(output_onnx, std::ios::binary);
+    ASSERT_TRUE(saved_stream.is_open());
+    ASSERT_TRUE(saved.ParseFromIstream(&saved_stream));
+  }
+
+  std::map<std::string, int> counts;
+  CountSubgraphInitializers(saved.graph(), counts, 0);
+  ASSERT_EQ(counts.size(), static_cast<size_t>(2));
+  for (const auto& [name, count] : counts) {
+    EXPECT_EQ(count, 1) << "subgraph initializer '" << name << "' was written " << count << " times";
+  }
+
+  std::shared_ptr<Model> reloaded;
+  ASSERT_STATUS_OK(Model::Load(output_onnx.native(), reloaded, nullptr, *logger));
+
+  std::filesystem::remove(output_onnx);
+  std::filesystem::remove(output_onnx.parent_path() / output_external);
+}
+
+}  // namespace
+
+// Subgraph initializers small enough to stay embedded in the .onnx file.
+TEST(SaveWithExternalInitializers, SubgraphInitializersBelowThresholdNotDuplicated) {
+  SaveAndCheckSubgraphInitializers(/*rows*/ 8, /*cols*/ 8, /*size_threshold*/ 1024);
+}
+
+// Subgraph initializers large enough to be written to the external data file.
+TEST(SaveWithExternalInitializers, SubgraphInitializersAboveThresholdNotDuplicated) {
+  SaveAndCheckSubgraphInitializers(/*rows*/ 512, /*cols*/ 512, /*size_threshold*/ 1024);
 }
 
 }  // namespace test

--- a/onnxruntime/test/framework/save_model_with_external_initializers.cc
+++ b/onnxruntime/test/framework/save_model_with_external_initializers.cc
@@ -216,6 +216,11 @@ void CountSubgraphInitializers(const GraphProto& graph, std::map<std::string, in
     for (const auto& tensor : graph.initializer()) {
       counts[tensor.name()]++;
     }
+#if !defined(DISABLE_SPARSE_TENSORS)
+    for (const auto& sparse_tensor : graph.sparse_initializer()) {
+      counts[sparse_tensor.values().name()]++;
+    }
+#endif
   }
   for (const auto& node : graph.node()) {
     for (const auto& attribute : node.attribute()) {
@@ -278,6 +283,132 @@ TEST(SaveWithExternalInitializers, SubgraphInitializersBelowThresholdNotDuplicat
 TEST(SaveWithExternalInitializers, SubgraphInitializersAboveThresholdNotDuplicated) {
   SaveAndCheckSubgraphInitializers(/*rows*/ 512, /*cols*/ 512, /*size_threshold*/ 1024);
 }
+
+#if !defined(DISABLE_SPARSE_TENSORS)
+namespace {
+
+// Same shape as MakeIfBranch, but the branch owns a sparse initializer. The Graph
+// constructor converts it to a dense in-memory initializer and tracks the name, and
+// saving re-emits it as a sparse_initializer entry in the subgraph proto.
+void MakeIfBranchWithSparseInitializer(GraphProto& graph, const std::string& graph_name,
+                                       const std::string& weight_name, const std::string& output_name,
+                                       int64_t rows, int64_t cols) {
+  graph.set_name(graph_name);
+
+  SparseTensorProto* sparse = graph.add_sparse_initializer();
+  TensorProto* values = sparse->mutable_values();
+  values->set_name(weight_name);
+  values->set_data_type(TensorProto_DataType_FLOAT);
+  values->add_dims(2);
+  const float nonzero_values[2] = {1.0f, 2.0f};
+  values->set_raw_data(nonzero_values, sizeof(nonzero_values));
+  TensorProto* indices = sparse->mutable_indices();
+  indices->set_name(weight_name + "_indices");
+  indices->set_data_type(TensorProto_DataType_INT64);
+  indices->add_dims(2);
+  const int64_t nonzero_indices[2] = {0, rows * cols - 1};
+  indices->set_raw_data(nonzero_indices, sizeof(nonzero_indices));
+  sparse->add_dims(rows * cols);
+
+  NodeProto* node = graph.add_node();
+  node->set_op_type("Identity");
+  node->add_input(weight_name);
+  node->add_output(output_name);
+
+  ValueInfoProto* output = graph.add_output();
+  output->set_name(output_name);
+  auto* tensor_type = output->mutable_type()->mutable_tensor_type();
+  tensor_type->set_elem_type(TensorProto_DataType_FLOAT);
+  tensor_type->mutable_shape()->add_dim()->set_dim_value(rows * cols);
+}
+
+ModelProto MakeModelWithSparseSubgraphInitializers(int64_t rows, int64_t cols) {
+  ModelProto model;
+  model.set_ir_version(8);
+  OperatorSetIdProto* opset = model.add_opset_import();
+  opset->set_domain("");
+  opset->set_version(13);
+
+  GraphProto* graph = model.mutable_graph();
+  graph->set_name("main");
+
+  ValueInfoProto* cond = graph->add_input();
+  cond->set_name("cond");
+  cond->mutable_type()->mutable_tensor_type()->set_elem_type(TensorProto_DataType_BOOL);
+  cond->mutable_type()->mutable_tensor_type()->mutable_shape();
+
+  NodeProto* if_node = graph->add_node();
+  if_node->set_op_type("If");
+  if_node->add_input("cond");
+  if_node->add_output("y");
+
+  AttributeProto* then_attr = if_node->add_attribute();
+  then_attr->set_name("then_branch");
+  then_attr->set_type(AttributeProto_AttributeType_GRAPH);
+  MakeIfBranchWithSparseInitializer(*then_attr->mutable_g(), "then", "Sa", "then_out", rows, cols);
+
+  AttributeProto* else_attr = if_node->add_attribute();
+  else_attr->set_name("else_branch");
+  else_attr->set_type(AttributeProto_AttributeType_GRAPH);
+  MakeIfBranchWithSparseInitializer(*else_attr->mutable_g(), "else", "Sb", "else_out", rows, cols);
+
+  ValueInfoProto* y = graph->add_output();
+  y->set_name("y");
+  auto* y_type = y->mutable_type()->mutable_tensor_type();
+  y_type->set_elem_type(TensorProto_DataType_FLOAT);
+  y_type->mutable_shape()->add_dim()->set_dim_value(rows * cols);
+  return model;
+}
+
+}  // namespace
+
+// Subgraphs owning sparse initializers must keep exactly one sparse_initializer
+// entry each after saving.
+TEST(SaveWithExternalInitializers, SubgraphSparseInitializersNotDuplicated) {
+  auto logger = DefaultLoggingManager().CreateLogger("SaveWithExternalInitializers");
+
+  const auto output_onnx = std::filesystem::temp_directory_path() / "subgraph_sparse_initializers.onnx";
+  const std::filesystem::path output_external{"subgraph_sparse_initializers.onnx.data"};
+  std::filesystem::remove(output_onnx);
+  std::filesystem::remove(output_onnx.parent_path() / output_external);
+
+  const auto input_onnx = std::filesystem::temp_directory_path() / "subgraph_sparse_input.onnx";
+  {
+    ModelProto input_proto = MakeModelWithSparseSubgraphInitializers(/*rows*/ 8, /*cols*/ 8);
+    std::ofstream input_stream(input_onnx, std::ios::binary);
+    ASSERT_TRUE(input_proto.SerializeToOstream(&input_stream));
+  }
+  std::shared_ptr<Model> model;
+  ASSERT_STATUS_OK(Model::Load(input_onnx.native(), model, nullptr, *logger));
+
+  ModelSavingOptions saving_options{/*size_threshold*/ 1024};
+  saving_options.align_offset = true;
+  ASSERT_STATUS_OK(Model::SaveWithExternalInitializers(*model, output_onnx, output_external, saving_options));
+
+  ModelProto saved;
+  {
+    std::ifstream saved_stream(output_onnx, std::ios::binary);
+    ASSERT_TRUE(saved_stream.is_open());
+    ASSERT_TRUE(saved.ParseFromIstream(&saved_stream));
+  }
+
+  std::map<std::string, int> counts;
+  CountSubgraphInitializers(saved.graph(), counts, 0);
+  ASSERT_EQ(counts.size(), static_cast<size_t>(2));
+  for (const auto& [name, count] : counts) {
+    EXPECT_EQ(count, 1) << "subgraph initializer '" << name << "' was written " << count << " times";
+  }
+
+  // Reloading the saved model is not asserted here: DenseTensorToSparseTensorProto narrows
+  // the indices to the smallest integer type that fits (int8 here), while the onnx checker
+  // requires INT64 for sparse indices, so reloading a model with subgraph sparse initializers
+  // fails for that unrelated, pre-existing reason regardless of the duplication fix.
+
+  std::filesystem::remove(input_onnx);
+  std::filesystem::remove(output_onnx);
+  std::filesystem::remove(output_onnx.parent_path() / output_external);
+}
+#endif  // !defined(DISABLE_SPARSE_TENSORS)
 
 }  // namespace test
 }  // namespace onnxruntime

--- a/onnxruntime/test/framework/save_model_with_external_initializers.cc
+++ b/onnxruntime/test/framework/save_model_with_external_initializers.cc
@@ -132,7 +132,6 @@ TEST(SaveWithExternalInitializers, ModelWithOriginalExternalDataAlignOffset) {
       ORT_TSTR("model_with_new_external_initializers.bin"), model_saving_options));
 }
 
-
 namespace {
 
 // Builds a model whose If branches own their initializers. The optimized-model


### PR DESCRIPTION
### Description

`Graph::AddExternalInitializersToGraphProtoImpl()` recurses into subgraphs and re-adds every initializer, but never clears the entries that `Node::ToProto()` already placed in the subgraph proto. Each subgraph initializer therefore appears twice in the saved model, and the stale entry keeps the source model's data location:

```
If.then_branch:
  Wa -> source.onnx.data   offset 0        (stale entry, not removed)
  Wa -> saved.onnx.data    offset 0        (re-added by the recursion)
```

The saved model violates the ONNX spec and fails to load:

```
Data of TensorProto ( tensor name: Wa ) should be stored in source.onnx.data, but it is not regular file.
```

Reproduced with stock builds of 1.26.0, 1.29.0 and current `main`.

Fix by clearing the subgraph proto's initializers before the recursion, the same way the sibling path `ToGraphProtoWithCustomInitializerHandlingImpl()` already does. The recursion re-adds every initializer (dense, string, and sparse), so the clear is lossless.

Added two tests (subgraph initializer embedded vs. externalized); both fail without the fix.

#### Update (2026-09-09)

- A second trigger path: `SessionOptions.optimized_model_filepath` combined with the `session.optimized_model_external_initializers_*` entries.
- Also reproduced on ONNX Runtime 1.23.2 and 1.24.4, at every graph optimization level including `ORT_DISABLE_ALL`.
- `If` branches with no author-written initializers are also affected, because a `Constant` folded into the branch is promoted to an initializer before serialization.
- Interim workaround: dropping `optimized_model_filepath` or the `..._external_initializers_file_name` entry avoids the buggy save path.
- The existing fixture `testdata/loop_sub_one.onnx` (a `Loop` body owning an initializer) reproduces the bug directly.

Reference: https://github.com/microsoft/onnxruntime/pull/32474#issuecomment-5588925865

### Motivation and Context

Saving an optimized model with external initializers silently produces an invalid model whenever a subgraph owns an initializer, regardless of data location or size — a 256-byte tensor in an `If` branch reproduces it. This is easy to hit: the onnx Python package's `save_as_external_data=True` externalizes subgraph initializers by default. Saving succeeds and the failure only surfaces when the saved model is loaded.


