### PR TITLE
Fix CUDA plugin device discovery on WSL

### DIFF
--- a/onnxruntime/core/providers/cuda/plugin/cuda_device_mapping.h
+++ b/onnxruntime/core/providers/cuda/plugin/cuda_device_mapping.h
@@ -1,0 +1,55 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include <algorithm>
+#include <cctype>
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <string_view>
+
+#include "gsl/gsl"
+
+namespace onnxruntime::cuda_plugin {
+
+inline std::string NormalizePciBusId(std::string_view pci_bus_id) {
+  std::string normalized{pci_bus_id};
+  std::transform(normalized.begin(), normalized.end(), normalized.begin(), [](unsigned char c) {
+    return static_cast<char>(std::tolower(c));
+  });
+  return normalized;
+}
+
+inline std::optional<int> FindCudaOrdinalForHardwareDeviceIdentity(
+    std::string_view hardware_device_identity,
+    gsl::span<const std::string> cuda_device_identities,
+    gsl::span<const uint8_t> assigned_cuda_ordinals) {
+  if (hardware_device_identity.empty()) {
+    return std::nullopt;
+  }
+
+  for (size_t i = 0; i < cuda_device_identities.size(); ++i) {
+    if (assigned_cuda_ordinals[i] == 0 &&
+        cuda_device_identities[i] == hardware_device_identity) {
+      return static_cast<int>(i);
+    }
+  }
+
+  return std::nullopt;
+}
+
+inline std::optional<int> FindCudaOrdinalWithoutIdentity(
+    gsl::span<const std::string> cuda_device_identities,
+    gsl::span<const uint8_t> assigned_cuda_ordinals) {
+  for (size_t i = 0; i < cuda_device_identities.size(); ++i) {
+    if (assigned_cuda_ordinals[i] == 0 && cuda_device_identities[i].empty()) {
+      return static_cast<int>(i);
+    }
+  }
+
+  return std::nullopt;
+}
+
+}  // namespace onnxruntime::cuda_plugin

--- a/onnxruntime/core/providers/cuda/plugin/cuda_ep_factory.cc
+++ b/onnxruntime/core/providers/cuda/plugin/cuda_ep_factory.cc
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 #include "cuda_ep_factory.h"
+#include "cuda_device_mapping.h"
 #include "cuda_ep.h"
 #include "cuda_plugin_kernels.h"
 #include "core/common/string_utils.h"
@@ -17,6 +18,10 @@
 #include <optional>
 #include <string>
 #include <string_view>
+
+#ifdef _WIN32
+#include <cuda.h>
+#endif
 
 namespace onnxruntime {
 namespace cuda_plugin {
@@ -60,6 +65,10 @@ CudaEpFactory::~CudaEpFactory() {
 
   if (kernel_registry_ != nullptr) {
     ep_api_.ReleaseKernelRegistry(kernel_registry_);
+  }
+
+  for (const auto& entry : runtime_discovered_hardware_devices_) {
+    ep_api_.ReleaseHardwareDevice(entry.second);
   }
 }
 
@@ -149,6 +158,44 @@ bool IsCudaMempoolUnsupportedStatus(const OrtApi& ort_api, const OrtStatus* stat
           std::strstr(msg, "operation not supported") != nullptr);
 }
 
+std::string GetCudaDeviceIdentity(int cuda_ordinal) {
+#ifdef _WIN32
+  CUdevice device;
+  char luid[8]{};
+  unsigned int node_mask = 0;
+  if (cuDeviceGet(&device, cuda_ordinal) == CUDA_SUCCESS &&
+      cuDeviceGetLuid(luid, &node_mask, device) == CUDA_SUCCESS) {
+    uint64_t luid_value = 0;
+    static_assert(sizeof(luid_value) == sizeof(luid));
+    std::memcpy(&luid_value, luid, sizeof(luid_value));
+    return std::to_string(luid_value);
+  }
+#else
+  char pci_bus_id[32]{};
+  if (cudaDeviceGetPCIBusId(pci_bus_id, sizeof(pci_bus_id), cuda_ordinal) == cudaSuccess) {
+    return NormalizePciBusId(pci_bus_id);
+  }
+#endif
+
+  return {};
+}
+
+std::string GetHardwareDeviceIdentity(const OrtApi& ort_api,
+                                      const OrtHardwareDevice& device) {
+  const OrtKeyValuePairs* metadata = ort_api.HardwareDevice_Metadata(&device);
+  if (metadata == nullptr) {
+    return {};
+  }
+
+#ifdef _WIN32
+  const char* luid = ort_api.GetKeyValue(metadata, "LUID");
+  return luid == nullptr ? std::string{} : std::string{luid};
+#else
+  const char* pci_bus_id = ort_api.GetKeyValue(metadata, "pci_bus_id");
+  return pci_bus_id == nullptr ? std::string{} : NormalizePciBusId(pci_bus_id);
+#endif
+}
+
 }  // namespace
 
 CudaEpFactory::HardwareDeviceKey CudaEpFactory::MakeDeviceKey(const OrtApi& ort_api,
@@ -196,7 +243,90 @@ OrtStatus* ORT_API_CALL CudaEpFactory::GetSupportedDevicesImpl(
     cuda_device_count = 0;  // no CUDA devices available
   }
 
-  int cuda_device_index = 0;
+  InlinedVector<std::string> cuda_device_identities;
+  InlinedVector<uint8_t> assigned_cuda_ordinals;
+  cuda_device_identities.reserve(cuda_device_count);
+  assigned_cuda_ordinals.reserve(cuda_device_count);
+  for (int cuda_ordinal = 0; cuda_ordinal < cuda_device_count; ++cuda_ordinal) {
+    cuda_device_identities.emplace_back(GetCudaDeviceIdentity(cuda_ordinal));
+    assigned_cuda_ordinals.push_back(0);
+  }
+
+  auto add_ep_device = [&](const OrtHardwareDevice& device, int cuda_ordinal) -> OrtStatus* {
+    const auto device_key = CudaEpFactory::MakeDeviceKey(factory->ort_api_, device, cuda_ordinal);
+    DeviceCacheEntry* cache_entry = nullptr;
+    {
+      std::lock_guard<std::mutex> lock(factory->device_cache_mutex_);
+      auto [it, inserted] = factory->device_cache_.try_emplace(device_key);
+      if (inserted) {
+        it->second.cuda_device_id = cuda_ordinal;
+        it->second.device_memory_info = Ort::MemoryInfo{"Cuda",
+                                                        OrtMemoryInfoDeviceType_GPU,
+                                                        factory->vendor_id_,
+                                                        static_cast<uint32_t>(cuda_ordinal),
+                                                        OrtDeviceMemoryType_DEFAULT,
+                                                        /*alignment is default*/ 0,
+                                                        OrtAllocatorType::OrtDeviceAllocator};
+        it->second.pinned_memory_info = Ort::MemoryInfo{"CudaPinned",
+                                                        OrtAllocatorType::OrtDeviceAllocator,
+                                                        cuda_ordinal,
+                                                        OrtMemType::OrtMemTypeCPU};
+      }
+
+      cache_entry = &it->second;
+      factory->ordinal_to_device_key_[cuda_ordinal] = device_key;
+    }
+
+    OrtKeyValuePairs* ep_metadata = nullptr;
+    OrtKeyValuePairs* ep_options = nullptr;
+    factory->ort_api_.CreateKeyValuePairs(&ep_metadata);
+    factory->ort_api_.CreateKeyValuePairs(&ep_options);
+    factory->ort_api_.AddKeyValuePair(ep_metadata, "cuda_device_id", std::to_string(cuda_ordinal).c_str());
+    factory->ort_api_.AddKeyValuePair(ep_options, "device_id", std::to_string(cuda_ordinal).c_str());
+
+    cudaDeviceProp prop;
+    if (cudaGetDeviceProperties(&prop, cuda_ordinal) == cudaSuccess) {
+      factory->ort_api_.AddKeyValuePair(ep_metadata, "cuda_device_name", prop.name);
+      factory->ort_api_.AddKeyValuePair(
+          ep_metadata, "cuda_compute_capability",
+          (std::to_string(prop.major) + "." + std::to_string(prop.minor)).c_str());
+    }
+
+    OrtEpDevice* ep_device = nullptr;
+    auto* status = factory->ep_api_.CreateEpDevice(factory, &device, ep_metadata, ep_options,
+                                                   &ep_device);
+    factory->ort_api_.ReleaseKeyValuePairs(ep_metadata);
+    factory->ort_api_.ReleaseKeyValuePairs(ep_options);
+
+    if (status != nullptr) {
+      return status;
+    }
+
+    auto release_current_ep_device = [factory](OrtEpDevice* device_to_release) {
+      factory->ep_api_.ReleaseEpDevice(device_to_release);
+    };
+    std::unique_ptr<OrtEpDevice, decltype(release_current_ep_device)> ep_device_guard(
+        ep_device, release_current_ep_device);
+
+    status = factory->ep_api_.EpDevice_AddAllocatorInfo(ep_device, cache_entry->device_memory_info);
+    if (status != nullptr) {
+      return status;
+    }
+
+    status = factory->ep_api_.EpDevice_AddAllocatorInfo(ep_device, cache_entry->pinned_memory_info);
+    if (status != nullptr) {
+      return status;
+    }
+
+    ep_devices[num_ep_devices++] = ep_device_guard.release();
+    return nullptr;
+  };
+
+  InlinedVector<const OrtHardwareDevice*> hardware_devices_without_identity;
+  hardware_devices_without_identity.reserve(num_devices);
+
+  // Reserve all exact hardware identity matches before considering devices
+  // without identity, so an unknown device cannot consume a later exact match.
   for (size_t i = 0; i < num_devices && num_ep_devices < max_ep_devices; ++i) {
     const OrtHardwareDevice& device = *hw_devices[i];
     auto hw_type = factory->ort_api_.HardwareDevice_Type(&device);
@@ -210,92 +340,106 @@ OrtStatus* ORT_API_CALL CudaEpFactory::GetSupportedDevicesImpl(
         continue;  // Skip non-NVIDIA GPUs
       }
 
-      // CUDA uses contiguous ordinals for CUDA-visible NVIDIA devices. Build that
-      // mapping from the filtered hardware-device list instead of relying on the
-      // ORT hardware device id, which is not guaranteed to be a CUDA ordinal.
-      int current_device_id = cuda_device_index++;
-
-      // Validate the assigned ordinal is within the range of CUDA-visible devices.
-      // If hardware enumeration reports GPUs not visible to CUDA (e.g. due to
-      // CUDA_VISIBLE_DEVICES), skip them to avoid failures in allocator/stream creation.
-      if (current_device_id >= cuda_device_count) {
+      const std::string hardware_device_identity =
+          GetHardwareDeviceIdentity(factory->ort_api_, device);
+      if (hardware_device_identity.empty()) {
+        hardware_devices_without_identity.push_back(&device);
         continue;
       }
-      const auto device_key = CudaEpFactory::MakeDeviceKey(factory->ort_api_, device, current_device_id);
-      DeviceCacheEntry* cache_entry = nullptr;
+
+      auto cuda_ordinal = FindCudaOrdinalForHardwareDeviceIdentity(
+          hardware_device_identity, cuda_device_identities, assigned_cuda_ordinals);
+      if (!cuda_ordinal.has_value()) {
+        continue;
+      }
+
+      assigned_cuda_ordinals[*cuda_ordinal] = 1;
+      if (auto* status = add_ep_device(device, *cuda_ordinal); status != nullptr) {
+        return release_ep_devices(status);
+      }
+    }
+  }
+
+  // Preserve the previous positional behavior only when both sides lack a
+  // platform identity. Never assign an unidentified hardware device to a CUDA
+  // ordinal with a known identity.
+  for (const OrtHardwareDevice* device : hardware_devices_without_identity) {
+    if (num_ep_devices >= max_ep_devices) {
+      break;
+    }
+
+    auto cuda_ordinal =
+        FindCudaOrdinalWithoutIdentity(cuda_device_identities, assigned_cuda_ordinals);
+    if (!cuda_ordinal.has_value()) {
+      continue;
+    }
+
+    assigned_cuda_ordinals[*cuda_ordinal] = 1;
+    if (auto* status = add_ep_device(*device, *cuda_ordinal); status != nullptr) {
+      return release_ep_devices(status);
+    }
+  }
+
+  // Platform discovery may not expose every CUDA-visible device. In particular, WSL
+  // provides CUDA through /dev/dxg but sysfs reports Microsoft synthetic adapters,
+  // which the NVIDIA factory must not claim. Create descriptors for any remaining
+  // CUDA ordinals using the CUDA runtime as the authoritative device source.
+  for (int cuda_ordinal = 0;
+       cuda_ordinal < cuda_device_count && num_ep_devices < max_ep_devices;
+       ++cuda_ordinal) {
+    if (assigned_cuda_ordinals[cuda_ordinal] != 0) {
+      continue;
+    }
+
+    OrtHardwareDevice* runtime_device = nullptr;
+    {
+      std::lock_guard<std::mutex> lock(factory->device_cache_mutex_);
+      auto it = factory->runtime_discovered_hardware_devices_.find(cuda_ordinal);
+      if (it != factory->runtime_discovered_hardware_devices_.end()) {
+        runtime_device = it->second;
+      }
+    }
+
+    if (runtime_device == nullptr) {
+      OrtKeyValuePairs* hw_metadata = nullptr;
+      factory->ort_api_.CreateKeyValuePairs(&hw_metadata);
+      factory->ort_api_.AddKeyValuePair(hw_metadata, "cuda_runtime_discovered", "1");
+      factory->ort_api_.AddKeyValuePair(hw_metadata, "Discrete", "1");
+
+      if (!cuda_device_identities[cuda_ordinal].empty()) {
+#ifdef _WIN32
+        factory->ort_api_.AddKeyValuePair(hw_metadata, "LUID",
+                                          cuda_device_identities[cuda_ordinal].c_str());
+#else
+        factory->ort_api_.AddKeyValuePair(hw_metadata, "pci_bus_id",
+                                          cuda_device_identities[cuda_ordinal].c_str());
+#endif
+      }
+
+      auto* status = factory->ep_api_.CreateHardwareDevice(
+          OrtHardwareDeviceType::OrtHardwareDeviceType_GPU,
+          factory->vendor_id_,
+          /*device_id*/ 0,
+          factory->vendor_.c_str(),
+          hw_metadata,
+          &runtime_device);
+      factory->ort_api_.ReleaseKeyValuePairs(hw_metadata);
+      if (status != nullptr) {
+        return release_ep_devices(status);
+      }
+
       {
         std::lock_guard<std::mutex> lock(factory->device_cache_mutex_);
-        auto [it, inserted] = factory->device_cache_.try_emplace(device_key);
-        if (inserted) {
-          it->second.cuda_device_id = current_device_id;
-          it->second.device_memory_info = Ort::MemoryInfo{"Cuda",
-                                                          OrtMemoryInfoDeviceType_GPU,
-                                                          factory->vendor_id_,
-                                                          static_cast<uint32_t>(current_device_id),
-                                                          OrtDeviceMemoryType_DEFAULT,
-                                                          /*alignment is default*/ 0,
-                                                          OrtAllocatorType::OrtDeviceAllocator};
-          it->second.pinned_memory_info = Ort::MemoryInfo{"CudaPinned",
-                                                          OrtAllocatorType::OrtDeviceAllocator,
-                                                          current_device_id,
-                                                          OrtMemType::OrtMemTypeCPU};
-        }
-
-        cache_entry = &it->second;
-        current_device_id = cache_entry->cuda_device_id;
-        // Build ordinal → key mapping for CreateAllocatorImpl lookups.
-        factory->ordinal_to_device_key_[current_device_id] = device_key;
-      }
-
-      OrtKeyValuePairs* ep_metadata = nullptr;
-      OrtKeyValuePairs* ep_options = nullptr;
-      factory->ort_api_.CreateKeyValuePairs(&ep_metadata);
-      factory->ort_api_.CreateKeyValuePairs(&ep_options);
-      factory->ort_api_.AddKeyValuePair(ep_metadata, "cuda_device_id", std::to_string(current_device_id).c_str());
-      factory->ort_api_.AddKeyValuePair(ep_options, "device_id", std::to_string(current_device_id).c_str());
-
-      // Get CUDA device properties for metadata
-      {
-        cudaDeviceProp prop;
-        if (cudaGetDeviceProperties(&prop, current_device_id) == cudaSuccess) {
-          factory->ort_api_.AddKeyValuePair(ep_metadata, "cuda_device_name", prop.name);
-          factory->ort_api_.AddKeyValuePair(
-              ep_metadata, "cuda_compute_capability",
-              (std::to_string(prop.major) + "." + std::to_string(prop.minor)).c_str());
+        auto [it, inserted] = factory->runtime_discovered_hardware_devices_.emplace(cuda_ordinal, runtime_device);
+        if (!inserted) {
+          factory->ep_api_.ReleaseHardwareDevice(runtime_device);
+          runtime_device = it->second;
         }
       }
+    }
 
-      OrtEpDevice* ep_device = nullptr;
-      auto* status = factory->ep_api_.CreateEpDevice(factory, &device, ep_metadata, ep_options,
-                                                     &ep_device);
-      factory->ort_api_.ReleaseKeyValuePairs(ep_metadata);
-      factory->ort_api_.ReleaseKeyValuePairs(ep_options);
-
-      if (status != nullptr) {
-        return release_ep_devices(status);
-      }
-
-      auto release_current_ep_device = [factory](OrtEpDevice* device) {
-        factory->ep_api_.ReleaseEpDevice(device);
-      };
-      // ep_device_guard owns the current device. On error, release_ep_devices cleans up
-      // previously committed devices [0, num_ep_devices), while the guard cleans up this one.
-      std::unique_ptr<OrtEpDevice, decltype(release_current_ep_device)> ep_device_guard(ep_device, release_current_ep_device);
-
-      // Register allocator info for GPU device memory
-      status = factory->ep_api_.EpDevice_AddAllocatorInfo(ep_device, cache_entry->device_memory_info);
-      if (status != nullptr) {
-        return release_ep_devices(status);
-      }
-
-      // Register allocator info for pinned host memory associated with the
-      // same CUDA ordinal as the device allocator above.
-      status = factory->ep_api_.EpDevice_AddAllocatorInfo(ep_device, cache_entry->pinned_memory_info);
-      if (status != nullptr) {
-        return release_ep_devices(status);
-      }
-
-      ep_devices[num_ep_devices++] = ep_device_guard.release();
+    if (auto* status = add_ep_device(*runtime_device, cuda_ordinal); status != nullptr) {
+      return release_ep_devices(status);
     }
   }
 

--- a/onnxruntime/core/providers/cuda/plugin/cuda_ep_factory.cc
+++ b/onnxruntime/core/providers/cuda/plugin/cuda_ep_factory.cc
@@ -404,7 +404,12 @@ OrtStatus* ORT_API_CALL CudaEpFactory::GetSupportedDevicesImpl(
       OrtKeyValuePairs* hw_metadata = nullptr;
       factory->ort_api_.CreateKeyValuePairs(&hw_metadata);
       factory->ort_api_.AddKeyValuePair(hw_metadata, "cuda_runtime_discovered", "1");
-      factory->ort_api_.AddKeyValuePair(hw_metadata, "Discrete", "1");
+
+      cudaDeviceProp prop;
+      if (cudaGetDeviceProperties(&prop, cuda_ordinal) == cudaSuccess) {
+        factory->ort_api_.AddKeyValuePair(hw_metadata, "Discrete",
+                                          prop.integrated == 0 ? "1" : "0");
+      }
 
       if (!cuda_device_identities[cuda_ordinal].empty()) {
 #ifdef _WIN32

--- a/onnxruntime/core/providers/cuda/plugin/cuda_ep_factory.h
+++ b/onnxruntime/core/providers/cuda/plugin/cuda_ep_factory.h
@@ -160,6 +160,11 @@ class CudaEpFactory : public OrtEpFactory {
   // Ordinal-to-HardwareDeviceKey mapping built during GetSupportedDevicesImpl.
   InlinedHashMap<int, HardwareDeviceKey> ordinal_to_device_key_;
 
+  // Hardware devices created for CUDA-visible ordinals that platform discovery did not expose.
+  // This occurs on WSL, where CUDA devices are available through /dev/dxg while Linux sysfs only
+  // reports Microsoft synthetic display adapters.
+  InlinedHashMap<int, OrtHardwareDevice*> runtime_discovered_hardware_devices_;
+
   /// Find the DeviceCacheEntry for a given CUDA ordinal.
   /// Returns nullptr if the ordinal has not been registered.
   DeviceCacheEntry* FindDeviceCacheEntryByOrdinal(int cuda_ordinal);

--- a/onnxruntime/test/providers/cuda/plugin/cuda_device_mapping_test.cc
+++ b/onnxruntime/test/providers/cuda/plugin/cuda_device_mapping_test.cc
@@ -1,0 +1,87 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#if defined(ORT_UNIT_TEST_HAS_CUDA_PLUGIN_EP)
+
+#include <array>
+#include <cstdint>
+#include <string>
+
+#include "gtest/gtest.h"
+
+#include "core/providers/cuda/plugin/cuda_device_mapping.h"
+
+namespace onnxruntime::cuda_plugin::test {
+namespace {
+
+TEST(CudaDeviceMappingTest, MatchesReorderedDevicesByPciBusId) {
+  const std::array<std::string, 2> cuda_pci_bus_ids{"0000:02:00.0", "0000:01:00.0"};
+  std::array<uint8_t, 2> assigned{};
+
+  EXPECT_EQ(FindCudaOrdinalForHardwareDeviceIdentity("0000:01:00.0", cuda_pci_bus_ids, assigned), 1);
+}
+
+TEST(CudaDeviceMappingTest, LeavesMissingPrefixOrdinalForRuntimeDiscovery) {
+  const std::array<std::string, 2> cuda_pci_bus_ids{"0000:01:00.0", "0000:02:00.0"};
+  std::array<uint8_t, 2> assigned{};
+
+  auto ordinal = FindCudaOrdinalForHardwareDeviceIdentity("0000:02:00.0", cuda_pci_bus_ids, assigned);
+  ASSERT_EQ(ordinal, 1);
+  assigned[*ordinal] = 1;
+
+  EXPECT_EQ(assigned[0], 0);
+}
+
+TEST(CudaDeviceMappingTest, DoesNotAssignKnownHiddenHardwareDevice) {
+  const std::array<std::string, 1> cuda_pci_bus_ids{"0000:01:00.0"};
+  const std::array<uint8_t, 1> assigned{};
+
+  EXPECT_EQ(FindCudaOrdinalForHardwareDeviceIdentity("0000:02:00.0", cuda_pci_bus_ids, assigned),
+            std::nullopt);
+}
+
+TEST(CudaDeviceMappingTest, MatchesDuplicateMigPciBusIdsToDistinctOrdinals) {
+  const std::array<std::string, 2> cuda_pci_bus_ids{"0000:01:00.0", "0000:01:00.0"};
+  std::array<uint8_t, 2> assigned{};
+
+  auto first_ordinal = FindCudaOrdinalForHardwareDeviceIdentity("0000:01:00.0", cuda_pci_bus_ids, assigned);
+  ASSERT_EQ(first_ordinal, 0);
+  assigned[*first_ordinal] = 1;
+
+  EXPECT_EQ(FindCudaOrdinalForHardwareDeviceIdentity("0000:01:00.0", cuda_pci_bus_ids, assigned), 1);
+}
+
+TEST(CudaDeviceMappingTest, PositionalFallbackOnlyUsesCudaDevicesWithoutIdentity) {
+  const std::array<std::string, 2> cuda_pci_bus_ids{"", ""};
+  std::array<uint8_t, 2> assigned{};
+
+  auto first_ordinal = FindCudaOrdinalWithoutIdentity(cuda_pci_bus_ids, assigned);
+  ASSERT_EQ(first_ordinal, 0);
+  assigned[*first_ordinal] = 1;
+
+  EXPECT_EQ(FindCudaOrdinalWithoutIdentity(cuda_pci_bus_ids, assigned), 1);
+}
+
+TEST(CudaDeviceMappingTest, UnknownHardwareCannotStealKnownCudaIdentity) {
+  const std::array<std::string, 2> cuda_device_identities{"0000:01:00.0", ""};
+  const std::array<uint8_t, 2> assigned{};
+
+  EXPECT_EQ(FindCudaOrdinalWithoutIdentity(cuda_device_identities, assigned), 1);
+}
+
+TEST(CudaDeviceMappingTest, ExactMatchIsReservedBeforeUnknownHardwareFallback) {
+  const std::array<std::string, 2> cuda_device_identities{"0000:02:00.0", ""};
+  std::array<uint8_t, 2> assigned{};
+
+  auto exact_ordinal =
+      FindCudaOrdinalForHardwareDeviceIdentity("0000:02:00.0", cuda_device_identities, assigned);
+  ASSERT_EQ(exact_ordinal, 0);
+  assigned[*exact_ordinal] = 1;
+
+  EXPECT_EQ(FindCudaOrdinalWithoutIdentity(cuda_device_identities, assigned), 1);
+}
+
+}  // namespace
+}  // namespace onnxruntime::cuda_plugin::test
+
+#endif  // defined(ORT_UNIT_TEST_HAS_CUDA_PLUGIN_EP)

--- a/onnxruntime/test/providers/cuda/plugin/cuda_plugin_arena_test.cc
+++ b/onnxruntime/test/providers/cuda/plugin/cuda_plugin_arena_test.cc
@@ -8,6 +8,7 @@
 #if defined(ORT_UNIT_TEST_HAS_CUDA_PLUGIN_EP)
 
 #include <algorithm>
+#include <array>
 #include <atomic>
 #include <cstdint>
 #include <cstring>
@@ -19,7 +20,9 @@
 
 #include <cuda_runtime_api.h>
 #include <gtest/gtest.h>
+#include <gsl/gsl>
 
+#include "core/session/abi_devices.h"
 #include "core/session/onnxruntime_cxx_api.h"
 #include "test/util/include/file_util.h"
 
@@ -126,6 +129,52 @@ TEST(CudaPluginDeviceDiscoveryTest, ReturnsDeviceWhenCudaRuntimeFindsGpu) {
   auto cuda_device = FindCudaPluginDevice(env);
   ASSERT_TRUE(cuda_device) << "CUDA runtime found " << device_count
                            << " device(s), but GetEpDevices() did not return the CUDA plugin EP.";
+}
+
+TEST(CudaPluginDeviceDiscoveryTest, CreatesRuntimeDevicesWithoutPlatformDevices) {
+  int device_count = 0;
+  cudaError_t err = cudaGetDeviceCount(&device_count);
+  if (err != cudaSuccess || device_count == 0) {
+    GTEST_SKIP() << "No CUDA device available.";
+  }
+
+  Ort::Env env;
+  ScopedCudaPluginRegistration registration(env, "CudaPluginRuntimeDiscoveryTest");
+  if (!registration.IsAvailable()) {
+    GTEST_SKIP() << "CUDA plugin EP library not found.";
+  }
+
+  auto registered_cuda_device = FindCudaPluginDevice(env);
+  ASSERT_TRUE(registered_cuda_device);
+  const auto* registered_ep_device =
+      static_cast<const OrtEpDevice*>(registered_cuda_device);
+  OrtEpFactory* factory = registered_ep_device->GetMutableFactory();
+  ASSERT_NE(factory, nullptr);
+
+  std::array<OrtEpDevice*, 8> runtime_devices{};
+  size_t num_runtime_devices = 0;
+  Ort::Status status{factory->GetSupportedDevices(
+      factory, nullptr, 0, runtime_devices.data(), runtime_devices.size(),
+      &num_runtime_devices)};
+  ASSERT_TRUE(status.IsOK()) << status.GetErrorMessage();
+
+  auto release_runtime_devices = gsl::finally([&]() {
+    for (size_t i = 0; i < num_runtime_devices; ++i) {
+      Ort::GetApi().GetEpApi()->ReleaseEpDevice(runtime_devices[i]);
+    }
+  });
+
+  ASSERT_EQ(num_runtime_devices,
+            std::min(static_cast<size_t>(device_count), runtime_devices.size()));
+  for (size_t i = 0; i < num_runtime_devices; ++i) {
+    Ort::ConstEpDevice runtime_device{runtime_devices[i]};
+    EXPECT_STREQ(runtime_device.Device().Metadata().GetValue("cuda_runtime_discovered"), "1");
+
+    cudaDeviceProp prop;
+    ASSERT_EQ(cudaGetDeviceProperties(&prop, static_cast<int>(i)), cudaSuccess);
+    EXPECT_STREQ(runtime_device.Device().Metadata().GetValue("Discrete"),
+                 prop.integrated == 0 ? "1" : "0");
+  }
 }
 
 class CudaPluginArenaTest : public ::testing::Test {

--- a/onnxruntime/test/providers/cuda/plugin/cuda_plugin_arena_test.cc
+++ b/onnxruntime/test/providers/cuda/plugin/cuda_plugin_arena_test.cc
@@ -110,6 +110,24 @@ Ort::ConstEpDevice FindCudaPluginDevice(Ort::Env& env) {
 
 }  // namespace
 
+TEST(CudaPluginDeviceDiscoveryTest, ReturnsDeviceWhenCudaRuntimeFindsGpu) {
+  int device_count = 0;
+  cudaError_t err = cudaGetDeviceCount(&device_count);
+  if (err != cudaSuccess || device_count == 0) {
+    GTEST_SKIP() << "No CUDA device available.";
+  }
+
+  Ort::Env env;
+  ScopedCudaPluginRegistration registration(env, "CudaPluginDeviceDiscoveryTest");
+  if (!registration.IsAvailable()) {
+    GTEST_SKIP() << "CUDA plugin EP library not found.";
+  }
+
+  auto cuda_device = FindCudaPluginDevice(env);
+  ASSERT_TRUE(cuda_device) << "CUDA runtime found " << device_count
+                           << " device(s), but GetEpDevices() did not return the CUDA plugin EP.";
+}
+
 class CudaPluginArenaTest : public ::testing::Test {
  protected:
   void SetUp() override {


### PR DESCRIPTION
Fixes `GetEpDevices()` failing to return the CUDA plugin EP on WSL.

WSL exposes CUDA devices through  /dev/dxg , while Linux hardware discovery may only report Microsoft synthetic display adapters. The CUDA plugin previously rejected those adapters and returned no CUDA device.

This change:

 - Matches CUDA devices using PCI bus IDs on Linux and LUIDs on Windows.
 - Creates runtime-backed hardware descriptors for CUDA devices missing from platform discovery.
 - Handles partial discovery, reordered devices,  CUDA_VISIBLE_DEVICES , and duplicate MIG PCI IDs.
 - Preserves positional matching only when neither side provides a hardware identity.

Testing

 - Built the CUDA plugin and provider tests for SM 8.6 on an NVIDIA A2000 under WSL.
 - Passed 20 focused device-mapping, discovery, session creation, and inference tests.
 - Reviewed through multiple independent review/fix cycles with no remaining findings.