### PR TITLE
Harden ORT model required table validation

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
       - name: misspell # Check spellings as well
-        uses: reviewdog/action-misspell@d6429416b12b09b4e2768307d53bef58d172e962 # v1.27.0
+        uses: reviewdog/action-misspell@ba7ac4030fa6812f8c8b2d4e516af8bc99553c32 # v1.28.0
         with:
           github_token: ${{ secrets.github_token }}
           locale: "US"

--- a/onnxruntime/core/flatbuffers/flatbuffers_utils.cc
+++ b/onnxruntime/core/flatbuffers/flatbuffers_utils.cc
@@ -282,6 +282,7 @@ Status LoadValueInfoOrtFormat(const fbs::ValueInfo& fbs_value_info,
 Status LoadOpsetImportOrtFormat(const flatbuffers::Vector<flatbuffers::Offset<fbs::OperatorSetId>>* fbs_op_set_ids,
                                 std::unordered_map<std::string, int>& domain_to_version) {
   ORT_RETURN_IF(nullptr == fbs_op_set_ids, "Model must have opset imports. Invalid ORT format model.");
+  ORT_RETURN_IF_ERROR(ValidateRequiredTableOffsets(fbs_op_set_ids, "opset import"));
 
   domain_to_version.clear();
   domain_to_version.reserve(fbs_op_set_ids->size());

--- a/onnxruntime/core/flatbuffers/flatbuffers_utils.cc
+++ b/onnxruntime/core/flatbuffers/flatbuffers_utils.cc
@@ -196,6 +196,7 @@ static Status LoadTensorDimensionOrtFormat(const fbs::Dimension& fbs_dim,
 static Status LoadTensorShapeOrtFormat(const fbs::Shape& fbs_shape, TensorShapeProto& shape_proto) {
   auto fbs_dims = fbs_shape.dim();
   if (fbs_dims) {
+    ORT_RETURN_IF_ERROR(ValidateRequiredTableOffsets(fbs_dims, "dimension"));
     auto dims = shape_proto.mutable_dim();
     dims->Reserve(fbs_dims->size());
     for (const auto fbs_dim : *fbs_dims) {

--- a/onnxruntime/core/flatbuffers/flatbuffers_utils.h
+++ b/onnxruntime/core/flatbuffers/flatbuffers_utils.h
@@ -50,6 +50,24 @@ onnxruntime::common::Status LoadOpsetImportOrtFormat(
     const flatbuffers::Vector<flatbuffers::Offset<fbs::OperatorSetId>>* fbs_op_set_ids,
     std::unordered_map<std::string, int>& domain_to_version);
 
+template <typename T>
+inline onnxruntime::common::Status ValidateRequiredTableOffsets(
+    const flatbuffers::Vector<flatbuffers::Offset<T>>* fbs_entries,
+    const char* entry_description) {
+  if (fbs_entries == nullptr) {
+    return onnxruntime::common::Status::OK();
+  }
+
+  const auto* raw_offsets = reinterpret_cast<const uint8_t*>(fbs_entries->Data());
+  for (flatbuffers::uoffset_t i = 0; i < fbs_entries->size(); ++i) {
+    const auto entry_offset =
+        flatbuffers::ReadScalar<flatbuffers::uoffset_t>(raw_offsets + i * sizeof(flatbuffers::uoffset_t));
+    ORT_RETURN_IF(entry_offset == 0, "Null ", entry_description, " entry. Invalid ORT format model.");
+  }
+
+  return onnxruntime::common::Status::OK();
+}
+
 // check if filename ends in .ort
 bool IsOrtFormatModel(const PathString& filename);
 

--- a/onnxruntime/core/framework/kernel_type_str_resolver.cc
+++ b/onnxruntime/core/framework/kernel_type_str_resolver.cc
@@ -202,6 +202,11 @@ static std::string LoadFromOrtFormatImpl(const fbs::KernelTypeStrResolver& fbs_k
   if (!fbs_op_kernel_type_str_args) {
     return "op_kernel_type_str_args is null.";
   }
+  if (const auto status = fbs::utils::ValidateRequiredTableOffsets(fbs_op_kernel_type_str_args,
+                                                                   "op kernel type string arguments");
+      !status.IsOK()) {
+    return status.ErrorMessage();
+  }
 
   OpKernelTypeStrMap op_kernel_type_str_map{};
   op_kernel_type_str_map.reserve(fbs_op_kernel_type_str_args->size());
@@ -219,6 +224,11 @@ static std::string LoadFromOrtFormatImpl(const fbs::KernelTypeStrResolver& fbs_k
     if (!fbs_kernel_type_str_args) {
       return "kernel_type_str_args is null.";
     }
+    if (const auto status = fbs::utils::ValidateRequiredTableOffsets(fbs_kernel_type_str_args,
+                                                                     "kernel type string arguments");
+        !status.IsOK()) {
+      return status.ErrorMessage();
+    }
 
     KernelTypeStrToArgsMap kernel_type_str_map{};
     kernel_type_str_map.reserve(fbs_kernel_type_str_args->size());
@@ -235,6 +245,10 @@ static std::string LoadFromOrtFormatImpl(const fbs::KernelTypeStrResolver& fbs_k
       const auto* fbs_args = fbs_kernel_type_str_args_entry->args();
       if (!fbs_args) {
         return "args is null.";
+      }
+      if (const auto status = fbs::utils::ValidateRequiredTableOffsets(fbs_args, "kernel type string argument");
+          !status.IsOK()) {
+        return status.ErrorMessage();
       }
 
       InlinedVector<ArgTypeAndIndex> args{};

--- a/onnxruntime/core/graph/graph.cc
+++ b/onnxruntime/core/graph/graph.cc
@@ -6792,8 +6792,10 @@ common::Status Graph::LoadFromOrtFormat(const onnxruntime::fbs::Graph& fbs_graph
 
   // Initializers
   auto fbs_initializers = fbs_graph.initializers();
+  ORT_RETURN_IF_ERROR(fbs::utils::ValidateRequiredTableOffsets(fbs_initializers, "initializer"));
 #if !defined(DISABLE_SPARSE_TENSORS)
   auto fbs_sparse_initializers = fbs_graph.sparse_initializers();
+  ORT_RETURN_IF_ERROR(fbs::utils::ValidateRequiredTableOffsets(fbs_sparse_initializers, "sparse initializer"));
   flatbuffers::uoffset_t map_size = (fbs_initializers != nullptr ? fbs_initializers->size() : 0U) +
                                     (fbs_sparse_initializers != nullptr ? fbs_sparse_initializers->size() : 0U);
 #else
@@ -6863,6 +6865,7 @@ common::Status Graph::LoadFromOrtFormat(const onnxruntime::fbs::Graph& fbs_graph
   // NodeArgs
   auto fbs_node_args = fbs_graph.node_args();
   if (fbs_node_args) {
+    ORT_RETURN_IF_ERROR(fbs::utils::ValidateRequiredTableOffsets(fbs_node_args, "node arg"));
     node_args_.reserve(fbs_node_args->size());
     for (const auto* fbs_value_info : *fbs_node_args) {
       ORT_RETURN_IF(nullptr == fbs_value_info, "NodeArg is missing. Invalid ORT format model.");
@@ -6881,7 +6884,9 @@ common::Status Graph::LoadFromOrtFormat(const onnxruntime::fbs::Graph& fbs_graph
   // referenced indices. We compute the required slot count from actual node and edge data rather
   // than trusting the serialized max_node_index field.
   auto* fbs_nodes = fbs_graph.nodes();
+  ORT_RETURN_IF_ERROR(fbs::utils::ValidateRequiredTableOffsets(fbs_nodes, "node"));
   auto* fbs_node_edges = fbs_graph.node_edges();
+  ORT_RETURN_IF_ERROR(fbs::utils::ValidateRequiredTableOffsets(fbs_node_edges, "node edge"));
 
   uint32_t max_referenced_node_index = 0;
   bool has_referenced_node_index = false;

--- a/onnxruntime/core/graph/graph.cc
+++ b/onnxruntime/core/graph/graph.cc
@@ -826,6 +826,7 @@ Status Node::LoadFromOrtFormat(const onnxruntime::fbs::Node& fbs_node,
           std::vector<NodeArg*>& node_args,
           bool check_parent_graph = false) -> Status {
     ORT_RETURN_IF(nullptr == fbs_node_arg_names, "fbs_node_arg_names cannot be null");
+    ORT_RETURN_IF_ERROR(fbs::utils::ValidateRequiredTableOffsets(fbs_node_arg_names, "node argument name"));
     node_args.reserve(fbs_node_arg_names->size());
     for (const auto* node_arg_name : *fbs_node_arg_names) {
       ORT_RETURN_IF(nullptr == node_arg_name, "node_arg_name cannot be null");
@@ -853,6 +854,7 @@ Status Node::LoadFromOrtFormat(const onnxruntime::fbs::Node& fbs_node,
   // attributes
   auto fbs_attributes = fbs_node.attributes();
   if (fbs_attributes) {
+    ORT_RETURN_IF_ERROR(fbs::utils::ValidateRequiredTableOffsets(fbs_attributes, "attribute"));
     for (const auto* fbs_attr : *fbs_attributes) {
       ORT_RETURN_IF(nullptr == fbs_attr, "fbs_attr cannot be null");
       AttributeProto attr_proto;
@@ -6972,6 +6974,7 @@ common::Status Graph::LoadFromOrtFormat(const onnxruntime::fbs::Graph& fbs_graph
   auto add_node_args = [&](const flatbuffers::Vector<flatbuffers::Offset<flatbuffers::String>>* fbs_node_args,
                            std::vector<const NodeArg*>& node_args) -> Status {
     if (fbs_node_args != nullptr) {
+      ORT_RETURN_IF_ERROR(fbs::utils::ValidateRequiredTableOffsets(fbs_node_args, "graph node argument name"));
       node_args.reserve(fbs_node_args->size());
       for (const auto* fbs_node_arg_name : *fbs_node_args) {
         ORT_RETURN_IF(nullptr == fbs_node_arg_name, "NodeArg Name is missing. Invalid ORT format model.");

--- a/onnxruntime/core/graph/graph_flatbuffers_utils.cc
+++ b/onnxruntime/core/graph/graph_flatbuffers_utils.cc
@@ -517,6 +517,7 @@ Status LoadAttributeOrtFormat(const fbs::Attribute& fbs_attr,
     case AttributeProto_AttributeType_STRINGS: {
       auto fbs_strings = fbs_attr.strings();
       ORT_RETURN_IF(nullptr == fbs_strings, "Null strings attribute. Invalid ORT format model.");
+      ORT_RETURN_IF_ERROR(ValidateRequiredTableOffsets(fbs_strings, "string attribute"));
       auto* strings = attr_proto.mutable_strings();
       strings->Reserve(fbs_strings->size());
       for (const auto* fbs_str : *fbs_strings) {
@@ -527,6 +528,7 @@ Status LoadAttributeOrtFormat(const fbs::Attribute& fbs_attr,
     case AttributeProto_AttributeType_TENSORS: {
       auto fbs_tensors = fbs_attr.tensors();
       ORT_RETURN_IF(nullptr == fbs_tensors, "Null tensors attribute. Invalid ORT format model.");
+      ORT_RETURN_IF_ERROR(ValidateRequiredTableOffsets(fbs_tensors, "tensor attribute"));
       auto* tensors = attr_proto.mutable_tensors();
       tensors->Reserve(fbs_tensors->size());
       for (const auto* fbs_tensor : *fbs_tensors) {

--- a/onnxruntime/core/graph/model.cc
+++ b/onnxruntime/core/graph/model.cc
@@ -1016,6 +1016,7 @@ common::Status Model::LoadFromOrtFormat(const fbs::Model& fbs_model,
 
   // Load the model metadata
   if (const auto* fbs_metadata_props = fbs_model.metadata_props()) {
+    ORT_RETURN_IF_ERROR(fbs::utils::ValidateRequiredTableOffsets(fbs_metadata_props, "metadata property"));
     model->model_metadata_.reserve(fbs_metadata_props->size());
     for (const auto* prop : *fbs_metadata_props) {
       ORT_RETURN_IF(nullptr == prop, "Null entry in metadata_props. Invalid ORT format model.");

--- a/onnxruntime/core/graph/runtime_optimization_record_container.cc
+++ b/onnxruntime/core/graph/runtime_optimization_record_container.cc
@@ -144,6 +144,8 @@ static Status LoadRuntimeOptimizationRecordFromOrtFormat(
 
   auto& produced_op_ids = runtime_optimization_record.produced_op_ids;
   if (const auto* fbs_produced_op_ids = fbs_runtime_optimization_record.produced_op_ids()) {
+    ORT_RETURN_IF_ERROR(fbs::utils::ValidateRequiredTableOffsets(fbs_produced_op_ids,
+                                                                 "runtime optimization produced op id"));
     produced_op_ids.reserve(fbs_produced_op_ids->size());
     for (const auto* fbs_produced_op_id : *fbs_produced_op_ids) {
       ORT_FORMAT_RETURN_IF_NULL(fbs_produced_op_id, "runtime optimization record produced op id");
@@ -159,19 +161,19 @@ static Status LoadRuntimeOptimizationRecordFromOrtFormat(
 
 Status RuntimeOptimizationRecordContainer::LoadFromOrtFormat(
     const FbsRuntimeOptimizationRecordContainer& fbs_runtime_optimizations) {
+  ORT_RETURN_IF_ERROR(fbs::utils::ValidateRequiredTableOffsets(&fbs_runtime_optimizations,
+                                                               "runtime optimization container"));
   OptimizerNameToRecordsMap optimizer_name_to_records;
   for (const auto* fbs_runtime_optimization : fbs_runtime_optimizations) {
-    if (!fbs_runtime_optimization) continue;
-
     std::string optimizer_name;
     fbs::utils::LoadStringFromOrtFormat(optimizer_name, fbs_runtime_optimization->optimizer_name());
 
     std::vector<RuntimeOptimizationRecord> records;
     if (const auto* fbs_runtime_optimization_records = fbs_runtime_optimization->runtime_optimization_records()) {
+      ORT_RETURN_IF_ERROR(fbs::utils::ValidateRequiredTableOffsets(fbs_runtime_optimization_records,
+                                                                   "runtime optimization record"));
       records.reserve(fbs_runtime_optimization_records->size());
       for (const auto* fbs_runtime_optimization_record : *fbs_runtime_optimization_records) {
-        if (!fbs_runtime_optimization_record) continue;
-
         RuntimeOptimizationRecord runtime_optimization_record;
         ORT_RETURN_IF_ERROR(LoadRuntimeOptimizationRecordFromOrtFormat(*fbs_runtime_optimization_record,
                                                                        runtime_optimization_record));

--- a/onnxruntime/test/framework/ort_model_only_test.cc
+++ b/onnxruntime/test/framework/ort_model_only_test.cc
@@ -18,6 +18,7 @@
 #include "test/util/include/asserts.h"
 #include "test/util/include/inference_session_wrapper.h"
 
+#include <algorithm>
 #include <filesystem>
 #include "flatbuffers/idl.h"
 #include "flatbuffers/util.h"
@@ -59,14 +60,19 @@ flatbuffers::Offset<fbs::TypeInfo> CreateFloatTensorTypeInfo(flatbuffers::FlatBu
 }
 
 std::vector<uint8_t> BuildOrtModelBuffer(
-    const std::function<flatbuffers::Offset<fbs::Graph>(flatbuffers::FlatBufferBuilder&)>& create_graph) {
+    const std::function<flatbuffers::Offset<fbs::Graph>(flatbuffers::FlatBufferBuilder&)>& create_graph,
+    bool include_metadata_property = false) {
   flatbuffers::FlatBufferBuilder builder;
 
   const auto graph = create_graph(builder);
   std::vector<flatbuffers::Offset<fbs::OperatorSetId>> opset_imports{
       fbs::CreateOperatorSetIdDirect(builder, "", 18)};
+  std::vector<flatbuffers::Offset<fbs::StringStringEntry>> metadata_props;
+  if (include_metadata_property) {
+    metadata_props.push_back(fbs::CreateStringStringEntryDirect(builder, "key", "value"));
+  }
   const auto model = fbs::CreateModelDirect(builder, 8, &opset_imports, "ort-model-test", "1", "",
-                                            1, "", graph, "");
+                                            1, "", graph, "", include_metadata_property ? &metadata_props : nullptr);
   const auto session = fbs::CreateInferenceSessionDirect(builder,
                                                          std::to_string(kOrtModelVersion).c_str(), model);
   fbs::FinishInferenceSessionBuffer(builder, session);
@@ -148,6 +154,44 @@ TEST(OrtModelTest, RejectsInitializerRawDataSizeMismatch) {
   const auto status = LoadOrtBuffer(buffer, true);
   ASSERT_FALSE(status.IsOK());
   EXPECT_THAT(status.ErrorMessage(), testing::HasSubstr("raw data size mismatch"));
+}
+
+TEST(OrtModelTest, RejectsNullNodeArgTableEntry) {
+  auto buffer = BuildOrtModelBuffer([](flatbuffers::FlatBufferBuilder& builder) {
+    std::vector<flatbuffers::Offset<fbs::ValueInfo>> node_args{
+        fbs::CreateValueInfoDirect(builder, "X", "", CreateFloatTensorTypeInfo(builder, 1))};
+    return fbs::CreateGraphDirect(builder, nullptr, &node_args);
+  });
+
+  const auto* fbs_session = fbs::GetInferenceSession(buffer.data());
+  ASSERT_NE(fbs_session, nullptr);
+  ASSERT_NE(fbs_session->model(), nullptr);
+  ASSERT_NE(fbs_session->model()->graph(), nullptr);
+  const auto* fbs_node_args = fbs_session->model()->graph()->node_args();
+  ASSERT_NE(fbs_node_args, nullptr);
+  auto* raw_offsets = const_cast<uint8_t*>(reinterpret_cast<const uint8_t*>(fbs_node_args->Data()));
+  std::fill_n(raw_offsets, sizeof(flatbuffers::uoffset_t), 0);
+
+  const auto status = LoadOrtBuffer(buffer);
+  ASSERT_FALSE(status.IsOK());
+  EXPECT_THAT(status.ErrorMessage(), testing::HasSubstr("Null node arg entry"));
+}
+
+TEST(OrtModelTest, RejectsNullMetadataPropertyTableEntry) {
+  auto buffer = BuildOrtModelBuffer(
+      [](flatbuffers::FlatBufferBuilder& builder) { return fbs::CreateGraph(builder); }, true);
+
+  const auto* fbs_session = fbs::GetInferenceSession(buffer.data());
+  ASSERT_NE(fbs_session, nullptr);
+  ASSERT_NE(fbs_session->model(), nullptr);
+  const auto* fbs_metadata_props = fbs_session->model()->metadata_props();
+  ASSERT_NE(fbs_metadata_props, nullptr);
+  auto* raw_offsets = const_cast<uint8_t*>(reinterpret_cast<const uint8_t*>(fbs_metadata_props->Data()));
+  std::fill_n(raw_offsets, sizeof(flatbuffers::uoffset_t), 0);
+
+  const auto status = LoadOrtBuffer(buffer);
+  ASSERT_FALSE(status.IsOK());
+  EXPECT_THAT(status.ErrorMessage(), testing::HasSubstr("Null metadata property entry"));
 }
 
 TEST(OrtModelTest, RejectsDanglingNodeEdge) {

--- a/onnxruntime/test/framework/ort_model_only_test.cc
+++ b/onnxruntime/test/framework/ort_model_only_test.cc
@@ -194,6 +194,69 @@ TEST(OrtModelTest, RejectsNullMetadataPropertyTableEntry) {
   EXPECT_THAT(status.ErrorMessage(), testing::HasSubstr("Null metadata property entry"));
 }
 
+TEST(OrtModelTest, RejectsNullNodeAttributeTableEntry) {
+  auto buffer = BuildOrtModelBuffer([](flatbuffers::FlatBufferBuilder& builder) {
+    std::vector<flatbuffers::Offset<flatbuffers::String>> empty_args;
+    std::vector<int32_t> empty_arg_counts;
+    std::vector<flatbuffers::Offset<fbs::Attribute>> attributes{
+        fbs::CreateAttributeDirect(builder, "axis", "", fbs::AttributeType::INT, 0.0f, 0)};
+    std::vector<flatbuffers::Offset<fbs::Node>> nodes{
+        fbs::CreateNodeDirect(builder, "n", "", "", 1, 0, "Identity",
+                              fbs::NodeType::Primitive, nullptr,
+                              &empty_args, &empty_args, &attributes,
+                              &empty_arg_counts, &empty_args)};
+    return fbs::CreateGraphDirect(builder, nullptr, nullptr, &nodes, 1);
+  });
+
+  const auto* fbs_session = fbs::GetInferenceSession(buffer.data());
+  ASSERT_NE(fbs_session, nullptr);
+  ASSERT_NE(fbs_session->model(), nullptr);
+  ASSERT_NE(fbs_session->model()->graph(), nullptr);
+  const auto* fbs_nodes = fbs_session->model()->graph()->nodes();
+  ASSERT_NE(fbs_nodes, nullptr);
+  const auto* fbs_node = fbs_nodes->Get(0);
+  ASSERT_NE(fbs_node, nullptr);
+  const auto* fbs_attributes = fbs_node->attributes();
+  ASSERT_NE(fbs_attributes, nullptr);
+  auto* raw_offsets = const_cast<uint8_t*>(reinterpret_cast<const uint8_t*>(fbs_attributes->Data()));
+  std::fill_n(raw_offsets, sizeof(flatbuffers::uoffset_t), 0);
+
+  const auto status = LoadOrtBuffer(buffer);
+  ASSERT_FALSE(status.IsOK());
+  EXPECT_THAT(status.ErrorMessage(), testing::HasSubstr("Null attribute entry"));
+}
+
+TEST(OrtModelTest, RejectsNullDimensionTableEntry) {
+  auto buffer = BuildOrtModelBuffer([](flatbuffers::FlatBufferBuilder& builder) {
+    std::vector<flatbuffers::Offset<fbs::ValueInfo>> node_args{
+        fbs::CreateValueInfoDirect(builder, "X", "", CreateFloatTensorTypeInfo(builder, 1))};
+    return fbs::CreateGraphDirect(builder, nullptr, &node_args);
+  });
+
+  const auto* fbs_session = fbs::GetInferenceSession(buffer.data());
+  ASSERT_NE(fbs_session, nullptr);
+  ASSERT_NE(fbs_session->model(), nullptr);
+  ASSERT_NE(fbs_session->model()->graph(), nullptr);
+  const auto* fbs_node_args = fbs_session->model()->graph()->node_args();
+  ASSERT_NE(fbs_node_args, nullptr);
+  const auto* fbs_node_arg = fbs_node_args->Get(0);
+  ASSERT_NE(fbs_node_arg, nullptr);
+  const auto* fbs_type = fbs_node_arg->type();
+  ASSERT_NE(fbs_type, nullptr);
+  const auto* fbs_tensor_type = fbs_type->value_as_tensor_type();
+  ASSERT_NE(fbs_tensor_type, nullptr);
+  const auto* fbs_shape = fbs_tensor_type->shape();
+  ASSERT_NE(fbs_shape, nullptr);
+  const auto* fbs_dims = fbs_shape->dim();
+  ASSERT_NE(fbs_dims, nullptr);
+  auto* raw_offsets = const_cast<uint8_t*>(reinterpret_cast<const uint8_t*>(fbs_dims->Data()));
+  std::fill_n(raw_offsets, sizeof(flatbuffers::uoffset_t), 0);
+
+  const auto status = LoadOrtBuffer(buffer);
+  ASSERT_FALSE(status.IsOK());
+  EXPECT_THAT(status.ErrorMessage(), testing::HasSubstr("Null dimension entry"));
+}
+
 TEST(OrtModelTest, RejectsDanglingNodeEdge) {
   const auto buffer = BuildOrtModelBuffer([](flatbuffers::FlatBufferBuilder& builder) {
     std::vector<flatbuffers::Offset<fbs::NodeEdge>> node_edges{


### PR DESCRIPTION
## Summary

- Restore raw FlatBuffer offset validation for required ORT model table vectors.
- Validate opset imports, initializers, sparse initializers, node arguments,
  nodes, node edges, and metadata properties.
- Add regression tests for null node-argument and metadata-property entries.

## Testing

- clang-format 20.1.8
- git diff --check
- VS Code C++ diagnostics

Native tests were not run because this machine has no C++ compiler, CMake,
Ninja, Visual Studio Build Tools, or existing ONNX Runtime build.