### PR TITLE
Fix concurrent XNNPACK allocator initialization

### DIFF
--- a/onnxruntime/core/providers/xnnpack/xnnpack_execution_provider.cc
+++ b/onnxruntime/core/providers/xnnpack/xnnpack_execution_provider.cc
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+#include <mutex>
 #include <string_view>
 #include <unordered_map>
 #include <unordered_set>
@@ -183,20 +184,24 @@ XnnpackExecutionProvider::XnnpackExecutionProvider(const XnnpackExecutionProvide
 
 std::vector<AllocatorPtr> XnnpackExecutionProvider::CreatePreferredAllocators() {
   const auto& [stored_allocator, xnn_allocator] = GetStoredAllocator();
-  if (!stored_allocator) {
-    const AllocatorCreationInfo allocator_info(
-        [](int) {
-          // lazy create the allocator
-          return std::make_unique<CPUAllocator>(OrtMemoryInfo(kXnnpackExecutionProvider,
-                                                              OrtAllocatorType::OrtDeviceAllocator));
-        });
-    stored_allocator = CreateAllocator(allocator_info);
-  }
-  xnn_allocator->context = stored_allocator.get();
-  const xnn_status st = xnn_initialize(xnn_allocator);
-  if (st != xnn_status_success) {
-    ORT_THROW("XNNPACK initialization failed with status ", st);
-  }
+  // XNNPACK retains the allocator context globally, so publish it once and keep
+  // the owning allocator alive across concurrent EP creation and destruction.
+  static std::once_flag init_once;
+  std::call_once(init_once, [&]() {
+    if (!stored_allocator) {
+      const AllocatorCreationInfo allocator_info(
+          [](int) {
+            return std::make_unique<CPUAllocator>(OrtMemoryInfo(kXnnpackExecutionProvider,
+                                                                OrtAllocatorType::OrtDeviceAllocator));
+          });
+      stored_allocator = CreateAllocator(allocator_info);
+    }
+    xnn_allocator->context = stored_allocator.get();
+    const xnn_status st = xnn_initialize(xnn_allocator);
+    if (st != xnn_status_success) {
+      ORT_THROW("XNNPACK initialization failed with status ", st);
+    }
+  });
   return std::vector<AllocatorPtr>{stored_allocator};
 }
 

--- a/onnxruntime/test/providers/xnnpack/xnnpack_basic_test.cc
+++ b/onnxruntime/test/providers/xnnpack/xnnpack_basic_test.cc
@@ -1,8 +1,14 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+#include <array>
+#include <condition_variable>
+#include <cstdlib>
+#include <exception>
+#include <mutex>
 #include <random>
 #include <string>
+#include <thread>
 
 #include "core/common/logging/logging.h"
 #include "core/common/span_utils.h"
@@ -29,6 +35,7 @@
 #endif
 
 #include "gtest/gtest.h"
+#include "xnnpack.h"
 
 using namespace ONNX_NAMESPACE;
 using namespace onnxruntime::logging;
@@ -40,6 +47,88 @@ extern std::unique_ptr<Ort::Env> ort_env;
 
 namespace onnxruntime {
 namespace test {
+
+#if GTEST_HAS_DEATH_TEST
+namespace {
+void TestConcurrentAllocatorInitialization() {
+  constexpr size_t num_threads = 32;
+  std::array<std::unique_ptr<IExecutionProvider>, num_threads> providers;
+  std::array<AllocatorPtr, num_threads> allocators;
+  std::array<std::exception_ptr, num_threads> errors;
+  for (auto& provider : providers) {
+    provider = DefaultXnnpackExecutionProvider();
+  }
+
+  std::mutex mutex;
+  std::condition_variable cv;
+  size_t ready = 0;
+  bool start = false;
+  InlinedVector<std::thread> threads;
+  threads.reserve(num_threads);
+  for (size_t i = 0; i < num_threads; ++i) {
+    threads.emplace_back([&, i]() {
+      {
+        std::unique_lock<std::mutex> lock(mutex);
+        ++ready;
+        cv.notify_all();
+        cv.wait(lock, [&]() { return start; });
+      }
+      ORT_TRY {
+        auto preferred_allocators = providers[i]->CreatePreferredAllocators();
+        ORT_ENFORCE(preferred_allocators.size() == 1);
+        allocators[i] = preferred_allocators[0];
+      }
+      ORT_CATCH(...) {
+        errors[i] = std::current_exception();
+      }
+    });
+  }
+  {
+    std::unique_lock<std::mutex> lock(mutex);
+    cv.wait(lock, [&]() { return ready == num_threads; });
+    start = true;
+  }
+  cv.notify_all();
+  for (auto& thread : threads) {
+    thread.join();
+  }
+
+  ASSERT_NE(allocators[0], nullptr);
+  for (size_t i = 0; i < num_threads; ++i) {
+    ASSERT_EQ(errors[i], nullptr);
+    ASSERT_EQ(allocators[i], allocators[0]);
+    providers[i].reset();
+  }
+
+  auto* allocator = allocators[0].get();
+  for (auto& retained_allocator : allocators) {
+    retained_allocator.reset();
+  }
+  // Exercise XNNPACK's retained allocator context after all EP owners are gone.
+  xnn_workspace_t workspace = nullptr;
+  ASSERT_EQ(xnn_create_workspace(&workspace), xnn_status_success);
+  ASSERT_EQ(xnn_release_workspace(workspace), xnn_status_success);
+
+  auto preferred_allocators = DefaultXnnpackExecutionProvider()->CreatePreferredAllocators();
+  ASSERT_EQ(preferred_allocators.size(), 1U);
+  ASSERT_EQ(preferred_allocators[0].get(), allocator);
+  void* buffer = allocator->Alloc(64);
+  ASSERT_NE(buffer, nullptr);
+  allocator->Free(buffer);
+}
+}  // namespace
+
+TEST(XnnpackEPDeathTest, ConcurrentAllocatorInitialization) {
+  // Re-exec so earlier XNNPACK tests cannot hide a race in first-time initialization.
+  GTEST_FLAG_SET(death_test_style, "threadsafe");
+  ASSERT_EXIT(
+      {
+        TestConcurrentAllocatorInitialization();
+        std::_Exit(::testing::Test::HasFailure() ? EXIT_FAILURE : EXIT_SUCCESS);
+      },
+      ::testing::ExitedWithCode(EXIT_SUCCESS), "");
+}
+#endif
 
 // test uses ONNX model so can't be run in a minimal build.
 // TODO: When we need XNNPACK in a minimal build we should add an ORT format version of the model


### PR DESCRIPTION
### Description

Make the process-wide XNNPACK allocator initialization thread-safe with `std::call_once`. The once callback covers allocator creation, wrapper context publication, and `xnn_initialize`, so concurrent EPs cannot replace the allocator or rewrite the context while existing kernels use it.

Initialization errors still throw inside the callback, allowing a retry. The existing stored-allocator guard is retained so a retry does not replace an allocator XNNPACK may already have retained.

Add a cold-start regression test that re-executes in a fresh subprocess, synchronizes 32 calls to `CreatePreferredAllocators()`, and checks allocator identity across EPs. After releasing the per-EP owners, it exercises XNNPACK's retained allocator through workspace allocation/release and verifies subsequent EP creation can still use the same allocator.

### Motivation and Context

Fixes #32461.

XNNPACK retains its allocator context process-wide. Concurrent first-time session initialization could replace the owning `shared_ptr` after XNNPACK captured its pointer, resulting in a dangling context. The wrapper is also read by existing kernels, so successful initialization must not rewrite it on subsequent EP creation.

### Validation

Locally built on macOS 26.3.1 arm64 with Apple Clang 17, Release, and XNNPACK enabled; no GPU required.

- **Negative control:** with the new test but the original provider implementation, 12 of 20 fresh-process runs failed under `MallocScribble=1` (including 7 SIGSEGV failures).
- **Fixed regression:** 100 of 100 fresh-process runs passed under `MallocScribble=1`.
- **XNNPACK suites:** all 20 enabled tests selected by `Xnnpack*` passed; 12 existing tests remain disabled.
- Pinned lintrunner / clang-format checks and `git diff --check` passed.

Build configuration:

```sh
python tools/ci_build/build.py --config Release --build_dir build/MacOS \
  --update --build_shared_lib --use_xnnpack --cmake_generator Ninja \
  --skip_submodule_sync --cmake_extra_defines \
  CMAKE_OSX_ARCHITECTURES=arm64 FETCHCONTENT_TRY_FIND_PACKAGE_MODE=NEVER
python tools/ci_build/build.py --config Release --build_dir build/MacOS \
  --build --build_shared_lib --use_xnnpack --parallel 5 \
  --target onnxruntime_provider_test
```

The pinned-dependency option avoids a locally installed Protobuf/runtime mismatch. When building only the provider-test target, I copied `onnxruntime/test/testdata` and `samples` to the build output directory, matching the fixture-copy steps normally attached to `onnxruntime_test_all`.

From `build/MacOS/Release`:

```sh
MallocScribble=1 ./onnxruntime_provider_test \
  --gtest_filter=XnnpackEPDeathTest.ConcurrentAllocatorInitialization --gtest_repeat=100
MallocScribble=1 ./onnxruntime_provider_test --gtest_filter='Xnnpack*'
```

The regression directly exercises allocator initialization/lifetime, not the reporter's complete React Native workload. iOS/React Native and native Windows have not been tested locally. The subprocess test is guarded by `GTEST_HAS_DEATH_TEST` and is not compiled on iOS/WASM. Initialization-failure retry behavior was reviewed but not fault-injection tested.
