### PR TITLE
[CUDA] Add Hadamard rotation and per-token KV scales to PagedAttention

### DIFF
--- a/docs/ContribOperators.md
+++ b/docs/ContribOperators.md
@@ -4804,9 +4804,9 @@ This version of the operator has been available since version 1 of the 'com.micr
 <dt><tt>value</tt> (optional) : T</dt>
 <dd>Value with shape (num_tokens, kv_hidden_size). Must be absent when 'kv_cache_layout' is 'LATENT'.</dd>
 <dt><tt>key_cache</tt> : T_CACHE</dt>
-<dd>Block-based key cache with shape (num_blocks, block_size, kv_num_heads, head_size). This is updated in place within the op. When 'kv_cache_layout' is 'LATENT' this is the only cache, and V is read from its leading v_head_size channels.</dd>
+<dd>Block-based key cache with shape (num_blocks, block_size, kv_num_heads, cache_head_size), where cache_head_size is (head_size + 1) / 2 for packed INT4 and head_size otherwise. This is updated in place within the op. When 'kv_cache_layout' is 'LATENT' this is the only cache, and V is read from its leading v_head_size channels.</dd>
 <dt><tt>value_cache</tt> (optional) : T_CACHE</dt>
-<dd>Block-based value cache with shape (num_blocks, block_size, kv_num_heads, head_size). This is updated in place within the op. This should be the same shape as key_cache. Must be absent when 'kv_cache_layout' is 'LATENT'.</dd>
+<dd>Block-based value cache with shape (num_blocks, block_size, kv_num_heads, cache_head_size), where cache_head_size is (head_size + 1) / 2 for packed INT4 and head_size otherwise. This is updated in place within the op. This should be the same shape as key_cache. Must be absent when 'kv_cache_layout' is 'LATENT'.</dd>
 <dt><tt>cumulative_sequence_length</tt> : S</dt>
 <dd>A tensor with shape (batch_size + 1). It specifies the cumulative sequence lengths between the packed entries in Q/K/V.</dd>
 <dt><tt>past_seqlens</tt> : S</dt>
@@ -4839,9 +4839,9 @@ This version of the operator has been available since version 1 of the 'com.micr
 <dt><tt>output</tt> : T</dt>
 <dd>2D output tensor with shape (num_tokens, num_heads * v_head_size), which is (num_tokens, hidden_size) unless 'kv_cache_layout' is 'LATENT' with a narrower v_head_size.</dd>
 <dt><tt>key_cache_out</tt> (optional) : T_CACHE</dt>
-<dd>Block-based key cache with shape (num_blocks, block_size, kv_num_heads, head_size). This is always the same tensor as key_cache.</dd>
+<dd>Aliases key_cache with the same shape and element type, including its packed dimension for INT4.</dd>
 <dt><tt>value_cache_out</tt> (optional) : T_CACHE</dt>
-<dd>Block-based value cache with shape (num_blocks, block_size, kv_num_heads, head_size). This is always the same tensor as value_cache. Must be absent when 'kv_cache_layout' is 'LATENT'.</dd>
+<dd>Aliases value_cache with the same shape and element type, including its packed dimension for INT4. Must be absent when 'kv_cache_layout' is 'LATENT'.</dd>
 </dl>
 
 #### Type Constraints
@@ -4849,7 +4849,7 @@ This version of the operator has been available since version 1 of the 'com.micr
 <dl>
 <dt><tt>T</tt> : tensor(float16), tensor(bfloat16)</dt>
 <dd>Constrain input and output to float tensors.</dd>
-<dt><tt>T_CACHE</tt> : tensor(float16), tensor(bfloat16), tensor(int8), tensor(float8e4m3fn)</dt>
+<dt><tt>T_CACHE</tt> : tensor(float16), tensor(bfloat16), tensor(int8), tensor(float8e4m3fn), tensor(uint8)</dt>
 <dd>Constrain the KV cache to float or quantized tensors.</dd>
 <dt><tt>T_KV_SCALE</tt> : tensor(float)</dt>
 <dd>Constrain KV cache scales to float tensors.</dd>

--- a/docs/ContribOperators.md
+++ b/docs/ContribOperators.md
@@ -4762,22 +4762,24 @@ This version of the operator has been available since version 1 of the 'com.micr
 <dl>
 <dt><tt>do_rotary</tt> : int</dt>
 <dd>Whether to use rotary position embedding. Default value is 0.</dd>
-<dt><tt>is_causal</tt> : int</dt>
+<dt><tt>is_causal</tt> : int (default is 1)</dt>
 <dd>Whether the attention mask is causal (bottom-right aligned). Default value is 1. Set to 0 for a block drafter whose query tokens attend to each other bidirectionally; local_window_size then bounds the mask on the left only.</dd>
-<dt><tt>k_cache_dtype</tt> : string</dt>
+<dt><tt>k_cache_dtype</tt> : string (default is )</dt>
 <dd>Logical element type stored in 'key_cache', named after the ONNX element type it denotes: '' (the default) means the cache tensor's own element type is also the logical type. 'float16', 'bfloat16', 'int8' and 'float8e4m3fn' name that same type explicitly and must agree with the tensor. 'int4' and 'float4e2m1' name sub-byte types packed two per byte into a uint8 cache, where the last cache dimension holds (head_size + 1) / 2 bytes and logical element 2*i occupies the low-order bits of byte i. Every value is a signed, zero-symmetric type: quantization uses a scale with no zero point, so unsigned logical types are not expressible.</dd>
-<dt><tt>k_quant_type</tt> : string</dt>
-<dd>Quantization granularity of the key cache: 'NONE', 'PER_TENSOR' or 'PER_CHANNEL'. Must be non-'NONE' exactly when 'key_cache' has a quantized element type, and then 'k_scale' is required. Default value is 'NONE'.</dd>
-<dt><tt>kv_cache_layout</tt> : string</dt>
+<dt><tt>k_quant_type</tt> : string (default is NONE)</dt>
+<dd>Quantization granularity of the key cache: 'NONE', 'PER_TENSOR', 'PER_CHANNEL' or 'PER_TOKEN'. Must be non-'NONE' exactly when 'key_cache' has a quantized element type, and then 'k_scale' is required except for PER_TOKEN, which requires 'key_scale_cache' and forbids 'k_scale'. Default value is 'NONE'.</dd>
+<dt><tt>kv_cache_layout</tt> : string (default is SEPARATE)</dt>
 <dd>Physical layout of the KV cache: 'SEPARATE' or 'LATENT'. 'SEPARATE' (the default) uses distinct 'key_cache' and 'value_cache' tensors. 'LATENT' selects absorbed Multi-head Latent Attention: there is a single cache, 'value' and 'value_cache' must be absent, 'kv_num_heads' must be 1, and V for every head is the leading 'v_head_size' channels of the same 'key_cache' row that supplies K. Default value is 'SEPARATE'.</dd>
 <dt><tt>kv_num_heads</tt> : int (required)</dt>
 <dd>Number of attention heads for k and v</dd>
-<dt><tt>local_window_size</tt> : int</dt>
+<dt><tt>local_window_size</tt> : int (default is -1)</dt>
 <dd>left_window_size for local attention (like Mistral). Default value is -1 meaning unused.</dd>
 <dt><tt>num_heads</tt> : int (required)</dt>
 <dd>Number of attention heads for q</dd>
 <dt><tt>qk_norm_epsilon</tt> : float</dt>
 <dd>Epsilon used by the Q/K RMSNorm when 'q_norm_weight' and 'k_norm_weight' are provided. Default value is 1e-6.</dd>
+<dt><tt>qk_rotation</tt> : string (default is NONE)</dt>
+<dd>NONE or HADAMARD. Apply a per-head orthonormal Walsh-Hadamard transform to Q and K after QK-Norm and rotary embedding. Requires a power-of-two head_size in [16, 256], SEPARATE layout, and no PER_CHANNEL key quantization.</dd>
 <dt><tt>rotary_interleaved</tt> : int</dt>
 <dd>Rotate using interleaved pattern. Default value is 0 (False).</dd>
 <dt><tt>rotary_offset</tt> : int</dt>
@@ -4786,62 +4788,72 @@ This version of the operator has been available since version 1 of the 'com.micr
 <dd>Custom scale will be used if specified. Default value is 1/sqrt(head_size)</dd>
 <dt><tt>softcap</tt> : float</dt>
 <dd>Softcap value for attention weights. Default value is 0.</dd>
-<dt><tt>v_cache_dtype</tt> : string</dt>
+<dt><tt>v_cache_dtype</tt> : string (default is )</dt>
 <dd>Logical element type stored in 'value_cache', with the same values and packing rule as 'k_cache_dtype'. Default value is '' (use the cache tensor's element type).</dd>
 <dt><tt>v_head_size</tt> : int</dt>
 <dd>Width of the value head, which may be narrower than head_size. Only valid when 'kv_cache_layout' is 'LATENT' (DeepSeek-V3 uses head_size=576 and v_head_size=512). When v_head_size differs from head_size the 'scale' attribute is required, because the 1/sqrt(head_size) default no longer matches the pre-absorption head width. Default value is 0, meaning the same as head_size.</dd>
-<dt><tt>v_quant_type</tt> : string</dt>
-<dd>Quantization granularity of the value cache: 'NONE', 'PER_TENSOR' or 'PER_CHANNEL'. Must be non-'NONE' exactly when 'value_cache' has a quantized element type, and then 'v_scale' is required. Default value is 'NONE'.</dd>
+<dt><tt>v_quant_type</tt> : string (default is NONE)</dt>
+<dd>Quantization granularity of the value cache: 'NONE', 'PER_TENSOR', 'PER_CHANNEL' or 'PER_TOKEN'. Must be non-'NONE' exactly when 'value_cache' has a quantized element type, and then 'v_scale' is required except for PER_TOKEN, which requires 'value_scale_cache' and forbids 'v_scale'. Default value is 'NONE'.</dd>
+<dt><tt>v_rotation</tt> : string (default is NONE)</dt>
+<dd>NONE or HADAMARD. Rotate V before caching and invert the transform on the attention output. Requires a power-of-two v_head_size in [16, 256], SEPARATE layout, and no PER_CHANNEL value quantization.</dd>
 </dl>
 
-#### Inputs (8 - 17)
+#### Inputs (8 - 19)
 
 <dl>
 <dt><tt>query</tt> : T</dt>
-<dd>Query with shape (num_tokens, hidden_size), or packed QKV with shape (num_tokens, d) where d is (num_heads * head_size + 2 * kv_num_heads * head_size).</dd>
+<dd></dd>
 <dt><tt>key</tt> (optional) : T</dt>
-<dd>Key with shape (num_tokens, kv_hidden_size) </dd>
+<dd></dd>
 <dt><tt>value</tt> (optional) : T</dt>
-<dd>Value with shape (num_tokens, kv_hidden_size). Must be absent when 'kv_cache_layout' is 'LATENT'.</dd>
+<dd></dd>
 <dt><tt>key_cache</tt> : T_CACHE</dt>
-<dd>Block-based key cache with shape (num_blocks, block_size, kv_num_heads, cache_head_size), where cache_head_size is (head_size + 1) / 2 for packed INT4 and head_size otherwise. This is updated in place within the op. When 'kv_cache_layout' is 'LATENT' this is the only cache, and V is read from its leading v_head_size channels.</dd>
+<dd></dd>
 <dt><tt>value_cache</tt> (optional) : T_CACHE</dt>
-<dd>Block-based value cache with shape (num_blocks, block_size, kv_num_heads, cache_head_size), where cache_head_size is (head_size + 1) / 2 for packed INT4 and head_size otherwise. This is updated in place within the op. This should be the same shape as key_cache. Must be absent when 'kv_cache_layout' is 'LATENT'.</dd>
+<dd></dd>
 <dt><tt>cumulative_sequence_length</tt> : S</dt>
-<dd>A tensor with shape (batch_size + 1). It specifies the cumulative sequence lengths between the packed entries in Q/K/V.</dd>
+<dd></dd>
 <dt><tt>past_seqlens</tt> : S</dt>
-<dd>A tensor with shape (batch_size). It specifies the past lengths of cached sequence in the KV cache.</dd>
+<dd></dd>
 <dt><tt>block_table</tt> : S</dt>
-<dd>2D tensor with shape (batch_size, max_blocks_per_sequence) that maps each sequence in the batch to itscorresponding blocks in the KV cache.</dd>
+<dd></dd>
 <dt><tt>cos_cache</tt> (optional) : T</dt>
-<dd>2D tensor with shape (max total seqlen, head_size / 2).</dd>
+<dd></dd>
 <dt><tt>sin_cache</tt> (optional) : T</dt>
-<dd>2D tensor with shape (max total seqlen, head_size / 2).</dd>
+<dd></dd>
 <dt><tt>slot_mapping</tt> (optional) : S</dt>
-<dd>1D tensor with shape (num_tokens). For each query token, the flat slot index (block_id * block_size + offset_in_block) at which its key/value is written into the KV cache. A value of -1 skips the cache write for that token, which lets a scheduler suppress stores for prefix-cache hits or rejected speculative tokens. When absent, slots are derived from 'past_seqlens', 'cumulative_sequence_length' and 'block_table' as before. 'block_table' is still required, because it defines the read path.</dd>
+<dd></dd>
 <dt><tt>head_sink</tt> (optional) : T</dt>
-<dd>1D tensor with shape (num_heads). Each head has a learnable sink logit that participates in the softmax denominator but contributes no value, so attention can 'do nothing'.</dd>
+<dd></dd>
 <dt><tt>q_norm_weight</tt> (optional) : T</dt>
-<dd>1D tensor with shape (head_size). RMSNorm gain applied to each query head before rotary embedding. Must be provided together with 'k_norm_weight'.</dd>
+<dd></dd>
 <dt><tt>k_norm_weight</tt> (optional) : T</dt>
-<dd>1D tensor with shape (head_size). RMSNorm gain applied to each key head before rotary embedding and before the key is written to the KV cache. Must be provided together with 'q_norm_weight'.</dd>
+<dd></dd>
 <dt><tt>k_scale</tt> (optional) : T_KV_SCALE</dt>
-<dd>Dequantization scale of the key cache. Shape is (1) when 'k_quant_type' is 'PER_TENSOR' and (kv_num_heads, 1, head_size) when it is 'PER_CHANNEL'. Quantization is symmetric (no zero point).</dd>
+<dd></dd>
 <dt><tt>v_scale</tt> (optional) : T_KV_SCALE</dt>
-<dd>Dequantization scale of the value cache. Shape is (1) when 'v_quant_type' is 'PER_TENSOR' and (kv_num_heads, 1, head_size) when it is 'PER_CHANNEL'. Quantization is symmetric (no zero point).</dd>
+<dd></dd>
 <dt><tt>attention_metadata</tt> (optional) : S</dt>
-<dd>1D tensor with shape (2) or (3) holding [max_query_len_bound, max_kv_len_bound, optional max_kv_len_lower_bound] in CPU memory. max_query_len_bound is an upper bound on the number of new tokens any one sequence contributes; max_kv_len_bound is an upper bound on past_seqlens[i] + query_len[i]. Both are replay-wide upper bounds, never exact per-step values: they must hold for every step this node -- or a CUDA Graph capturing it -- will serve, and 0 means 'unknown'. They may only select the backend and size launch dimensions and workspaces; they never enter a mask comparison, so over-estimating only costs empty work. max_kv_len_lower_bound is a replay-wide lower bound on the largest per-sequence KV length in the batch and 0 means 'unknown'. It is a provider-neutral performance hint; omitting it preserves the shape-(2) contract and disables optimizations that require a lower bound unless the op reads exact lengths back from the device. The op can otherwise obtain the upper bounds only by copying 'cumulative_sequence_length' and 'past_seqlens' back from the device and synchronizing the stream on every call, which stalls the pipeline once per node per step and makes the op impossible to capture into a CUDA Graph. Schedulers already track these bounds on the host, so supplying them is normally free. When absent, the op falls back to the device readback. The upper bounds are trusted: an under-sized bound violates the contract and may omit attention work.</dd>
+<dd></dd>
+<dt><tt>key_scale_cache</tt> (optional) : T_SCALE_CACHE</dt>
+<dd></dd>
+<dt><tt>value_scale_cache</tt> (optional) : T_SCALE_CACHE</dt>
+<dd></dd>
 </dl>
 
-#### Outputs (1 - 3)
+#### Outputs (1 - 5)
 
 <dl>
 <dt><tt>output</tt> : T</dt>
-<dd>2D output tensor with shape (num_tokens, num_heads * v_head_size), which is (num_tokens, hidden_size) unless 'kv_cache_layout' is 'LATENT' with a narrower v_head_size.</dd>
+<dd></dd>
 <dt><tt>key_cache_out</tt> (optional) : T_CACHE</dt>
-<dd>Aliases key_cache with the same shape and element type, including its packed dimension for INT4.</dd>
+<dd></dd>
 <dt><tt>value_cache_out</tt> (optional) : T_CACHE</dt>
-<dd>Aliases value_cache with the same shape and element type, including its packed dimension for INT4. Must be absent when 'kv_cache_layout' is 'LATENT'.</dd>
+<dd></dd>
+<dt><tt>key_scale_cache_out</tt> (optional) : T_SCALE_CACHE</dt>
+<dd></dd>
+<dt><tt>value_scale_cache_out</tt> (optional) : T_SCALE_CACHE</dt>
+<dd></dd>
 </dl>
 
 #### Type Constraints
@@ -4851,6 +4863,8 @@ This version of the operator has been available since version 1 of the 'com.micr
 <dd>Constrain input and output to float tensors.</dd>
 <dt><tt>T_CACHE</tt> : tensor(float16), tensor(bfloat16), tensor(int8), tensor(float8e4m3fn), tensor(uint8)</dt>
 <dd>Constrain the KV cache to float or quantized tensors.</dd>
+<dt><tt>T_SCALE_CACHE</tt> : tensor(float16), tensor(float)</dt>
+<dd>Dynamic paged quantization scales.</dd>
 <dt><tt>T_KV_SCALE</tt> : tensor(float)</dt>
 <dd>Constrain KV cache scales to float tensors.</dd>
 <dt><tt>S</tt> : tensor(int32)</dt>

--- a/docs/contrib_ops/cuda/paged_attention.md
+++ b/docs/contrib_ops/cuda/paged_attention.md
@@ -178,6 +178,9 @@ matches the landing order in [§19](#19-phasing), so the schema grows monotonica
 | 17 | `query_positions` | `S` (opt) | `(token_count,)` | **new — §4.8** |
 | 18 | `attention_bias` | `T` (opt) | `(batch_size or 1, num_heads or 1, query_length_capacity, context_length_capacity)` | **new — §10** |
 
+For `k_cache_dtype=v_cache_dtype="int4"`, the cache tensors use `uint8` storage and their last
+dimension is `(head_size + 1) / 2`, not `head_size`.
+
 `max_context_len` is the largest per-sequence total KV length in the batch, bounded above by
 `block_table.shape[1] * block_size`.
 
@@ -248,9 +251,9 @@ ops without translation.
 `k_cache_dtype` and `v_cache_dtype` name the *logical* element type of each cache. Every value is
 spelled as the ONNX element type it denotes. `""` — the default — means the cache tensor's own
 element type is also the logical type; `"float16"`, `"bfloat16"`, `"int8"` and `"float8e4m3fn"` name
-that same type explicitly and must agree with the tensor. The reserved values `"int4"` and
-`"float4e2m1"` describe sub-byte types packed two per byte into a `uint8` cache (§21.4), which
-no ONNX tensor type can express here; they are rejected until a sub-byte backend exists. Every
+that same type explicitly and must agree with the tensor. `"int4"` describes signed values packed
+two per byte in a `uint8` cache and is supported by the CUDA INT4 build. A `uint8` cache requires
+an explicit `"int4"` attribute; `"float4e2m1"` remains reserved and rejected. Every
 value is a signed, zero-symmetric type — there is no zero-point input, so `uint4` / `uint8` are
 deliberately not in the vocabulary (§8.3.1).
 
@@ -434,7 +437,7 @@ varlen layout has no `(batch, seq)` grid — but it does mean a GQA↔PagedAtten
 | Name | Allowed | Change |
 |---|---|---|
 | `T` | `float16`, `bfloat16` | unchanged |
-| `T_CACHE` | `float16`, `bfloat16`, `int8`, `float8e4m3fn` | **new** (split out of `T`) |
+| `T_CACHE` | `float16`, `bfloat16`, `int8`, `float8e4m3fn`, `uint8` | **new** (split out of `T`) |
 | `T_KV_SCALE` | `float` | **new** |
 | `QK` | `float`, `float16`, `bfloat16` | **new** — §11 |
 | `S` | `int32` | unchanged |
@@ -443,10 +446,8 @@ Splitting `T_CACHE` out of `T` is backward compatible: every previously valid mo
 `T_CACHE == T`. The constraint name is `T_KV_SCALE`, matching GQA and the registration already in
 `paged_attention.cc`.
 
-`uint8` is **intentionally** omitted from `T_CACHE`, even though GQA's `T_CACHE` already admits it
-for packed INT4. There is no unsigned or sub-byte logical cache format specified for this operator
-yet (§21), and widening a type constraint later is itself a compatible change, so nothing is lost by
-waiting. This is a deliberate divergence from GQA, not an oversight.
+`uint8` stores packed signed INT4, not an unsigned logical cache type. Its CUDA registrations require
+`onnxruntime_USE_INT4_KV_CACHE=ON`.
 
 ## 5. Feature: `slot_mapping`
 
@@ -637,22 +638,20 @@ if (needs_prologue) {
 
 ### 8.1 Goal
 
-Store the block cache in INT8 or FP8 E4M3 while `query` remains FP16/BF16, halving (or better) the
-dominant memory consumer in a serving deployment and proportionally reducing HBM traffic on the
-decode path. Scope for this phase: **`PER_TENSOR` and `PER_CHANNEL`**, with `k_cache_dtype` and
-`v_cache_dtype` left at `""` (or naming the cache tensor's own element type).
-INT4 is deferred ([§19](#19-phasing)).
+Store the block cache in INT8, FP8 E4M3, or packed INT4 while `query` remains FP16/BF16, halving (or
+better) the dominant memory consumer in a serving deployment and proportionally reducing HBM traffic
+on the decode path. Scope for this phase: **`PER_TENSOR` and `PER_CHANNEL`** static scales.
+INT4 uses the portable decode and gather paths plus a dedicated XQA decode kernel. Performance and
+model-quality evaluation are separate gates; reduced cache storage alone does not establish either.
 
 ### 8.2 Schema
 
-- `key_cache` / `value_cache` move from `T` to `T_CACHE ∈ {float16, bfloat16, int8, float8e4m3fn}`.
-  `uint8` is intentionally excluded until a sub-byte format is specified (§4.9, §21).
+- `key_cache` / `value_cache` use `T_CACHE ∈ {float16, bfloat16, int8, float8e4m3fn, uint8}`.
 - `k_scale` / `v_scale` (inputs 14, 15), type `T_KV_SCALE` = **always FP32**, matching GQA.
-- Attributes `k_quant_type`, `v_quant_type` ∈ `{"NONE", "PER_TENSOR", "PER_CHANNEL"}`, plus
-  independent `k_cache_dtype` and `v_cache_dtype` attributes, which stay `""` while every logical
-  type is expressible as an ONNX element type.
+- Attributes `k_quant_type`, `v_quant_type` ∈ `{"NONE", "PER_TENSOR", "PER_CHANNEL"}`,
+  plus independent `k_cache_dtype` and `v_cache_dtype` attributes. Packed INT4 requires `"int4"`.
 - Kernel becomes `PagedAttention<T, T_CACHE>`, registered for the same combinations GQA uses:
-  `{MLFloat16, BFloat16} × {same as T, int8_t, Float8E4M3FN}` (plus `uint8_t` if and when INT4 lands).
+  `{MLFloat16, BFloat16} × {same as T, int8_t, Float8E4M3FN, uint8_t}`, with the narrow formats build-gated.
 
 ### 8.3 Scale layout under the block layout
 
@@ -678,7 +677,11 @@ Symmetric quantization, same formulas as GQA:
 |---|---|---|
 | INT8 | `[-128, 127]` | `q = clamp(round(x / scale), -128, 127)` |
 | FP8 E4M3 | `[-448, 448]` | `q = clamp(x / scale, -448, 448)` |
-| INT4 (deferred) | `[-8, 7]`, 2/byte | last cache dim becomes `(head_size + 1) / 2` |
+| INT4 | `[-8, 7]`, 2/byte | `clamp(round(x / scale), -8, 7)`; last cache dim `(head_size + 1) / 2` |
+
+INT4 uses round-to-nearest-even and stores `q + 8`, with the even channel in the low nibble.
+Zero-filled logical padding is `0x88`, not `0x00`. The caller initializes unwritten slots;
+the operator preserves every slot not selected by the write map.
 
 #### 8.3.1 Zero point: always 0, and why the vocabulary is signed-only
 
@@ -715,6 +718,11 @@ versioned-successor topic rather than a late addition.
 scattered to their slots. This is a natural fit: the kernel is already elementwise over
 `(token, kv_head, channel)`, which is exactly the `PER_CHANNEL` scale index.
 
+Packed INT4 selects `ReshapeAndCacheHeads` instead: one block per `(token, kv_head)` for each
+tensor, so a whole head is resident when its channel pairs are packed into nibbles. The original
+elementwise path remains for native, INT8, and FP8 caches. Both paths reuse the explicit/derived
+slot resolvers and skip negative or out-of-range write slots.
+
 ### 8.5 Read path
 
 Phase 2 (correctness first): **dequantize-on-gather**. The MEA fallback already materializes a
@@ -730,6 +738,10 @@ output afterward. Both are `O(num_heads * head_size)` passes and avoid touching 
 is the path that makes a quantized cache actually pay off; the gather-based Phase 2 mostly buys
 memory capacity, not bandwidth.
 
+Packed INT4 unpacks a nibble at a time through the same `ReadPagedCache` accessor on both the
+split-KV decode and the gather paths, so the scale foldings above are unchanged. Gather still
+materializes an FP16/BF16 staging buffer, so INT4 does not reduce that prefill allocation.
+
 ### 8.6 Build gating
 
 Mirror GQA: `onnxruntime_USE_FP8_KV_CACHE` (default ON), `onnxruntime_USE_INT4_KV_CACHE`
@@ -741,15 +753,16 @@ Mirror GQA: `onnxruntime_USE_FP8_KV_CACHE` (default ON), `onnxruntime_USE_INT4_K
   `k_quant_type == "NONE"` is `INVALID_ARGUMENT`.
 - `T_CACHE != T` requires a non-`NONE` quant type; `T_CACHE == T` requires both to be `NONE` and both
   scales to be absent.
-- `k_cache_dtype` and `v_cache_dtype` are `""` for every cache this operator stores, quantized or
-  not: the cache tensor's element type is the logical element type. Naming that type explicitly
+- `k_cache_dtype` and `v_cache_dtype` may be `""` for non-packed caches, quantized or not:
+  the cache tensor's element type is the logical element type. Naming that type explicitly
   (`"float16"`, `"bfloat16"`, `"int8"`, `"float8e4m3fn"`) is accepted but must agree with the tensor.
-  `"int4"` and `"float4e2m1"` are reserved for a `uint8` packed cache and are rejected
-  until one exists. Unsigned logical types (`uint4`, `uint8`) are rejected outright: quantization
+  `"int4"` requires a `uint8` cache with packed last dimension; `"float4e2m1"` remains unsupported.
+  Unsigned logical types (`uint4`, `uint8`) are rejected outright: quantization
   here has no zero point (§8.3.1).
 - In `"LATENT"` mode only K storage exists: `k_quant_type` and `k_scale` describe the latent row,
   `v_quant_type` and `v_cache_dtype` must be unset, and `v_scale` must be
   absent because V is a view of K.
+- `LATENT` rejects packed INT4 in this implementation.
 - FP8 is available when ORT is built with `onnxruntime_USE_FP8_KV_CACHE`; no additional runtime
   architecture gate is required for the conversion path used by this operator.
 - `PER_CHANNEL` scale shape must be exactly `(kv_num_heads, 1, head_size)` for both K and V. There
@@ -770,8 +783,9 @@ Mirror GQA: `onnxruntime_USE_FP8_KV_CACHE` (default ON), `onnxruntime_USE_INT4_K
 > - Because a quantized cache never reaches Flash's *paged* kernel, the `block_size` tiling
 >   constraint of §18.1 does not apply to it; Flash eligibility skips that check when the cache is
 >   quantized. Any power-of-two `block_size >= 16` works with a quantized cache on either backend.
-> - **`uint8` / INT4 not added.** `T_CACHE` is `{float16, bfloat16, int8, float8e4m3fn}`, so
->   `k_cache_dtype` and `v_cache_dtype` must be `""` or name the cache tensor's own element type.
+> - **INT4 extension:** `uint8` packed caches are read by the portable decode/gather paths, and by a
+>   dedicated FP16 XQA decode kernel at `head_size = 256`, `group_size = 6` with `PER_CHANNEL`
+>   scales for both K and V. Other XQA specializations remain limited to native/INT8/FP8 formats.
 > - **No architecture gate for portable FP8 decode.** `Float8E4M3FN`'s converting constructor uses
 >   `__nv_cvt_float_to_fp8`, which is available on every architecture ORT builds for from CUDA 11.8
 >   onward. FP8 remains gated at *build* time by `onnxruntime_USE_FP8_KV_CACHE`.
@@ -844,6 +858,14 @@ Mirror GQA: `onnxruntime_USE_FP8_KV_CACHE` (default ON), `onnxruntime_USE_INT4_K
 >   reuses. It lives outside the `USE_FLASH_ATTENTION` / `USE_MEMORY_EFFICIENT_ATTENTION` guards
 >   because the decode backend needs neither.
 > - **Still deferred from P5:** the fused MLA decode backend (§12.7).
+
+### 8.8 Packed INT4 tests
+
+Operator tests are in `onnxruntime/test/python/transformers/test_paged_attention_int4.py`, covering
+FP16/BF16, packed/derived writes, skipped slots, exact nibble encoding, zero padding,
+prefill/decode/speculative attention, norm/RoPE ordering, negative contracts, and the XQA decode
+path. INT8 and FP8 regression cases and extreme scale saturation are also covered. They skip when
+INT4 CUDA kernels are not built.
 
 ## 9. Feature: Sliding Window Attention
 
@@ -1392,10 +1414,10 @@ Consolidated, to be implemented in `paged_attention_helper::CheckInputs`. Every 
   `PER_CHANNEL` (both K and V — `v_scale` only exists alongside a `value_cache`, so its last
   dimension is always `head_size`); present iff the corresponding quant type is not `NONE`.
 - `T_CACHE != T` iff a quant type is not `NONE`.
-- `k_cache_dtype` and `v_cache_dtype` must be `""` or name the cache tensor's own element type:
-  every logical element type this operator stores is expressible as an ONNX element type. The
-  reserved sub-byte values are rejected until a `uint8` packed cache exists. FP8 availability is
-  controlled by `onnxruntime_USE_FP8_KV_CACHE`, without an additional runtime architecture gate.
+- Non-packed cache-dtype attributes must be `""` or name the cache tensor's own element type.
+  Packed `uint8` caches require explicit `"int4"` and `onnxruntime_USE_INT4_KV_CACHE`.
+  Other sub-byte formats remain unsupported. FP8 availability is controlled by
+  `onnxruntime_USE_FP8_KV_CACHE`, without an additional runtime architecture gate.
 - `attention_metadata`: rank 1, `dim0 ∈ {2, 3}`, `int32`, CPU-resident; entries `>= 0`; the first
   two entries are trusted upper bounds and the optional third is a trusted lower bound for every
   step served by the node or captured graph (§4.7). Bounds may only select implementations or size
@@ -1596,7 +1618,7 @@ These block the feature work and should land ahead of it.
 | **P4 — MLA (correctness)** | `kv_cache_layout="LATENT"`, `v_head_size`, `rotary_offset`, V-aliases-K, optional `value_cache`, unfused MLA reference kernel, absorbed↔non-absorbed equivalence tests (§12) | attrs `kv_cache_layout`, `v_head_size`, `rotary_offset`; input 4 optional |
 | **P5 — Performance** | Paged decode kernel with in-kernel dequant; fused MLA backend (FlashMLA / FlashInfer MLA, §12.7); `softcap` on decode; **remove the D→H sync and make the op CUDA-graph-capturable (§4.7)**; optional `attention_metadata` replay-wide bounds | input 16 |
 | **P6 — Completeness** | `query_positions` (§4.8); `attention_bias` (§10); `output_qk` (§11) | inputs 17–18, output 3, attr `qk_output` |
-| **Later** | INT4 cache; MLA quantized latent cache tuning; non-CUDA EPs | — |
+| **Later** | MLA quantized latent cache tuning; non-CUDA EPs | — |
 
 Status: P0–P4 are implemented, except the `.Alias` registration. P5 is partially
 implemented — the paged decode kernel with in-kernel dequantization (including `softcap`, sliding
@@ -1682,7 +1704,7 @@ expressibility for formats no ORT model uses today, at the cost of invalidating 
 serialized graph and every test. The decision is therefore:
 
 > Treat the separate-cache representation as **permanent** for `com.microsoft::PagedAttention`
-> opset 1. If a merged or sub-byte cache becomes a real requirement, introduce a separately versioned
+> opset 1. If a merged cache becomes a real requirement, introduce a separately versioned
 > schema or a new operator name with a migration tool — do not change the meaning of inputs, outputs
 > or attributes in place.
 
@@ -1692,8 +1714,8 @@ The complete deferred list:
 - one required functional `kv_cache_out` instead of two optional aliasing outputs;
 - removal of `kv_num_heads` in favor of `kv_cache.shape[2]`;
 - quantization granularity inferred from scale shape, and zero points (§21.3);
-- sub-byte logical types stored in `uint8` tensors — the `k_cache_dtype` / `v_cache_dtype` attributes
-  that name them are adopted in §4.5, but no backend decodes a packed cache yet (§21.4);
+- sub-byte logical types other than INT4 stored in `uint8` tensors; INT4 is implemented without
+  reinterpreting existing tensor types (§21.4);
 - inline scales or zero points packed into cache rows (§21.3, note);
 - a physical `HND` cache layout (§21.6);
 - renaming `local_window_size` to `window_size_left` / `window_size_right`, and the
@@ -1784,11 +1806,10 @@ introduces correction terms in both the QK and PV products.
 
 ### 21.4 `k_cache_dtype` / `v_cache_dtype` for sub-byte caches
 
-**The attributes themselves are adopted in §4.5**; only their sub-byte *values* are deferred, because
-no backend decodes a packed cache yet. They were adopted rather than deferred because the obvious
-alternative — a `k_cache_bit_width` / `v_cache_bit_width` pair — is redundant against the cache
-tensor's element type for every format that exists today and still insufficient for the format it
-was meant to describe.
+**The attributes and the `"int4"` value are implemented in §4.5 and §8.** Portable paged decode,
+gather, and one XQA specialization read packed INT4 caches. Other sub-byte values remain deferred.
+A `k_cache_bit_width` / `v_cache_bit_width` pair would be redundant against the cache tensor's
+element type for native formats and could not distinguish INT4 from FP4.
 
 For `int8` and `float8e4m3fn` each cache tensor's own element type is the logical type and its
 corresponding cache-dtype attribute stays `""`. Sub-byte needs more:
@@ -1804,6 +1825,9 @@ corresponding cache-dtype attribute stays `""`. Sub-byte needs more:
 | `"float16"`, `"bfloat16"`, `"int8"`, `"float8e4m3fn"` | the same type, named explicitly | unchanged |
 | `"int4"`, `"float4e2m1"` | `uint8` | logical width / 2 |
 | `"int2"` | `uint8` | logical width / 4 |
+
+Only the `"int4"` sub-byte row is implemented, and only for `SEPARATE` caches. The merged and
+latent packed layouts discussed below remain proposals.
 
 where `E = head_size + v_head_size` under `"KV_CONCAT"`, or `kv_pack_dim`'s logical width under
 `"LATENT"`. Packing order must be specified or implementations will diverge: **logical element `2i`
@@ -1872,7 +1896,7 @@ migration tool over serialized graphs is cheap compared with breaking a shipped 
 | §21.2 merged `kv_cache` | **No** | Deferred to a versioned successor |
 | §21.5 required `kv_cache_out` | **No** | Deferred; §4.4 registers the alias instead |
 | §21.3 scale-shape granularity, zero points | Yes | Deferred — explicit attributes in §4.5 are preferred while only two granularities exist |
-| §21.4 `k_cache_dtype` / `v_cache_dtype` | Yes | **Adopted** — §4.5; only the sub-byte *values* wait for a packed-cache backend |
+| §21.4 `k_cache_dtype` / `v_cache_dtype` | Yes | **Implemented**, including packed INT4; other sub-byte values remain deferred |
 | §21.6 `kv_layout` | Yes | Deferred until a backend requires `HND` |
 | §21.5 `window_size_*` rename | Yes, with deprecated aliases | Deferred with the lookahead window |
 | `attention_metadata` | Yes | **Adopted, redesigned** — §4.7 |

--- a/docs/contrib_ops/cuda/paged_attention.md
+++ b/docs/contrib_ops/cuda/paged_attention.md
@@ -153,8 +153,8 @@ under a both-or-neither rule, and the seven attributes `num_heads`, `kv_num_head
 
 ### 4.3 Inputs
 
-Indices 0–9 are unchanged from the shipped schema. Indices 10–18 are new and optional. The order
-matches the landing order in [§19](#19-phasing), so the schema grows monotonically per phase.
+Indices 0–9 are unchanged from the shipped schema. Indices 10–18 are implemented optional inputs.
+The proposed `query_positions` and `attention_bias` inputs follow them at indices 19–20.
 
 | Idx | Name | Type | Shape | Status |
 |-----|------|------|-------|--------|
@@ -175,11 +175,14 @@ matches the landing order in [§19](#19-phasing), so the schema grows monotonica
 | 14 | `k_scale` | `T_KV_SCALE` (opt) | `(1,)` or `(kv_num_heads, 1, head_size)` | **new — §8** |
 | 15 | `v_scale` | `T_KV_SCALE` (opt) | `(1,)` or `(kv_num_heads, 1, head_size)` | **new — §8**; absent in `LATENT` |
 | 16 | `attention_metadata` | `S` (opt, **CPU**) | `(2,)` or `(3,)` | **new — trusted bounds only, §4.7** |
-| 17 | `query_positions` | `S` (opt) | `(token_count,)` | **new — §4.8** |
-| 18 | `attention_bias` | `T` (opt) | `(batch_size or 1, num_heads or 1, query_length_capacity, context_length_capacity)` | **new — §10** |
+| 17 | `key_scale_cache` | `T_SCALE_CACHE` (opt) | `(num_blocks, block_size, kv_num_heads)` | implemented for `PER_TOKEN`, §8 |
+| 18 | `value_scale_cache` | `T_SCALE_CACHE` (opt) | `(num_blocks, block_size, kv_num_heads)` | implemented for `PER_TOKEN`, §8 |
+| 19 | `query_positions` | `S` (opt) | `(token_count,)` | proposed — §4.8 |
+| 20 | `attention_bias` | `T` (opt) | `(batch_size or 1, num_heads or 1, query_length_capacity, context_length_capacity)` | proposed — §10 |
 
 For `k_cache_dtype=v_cache_dtype="int4"`, the cache tensors use `uint8` storage and their last
-dimension is `(head_size + 1) / 2`, not `head_size`.
+dimension is `(head_size + 1) / 2`, not `head_size`. Scale tensors are paged with the same slot map
+and block table as the payload. Copying or evicting a block must include its scale tensors.
 
 `max_context_len` is the largest per-sequence total KV length in the batch, bounded above by
 `block_table.shape[1] * block_size`.
@@ -203,14 +206,20 @@ the V view of `key_cache` (§12.3).
 | 0 | `output` | `T` | `(token_count, num_heads * effective_v_head_size)` | existing (shape generalized by §12) |
 | 1 | `key_cache_out` | `T_CACHE` (opt) | aliases `key_cache` | existing |
 | 2 | `value_cache_out` | `T_CACHE` (opt) | aliases `value_cache` | existing |
-| 3 | `output_qk` | `QK` (opt) | `(num_heads, token_count, max_context_len)` | **new — §11** |
+| 3 | `key_scale_cache_out` | `T_SCALE_CACHE` (opt) | aliases `key_scale_cache` | implemented, §8 |
+| 4 | `value_scale_cache_out` | `T_SCALE_CACHE` (opt) | aliases `value_scale_cache` | implemented, §8 |
+| 5 | `output_qk` | `QK` (opt) | `(num_heads, token_count, max_context_len)` | proposed — §11 |
 
 In `SEPARATE` mode outputs 1 and 2 are both present or both absent, preserving the shipped rule. In
 `LATENT` mode output 1 may be present and output 2 must be absent.
 
-Requesting `output_qk` requires a four-entry ONNX output list. Unused optional output positions are
+The proposed `output_qk` requires a six-entry ONNX output list. Unused optional output positions are
 represented by an **empty output name**; indices are never compacted. A `LATENT` node requesting
-`output_qk` therefore writes `[output, key_cache_out-or-empty, "", output_qk]`.
+`output_qk` would therefore write `[output, key_cache_out-or-empty, "", "", "", output_qk]`.
+
+Scale-cache outputs are independently optional. When present, they must alias the corresponding
+inputs, just like the existing payload-cache outputs; the operator updates the input caches even
+when these optional outputs are absent. `LATENT` does not support scale caches.
 
 `output_qk` uses its own `QK` type constraint rather than `T`, matching GQA, so the QK matrix can be
 emitted in `float32` independently of the activation type.
@@ -239,10 +248,12 @@ ops without translation.
 | `do_rotary` | INT | `0` | existing |
 | `rotary_interleaved` | INT | `0` | existing |
 | `qk_norm_epsilon` | FLOAT | `1e-6` | **new — §7** |
-| `k_quant_type` | STRING | `"NONE"` | **new — §8**; `NONE` \| `PER_TENSOR` \| `PER_CHANNEL` |
+| `k_quant_type` | STRING | `"NONE"` | **new — §8**; `NONE` \| `PER_TENSOR` \| `PER_CHANNEL` \| `PER_TOKEN` |
 | `v_quant_type` | STRING | `"NONE"` | **new — §8**; same value set |
 | `k_cache_dtype` | STRING | `""` | **new — §8**; `""` = the K cache tensor's own element type |
 | `v_cache_dtype` | STRING | `""` | **new — §8**; `""` = the V cache tensor's own element type |
+| `qk_rotation` | STRING | `"NONE"` | `NONE` \| `HADAMARD`; applied after QK-Norm and RoPE, §8.8 |
+| `v_rotation` | STRING | `"NONE"` | `NONE` \| `HADAMARD`; inverted on the output, §8.8 |
 | `v_head_size` | INT | `0` | **new — §12**; `0` = `head_size`. Non-zero and `!= head_size` is legal **only** in `LATENT` |
 | `rotary_offset` | INT | `0` | **new — §12.5** |
 | `kv_cache_layout` | STRING | `"SEPARATE"` | **new — §12**; `SEPARATE` \| `LATENT` |
@@ -439,6 +450,7 @@ varlen layout has no `(batch, seq)` grid — but it does mean a GQA↔PagedAtten
 | `T` | `float16`, `bfloat16` | unchanged |
 | `T_CACHE` | `float16`, `bfloat16`, `int8`, `float8e4m3fn`, `uint8` | **new** (split out of `T`) |
 | `T_KV_SCALE` | `float` | **new** |
+| `T_SCALE_CACHE` | `float16`, `float` | dynamic per-token scales, §8 |
 | `QK` | `float`, `float16`, `bfloat16` | **new** — §11 |
 | `S` | `int32` | unchanged |
 
@@ -447,7 +459,8 @@ Splitting `T_CACHE` out of `T` is backward compatible: every previously valid mo
 `paged_attention.cc`.
 
 `uint8` stores packed signed INT4, not an unsigned logical cache type. Its CUDA registrations require
-`onnxruntime_USE_INT4_KV_CACHE=ON`.
+`onnxruntime_USE_INT4_KV_CACHE=ON`. Both scale caches share `T_SCALE_CACHE`, so when both are present
+their element types must match.
 
 ## 5. Feature: `slot_mapping`
 
@@ -638,17 +651,18 @@ if (needs_prologue) {
 
 ### 8.1 Goal
 
-Store the block cache in INT8, FP8 E4M3, or packed INT4 while `query` remains FP16/BF16, halving (or
-better) the dominant memory consumer in a serving deployment and proportionally reducing HBM traffic
-on the decode path. Scope for this phase: **`PER_TENSOR` and `PER_CHANNEL`** static scales.
-INT4 uses the portable decode and gather paths plus a dedicated XQA decode kernel. Performance and
+Store the block cache in INT8, FP8 E4M3, or packed INT4 while `query` remains FP16/BF16, halving (or better) the
+dominant memory consumer in a serving deployment and proportionally reducing HBM traffic on the
+decode path. Static `PER_TENSOR` / `PER_CHANNEL` and dynamic `PER_TOKEN` scales are supported.
+INT4 and per-token scales use the portable decode and gather paths, not XQA. Performance and
 model-quality evaluation are separate gates; reduced cache storage alone does not establish either.
 
 ### 8.2 Schema
 
 - `key_cache` / `value_cache` use `T_CACHE ∈ {float16, bfloat16, int8, float8e4m3fn, uint8}`.
 - `k_scale` / `v_scale` (inputs 14, 15), type `T_KV_SCALE` = **always FP32**, matching GQA.
-- Attributes `k_quant_type`, `v_quant_type` ∈ `{"NONE", "PER_TENSOR", "PER_CHANNEL"}`,
+- `key_scale_cache` / `value_scale_cache` (inputs 17/18, outputs 3/4) use `T_SCALE_CACHE`, FP16 or FP32.
+- Attributes `k_quant_type`, `v_quant_type` ∈ `{"NONE", "PER_TENSOR", "PER_CHANNEL", "PER_TOKEN"}`,
   plus independent `k_cache_dtype` and `v_cache_dtype` attributes. Packed INT4 requires `"int4"`.
 - Kernel becomes `PagedAttention<T, T_CACHE>`, registered for the same combinations GQA uses:
   `{MLFloat16, BFloat16} × {same as T, int8_t, Float8E4M3FN, uint8_t}`, with the narrow formats build-gated.
@@ -664,6 +678,12 @@ quantize/dequantize helpers index only on `(kv_head, channel)` and are layout-ag
 |---|---|---|
 | `PER_TENSOR` | `(1,)` | scalar |
 | `PER_CHANNEL` | `(kv_num_heads, 1, head_size)` | `scale[h * head_size + c]` |
+| `PER_TOKEN` | `(num_blocks, block_size, kv_num_heads)` | `scale_cache[slot * kv_num_heads + h]` |
+
+`PER_TOKEN` computes `amax(abs(head)) / qmax` at cache-write time (`qmax` is 7, 127, or 448).
+Quantization uses the scale after conversion to its stored type. A zero head stores scale 0 and
+zero codes. Nonzero FP16 scales are clamped to `[2^-24, 65504]` before conversion to avoid a zero
+or infinite stored scale. The scale reduction and write are entirely on device, with no host readback.
 
 `v_scale` uses the same last dimension, `head_size`: it exists only where a `value_cache` exists,
 which is `"SEPARATE"` mode, and `effective_v_head_size == head_size` there (§12.3). Under
@@ -718,10 +738,10 @@ versioned-successor topic rather than a late addition.
 scattered to their slots. This is a natural fit: the kernel is already elementwise over
 `(token, kv_head, channel)`, which is exactly the `PER_CHANNEL` scale index.
 
-Packed INT4 selects `ReshapeAndCacheHeads` instead: one block per `(token, kv_head)` for each
-tensor, so a whole head is resident when its channel pairs are packed into nibbles. The original
-elementwise path remains for native, INT8, and FP8 caches. Both paths reuse the explicit/derived
-slot resolvers and skip negative or out-of-range write slots.
+INT4, dynamic scales, or rotation select `ReshapeAndCacheHeads`: one block per `(token, kv_head)`
+for each tensor. It performs the optional transform, dynamic amax reduction, and pair packing.
+The original elementwise path remains for unrotated native, INT8, and FP8 caches with static scales.
+Both paths reuse the explicit/derived slot resolvers and skip negative or out-of-range write slots.
 
 ### 8.5 Read path
 
@@ -738,9 +758,10 @@ output afterward. Both are `O(num_heads * head_size)` passes and avoid touching 
 is the path that makes a quantized cache actually pay off; the gather-based Phase 2 mostly buys
 memory capacity, not bandwidth.
 
-Packed INT4 unpacks a nibble at a time through the same `ReadPagedCache` accessor on both the
-split-KV decode and the gather paths, so the scale foldings above are unchanged. Gather still
-materializes an FP16/BF16 staging buffer, so INT4 does not reduce that prefill allocation.
+For `PER_TOKEN`, split-KV decode multiplies each completed QK dot product by the key token's scale
+before softcap/softmax. The value token's scale multiplies its unnormalized probability, never the
+softmax denominator. Gather unpacks and scales individual elements into the existing FP16/BF16
+buffer. INT4 does not reduce that prefill staging allocation.
 
 ### 8.6 Build gating
 
@@ -749,8 +770,11 @@ Mirror GQA: `onnxruntime_USE_FP8_KV_CACHE` (default ON), `onnxruntime_USE_INT4_K
 
 ### 8.7 Validation
 
-- `k_quant_type != "NONE"` requires `k_scale`; likewise for V. Conversely, a `k_scale` with
-  `k_quant_type == "NONE"` is `INVALID_ARGUMENT`.
+- `PER_TENSOR` / `PER_CHANNEL` require the matching static scale and forbid the scale cache.
+  `PER_TOKEN` requires the matching scale cache and forbids the static scale. `NONE` forbids both.
+- Scale-cache rank must be 3, with dimensions exactly `(num_blocks, block_size, kv_num_heads)`.
+- Packed INT4 and per-token writes currently require `head_size <= 1024`, in addition to the
+  existing multiple-of-eight head-width constraint.
 - `T_CACHE != T` requires a non-`NONE` quant type; `T_CACHE == T` requires both to be `NONE` and both
   scales to be absent.
 - `k_cache_dtype` and `v_cache_dtype` may be `""` for non-packed caches, quantized or not:
@@ -762,7 +786,7 @@ Mirror GQA: `onnxruntime_USE_FP8_KV_CACHE` (default ON), `onnxruntime_USE_INT4_K
 - In `"LATENT"` mode only K storage exists: `k_quant_type` and `k_scale` describe the latent row,
   `v_quant_type` and `v_cache_dtype` must be unset, and `v_scale` must be
   absent because V is a view of K.
-- `LATENT` rejects packed INT4 in this implementation.
+- `LATENT` rejects packed INT4, per-token scale caches, and Hadamard rotation in this implementation.
 - FP8 is available when ORT is built with `onnxruntime_USE_FP8_KV_CACHE`; no additional runtime
   architecture gate is required for the conversion path used by this operator.
 - `PER_CHANNEL` scale shape must be exactly `(kv_num_heads, 1, head_size)` for both K and V. There
@@ -783,9 +807,8 @@ Mirror GQA: `onnxruntime_USE_FP8_KV_CACHE` (default ON), `onnxruntime_USE_INT4_K
 > - Because a quantized cache never reaches Flash's *paged* kernel, the `block_size` tiling
 >   constraint of §18.1 does not apply to it; Flash eligibility skips that check when the cache is
 >   quantized. Any power-of-two `block_size >= 16` works with a quantized cache on either backend.
-> - **INT4 extension:** `uint8` packed caches are read by the portable decode/gather paths, and by a
->   dedicated FP16 XQA decode kernel at `head_size = 256`, `group_size = 6` with `PER_CHANNEL`
->   scales for both K and V. Other XQA specializations remain limited to native/INT8/FP8 formats.
+> - **INT4 extension:** `uint8` packed caches and per-token scales are implemented on the portable
+>   decode/gather paths. XQA remains limited to its existing native/INT8/FP8 formats and static scales.
 > - **No architecture gate for portable FP8 decode.** `Float8E4M3FN`'s converting constructor uses
 >   `__nv_cvt_float_to_fp8`, which is available on every architecture ORT builds for from CUDA 11.8
 >   onward. FP8 remains gated at *build* time by `onnxruntime_USE_FP8_KV_CACHE`.
@@ -811,7 +834,7 @@ Mirror GQA: `onnxruntime_USE_FP8_KV_CACHE` (default ON), `onnxruntime_USE_INT4_K
 > limit. Other quantized configurations use `PagedDecodeSplitKV` and `PagedDecodeReduce` from
 > `paged_attention_impl.cu`.
 >
-> - **Both scale foldings are exact and granularity-agnostic.** K folds into Q at load time
+> - **Static scale foldings.** K folds into Q at load time
 >   (`q_sh[c] = float(q[c]) * GetCacheScale(k_scale, kv_head * head_size + c, k_per_channel)`), so
 >   `PER_TENSOR` is just the `per_channel == false` branch of the same expression rather than a
 >   separate "fold into the softmax scale" path. V folds into the epilogue: `v_scale_c` does not
@@ -859,13 +882,26 @@ Mirror GQA: `onnxruntime_USE_FP8_KV_CACHE` (default ON), `onnxruntime_USE_INT4_K
 >   because the decode backend needs neither.
 > - **Still deferred from P5:** the fused MLA decode backend (§12.7).
 
-### 8.8 Packed INT4 tests
+### 8.8 Block-diagonal Hadamard rotation
+
+`qk_rotation="HADAMARD"` applies a symmetric orthonormal Walsh-Hadamard transform independently
+to every Q/K head, after QK-Norm and RoPE. Q is transformed in the fused prologue; K is transformed
+once in the cache writer. `v_rotation="HADAMARD"` transforms V in the writer and applies the same
+transform to the output after the backend and attention-sink epilogue. Each enabled transform
+requires a power-of-two head width in `[16, 256]` and `SEPARATE` layout. `PER_CHANNEL` quantization
+on that rotated cache is rejected; K/V quantization modes and rotations remain independent.
+
+The shared-memory FP32 butterfly costs `O(head_size * log2(head_size))`, with final conversion to
+the activation dtype for Q/output. Since `H H^T = H^2 = I`, scores and output are unchanged in exact
+arithmetic: `(QH)(KH)^T = QK^T` and `(softmax(scores) VH) H = softmax(scores) V`.
+Tests isolate this property with an unquantized cache before checking INT4 error. Rotation is
+CUDA-only; WebGPU rejects it rather than silently ignoring the attributes.
 
 Operator tests are in `onnxruntime/test/python/transformers/test_paged_attention_int4.py`, covering
-FP16/BF16, packed/derived writes, skipped slots, exact nibble encoding, zero padding,
-prefill/decode/speculative attention, norm/RoPE ordering, negative contracts, and the XQA decode
-path. INT8 and FP8 regression cases and extreme scale saturation are also covered. They skip when
-INT4 CUDA kernels are not built.
+FP16/BF16, packed/derived writes, skipped slots, exact nibble encoding, zero padding, scale-cache
+outputs, prefill/decode/speculative attention, norm/RoPE ordering, negative contracts, and CUDA
+graph replay with changed input amplitudes. Static/per-token INT8 and FP8 regression cases and
+extreme scale saturation are also covered. They skip when INT4 CUDA kernels are not built.
 
 ## 9. Feature: Sliding Window Attention
 
@@ -1029,7 +1065,7 @@ across all sequences, all heads, or both, exactly as GQA does.
 
 ### 10.2 Design
 
-Input 18, `attention_bias`, type `T`. For packed token `t` belonging to sequence `b`, let
+Proposed input 20, `attention_bias`, type `T`. For packed token `t` belonging to sequence `b`, let
 `j = t - cumulative_sequence_length[b]` be its sequence-local query offset. Query head `h` and
 logical KV position `k` use:
 
@@ -1080,7 +1116,7 @@ performance requirement justifies adding it to both attention operators.
   The op must reject configurations where the output tensor would exceed a configurable byte
   threshold rather than attempting the allocation.
 - `qk_output != 0` with fewer than 4 outputs, or 4 outputs with `qk_output == 0`, is
-  `INVALID_ARGUMENT`. Shape inference must only touch output 3 when `ctx.getNumOutputs() > 3`.
+  `INVALID_ARGUMENT`. Shape inference must only touch output 5 when `ctx.getNumOutputs() > 5`.
 
 ## 12. Feature: Multi-head Latent Attention (MLA)
 
@@ -1412,7 +1448,11 @@ Consolidated, to be implemented in `paged_attention_helper::CheckInputs`. Every 
 - `q_norm_weight` / `k_norm_weight`: both-or-neither; rank 1, `dim0 == head_size`, type `T`.
 - `k_scale` / `v_scale`: FP32; `(1,)` for `PER_TENSOR`, `(kv_num_heads, 1, head_size)` for
   `PER_CHANNEL` (both K and V — `v_scale` only exists alongside a `value_cache`, so its last
-  dimension is always `head_size`); present iff the corresponding quant type is not `NONE`.
+  dimension is always `head_size`); present only for `PER_TENSOR` or `PER_CHANNEL`.
+- `key_scale_cache` / `value_scale_cache`: FP16 or FP32 with shape
+  `(num_blocks, block_size, kv_num_heads)`, present only for `PER_TOKEN`. Their optional outputs
+  alias the corresponding inputs. Named scale outputs require matching inputs; empty optional
+  output slots are allowed. Hadamard and packed-cache restrictions are listed in §8.7–§8.8.
 - `T_CACHE != T` iff a quant type is not `NONE`.
 - Non-packed cache-dtype attributes must be `""` or name the cache tensor's own element type.
   Packed `uint8` caches require explicit `"int4"` and `onnxruntime_USE_INT4_KV_CACHE`.
@@ -1465,7 +1505,7 @@ invalid. No other host-supplied value is permitted to bound a launch or workspac
   - `value_cache` (input 4) is now optional: guard `getInputShape(ctx, 4)` and the output-2
     propagation on `ctx.hasInput(4)` before any write.
   - The shipped `getNumOutputs() > 1 ⇒ getNumOutputs() == 3` rule must be relaxed to admit a
-    four-entry output list with empty names at unused optional cache positions (§4.4), while keeping
+    six-entry output list with empty names at unused optional cache positions (§4.4), while keeping
     the both-or-neither rule for `SEPARATE` mode.
   - Output 3 (`output_qk`) is written only when `ctx.getNumOutputs() > 3`, guarded before any write,
     consistent with the contrib-op shape-inference memory-safety rules.
@@ -1617,8 +1657,8 @@ These block the feature work and should land ahead of it.
 | **P3 — Memory** | Quantized cache INT8/FP8, `PER_TENSOR` + `PER_CHANNEL`, dequant-on-gather read path (§8) | `T_CACHE`, `T_KV_SCALE`, inputs 14–15, 4 attrs |
 | **P4 — MLA (correctness)** | `kv_cache_layout="LATENT"`, `v_head_size`, `rotary_offset`, V-aliases-K, optional `value_cache`, unfused MLA reference kernel, absorbed↔non-absorbed equivalence tests (§12) | attrs `kv_cache_layout`, `v_head_size`, `rotary_offset`; input 4 optional |
 | **P5 — Performance** | Paged decode kernel with in-kernel dequant; fused MLA backend (FlashMLA / FlashInfer MLA, §12.7); `softcap` on decode; **remove the D→H sync and make the op CUDA-graph-capturable (§4.7)**; optional `attention_metadata` replay-wide bounds | input 16 |
-| **P6 — Completeness** | `query_positions` (§4.8); `attention_bias` (§10); `output_qk` (§11) | inputs 17–18, output 3, attr `qk_output` |
-| **Later** | MLA quantized latent cache tuning; non-CUDA EPs | — |
+| **P6 — Completeness** | `query_positions` (§4.8); `attention_bias` (§10); `output_qk` (§11) | proposed inputs 19–20, output 5, attr `qk_output` |
+| **Later** | INT4 cache; MLA quantized latent cache tuning; non-CUDA EPs | — |
 
 Status: P0–P4 are implemented, except the `.Alias` registration. P5 is partially
 implemented — the paged decode kernel with in-kernel dequantization (including `softcap`, sliding
@@ -1714,8 +1754,8 @@ The complete deferred list:
 - one required functional `kv_cache_out` instead of two optional aliasing outputs;
 - removal of `kv_num_heads` in favor of `kv_cache.shape[2]`;
 - quantization granularity inferred from scale shape, and zero points (§21.3);
-- sub-byte logical types other than INT4 stored in `uint8` tensors; INT4 is implemented without
-  reinterpreting existing tensor types (§21.4);
+- sub-byte logical types other than INT4 stored in `uint8` tensors; INT4 is implemented by the
+  portable decode and gather paths without reinterpreting existing tensor types (§21.4);
 - inline scales or zero points packed into cache rows (§21.3, note);
 - a physical `HND` cache layout (§21.6);
 - renaming `local_window_size` to `window_size_left` / `window_size_right`, and the
@@ -1777,6 +1817,10 @@ block pool. That thin margin is what makes the merge deferrable.
 
 ### 21.3 Quantization: granularity from scale shape
 
+This is a deferred alternative to the explicit quantization attributes. The current implementation
+uses `PER_TOKEN` with separate `key_scale_cache` / `value_scale_cache` inputs (17/18); it does not
+infer per-token granularity from `k_scale` / `v_scale`.
+
 `k_quant_type` / `v_quant_type` would be removed; granularity read off the scale tensor instead:
 
 | `k_scale` shape | Granularity |
@@ -1806,8 +1850,8 @@ introduces correction terms in both the QK and PV products.
 
 ### 21.4 `k_cache_dtype` / `v_cache_dtype` for sub-byte caches
 
-**The attributes and the `"int4"` value are implemented in §4.5 and §8.** Portable paged decode,
-gather, and one XQA specialization read packed INT4 caches. Other sub-byte values remain deferred.
+**The attributes and the `"int4"` value are implemented in §4.5 and §8.** Portable paged decode and
+gather can read packed INT4 caches; XQA cannot. Other sub-byte values remain deferred.
 A `k_cache_bit_width` / `v_cache_bit_width` pair would be redundant against the cache tensor's
 element type for native formats and could not distinguish INT4 from FP4.
 
@@ -1895,7 +1939,7 @@ migration tool over serialized graphs is cheap compared with breaking a shipped 
 |---|---|---|
 | §21.2 merged `kv_cache` | **No** | Deferred to a versioned successor |
 | §21.5 required `kv_cache_out` | **No** | Deferred; §4.4 registers the alias instead |
-| §21.3 scale-shape granularity, zero points | Yes | Deferred — explicit attributes in §4.5 are preferred while only two granularities exist |
+| §21.3 scale-shape granularity, zero points | Yes | Deferred — explicit `PER_TENSOR` / `PER_CHANNEL` / `PER_TOKEN` attributes remain authoritative |
 | §21.4 `k_cache_dtype` / `v_cache_dtype` | Yes | **Implemented**, including packed INT4; other sub-byte values remain deferred |
 | §21.6 `kv_layout` | Yes | Deferred until a backend requires `HND` |
 | §21.5 `window_size_*` rename | Yes, with deprecated aliases | Deferred with the lookahead window |

--- a/onnxruntime/contrib_ops/cpu/bert/attention_common.h
+++ b/onnxruntime/contrib_ops/cpu/bert/attention_common.h
@@ -68,9 +68,10 @@ enum class KVQuantizationType : int {
   NONE = 0,
   PER_TENSOR = 1,
   PER_CHANNEL = 2,
+  PER_TOKEN = 3,
 };
 
-inline KVQuantizationType StringToKVQuantizationType(std::string s) {
+inline KVQuantizationType StringToKVQuantizationType(std::string s, bool allow_per_token = false) {
   std::transform(s.begin(), s.end(), s.begin(), [](unsigned char c) { return std::toupper(c); });
   if (s == "NONE") {
     return KVQuantizationType::NONE;
@@ -81,8 +82,11 @@ inline KVQuantizationType StringToKVQuantizationType(std::string s) {
   if (s == "PER_CHANNEL") {
     return KVQuantizationType::PER_CHANNEL;
   }
+  if (allow_per_token && s == "PER_TOKEN") {
+    return KVQuantizationType::PER_TOKEN;
+  }
   ORT_THROW("Invalid KV quantization type: '", s,
-            "'. Valid values are: NONE, PER_TENSOR, PER_CHANNEL.");
+            "'. Valid values are: NONE, PER_TENSOR, PER_CHANNEL", allow_per_token ? ", PER_TOKEN." : ".");
 }
 
 // Logical element type of a KV cache. Members are named after the ONNX element type they denote.

--- a/onnxruntime/contrib_ops/cpu/bert/attention_parameters.h
+++ b/onnxruntime/contrib_ops/cpu/bert/attention_parameters.h
@@ -141,12 +141,13 @@ struct PagedAttentionParameters : AttentionParameters {
   // Per-head Q/K RMSNorm (QK-Norm) prologue applied before RoPE (inputs 12/13).
   bool use_qk_norm = false;
   float qk_norm_epsilon = 1e-6f;
-  // Quantized paged KV cache. Scales are inputs 14/15 and are always FP32, as in
-  // GroupQueryAttention. The storage element type is carried by the kernel's TCACHE specialization;
-  // the k_cache_dtype / v_cache_dtype attributes only override it for sub-byte formats packed into
-  // uint8, which no backend supports yet.
+  // Quantized paged KV cache. Static scales (inputs 14/15) are FP32; dynamic per-token scales
+  // (inputs 17/18) are FP16 or FP32. TCACHE carries the storage type, with explicit int4 attributes
+  // distinguishing the signed logical values packed into uint8.
   KVQuantizationType k_quant_type = KVQuantizationType::NONE;
   KVQuantizationType v_quant_type = KVQuantizationType::NONE;
+  bool qk_hadamard = false;
+  bool v_hadamard = false;
   // Multi-head Latent Attention (kv_cache_layout == "LATENT"). There is a single physical cache:
   // V of every head is the leading v_head_size channels of the same key_cache row, so 'value' and
   // 'value_cache' are absent. The inherited v_head_size / v_hidden_size hold the effective V width

--- a/onnxruntime/contrib_ops/cpu/bert/paged_attention_helper.h
+++ b/onnxruntime/contrib_ops/cpu/bert/paged_attention_helper.h
@@ -331,7 +331,7 @@ Status CheckKVCacheQuantization(const T* scale, const char* scale_name, const ch
     return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
                            "'", quant_type_name,
                            "' is set, but the KV cache element type is not quantized. "
-                           "Use an int8 or float8e4m3fn cache, or set '",
+                           "Use an int8, float8e4m3fn, or packed int4 cache, or set '",
                            quant_type_name, "' to 'NONE'.");
   }
   if (scale == nullptr) {
@@ -364,12 +364,13 @@ Status CheckKVCacheQuantization(const T* scale, const char* scale_name, const ch
 
 // Validates one side (K or V) of the `k_cache_dtype` / `v_cache_dtype` contract against
 // `storage_dtype`, the element type the kernel was instantiated for. DEFAULT means "the cache
-// tensor's element type is also the logical type" and always passes; naming that same type
-// explicitly is allowed but must agree. The sub-byte members describe a logical type packed two per
-// byte into a uint8 cache; the schema reserves them, but no backend decodes them yet, so they are
-// rejected here instead of being silently mis-read. See docs/contrib_ops/cuda/paged_attention.md §8.
+// tensor's element type is also the logical type"; naming that same type explicitly must agree.
+// Packed uint8 storage instead requires an explicit int4 logical type. Other sub-byte formats
+// remain unsupported. See docs/contrib_ops/cuda/paged_attention.md §8.
 inline Status CheckKVCacheDataType(const KVCacheDataType cache_dtype, const KVCacheDataType storage_dtype,
                                    const char* attr_name) {
+  ORT_RETURN_IF_NOT(storage_dtype != KVCacheDataType::INT4 || cache_dtype == KVCacheDataType::INT4,
+                    "A uint8 packed cache requires an explicit int4 cache dtype.");
   if (cache_dtype == KVCacheDataType::DEFAULT || cache_dtype == storage_dtype) {
     return Status::OK();
   }
@@ -511,7 +512,11 @@ Status CheckInputs(const T* query,
   // Check KV-Cache
   int num_blocks = 0;
   int block_size = 0;
-  ORT_RETURN_IF_ERROR(CheckKVCache(key_cache, value_cache, kv_num_heads, head_size, num_blocks, block_size));
+  const bool int4_cache = cache_storage_dtype == KVCacheDataType::INT4;
+  ORT_RETURN_IF_ERROR(CheckKVCache(key_cache, value_cache, kv_num_heads,
+                                   int4_cache ? (head_size + 1) / 2 : head_size, num_blocks, block_size));
+  ORT_RETURN_IF_NOT(!is_latent_kv || !int4_cache, "LATENT does not support an INT4 cache.");
+  ORT_RETURN_IF_NOT(!int4_cache || head_size <= 1024, "INT4 caches require head_size <= 1024.");
 
   // Check sequence length tensors
   int batch_size = 0;

--- a/onnxruntime/contrib_ops/cpu/bert/paged_attention_helper.h
+++ b/onnxruntime/contrib_ops/cpu/bert/paged_attention_helper.h
@@ -313,7 +313,17 @@ Status CheckQKNormWeights(const T* q_norm_weight, const T* k_norm_weight, const 
 template <typename T = Tensor>
 Status CheckKVCacheQuantization(const T* scale, const char* scale_name, const char* quant_type_name,
                                 const KVQuantizationType quant_type, const bool is_quantized_cache,
-                                const int kv_num_heads, const int head_size) {
+                                const int kv_num_heads, const int head_size, const T* scale_cache = nullptr,
+                                const int num_blocks = 0, const int block_size = 0) {
+  if (quant_type == KVQuantizationType::PER_TOKEN) {
+    ORT_RETURN_IF_NOT(is_quantized_cache && scale == nullptr && scale_cache != nullptr,
+                      "PER_TOKEN requires a quantized cache and a scale cache, and forbids static scales.");
+    const auto& dims = scale_cache->Shape().GetDims();
+    ORT_RETURN_IF_NOT(dims.size() == 3 && dims[0] == num_blocks && dims[1] == block_size && dims[2] == kv_num_heads,
+                      "Scale cache must have shape (num_blocks, block_size, kv_num_heads).");
+    return Status::OK();
+  }
+  ORT_RETURN_IF_NOT(scale_cache == nullptr, "Scale cache is only allowed with PER_TOKEN quantization.");
   if (quant_type == KVQuantizationType::NONE) {
     if (scale != nullptr) {
       return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
@@ -322,7 +332,7 @@ Status CheckKVCacheQuantization(const T* scale, const char* scale_name, const ch
     if (is_quantized_cache) {
       return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
                              "The KV cache has a quantized element type, so '", quant_type_name,
-                             "' must be 'PER_TENSOR' or 'PER_CHANNEL'.");
+                             "' must be 'PER_TENSOR', 'PER_CHANNEL', or 'PER_TOKEN'.");
     }
     return Status::OK();
   }
@@ -418,7 +428,11 @@ Status CheckInputs(const T* query,
                    int v_head_size_attr,
                    int rotary_offset,
                    bool has_explicit_scale,
-                   int max_threads_per_block) {
+                   int max_threads_per_block,
+                   const T* key_scale_cache = nullptr,
+                   const T* value_scale_cache = nullptr,
+                   bool qk_hadamard = false,
+                   bool v_hadamard = false) {
   const bool is_quantized_cache = IsQuantizedKVCacheDataType(cache_storage_dtype);
   if (max_threads_per_block > 0 && num_heads > max_threads_per_block) {
     return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT, "num_heads should be no larger than ", max_threads_per_block);
@@ -515,8 +529,21 @@ Status CheckInputs(const T* query,
   const bool int4_cache = cache_storage_dtype == KVCacheDataType::INT4;
   ORT_RETURN_IF_ERROR(CheckKVCache(key_cache, value_cache, kv_num_heads,
                                    int4_cache ? (head_size + 1) / 2 : head_size, num_blocks, block_size));
-  ORT_RETURN_IF_NOT(!is_latent_kv || !int4_cache, "LATENT does not support an INT4 cache.");
-  ORT_RETURN_IF_NOT(!int4_cache || head_size <= 1024, "INT4 caches require head_size <= 1024.");
+  ORT_RETURN_IF_NOT(!is_latent_kv || (!qk_hadamard && !v_hadamard && !int4_cache &&
+                                      key_scale_cache == nullptr && value_scale_cache == nullptr),
+                    "LATENT does not support Hadamard rotation, INT4, or per-token scale caches.");
+  const auto valid_hadamard_width = [](int width) {
+    return width >= 16 && width <= 256 && (width & (width - 1)) == 0;
+  };
+  ORT_RETURN_IF_NOT(!qk_hadamard || valid_hadamard_width(head_size),
+                    "qk_rotation HADAMARD requires a power-of-two head_size in [16, 256].");
+  ORT_RETURN_IF_NOT(!v_hadamard || valid_hadamard_width(v_head_size),
+                    "v_rotation HADAMARD requires a power-of-two v_head_size in [16, 256].");
+  ORT_RETURN_IF_NOT(!(qk_hadamard && k_quant_type == KVQuantizationType::PER_CHANNEL) &&
+                        !(v_hadamard && v_quant_type == KVQuantizationType::PER_CHANNEL),
+                    "Hadamard rotation does not support PER_CHANNEL quantization on the rotated cache.");
+  ORT_RETURN_IF_NOT(!(int4_cache || key_scale_cache != nullptr || value_scale_cache != nullptr) || head_size <= 1024,
+                    "INT4 and PER_TOKEN caches require head_size <= 1024.");
 
   // Check sequence length tensors
   int batch_size = 0;
@@ -565,10 +592,12 @@ Status CheckInputs(const T* query,
   // Check quantized KV cache. LATENT has no value cache to describe, and the block above already
   // required v_scale / v_quant_type to be unset there.
   ORT_RETURN_IF_ERROR(CheckKVCacheQuantization(k_scale, "k_scale", "k_quant_type", k_quant_type,
-                                               is_quantized_cache, kv_num_heads, head_size));
+                                               is_quantized_cache, kv_num_heads, head_size,
+                                               key_scale_cache, num_blocks, block_size));
   if (!is_latent_kv) {
     ORT_RETURN_IF_ERROR(CheckKVCacheQuantization(v_scale, "v_scale", "v_quant_type", v_quant_type,
-                                                 is_quantized_cache, kv_num_heads, v_head_size));
+                                                 is_quantized_cache, kv_num_heads, v_head_size,
+                                                 value_scale_cache, num_blocks, block_size));
   }
   ORT_RETURN_IF_ERROR(CheckKVCacheDataType(k_cache_dtype, cache_storage_dtype, "k_cache_dtype"));
   ORT_RETURN_IF_ERROR(CheckKVCacheDataType(v_cache_dtype, cache_storage_dtype, "v_cache_dtype"));
@@ -611,6 +640,8 @@ Status CheckInputs(const T* query,
     output_parameters->qk_norm_epsilon = qk_norm_epsilon;
     output_parameters->k_quant_type = k_quant_type;
     output_parameters->v_quant_type = v_quant_type;
+    output_parameters->qk_hadamard = qk_hadamard;
+    output_parameters->v_hadamard = v_hadamard;
   }
 
   return Status::OK();

--- a/onnxruntime/contrib_ops/cuda/bert/attention_data.h
+++ b/onnxruntime/contrib_ops/cuda/bert/attention_data.h
@@ -229,6 +229,9 @@ struct PagedAttentionData {
   // (kv_num_heads, 1, head_size) for PER_CHANNEL. nullptr when the cache is not quantized.
   const float* k_scale = nullptr;
   const float* v_scale = nullptr;
+  void* key_scale_cache = nullptr;
+  void* value_scale_cache = nullptr;
+  bool scale_cache_is_fp16 = true;
   const int* cumulative_seqlens_q = nullptr;
   const int* past_seqlens = nullptr;
   const int* block_table = nullptr;

--- a/onnxruntime/contrib_ops/cuda/bert/paged_attention.cc
+++ b/onnxruntime/contrib_ops/cuda/bert/paged_attention.cc
@@ -28,19 +28,20 @@ namespace cuda {
 
 constexpr int kFlashSplitKvMinSequenceLength = 512;
 
-#define REGISTER_KERNEL_TYPED(T, TCACHE)                                      \
-  ONNX_OPERATOR_TYPED_KERNEL_EX(                                              \
-      PagedAttention,                                                         \
-      kMSDomain,                                                              \
-      1,                                                                      \
-      T##_##TCACHE,                                                           \
-      kCudaExecutionProvider,                                                 \
-      (*KernelDefBuilder::Create())                                           \
-          .TypeConstraint("T", DataTypeImpl::GetTensorType<T>())              \
-          .TypeConstraint("T_CACHE", DataTypeImpl::GetTensorType<TCACHE>())   \
-          .TypeConstraint("T_KV_SCALE", DataTypeImpl::GetTensorType<float>()) \
-          .TypeConstraint("S", DataTypeImpl::GetTensorType<int32_t>())        \
-          .InputMemoryType(OrtMemTypeCPUInput, 16),                           \
+#define REGISTER_KERNEL_TYPED(T, TCACHE)                                                                                     \
+  ONNX_OPERATOR_TYPED_KERNEL_EX(                                                                                             \
+      PagedAttention,                                                                                                        \
+      kMSDomain,                                                                                                             \
+      1,                                                                                                                     \
+      T##_##TCACHE,                                                                                                          \
+      kCudaExecutionProvider,                                                                                                \
+      (*KernelDefBuilder::Create())                                                                                          \
+          .TypeConstraint("T", DataTypeImpl::GetTensorType<T>())                                                             \
+          .TypeConstraint("T_CACHE", DataTypeImpl::GetTensorType<TCACHE>())                                                  \
+          .TypeConstraint("T_KV_SCALE", DataTypeImpl::GetTensorType<float>())                                                \
+          .TypeConstraint("T_SCALE_CACHE", {DataTypeImpl::GetTensorType<MLFloat16>(), DataTypeImpl::GetTensorType<float>()}) \
+          .TypeConstraint("S", DataTypeImpl::GetTensorType<int32_t>())                                                       \
+          .InputMemoryType(OrtMemTypeCPUInput, 16),                                                                          \
       PagedAttention<T, TCACHE>);
 
 REGISTER_KERNEL_TYPED(MLFloat16, MLFloat16)
@@ -123,11 +124,18 @@ PagedAttention<T, TCACHE>::PagedAttention(const OpKernelInfo& info)
   qk_norm_epsilon_ = info.GetAttrOrDefault<float>("qk_norm_epsilon", 1e-6f);
   ORT_ENFORCE(std::isfinite(qk_norm_epsilon_) && qk_norm_epsilon_ > 0.0f,
               "qk_norm_epsilon must be a positive finite number");
-  k_quant_type_ = StringToKVQuantizationType(info.GetAttrOrDefault<std::string>("k_quant_type", "NONE"));
-  v_quant_type_ = StringToKVQuantizationType(info.GetAttrOrDefault<std::string>("v_quant_type", "NONE"));
+  k_quant_type_ = StringToKVQuantizationType(info.GetAttrOrDefault<std::string>("k_quant_type", "NONE"), true);
+  v_quant_type_ = StringToKVQuantizationType(info.GetAttrOrDefault<std::string>("v_quant_type", "NONE"), true);
+  const auto parse_rotation = [&](const char* name) {
+    const auto rotation = info.GetAttrOrDefault<std::string>(name, "NONE");
+    ORT_ENFORCE(rotation == "NONE" || rotation == "HADAMARD", name, " must be NONE or HADAMARD.");
+    return rotation == "HADAMARD";
+  };
+  qk_hadamard_ = parse_rotation("qk_rotation");
+  v_hadamard_ = parse_rotation("v_rotation");
   // Empty means the cache tensor's element type is also its logical type. Packed uint8 caches
-  // instead require an explicit int4 logical type. Other sub-byte formats remain unsupported. The
-  // string is parsed once here; everything downstream compares the enum.
+  // instead require an explicit int4 logical type. Other sub-byte formats remain unsupported. The string is
+  // parsed once here; everything downstream compares the enum.
   k_cache_dtype_ = StringToKVCacheDataType(info.GetAttrOrDefault<std::string>("k_cache_dtype", ""));
   v_cache_dtype_ = StringToKVCacheDataType(info.GetAttrOrDefault<std::string>("v_cache_dtype", ""));
 
@@ -176,6 +184,8 @@ Status PagedAttention<T, TCACHE>::ComputeInternal(OpKernelContext* context) cons
   const Tensor* v_scale = context->Input<Tensor>(15);
   // Resident in CPU memory (see the kernel def's InputMemoryType above).
   const Tensor* attention_metadata = context->Input<Tensor>(16);
+  const Tensor* key_scale_cache = context->Input<Tensor>(17);
+  const Tensor* value_scale_cache = context->Input<Tensor>(18);
 
   auto& device_prop = GetDeviceProp();
   PagedAttentionParameters parameters;
@@ -217,7 +227,9 @@ Status PagedAttention<T, TCACHE>::ComputeInternal(OpKernelContext* context) cons
                                                           v_head_size_,
                                                           rotary_offset_,
                                                           has_explicit_scale_,
-                                                          device_prop.maxThreadsPerBlock));
+                                                          device_prop.maxThreadsPerBlock,
+                                                          key_scale_cache, value_scale_cache,
+                                                          qk_hadamard_, v_hadamard_));
   parameters.local_window_size = local_window_size_;
   parameters.is_causal = is_causal_;
   parameters.do_rotary = do_rotary_;
@@ -279,6 +291,23 @@ Status PagedAttention<T, TCACHE>::ComputeInternal(OpKernelContext* context) cons
     return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
                            "value_cache and value_cache_out must be the same buffer");
   }
+
+  const auto bind_scale_cache = [&](const Tensor* input, int output_index) -> Status {
+    if (input == nullptr) {
+      const auto& outputs = Node().OutputDefs();
+      ORT_RETURN_IF_NOT(static_cast<size_t>(output_index) >= outputs.size() || !outputs[output_index]->Exists(),
+                        "Scale cache output requires its corresponding scale cache input.");
+      return Status::OK();
+    }
+    ORT_RETURN_IF_NOT(input->IsDataType<MLFloat16>() || input->IsDataType<float>(),
+                      "Scale caches must have float16 or float elements.");
+    Tensor* scale_output = context->Output(output_index, input->Shape());
+    ORT_RETURN_IF_NOT(scale_output == nullptr || scale_output->MutableDataRaw() == input->DataRaw(),
+                      "Scale cache input and output must be the same buffer.");
+    return Status::OK();
+  };
+  ORT_RETURN_IF_ERROR(bind_scale_cache(key_scale_cache, 3));
+  ORT_RETURN_IF_ERROR(bind_scale_cache(value_scale_cache, 4));
 
   // Empty query input: output is already shaped [0, hidden_size], and the cache outputs
   // alias the input caches (verified above), so no backend kernel or cache update is needed.
@@ -362,7 +391,7 @@ Status PagedAttention<T, TCACHE>::ComputeInternal(OpKernelContext* context) cons
 
   // The fused prologue (QK-Norm and/or rotary) writes densified Q and K into the workspace, so it
   // needs room for both. Plain packed-QKV only needs to densify Q.
-  const bool needs_qk_prologue = do_rotary_ || parameters.use_qk_norm;
+  const bool needs_qk_prologue = do_rotary_ || parameters.use_qk_norm || qk_hadamard_;
   size_t workspace_buffer_bytes = 0;
   if (needs_qk_prologue) {
     workspace_buffer_bytes = sizeof(T) * parameters.token_count * (parameters.hidden_size + parameters.kv_hidden_size);
@@ -463,13 +492,20 @@ Status PagedAttention<T, TCACHE>::ComputeInternal(OpKernelContext* context) cons
     return t == KVQuantizationType::PER_TENSOR || t == KVQuantizationType::PER_CHANNEL;
   };
 #ifdef USE_INT4_KV_CACHE
-  // INT4 XQA folds the PER_CHANNEL scale into Q and applies it to the output, so the kernel itself
-  // runs at unit scale.
+  // INT4 XQA takes PER_TOKEN scales through the loader's FP16 scale cache, or a PER_CHANNEL scale
+  // that is folded into Q and applied to the output, in which case the kernel runs at unit scale.
+  const auto int4_side_eligible = [](KVQuantizationType type, const Tensor* scale_cache) {
+    if (type == KVQuantizationType::PER_CHANNEL) {
+      return true;
+    }
+    return type == KVQuantizationType::PER_TOKEN && scale_cache != nullptr &&
+           scale_cache->IsDataType<MLFloat16>();
+  };
   const bool int4_xqa_eligible =
       enable_xqa_ && std::is_same_v<TCACHE, uint8_t> && std::is_same_v<T, MLFloat16> &&
       device_prop.major >= 8 && parameters.softcap == 0.0f && parameters.head_size == 256 && group_size == 6 &&
       (parameters.block_size % kXqaTokensPerPage) == 0 &&
-      k_quant_type_ == KVQuantizationType::PER_CHANNEL && v_quant_type_ == KVQuantizationType::PER_CHANNEL;
+      int4_side_eligible(k_quant_type_, key_scale_cache) && int4_side_eligible(v_quant_type_, value_scale_cache);
 #else
   constexpr bool int4_xqa_eligible = false;
 #endif
@@ -494,7 +530,8 @@ Status PagedAttention<T, TCACHE>::ComputeInternal(OpKernelContext* context) cons
       max_query_len_bound > 1 && max_query_len_bound <= 8;
   const bool portable_spec_dec_candidate =
       has_metadata_bounds && max_query_len_bound > 1 && max_query_len_bound <= 8 &&
-      std::is_same_v<TCACHE, uint8_t>;
+      (std::is_same_v<TCACHE, uint8_t> || k_quant_type_ == KVQuantizationType::PER_TOKEN ||
+       v_quant_type_ == KVQuantizationType::PER_TOKEN);
   // Only the FlashAttention backend takes a causality flag; the paged decode and CUTLASS kernels
   // both hard-code a bottom-right causal mask.
   bool use_paged_decode =
@@ -821,6 +858,10 @@ Status PagedAttention<T, TCACHE>::ComputeInternal(OpKernelContext* context) cons
                          : reinterpret_cast<CudaTCache*>(const_cast<TCACHE*>(value_cache->Data<TCACHE>()));
   data.k_scale = k_scale == nullptr ? nullptr : k_scale->Data<float>();
   data.v_scale = v_scale == nullptr ? nullptr : v_scale->Data<float>();
+  data.key_scale_cache = key_scale_cache == nullptr ? nullptr : const_cast<void*>(key_scale_cache->DataRaw());
+  data.value_scale_cache = value_scale_cache == nullptr ? nullptr : const_cast<void*>(value_scale_cache->DataRaw());
+  const Tensor* scale_cache = key_scale_cache != nullptr ? key_scale_cache : value_scale_cache;
+  data.scale_cache_is_fp16 = scale_cache == nullptr || scale_cache->IsDataType<MLFloat16>();
   data.cumulative_seqlens_q = reinterpret_cast<const int*>(cumulative_seqlens_q->Data<int>());
   data.past_seqlens = reinterpret_cast<const int*>(past_seqlens->Data<int>());
   data.cumulative_seqlens_kv = cumulative_seqlens_kv_ptr;

--- a/onnxruntime/contrib_ops/cuda/bert/paged_attention.cc
+++ b/onnxruntime/contrib_ops/cuda/bert/paged_attention.cc
@@ -47,6 +47,10 @@ REGISTER_KERNEL_TYPED(MLFloat16, MLFloat16)
 REGISTER_KERNEL_TYPED(BFloat16, BFloat16)
 REGISTER_KERNEL_TYPED(MLFloat16, int8_t)
 REGISTER_KERNEL_TYPED(BFloat16, int8_t)
+#ifdef USE_INT4_KV_CACHE
+REGISTER_KERNEL_TYPED(MLFloat16, uint8_t)
+REGISTER_KERNEL_TYPED(BFloat16, uint8_t)
+#endif
 #if defined(USE_FP8_KV_CACHE) && !defined(DISABLE_FLOAT8_TYPES)
 REGISTER_KERNEL_TYPED(MLFloat16, Float8E4M3FN)
 REGISTER_KERNEL_TYPED(BFloat16, Float8E4M3FN)
@@ -55,7 +59,7 @@ REGISTER_KERNEL_TYPED(BFloat16, Float8E4M3FN)
 // True when TCACHE stores quantized values that need a scale on read/write.
 template <typename TCACHE>
 constexpr bool IsQuantizedCacheType() {
-  if constexpr (std::is_same<TCACHE, int8_t>::value) {
+  if constexpr (std::is_same<TCACHE, int8_t>::value || std::is_same<TCACHE, uint8_t>::value) {
     return true;
 #if defined(USE_FP8_KV_CACHE) && !defined(DISABLE_FLOAT8_TYPES)
   } else if constexpr (std::is_same<TCACHE, Float8E4M3FN>::value) {
@@ -82,7 +86,9 @@ constexpr bool IsFp8CacheType() {
 // v_cache_dtype attribute can be checked against it.
 template <typename TCACHE>
 constexpr KVCacheDataType CacheStorageDataType() {
-  if constexpr (std::is_same<TCACHE, int8_t>::value) {
+  if constexpr (std::is_same<TCACHE, uint8_t>::value) {
+    return KVCacheDataType::INT4;
+  } else if constexpr (std::is_same<TCACHE, int8_t>::value) {
     return KVCacheDataType::INT8;
 #if defined(USE_FP8_KV_CACHE) && !defined(DISABLE_FLOAT8_TYPES)
   } else if constexpr (std::is_same<TCACHE, Float8E4M3FN>::value) {
@@ -119,10 +125,9 @@ PagedAttention<T, TCACHE>::PagedAttention(const OpKernelInfo& info)
               "qk_norm_epsilon must be a positive finite number");
   k_quant_type_ = StringToKVQuantizationType(info.GetAttrOrDefault<std::string>("k_quant_type", "NONE"));
   v_quant_type_ = StringToKVQuantizationType(info.GetAttrOrDefault<std::string>("v_quant_type", "NONE"));
-  // Empty (the default) means the cache tensor's own element type is the logical type, which covers
-  // every format this operator stores today. A non-empty value names a sub-byte logical type packed
-  // into a uint8 cache, which no build supports yet and is rejected during validation. The string is
-  // parsed once here; everything downstream compares the enum.
+  // Empty means the cache tensor's element type is also its logical type. Packed uint8 caches
+  // instead require an explicit int4 logical type. Other sub-byte formats remain unsupported. The
+  // string is parsed once here; everything downstream compares the enum.
   k_cache_dtype_ = StringToKVCacheDataType(info.GetAttrOrDefault<std::string>("k_cache_dtype", ""));
   v_cache_dtype_ = StringToKVCacheDataType(info.GetAttrOrDefault<std::string>("v_cache_dtype", ""));
 
@@ -253,7 +258,7 @@ Status PagedAttention<T, TCACHE>::ComputeInternal(OpKernelContext* context) cons
   key_cache_out_shape[0] = static_cast<int64_t>(parameters.num_blocks);
   key_cache_out_shape[1] = static_cast<int64_t>(parameters.block_size);
   key_cache_out_shape[2] = static_cast<int64_t>(parameters.kv_num_heads);
-  key_cache_out_shape[3] = static_cast<int64_t>(parameters.head_size);
+  key_cache_out_shape[3] = key_cache->Shape()[3];
   Tensor* key_cache_out = context->Output(1, key_cache_out_shape);
 
   // LATENT has a single physical cache, so there is no value_cache_out to produce.
@@ -263,7 +268,7 @@ Status PagedAttention<T, TCACHE>::ComputeInternal(OpKernelContext* context) cons
     value_cache_out_shape[0] = static_cast<int64_t>(parameters.num_blocks);
     value_cache_out_shape[1] = static_cast<int64_t>(parameters.block_size);
     value_cache_out_shape[2] = static_cast<int64_t>(parameters.kv_num_heads);
-    value_cache_out_shape[3] = static_cast<int64_t>(parameters.head_size);
+    value_cache_out_shape[3] = value_cache->Shape()[3];
     value_cache_out = context->Output(2, value_cache_out_shape);
   }
 
@@ -457,13 +462,25 @@ Status PagedAttention<T, TCACHE>::ComputeInternal(OpKernelContext* context) cons
   const auto is_supported_quant_type = [](KVQuantizationType t) {
     return t == KVQuantizationType::PER_TENSOR || t == KVQuantizationType::PER_CHANNEL;
   };
-  const bool quantized_xqa_eligible =
-      enable_xqa_ && kIsQuantizedCache && device_prop.major >= 8 && parameters.softcap == 0.0f &&
-      (parameters.head_size == 64 || parameters.head_size == 128 || parameters.head_size == 256) &&
-      (group_size == 4 || group_size == 6 || group_size == 8 || group_size == 16 || group_size == 32) &&
+#ifdef USE_INT4_KV_CACHE
+  // INT4 XQA folds the PER_CHANNEL scale into Q and applies it to the output, so the kernel itself
+  // runs at unit scale.
+  const bool int4_xqa_eligible =
+      enable_xqa_ && std::is_same_v<TCACHE, uint8_t> && std::is_same_v<T, MLFloat16> &&
+      device_prop.major >= 8 && parameters.softcap == 0.0f && parameters.head_size == 256 && group_size == 6 &&
       (parameters.block_size % kXqaTokensPerPage) == 0 &&
-      is_supported_quant_type(k_quant_type_) && is_supported_quant_type(v_quant_type_) &&
-      (!is_fp8_cache || device_prop.major >= 9 || (device_prop.major == 8 && device_prop.minor == 9));
+      k_quant_type_ == KVQuantizationType::PER_CHANNEL && v_quant_type_ == KVQuantizationType::PER_CHANNEL;
+#else
+  constexpr bool int4_xqa_eligible = false;
+#endif
+  const bool quantized_xqa_eligible =
+      int4_xqa_eligible || (enable_xqa_ && kIsQuantizedCache && !std::is_same_v<TCACHE, uint8_t> &&
+                            device_prop.major >= 8 && parameters.softcap == 0.0f &&
+                            (parameters.head_size == 64 || parameters.head_size == 128 || parameters.head_size == 256) &&
+                            (group_size == 4 || group_size == 6 || group_size == 8 || group_size == 16 || group_size == 32) &&
+                            (parameters.block_size % kXqaTokensPerPage) == 0 &&
+                            is_supported_quant_type(k_quant_type_) && is_supported_quant_type(v_quant_type_) &&
+                            (!is_fp8_cache || device_prop.major >= 9 || (device_prop.major == 8 && device_prop.minor == 9)));
   // Speculative verification steps (2..8 new tokens per sequence) run on the paged XQA kernel with
   // a packed lower-triangular mask built by PagedXqaSpecDecCausalMaskKernel. The gate is the
   // metadata query bound, not the aggregate token count: a zero-heavy ragged step can have
@@ -475,11 +492,15 @@ Status PagedAttention<T, TCACHE>::ComputeInternal(OpKernelContext* context) cons
       ((quantized_xqa_eligible && std::is_same<T, MLFloat16>::value) || native_spec_xqa_eligible) &&
       parameters.head_size == 256 && group_size == 6 &&
       max_query_len_bound > 1 && max_query_len_bound <= 8;
+  const bool portable_spec_dec_candidate =
+      has_metadata_bounds && max_query_len_bound > 1 && max_query_len_bound <= 8 &&
+      std::is_same_v<TCACHE, uint8_t>;
   // Only the FlashAttention backend takes a causality flag; the paged decode and CUTLASS kernels
   // both hard-code a bottom-right causal mask.
   bool use_paged_decode =
       decode_eligible && parameters.is_causal &&
-      ((decode_shaped && (kIsQuantizedCache || fp16_xqa_eligible || !flash_eligible)) || xqa_spec_dec_candidate);
+      ((decode_shaped && (kIsQuantizedCache || fp16_xqa_eligible || !flash_eligible)) ||
+       xqa_spec_dec_candidate || portable_spec_dec_candidate);
   bool use_flash_attention = flash_eligible && !use_paged_decode;
   const bool use_memory_efficient_attention = mea_eligible && !use_paged_decode && parameters.is_causal;
 
@@ -509,8 +530,9 @@ Status PagedAttention<T, TCACHE>::ComputeInternal(OpKernelContext* context) cons
     xqa_candidate = kIsQuantizedCache ? quantized_xqa_eligible : fp16_xqa_eligible;
   }
   const XqaQuantType xqa_kv_quant_type =
-      !kIsQuantizedCache ? XqaQuantType::kNone
-                         : (IsFp8CacheType<TCACHE>() ? XqaQuantType::kFp8 : XqaQuantType::kInt8);
+      std::is_same_v<TCACHE, uint8_t> ? XqaQuantType::kInt4
+      : !kIsQuantizedCache            ? XqaQuantType::kNone
+                                      : (IsFp8CacheType<TCACHE>() ? XqaQuantType::kFp8 : XqaQuantType::kInt8);
 
   // Obtaining the exact lengths from the device means copying the two cumulative arrays back and
   // blocking the host until they land, which drains everything already queued on the compute
@@ -727,7 +749,8 @@ Status PagedAttention<T, TCACHE>::ComputeInternal(OpKernelContext* context) cons
                                     device_prop, parameters.batch_size, parameters.num_heads,
                                     parameters.kv_num_heads, parameters.head_size,
                                     xqa_max_pages_per_seq * kXqaTokensPerPage,
-                                    xqa_kv_quant_type, std::is_same<T, BFloat16>::value);
+                                    int4_xqa_eligible ? XqaQuantType::kNone : xqa_kv_quant_type,
+                                    std::is_same<T, BFloat16>::value);
     xqa_workspace_buffer = GetScratchBuffer<void>(xqa_workspace_bytes, GetComputeStream(context));
     if (xqa_page_table_expanded) {
       xqa_page_table_buffer = GetScratchBuffer<void>(

--- a/onnxruntime/contrib_ops/cuda/bert/paged_attention.h
+++ b/onnxruntime/contrib_ops/cuda/bert/paged_attention.h
@@ -35,6 +35,8 @@ class PagedAttention final : public CudaKernel {
   float qk_norm_epsilon_;
   KVQuantizationType k_quant_type_;
   KVQuantizationType v_quant_type_;
+  bool qk_hadamard_;
+  bool v_hadamard_;
   // Logical element type stored in the cache when it cannot be expressed by the cache tensor's own
   // element type (sub-byte formats packed into uint8). DEFAULT uses the tensor's element type. The
   // attribute string is parsed once here so the hot path only compares enums.

--- a/onnxruntime/contrib_ops/cuda/bert/paged_attention_hadamard.cuh
+++ b/onnxruntime/contrib_ops/cuda/bert/paged_attention_hadamard.cuh
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <cuda_runtime.h>
+
+namespace onnxruntime {
+namespace contrib {
+namespace cuda {
+
+__device__ __forceinline__ float PagedHadamard(float value, float* shared_values, int head_size) {
+  const int channel = threadIdx.x;
+  for (int stride = 1; stride < head_size; stride <<= 1) {
+    shared_values[channel] = value;
+    __syncthreads();
+    const float partner = shared_values[channel ^ stride];
+    value = (channel & stride) ? partner - value : value + partner;
+    __syncthreads();
+  }
+  return value * rsqrtf(static_cast<float>(head_size));
+}
+
+template <typename T>
+__global__ void PagedHadamardHeads(const T* input, T* output, int head_size, int input_stride, int num_heads) {
+  extern __shared__ float shared_values[];
+  const int token = blockIdx.x;
+  const int head = blockIdx.y;
+  const int channel = threadIdx.x;
+  const float value = static_cast<float>(input[static_cast<int64_t>(token) * input_stride + head * head_size + channel]);
+  output[(static_cast<int64_t>(token) * num_heads + head) * head_size + channel] =
+      static_cast<T>(PagedHadamard(value, shared_values, head_size));
+}
+
+}  // namespace cuda
+}  // namespace contrib
+}  // namespace onnxruntime

--- a/onnxruntime/contrib_ops/cuda/bert/paged_attention_impl.cu
+++ b/onnxruntime/contrib_ops/cuda/bert/paged_attention_impl.cu
@@ -13,6 +13,7 @@
 #include "contrib_ops/cuda/bert/flash_attention/flash_api.h"
 #include "contrib_ops/cuda/bert/cutlass_fmha/memory_efficient_attention.h"
 #include "contrib_ops/cuda/bert/paged_attention_impl.h"
+#include "contrib_ops/cuda/bert/paged_attention_hadamard.cuh"
 #include "contrib_ops/cuda/bert/group_query_attention_qdq.cuh"
 #include "contrib_ops/cuda/bert/xqa/xqa_paged_loader.h"
 #include "core/providers/cuda/shared_inc/cuda_call.h"
@@ -51,6 +52,28 @@ struct IsQuantizedCache<uint8_t> : std::true_type {};
 template <>
 struct IsQuantizedCache<Float8E4M3FN> : std::true_type {};
 #endif
+
+struct PagedScaleCache {
+  void* values = nullptr;
+  bool is_fp16 = true;
+
+  __device__ float Load(int64_t index) const {
+    if (values == nullptr) return 1.0f;
+    return is_fp16 ? static_cast<float>(static_cast<const half*>(values)[index])
+                   : static_cast<const float*>(values)[index];
+  }
+
+  __device__ float Store(int64_t index, float scale) const {
+    if (is_fp16) {
+      scale = scale == 0.0f ? 0.0f : fminf(65504.0f, fmaxf(scale, 0x1p-24f));
+      const half stored = static_cast<half>(scale);
+      static_cast<half*>(values)[index] = stored;
+      return static_cast<float>(stored);
+    }
+    static_cast<float*>(values)[index] = scale;
+    return scale;
+  }
+};
 
 // PER_CHANNEL uses the flattened kv-hidden channel_index; PER_TENSOR uses scale[0].
 __device__ __forceinline__ float GetCacheScale(const float* __restrict__ scale, const int channel_index,
@@ -174,9 +197,8 @@ Status LaunchUnpackCumulative(const T* input, T* output, const int token_count, 
 // raw projection *before* RoPE, matching the reference implementations (and GroupQueryAttention's
 // UnpackRoPEAppend), so the value that lands in the paged KV cache is normalized-then-rotated K.
 //
-// Set norm_weight == nullptr to skip normalization, and rotary_embedding_dim == 0 to skip rotary
-// (the kernel then degenerates to an unpack/copy). At least one of the two must be enabled,
-// otherwise the caller should not launch this kernel at all.
+// Set norm_weight == nullptr to skip normalization, and rotary_embedding_dim == 0 to skip rotary.
+// The optional Q Hadamard transform runs last. At least one transformation must be enabled.
 //
 // `rotary_offset` is the first channel of the head that RoPE covers: the rotated span is
 // [rotary_offset, rotary_offset + rotary_embedding_dim) and every channel outside it is copied
@@ -206,6 +228,7 @@ __global__ void QkNormRotaryTNH(T* output,                            // TxNxH
                                 const int rotary_embedding_dim,
                                 const int rotary_offset,
                                 const bool interleaved,
+                                const bool hadamard,
                                 const int3 in_strides,     // TxNxH
                                 const int3 out_strides) {  // TxNxH
   // Use .x in innermost loop to access global memory efficiently
@@ -268,40 +291,36 @@ __global__ void QkNormRotaryTNH(T* output,                            // TxNxH
   }
   __syncthreads();
 
-  if (!valid) {
-    return;
-  }
-
   // A channel outside [rotary_offset, rotary_offset + rotary_embedding_dim) is copied through.
   // rotary_embedding_dim == 0 makes every lane take this branch, which is the pure
   // normalize-and-copy (or plain unpack) path. past_seqlens / cos_cache / sin_cache are then
   // never dereferenced and may be null.
   const int hr = h - rotary_offset;
-  if (hr < 0 || hr >= rotary_embedding_dim) {
-    output_data[h] = head_values[h];
-    return;
+  T rotated = valid ? head_values[h] : static_cast<T>(0.0f);
+  if (valid && hr >= 0 && hr < rotary_embedding_dim) {
+    const int half_rotary_embedding_dim = rotary_embedding_dim / 2;
+    const int position_id = past_seqlens[b] + s;
+    const int cache_offset = position_id * half_rotary_embedding_dim;
+    const T* cos_data = cos_cache + cache_offset;
+    const T* sin_data = sin_cache + cache_offset;
+    int cache_idx = 0;
+    T sign = 0;
+    int partner = 0;
+    if (interleaved) {
+      cache_idx = (hr / 2) % half_rotary_embedding_dim;
+      sign = (hr % 2 == 0) ? -1 : 1;
+      partner = (hr % 2 == 0) ? hr + 1 : hr - 1;
+    } else {
+      cache_idx = hr % half_rotary_embedding_dim;
+      sign = (hr < half_rotary_embedding_dim) ? -1 : 1;
+      partner = (hr + half_rotary_embedding_dim) % rotary_embedding_dim;
+    }
+    rotated = head_values[h] * cos_data[cache_idx] + sign * head_values[rotary_offset + partner] * sin_data[cache_idx];
   }
-
-  // Cache is (M, H/2)
-  const int half_rotary_embedding_dim = rotary_embedding_dim / 2;
-  const int position_id = past_seqlens[b] + s;
-  const int cache_offset = position_id * half_rotary_embedding_dim;
-  const T* cos_data = cos_cache + cache_offset;
-  const T* sin_data = sin_cache + cache_offset;
-
-  int cache_idx = 0;
-  T sign = 0;
-  int j = 0;
-  if (interleaved) {
-    cache_idx = (hr / 2) % half_rotary_embedding_dim;
-    sign = (hr % 2 == 0) ? -1 : 1;
-    j = (hr % 2 == 0) ? hr + 1 : hr - 1;  // i - sign
-  } else {
-    cache_idx = hr % half_rotary_embedding_dim;
-    sign = (hr < half_rotary_embedding_dim) ? -1 : 1;
-    j = (hr + half_rotary_embedding_dim) % rotary_embedding_dim;
+  if (hadamard) {
+    rotated = static_cast<T>(PagedHadamard(static_cast<float>(rotated), reduce_buffer, head_size));
   }
-  output_data[h] = head_values[h] * cos_data[cache_idx] + sign * head_values[rotary_offset + j] * sin_data[cache_idx];
+  if (valid) output_data[h] = rotated;
 }
 
 // Launches the fused QK-Norm / rotary prologue. Pass norm_weight == nullptr to disable QK-Norm and
@@ -313,7 +332,7 @@ Status LaunchQkNormRotaryKernel(cudaStream_t stream, T* output, const T* input, 
                                 const T* norm_weight, const float epsilon, const int batch_size,
                                 const int token_count, const int num_heads, const int head_size,
                                 const int rotary_embedding_dim, const int rotary_offset, const bool interleaved,
-                                const int in_seq_stride, const int max_threads_per_block) {
+                                const int in_seq_stride, const int max_threads_per_block, const bool hadamard = false) {
   if (batch_size == 0 || token_count == 0 || num_heads == 0) {
     return Status::OK();
   }
@@ -333,7 +352,7 @@ Status LaunchQkNormRotaryKernel(cudaStream_t stream, T* output, const T* input, 
   const dim3 block(tpb);
   QkNormRotaryTNH<<<grid, block, shared_bytes, stream>>>(
       output, input, cos_cache, sin_cache, past_seqlens, cumulative_seqlens_q, norm_weight, epsilon, batch_size,
-      head_size, rotary_embedding_dim, rotary_offset, interleaved, in_strides, out_strides);
+      head_size, rotary_embedding_dim, rotary_offset, interleaved, hadamard, in_strides, out_strides);
   return CUDA_CALL(cudaGetLastError());
 }
 
@@ -497,20 +516,35 @@ Status LaunchReshapeAndCacheImpl(const T* key, const T* value, TCACHE* key_cache
 
 template <typename T, typename TCACHE, typename SlotResolver>
 __global__ void ReshapeAndCacheHeads(const T* input, TCACHE* cache, const float* static_scale,
-                                    bool per_channel, SlotResolver resolver, int head_size, int kv_num_heads,
+                                    PagedScaleCache scale_cache, bool per_channel, bool hadamard,
+                                    SlotResolver resolver, int head_size, int kv_num_heads,
                                     int input_stride, int64_t num_slots) {
   const int token = blockIdx.x;
   const int head = blockIdx.y;
   const int channel = threadIdx.x;
   const int slot = resolver(token);
   if (slot < 0 || slot >= num_slots) return;
-  // Staging buffer for the INT4 nibble pack below.
   extern __shared__ float shared_values[];
   float value = channel < head_size
                     ? static_cast<float>(input[static_cast<int64_t>(token) * input_stride + head * head_size + channel])
                     : 0.0f;
+  if (hadamard) value = PagedHadamard(value, shared_values, head_size);
   const int64_t scale_index = static_cast<int64_t>(slot) * kv_num_heads + head;
-  const float scale = channel < head_size ? GetCacheScale(static_scale, head * head_size + channel, per_channel) : 1.0f;
+  float scale = channel < head_size ? GetCacheScale(static_scale, head * head_size + channel, per_channel) : 1.0f;
+  if (scale_cache.values != nullptr) {
+    shared_values[channel] = fabsf(value);
+    __syncthreads();
+    for (int stride = blockDim.x / 2; stride > 0; stride >>= 1) {
+      if (channel < stride) shared_values[channel] = fmaxf(shared_values[channel], shared_values[channel + stride]);
+      __syncthreads();
+    }
+    constexpr float quant_max = std::is_same_v<TCACHE, uint8_t> ? kInt4Max
+                               : std::is_same_v<TCACHE, int8_t> ? kInt8Max : kFp8E4M3Max;
+    if (channel == 0) shared_values[0] = scale_cache.Store(scale_index, shared_values[0] / quant_max);
+    __syncthreads();
+    scale = shared_values[0];
+    __syncthreads();
+  }
   if constexpr (std::is_same_v<TCACHE, uint8_t>) {
     const float scaled = scale == 0.0f ? 0.0f : value / scale;
     const float clamped = fminf(static_cast<float>(kInt4Max), fmaxf(static_cast<float>(kInt4Min), scaled));
@@ -535,12 +569,14 @@ Status LaunchCacheHeads(const T* key, const T* value, PagedAttentionData<T, TCAC
   const dim3 grid(parameters.token_count, parameters.kv_num_heads);
   const int64_t num_slots = static_cast<int64_t>(parameters.num_blocks) * parameters.block_size;
   ReshapeAndCacheHeads<<<grid, threads, threads * sizeof(float), stream>>>(
-      key, data.key_cache, data.k_scale, parameters.k_quant_type == KVQuantizationType::PER_CHANNEL, resolver,
+      key, data.key_cache, data.k_scale, PagedScaleCache{data.key_scale_cache, data.scale_cache_is_fp16},
+      parameters.k_quant_type == KVQuantizationType::PER_CHANNEL, parameters.qk_hadamard, resolver,
       parameters.head_size, parameters.kv_num_heads, key_stride, num_slots);
   CUDA_RETURN_IF_ERROR(cudaGetLastError());
   if (data.value_cache != nullptr) {
     ReshapeAndCacheHeads<<<grid, threads, threads * sizeof(float), stream>>>(
-        value, data.value_cache, data.v_scale, parameters.v_quant_type == KVQuantizationType::PER_CHANNEL, resolver,
+        value, data.value_cache, data.v_scale, PagedScaleCache{data.value_scale_cache, data.scale_cache_is_fp16},
+        parameters.v_quant_type == KVQuantizationType::PER_CHANNEL, parameters.v_hadamard, resolver,
         parameters.head_size, parameters.kv_num_heads, value_stride, num_slots);
   }
   return CUDA_CALL(cudaGetLastError());
@@ -635,7 +671,8 @@ __global__ void GatherAndExpandPagedKVCache(const TCACHE* __restrict__ key_cache
                                             const int head_size,
                                             const int block_size,
                                             const int max_num_blocks_per_seq,
-                                            const int64_t total_elems) {
+                                            const int64_t total_elems,
+                                            PagedScaleCache key_scale_cache, PagedScaleCache value_scale_cache) {
   const int64_t stride = static_cast<int64_t>(gridDim.x) * blockDim.x;
   const int64_t num_heads_times_head = static_cast<int64_t>(num_heads) * head_size;
   const int q_kv_head_ratio = num_heads / kv_num_heads;
@@ -695,10 +732,11 @@ __global__ void GatherAndExpandPagedKVCache(const TCACHE* __restrict__ key_cache
                               kv_head_id * head_size +
                               h;
 
-    gathered_key[tid] = static_cast<T>(ReadPagedCache(key_cache, paged_idx) *
-                                       GetCacheScale(k_scale, channel_index, k_per_channel));
-    gathered_value[tid] = static_cast<T>(ReadPagedCache(value_cache, paged_idx) *
-                                         GetCacheScale(v_scale, channel_index, v_per_channel));
+    const int64_t scale_index = paged_idx / head_size;
+    gathered_key[tid] = static_cast<T>(ReadPagedCache(key_cache, paged_idx) * key_scale_cache.Load(scale_index) *
+                       GetCacheScale(k_scale, channel_index, k_per_channel));
+    gathered_value[tid] = static_cast<T>(ReadPagedCache(value_cache, paged_idx) * value_scale_cache.Load(scale_index) *
+                       GetCacheScale(v_scale, channel_index, v_per_channel));
   }
 }
 
@@ -712,7 +750,8 @@ Status LaunchGatherAndExpandPagedKVCache(const TCACHE* key_cache, const TCACHE* 
                                          const int kv_num_heads, const int head_size,
                                          const int block_size, const int max_num_blocks_per_seq,
                                          const int total_kv_tokens, cudaStream_t stream,
-                                         const int max_threads_per_block) {
+                                         const int max_threads_per_block,
+                                         PagedScaleCache key_scale_cache, PagedScaleCache value_scale_cache) {
   const int64_t total_elems = static_cast<int64_t>(total_kv_tokens) * num_heads * head_size;
   if (total_elems == 0) {
     return Status::OK();
@@ -725,7 +764,7 @@ Status LaunchGatherAndExpandPagedKVCache(const TCACHE* key_cache, const TCACHE* 
       key_cache, value_cache, gathered_key, gathered_value, k_scale, v_scale, k_per_channel, v_per_channel,
       block_table, cumulative_seqlens_kv,
       batch_size, num_heads, kv_num_heads, head_size,
-      block_size, max_num_blocks_per_seq, total_elems);
+      block_size, max_num_blocks_per_seq, total_elems, key_scale_cache, value_scale_cache);
   return CUDA_CALL(cudaGetLastError());
 }
 
@@ -802,7 +841,8 @@ __global__ void PagedDecodeSplitKV(const T* __restrict__ query,
                                    const float scale,
                                    const float softcap,
                                    const int local_window_size,
-                                   const bool k_per_channel) {
+                                   const bool k_per_channel,
+                                   PagedScaleCache key_scale_cache, PagedScaleCache value_scale_cache) {
   extern __shared__ float paged_decode_smem[];
   const int channel_groups = PagedDecodeChannelGroups(head_size);
   const int acc_elems = channel_groups * head_size;
@@ -906,8 +946,7 @@ __global__ void PagedDecodeSplitKV(const T* __restrict__ query,
       float dot = 0.0f;
       if (block_id >= 0) {
         const int64_t key_offset =
-            (static_cast<int64_t>(block_id) * block_size + (pos % block_size)) * token_stride_in_page +
-            head_offset_in_page;
+            (static_cast<int64_t>(block_id) * block_size + (pos % block_size)) * token_stride_in_page + head_offset_in_page;
         for (int c = lane_id; c < head_size; c += 32) {
           dot += q_sh[c] * ReadPagedCache(key_cache, key_offset + c);
         }
@@ -917,6 +956,10 @@ __global__ void PagedDecodeSplitKV(const T* __restrict__ query,
         dot += __shfl_xor_sync(0xFFFFFFFFU, dot, offset);
       }
       if (lane_id == 0) {
+        if (block_id >= 0) {
+          dot *= key_scale_cache.Load((static_cast<int64_t>(block_id) * block_size + pos % block_size) *
+                                          kv_num_heads + kv_head_id);
+        }
         block_id_sh[t] = block_id;
         logits_sh[t] = block_id < 0 ? -FLT_MAX
                                     : (softcap > 0.0f ? softcap * tanhf(dot * softcap_scale) : dot * scale);
@@ -952,7 +995,10 @@ __global__ void PagedDecodeSplitKV(const T* __restrict__ query,
     float local_sum = 0.0f;
     for (int t = tid; t < tile_len; t += kPagedDecodeThreads) {
       const float p = __expf(logits_sh[t] - m_new);
-      logits_sh[t] = p;
+      const int block_id = block_id_sh[t];
+      const int pos = tile_begin + t;
+      logits_sh[t] = block_id < 0 ? 0.0f : p * value_scale_cache.Load(
+          (static_cast<int64_t>(block_id) * block_size + pos % block_size) * kv_num_heads + kv_head_id);
       local_sum += p;
     }
     red_sh[tid] = local_sum;
@@ -979,10 +1025,9 @@ __global__ void PagedDecodeSplitKV(const T* __restrict__ query,
             continue;
           }
           const int pos = tile_begin + t;
-          const int64_t value_offset =
-              (static_cast<int64_t>(block_id) * block_size + pos % block_size) * token_stride_in_page +
-              head_offset_in_page;
-          acc += logits_sh[t] * ReadPagedCache(value_cache, value_offset + c);
+            const int64_t value_offset =
+              (static_cast<int64_t>(block_id) * block_size + pos % block_size) * token_stride_in_page + head_offset_in_page;
+            acc += logits_sh[t] * ReadPagedCache(value_cache, value_offset + c);
         }
         acc_sh[c] = acc;
       }
@@ -997,8 +1042,7 @@ __global__ void PagedDecodeSplitKV(const T* __restrict__ query,
         }
         const int pos = tile_begin + t;
         const int64_t value_offset =
-            (static_cast<int64_t>(block_id) * block_size + pos % block_size) * token_stride_in_page +
-            head_offset_in_page;
+          (static_cast<int64_t>(block_id) * block_size + pos % block_size) * token_stride_in_page + head_offset_in_page;
         acc += logits_sh[t] * ReadPagedCache(value_cache, value_offset + c);
       }
       acc_sh[tid] = acc;
@@ -1129,13 +1173,15 @@ Status LaunchPagedDecodeAttention(const T* query, const TCACHE* key_cache, const
                                   const int head_size, const int block_size, const int max_num_blocks_per_seq,
                                   const int token_count, const int num_splits, const float scale,
                                   const float softcap, const int local_window_size,
-                                  const bool use_smooth_softmax, cudaStream_t stream) {
+                                  const bool use_smooth_softmax, cudaStream_t stream,
+                                  PagedScaleCache key_scale_cache, PagedScaleCache value_scale_cache) {
   const size_t smem_bytes = GetPagedDecodeSharedMemoryBytes(head_size);
   const dim3 grid(num_heads, token_count, num_splits);
   PagedDecodeSplitKV<T, TCACHE><<<grid, kPagedDecodeThreads, smem_bytes, stream>>>(
       query, key_cache, value_cache, k_scale, cumulative_seqlens_q, cumulative_seqlens_kv, block_table,
       partial_out, partial_max, partial_sum, batch_size, num_heads, kv_num_heads, head_size, block_size,
-      max_num_blocks_per_seq, token_count, num_splits, scale, softcap, local_window_size, k_per_channel);
+      max_num_blocks_per_seq, token_count, num_splits, scale, softcap, local_window_size, k_per_channel,
+      key_scale_cache, value_scale_cache);
   CUDA_RETURN_IF_ERROR(cudaGetLastError());
 
   const dim3 reduce_grid(num_heads, token_count);
@@ -1412,7 +1458,7 @@ Status PrepareQueryAndCache(cudaStream_t stream, contrib::PagedAttentionParamete
   int* cumulative_seqlens_q = const_cast<int*>(data.cumulative_seqlens_q);
   int* past_seqlens = const_cast<int*>(data.past_seqlens);
 
-  if (parameters.do_rotary || parameters.use_qk_norm) {
+  if (parameters.do_rotary || parameters.use_qk_norm || parameters.qk_hadamard) {
     // Fused QK-Norm + rotary prologue. Also unpacks Q and K in case of packed_qkv.
     auto q_buffer = data.workspace_buffer;
     auto k_buffer = data.workspace_buffer + token_count * num_heads * head_size;
@@ -1422,14 +1468,16 @@ Status PrepareQueryAndCache(cudaStream_t stream, contrib::PagedAttentionParamete
         stream, q_buffer, query, past_seqlens, cumulative_seqlens_q, data.cos_cache, data.sin_cache,
         data.q_norm_weight, parameters.qk_norm_epsilon, batch_size, token_count, num_heads, head_size,
         rotary_dim, parameters.rotary_offset, parameters.rotary_interleaved, packed_seq_stride,
-        max_threads_per_block));
-    ORT_RETURN_IF_ERROR(LaunchQkNormRotaryKernel<T>(
+        max_threads_per_block, parameters.qk_hadamard));
+      if (parameters.do_rotary || parameters.use_qk_norm) {
+        ORT_RETURN_IF_ERROR(LaunchQkNormRotaryKernel<T>(
         stream, k_buffer, key, past_seqlens, cumulative_seqlens_q, data.cos_cache, data.sin_cache,
         data.k_norm_weight, parameters.qk_norm_epsilon, batch_size, token_count, kv_num_heads, head_size,
         rotary_dim, parameters.rotary_offset, parameters.rotary_interleaved, packed_seq_stride,
         max_threads_per_block));
+        key = k_buffer;
+      }
     query = q_buffer;
-    key = k_buffer;
   } else if (parameters.is_packed_qkv) {
     // Only unpack Q. K and V are unpacked by ReshapeAndCache.
     auto q_buffer = data.workspace_buffer;
@@ -1446,7 +1494,8 @@ Status PrepareQueryAndCache(cudaStream_t stream, contrib::PagedAttentionParamete
   const int value_stride = parameters.is_packed_qkv ? q_hidden_size + 2 * kv_hidden_size : kv_hidden_size;
   const bool k_per_channel = parameters.k_quant_type == KVQuantizationType::PER_CHANNEL;
   const bool v_per_channel = parameters.v_quant_type == KVQuantizationType::PER_CHANNEL;
-  if constexpr (std::is_same_v<TCACHE, uint8_t>) {
+  if (std::is_same_v<TCACHE, uint8_t> || data.key_scale_cache != nullptr || data.value_scale_cache != nullptr ||
+      parameters.qk_hadamard || parameters.v_hadamard) {
     if (data.slot_mapping != nullptr) {
       ORT_RETURN_IF_ERROR(LaunchCacheHeads(key, value, data, parameters, ExplicitSlotResolver{data.slot_mapping},
                                            key_stride, value_stride, stream));
@@ -1518,7 +1567,9 @@ Status PagedDecodeAttention(
       data.decode_partial_out, data.decode_partial_max, data.decode_partial_sum,
       parameters.batch_size, parameters.num_heads, parameters.kv_num_heads, parameters.head_size,
       parameters.block_size, parameters.max_num_blocks_per_seq, parameters.token_count, data.num_splits,
-      scale, parameters.softcap, parameters.local_window_size, parameters.use_smooth_softmax, stream)));
+      scale, parameters.softcap, parameters.local_window_size, parameters.use_smooth_softmax, stream,
+      PagedScaleCache{data.key_scale_cache, data.scale_cache_is_fp16},
+      PagedScaleCache{data.value_scale_cache, data.scale_cache_is_fp16})));
 
   DUMP_TENSOR_INIT();
   DUMP_TENSOR("paged decode attention output", data.output, parameters.token_count, parameters.num_heads,
@@ -1705,8 +1756,12 @@ Status PagedXqaDecodeAttention(
                     : (kIsInt8Cache ? XqaQuantType::kInt8 : XqaQuantType::kNone);
   // A PER_CHANNEL scale has already been folded into Q / will be applied to the output, so XQA
   // receives a null scalar scale (which means one).
-  const float* xqa_k_scale = k_per_channel ? nullptr : data.k_scale;
-  const float* xqa_v_scale = v_per_channel ? nullptr : data.v_scale;
+  const float* xqa_k_scale = k_per_channel  ? nullptr
+                             : kIsInt4Cache ? reinterpret_cast<const float*>(data.key_scale_cache)
+                                            : data.k_scale;
+  const float* xqa_v_scale = v_per_channel  ? nullptr
+                             : kIsInt4Cache ? reinterpret_cast<const float*>(data.value_scale_cache)
+                                            : data.v_scale;
   if (data.use_xqa_spec_dec) {
     ORT_RETURN_IF_NOT(data.xqa_spec_dec_mask, "Speculative XQA mask scratch was not allocated.");
     const int words_per_row = (data.max_query_len + 31) / 32;
@@ -1807,7 +1862,9 @@ Status FlashAttention(
         data.key_cache, data.value_cache, data.gathered_key, data.gathered_value,
         data.k_scale, data.v_scale, k_per_channel, v_per_channel,
         block_table, cumulative_seqlens_kv, batch_size, /*num_heads*/ kv_num_heads, kv_num_heads,
-        head_size, block_size, max_num_blocks_per_seq, data.total_kv_tokens, stream, max_threads_per_block)));
+        head_size, block_size, max_num_blocks_per_seq, data.total_kv_tokens, stream, max_threads_per_block,
+        PagedScaleCache{data.key_scale_cache, data.scale_cache_is_fp16},
+        PagedScaleCache{data.value_scale_cache, data.scale_cache_is_fp16})));
 
     ORT_RETURN_IF_ERROR(onnxruntime::flash::mha_varlen_fwd(
         device_prop, stream, q, reinterpret_cast<void*>(data.gathered_key),
@@ -1886,7 +1943,9 @@ Status EfficientAttention(
       data.key_cache, data.value_cache, data.gathered_key, data.gathered_value,
       data.k_scale, data.v_scale, k_per_channel, v_per_channel,
       block_table, cumulative_seqlens_kv, batch_size, num_heads, kv_num_heads,
-      head_size, block_size, max_num_blocks_per_seq, total_kv_tokens, stream, max_threads_per_block)));
+      head_size, block_size, max_num_blocks_per_seq, total_kv_tokens, stream, max_threads_per_block,
+      PagedScaleCache{data.key_scale_cache, data.scale_cache_is_fp16},
+      PagedScaleCache{data.value_scale_cache, data.scale_cache_is_fp16})));
 
   MemoryEfficientAttentionParams p;
   p.sm = device_prop.major * 10 + device_prop.minor;
@@ -1945,23 +2004,34 @@ Status QkvToContext(
     return LatentAttention(device_prop, stream, parameters, data, scale);
   }
 
+  const auto finish_output = [&](Status status) -> Status {
+    ORT_RETURN_IF_ERROR(status);
+    if (parameters.v_hadamard) {
+      PagedHadamardHeads<<<dim3(parameters.token_count, parameters.num_heads), parameters.v_head_size,
+                          parameters.v_head_size * sizeof(float), stream>>>(
+          data.output, data.output, parameters.v_head_size, parameters.v_hidden_size, parameters.num_heads);
+      return CUDA_CALL(cudaGetLastError());
+    }
+    return Status::OK();
+  };
+
   if (data.use_xqa_decode) {
-    return PagedXqaDecodeAttention(device_prop, stream, parameters, data, scale);
+    return finish_output(PagedXqaDecodeAttention(device_prop, stream, parameters, data, scale));
   }
 
   if (data.use_paged_decode) {
-    return PagedDecodeAttention(device_prop, stream, parameters, data, scale);
+    return finish_output(PagedDecodeAttention(device_prop, stream, parameters, data, scale));
   }
 
 #if USE_FLASH_ATTENTION
   if (data.use_flash_attention) {
-    return FlashAttention(device_prop, stream, parameters, data, scale);
+    return finish_output(FlashAttention(device_prop, stream, parameters, data, scale));
   }
 #endif
 
 #if USE_MEMORY_EFFICIENT_ATTENTION
   if (data.use_memory_efficient_attention) {
-    return EfficientAttention(device_prop, stream, parameters, data, scale);
+    return finish_output(EfficientAttention(device_prop, stream, parameters, data, scale));
   }
 #endif
 

--- a/onnxruntime/contrib_ops/cuda/bert/paged_attention_impl.cu
+++ b/onnxruntime/contrib_ops/cuda/bert/paged_attention_impl.cu
@@ -13,6 +13,7 @@
 #include "contrib_ops/cuda/bert/flash_attention/flash_api.h"
 #include "contrib_ops/cuda/bert/cutlass_fmha/memory_efficient_attention.h"
 #include "contrib_ops/cuda/bert/paged_attention_impl.h"
+#include "contrib_ops/cuda/bert/group_query_attention_qdq.cuh"
 #include "contrib_ops/cuda/bert/xqa/xqa_paged_loader.h"
 #include "core/providers/cuda/shared_inc/cuda_call.h"
 #include "contrib_ops/cuda/bert/rotary_embedding_impl.h"
@@ -42,13 +43,16 @@ template <typename TCACHE>
 struct IsQuantizedCache : std::false_type {};
 template <>
 struct IsQuantizedCache<int8_t> : std::true_type {};
+#ifdef USE_INT4_KV_CACHE
+template <>
+struct IsQuantizedCache<uint8_t> : std::true_type {};
+#endif
 #if defined(USE_FP8_KV_CACHE) && !defined(DISABLE_FLOAT8_TYPES)
 template <>
 struct IsQuantizedCache<Float8E4M3FN> : std::true_type {};
 #endif
 
-// PER_CHANNEL scales are indexed by (kv_head * head_size + channel); PER_TENSOR uses scale[0].
-// `channel_index` is that flattened kv-hidden offset.
+// PER_CHANNEL uses the flattened kv-hidden channel_index; PER_TENSOR uses scale[0].
 __device__ __forceinline__ float GetCacheScale(const float* __restrict__ scale, const int channel_index,
                                                const bool per_channel) {
   if (scale == nullptr) {
@@ -84,6 +88,16 @@ __device__ __forceinline__ T DequantizeFromCache(const TCACHE value, const float
 #endif
   } else {
     return static_cast<T>(value);
+  }
+}
+
+template <typename TCACHE>
+__device__ __forceinline__ float ReadPagedCache(const TCACHE* cache, int64_t logical_index) {
+  if constexpr (std::is_same_v<TCACHE, uint8_t>) {
+    const uint8_t packed = cache[logical_index / 2];
+    return static_cast<float>(((packed >> ((logical_index & 1) * 4)) & 15) + kInt4Min);
+  } else {
+    return DequantizeFromCache<float, TCACHE>(cache[logical_index], 1.0f);
   }
 }
 
@@ -481,6 +495,57 @@ Status LaunchReshapeAndCacheImpl(const T* key, const T* value, TCACHE* key_cache
   return CUDA_CALL(cudaGetLastError());
 }
 
+template <typename T, typename TCACHE, typename SlotResolver>
+__global__ void ReshapeAndCacheHeads(const T* input, TCACHE* cache, const float* static_scale,
+                                    bool per_channel, SlotResolver resolver, int head_size, int kv_num_heads,
+                                    int input_stride, int64_t num_slots) {
+  const int token = blockIdx.x;
+  const int head = blockIdx.y;
+  const int channel = threadIdx.x;
+  const int slot = resolver(token);
+  if (slot < 0 || slot >= num_slots) return;
+  // Staging buffer for the INT4 nibble pack below.
+  extern __shared__ float shared_values[];
+  float value = channel < head_size
+                    ? static_cast<float>(input[static_cast<int64_t>(token) * input_stride + head * head_size + channel])
+                    : 0.0f;
+  const int64_t scale_index = static_cast<int64_t>(slot) * kv_num_heads + head;
+  const float scale = channel < head_size ? GetCacheScale(static_scale, head * head_size + channel, per_channel) : 1.0f;
+  if constexpr (std::is_same_v<TCACHE, uint8_t>) {
+    const float scaled = scale == 0.0f ? 0.0f : value / scale;
+    const float clamped = fminf(static_cast<float>(kInt4Max), fmaxf(static_cast<float>(kInt4Min), scaled));
+    shared_values[channel] = static_cast<float>(__float2int_rn(clamped) - kInt4Min);
+    __syncthreads();
+    if (channel < (head_size + 1) / 2) {
+      const int low = static_cast<int>(shared_values[2 * channel]);
+      const int high = 2 * channel + 1 < head_size ? static_cast<int>(shared_values[2 * channel + 1]) : -kInt4Min;
+      cache[scale_index * ((head_size + 1) / 2) + channel] = static_cast<uint8_t>(low | (high << 4));
+    }
+  } else if (channel < head_size) {
+    cache[scale_index * head_size + channel] = QuantizeToCache<float, TCACHE>(value, scale);
+  }
+}
+
+template <typename T, typename TCACHE, typename SlotResolver>
+Status LaunchCacheHeads(const T* key, const T* value, PagedAttentionData<T, TCACHE>& data,
+                        const PagedAttentionParameters& parameters, SlotResolver resolver,
+                        int key_stride, int value_stride, cudaStream_t stream) {
+  int threads = 1;
+  while (threads < parameters.head_size) threads <<= 1;
+  const dim3 grid(parameters.token_count, parameters.kv_num_heads);
+  const int64_t num_slots = static_cast<int64_t>(parameters.num_blocks) * parameters.block_size;
+  ReshapeAndCacheHeads<<<grid, threads, threads * sizeof(float), stream>>>(
+      key, data.key_cache, data.k_scale, parameters.k_quant_type == KVQuantizationType::PER_CHANNEL, resolver,
+      parameters.head_size, parameters.kv_num_heads, key_stride, num_slots);
+  CUDA_RETURN_IF_ERROR(cudaGetLastError());
+  if (data.value_cache != nullptr) {
+    ReshapeAndCacheHeads<<<grid, threads, threads * sizeof(float), stream>>>(
+        value, data.value_cache, data.v_scale, parameters.v_quant_type == KVQuantizationType::PER_CHANNEL, resolver,
+        parameters.head_size, parameters.kv_num_heads, value_stride, num_slots);
+  }
+  return CUDA_CALL(cudaGetLastError());
+}
+
 template <typename T, typename TCACHE>
 Status LaunchReshapeAndCache(const T* key, const T* value, TCACHE* key_cache, TCACHE* value_cache,
                              const float* k_scale, const float* v_scale, const bool k_per_channel,
@@ -630,10 +695,10 @@ __global__ void GatherAndExpandPagedKVCache(const TCACHE* __restrict__ key_cache
                               kv_head_id * head_size +
                               h;
 
-    gathered_key[tid] =
-        DequantizeFromCache<T, TCACHE>(key_cache[paged_idx], GetCacheScale(k_scale, channel_index, k_per_channel));
-    gathered_value[tid] =
-        DequantizeFromCache<T, TCACHE>(value_cache[paged_idx], GetCacheScale(v_scale, channel_index, v_per_channel));
+    gathered_key[tid] = static_cast<T>(ReadPagedCache(key_cache, paged_idx) *
+                                       GetCacheScale(k_scale, channel_index, k_per_channel));
+    gathered_value[tid] = static_cast<T>(ReadPagedCache(value_cache, paged_idx) *
+                                         GetCacheScale(v_scale, channel_index, v_per_channel));
   }
 }
 
@@ -840,11 +905,11 @@ __global__ void PagedDecodeSplitKV(const T* __restrict__ query,
                                : -1;
       float dot = 0.0f;
       if (block_id >= 0) {
-        const TCACHE* k_ptr = key_cache +
-                              (static_cast<int64_t>(block_id) * block_size + (pos % block_size)) * token_stride_in_page +
-                              head_offset_in_page;
+        const int64_t key_offset =
+            (static_cast<int64_t>(block_id) * block_size + (pos % block_size)) * token_stride_in_page +
+            head_offset_in_page;
         for (int c = lane_id; c < head_size; c += 32) {
-          dot += q_sh[c] * CacheToFloat<TCACHE>(k_ptr[c]);
+          dot += q_sh[c] * ReadPagedCache(key_cache, key_offset + c);
         }
       }
 #pragma unroll
@@ -914,10 +979,10 @@ __global__ void PagedDecodeSplitKV(const T* __restrict__ query,
             continue;
           }
           const int pos = tile_begin + t;
-          const TCACHE* v_ptr = value_cache +
-                                (static_cast<int64_t>(block_id) * block_size + (pos % block_size)) * token_stride_in_page +
-                                head_offset_in_page;
-          acc += logits_sh[t] * CacheToFloat<TCACHE>(v_ptr[c]);
+          const int64_t value_offset =
+              (static_cast<int64_t>(block_id) * block_size + pos % block_size) * token_stride_in_page +
+              head_offset_in_page;
+          acc += logits_sh[t] * ReadPagedCache(value_cache, value_offset + c);
         }
         acc_sh[c] = acc;
       }
@@ -931,10 +996,10 @@ __global__ void PagedDecodeSplitKV(const T* __restrict__ query,
           continue;
         }
         const int pos = tile_begin + t;
-        const TCACHE* v_ptr = value_cache +
-                              (static_cast<int64_t>(block_id) * block_size + (pos % block_size)) * token_stride_in_page +
-                              head_offset_in_page;
-        acc += logits_sh[t] * CacheToFloat<TCACHE>(v_ptr[c]);
+        const int64_t value_offset =
+            (static_cast<int64_t>(block_id) * block_size + pos % block_size) * token_stride_in_page +
+            head_offset_in_page;
+        acc += logits_sh[t] * ReadPagedCache(value_cache, value_offset + c);
       }
       acc_sh[tid] = acc;
     }
@@ -1381,11 +1446,22 @@ Status PrepareQueryAndCache(cudaStream_t stream, contrib::PagedAttentionParamete
   const int value_stride = parameters.is_packed_qkv ? q_hidden_size + 2 * kv_hidden_size : kv_hidden_size;
   const bool k_per_channel = parameters.k_quant_type == KVQuantizationType::PER_CHANNEL;
   const bool v_per_channel = parameters.v_quant_type == KVQuantizationType::PER_CHANNEL;
-  ORT_RETURN_IF_ERROR((LaunchReshapeAndCache<T, TCACHE>(
+  if constexpr (std::is_same_v<TCACHE, uint8_t>) {
+    if (data.slot_mapping != nullptr) {
+      ORT_RETURN_IF_ERROR(LaunchCacheHeads(key, value, data, parameters, ExplicitSlotResolver{data.slot_mapping},
+                                           key_stride, value_stride, stream));
+    } else {
+      DerivedSlotResolver resolver{data.block_table, past_seqlens, cumulative_seqlens_q, batch_size,
+                                    parameters.max_num_blocks_per_seq, parameters.block_size};
+      ORT_RETURN_IF_ERROR(LaunchCacheHeads(key, value, data, parameters, resolver, key_stride, value_stride, stream));
+    }
+  } else {
+    ORT_RETURN_IF_ERROR((LaunchReshapeAndCache<T, TCACHE>(
       key, value, data.key_cache, data.value_cache, data.k_scale, data.v_scale, k_per_channel, v_per_channel,
       const_cast<int*>(data.block_table), past_seqlens, cumulative_seqlens_q, data.slot_mapping, batch_size,
       parameters.max_num_blocks_per_seq, token_count, kv_hidden_size, parameters.block_size,
       parameters.num_blocks, key_stride, value_stride, stream, max_threads_per_block)));
+  }
 
   *query_out = query;
   return Status::OK();
@@ -1622,8 +1698,11 @@ Status PagedXqaDecodeAttention(
       false;
 #endif
   constexpr bool kIsInt8Cache = std::is_same<TCACHE, int8_t>::value;
+  constexpr bool kIsInt4Cache = std::is_same_v<TCACHE, uint8_t>;
   const XqaQuantType kv_quant_type =
-      kIsFp8Cache ? XqaQuantType::kFp8 : (kIsInt8Cache ? XqaQuantType::kInt8 : XqaQuantType::kNone);
+      kIsInt4Cache  ? XqaQuantType::kInt4
+      : kIsFp8Cache ? XqaQuantType::kFp8
+                    : (kIsInt8Cache ? XqaQuantType::kInt8 : XqaQuantType::kNone);
   // A PER_CHANNEL scale has already been folded into Q / will be applied to the output, so XQA
   // receives a null scalar scale (which means one).
   const float* xqa_k_scale = k_per_channel ? nullptr : data.k_scale;
@@ -1902,6 +1981,10 @@ INSTANTIATE_PAGED_ATTENTION(half, half)
 INSTANTIATE_PAGED_ATTENTION(BFloat16, BFloat16)
 INSTANTIATE_PAGED_ATTENTION(half, int8_t)
 INSTANTIATE_PAGED_ATTENTION(BFloat16, int8_t)
+#ifdef USE_INT4_KV_CACHE
+INSTANTIATE_PAGED_ATTENTION(half, uint8_t)
+INSTANTIATE_PAGED_ATTENTION(BFloat16, uint8_t)
+#endif
 #if defined(USE_FP8_KV_CACHE) && !defined(DISABLE_FLOAT8_TYPES)
 INSTANTIATE_PAGED_ATTENTION(half, Float8E4M3FN)
 INSTANTIATE_PAGED_ATTENTION(BFloat16, Float8E4M3FN)

--- a/onnxruntime/contrib_ops/cuda/bert/xqa/int4_cache.cuh
+++ b/onnxruntime/contrib_ops/cuda/bert/xqa/int4_cache.cuh
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <cstdint>
+#include <cuda_fp16.h>
+#include <cuda_runtime.h>
+
+template <typename Element>
+__device__ inline uint4 DequantizeInt4CacheGrain(uint32_t packed, float scale) {
+  union {
+    Element elements[8];
+    uint4 storage;
+  } result;
+#pragma unroll
+  for (uint32_t channel = 0; channel < 8; ++channel) {
+    const int code = static_cast<int>((packed >> (channel * 4)) & 15) - 8;
+    result.elements[channel] = static_cast<Element>(static_cast<float>(code) * scale);
+  }
+  return result.storage;
+}

--- a/onnxruntime/contrib_ops/cuda/bert/xqa/mha.h
+++ b/onnxruntime/contrib_ops/cuda/bert/xqa/mha.h
@@ -68,7 +68,11 @@ constexpr uint32_t tokensPerPage = TOKENS_PER_PAGE;
 
 using IOHead = Vec<InputElem, validElemsPerHead>;
 using InputHead = IOHead;
+#if defined(XQA_PAGED_INT4)
+using GMemCacheHead = Vec<uint8_t, validElemsPerHead / 2>;
+#else
 using GMemCacheHead = Vec<CacheElem, validElemsPerHead>;
+#endif
 
 constexpr uint32_t validElemsPerKHead = validElemsPerHead;
 constexpr bool lowPrecOutput = LOW_PREC_OUTPUT;

--- a/onnxruntime/contrib_ops/cuda/bert/xqa/mhaUtils.cuh
+++ b/onnxruntime/contrib_ops/cuda/bert/xqa/mhaUtils.cuh
@@ -19,6 +19,9 @@
 #include "ldgsts.cuh"
 #include "mha.h"
 #include "utils.cuh"
+#if defined(XQA_PAGED_INT4)
+#include "int4_cache.cuh"
+#endif
 
 // for beam search
 template <typename Head, uint32_t tokensPerPage, uint32_t nbPages>
@@ -128,6 +131,11 @@ __device__ inline void copyPartialHeadsAsync(
   const uint32_t segIdx = warpLane / thrdsPerSeg;
   const uint32_t segLane = warpLane % thrdsPerSeg;
   constexpr uint32_t partsPerWarpInst = exactDiv(grainBytes * warp_size, partBytes);
+#if defined(XQA_PAGED_INT4)
+  if constexpr (mha::is_same_v<mha::decay_t<decltype(src[0])>, GMemCacheHead>) {
+    __syncwarp();
+  }
+#endif
 #pragma unroll
   for (uint32_t i = 0; i < thrdLdBytes / grainBytes; i++) {
     const uint32_t idxHeadLocal = partsPerWarpInst * i + segIdx;
@@ -140,11 +148,27 @@ __device__ inline void copyPartialHeadsAsync(
     const bool isGrainInBound = (!isHeadPadded || idxGrainInsideHead < nbValidGrains);
     const SrcHead* const pSrcHead = src + localHeadIdxMap(idxHeadLocal);
     const bool isValidPage = (pSrcHead != nullptr);
-    const LdGrain* const pSrc = reinterpret_cast<const LdGrain*>(pSrcHead) + idxGrainInsideHead;
     LdGrain* const pDst = &dst.template at<swizzle>(dstHeadOffset + idxHeadLocal, segLane);
     assert(!hasBankConflict(pDst));
-    ldgsts::copyAsync<grainBytes>(pDst, pSrc, isValidPage && isHeadInBound && isGrainInBound ? grainBytes : 0u);
+#if defined(XQA_PAGED_INT4)
+    if constexpr (mha::is_same_v<SrcHead, GMemCacheHead>) {
+      static_assert(!isHeadPadded && sizeof(CacheElem) == 2);
+      const bool valid = isValidPage && isHeadInBound;
+      const uint32_t packed = valid ? reinterpret_cast<const uint32_t*>(pSrcHead)[idxGrainInsideHead] : 0x88888888U;
+      // The PER_CHANNEL scale is folded into Q and into the output, so a grain holds its raw codes.
+      *reinterpret_cast<uint4*>(pDst) = DequantizeInt4CacheGrain<CacheElem>(packed, 1.f);
+    } else
+#endif
+    {
+      const LdGrain* const pSrc = reinterpret_cast<const LdGrain*>(pSrcHead) + idxGrainInsideHead;
+      ldgsts::copyAsync<grainBytes>(pDst, pSrc, isValidPage && isHeadInBound && isGrainInBound ? grainBytes : 0u);
+    }
   }
+#if defined(XQA_PAGED_INT4)
+  if constexpr (mha::is_same_v<mha::decay_t<decltype(src[0])>, GMemCacheHead>) {
+    __syncwarp();
+  }
+#endif
 }
 
 template <typename Head, uint32_t maxNbCopiedHeads, uint32_t nbWarps, bool swizzle, bool isFull, uint32_t dstNbHeads,

--- a/onnxruntime/contrib_ops/cuda/bert/xqa/mhaUtils.cuh
+++ b/onnxruntime/contrib_ops/cuda/bert/xqa/mhaUtils.cuh
@@ -73,6 +73,9 @@ struct HeadPtr {
   Vec<KVCachePageIndex, nbPages> pageIndices;
   uint32_t nbKHeads;
   uint32_t offset;  // offset inside the first page.
+#if defined(XQA_PAGED_INT4)
+  const half* tokenScales;
+#endif
 
   __device__ inline Head& operator[](uint32_t i) const {
     return *(*this + i);
@@ -155,8 +158,11 @@ __device__ inline void copyPartialHeadsAsync(
       static_assert(!isHeadPadded && sizeof(CacheElem) == 2);
       const bool valid = isValidPage && isHeadInBound;
       const uint32_t packed = valid ? reinterpret_cast<const uint32_t*>(pSrcHead)[idxGrainInsideHead] : 0x88888888U;
-      // The PER_CHANNEL scale is folded into Q and into the output, so a grain holds its raw codes.
-      *reinterpret_cast<uint4*>(pDst) = DequantizeInt4CacheGrain<CacheElem>(packed, 1.f);
+      // A null tokenScales is a PER_CHANNEL scale the caller folded into Q / the output, so the
+      // grain dequantizes to its raw codes and the kernel runs at unit scale.
+      const float tokenScale =
+          (valid && src.tokenScales != nullptr) ? static_cast<float>(src.tokenScales[pSrcHead - src.pool]) : 1.f;
+      *reinterpret_cast<uint4*>(pDst) = DequantizeInt4CacheGrain<CacheElem>(packed, tokenScale);
     } else
 #endif
     {

--- a/onnxruntime/contrib_ops/cuda/bert/xqa/mha_impl.cuh
+++ b/onnxruntime/contrib_ops/cuda/bert/xqa/mha_impl.cuh
@@ -1553,7 +1553,11 @@ CUBIN_EXPORT __global__
 #if BEAM_WIDTH == 1
 #if PAGED_KV_CACHE_LAYOUT == 1
       const HeadPtr<GMemCacheHead const, tokensPerPage, nbPagesPerWarpTile> src{
-          cacheList.kCacheVLLM, pageIdx, nbKHeads, idxHeadBeg};
+          cacheList.kCacheVLLM, pageIdx, nbKHeads, idxHeadBeg
+    #if defined(XQA_PAGED_INT4)
+          , reinterpret_cast<const half*>(kCacheScale)
+    #endif
+        };
 #else
       const HeadPtr<GMemCacheHead const, tokensPerPage, nbPagesPerWarpTile> src{
           cacheList.pool, pageIdx, nbKHeads, idxHeadBeg};
@@ -1868,7 +1872,11 @@ CUBIN_EXPORT __global__
 #if BEAM_WIDTH == 1
 #if PAGED_KV_CACHE_LAYOUT == 1
       const HeadPtr<GMemCacheHead const, tokensPerPage, nbPagesPerVTile> src{
-          cacheList.vCacheVLLM, pageIdx, nbKHeads, idxHeadBeg};
+          cacheList.vCacheVLLM, pageIdx, nbKHeads, idxHeadBeg
+    #if defined(XQA_PAGED_INT4)
+          , reinterpret_cast<const half*>(vCacheScale)
+    #endif
+        };
 #else
       const HeadPtr<GMemCacheHead const, tokensPerPage, nbPagesPerVTile> src{
           cacheList.pool, pageIdx, nbKHeads, idxHeadBeg};

--- a/onnxruntime/contrib_ops/cuda/bert/xqa/mha_impl.cuh
+++ b/onnxruntime/contrib_ops/cuda/bert/xqa/mha_impl.cuh
@@ -1787,6 +1787,10 @@ CUBIN_EXPORT __global__
       smem.warpRowSum[warpIdx.y][warpIdx.x].storeFromReg<false>(warp, regRowSum);
       unused(xBar.produced.arrive());
     }
+#if defined(XQA_PAGED_INT4)
+    ldgsts::waitGroup<0>();
+    __syncthreads();
+#endif
   } else {
     assert(warpIdx.z == 1);
 #if CTA_ROW_MAX_BACKWARD_METHOD == 3
@@ -2211,6 +2215,10 @@ CUBIN_EXPORT __global__
     }
     const GemmOutRegTile outTile = toFp16(acc);
 
+  #if defined(XQA_PAGED_INT4)
+    ldgsts::waitGroup<0>();
+    __syncwarp();
+  #endif
     auto mergeAndSaveOutTile = [&](const GemmOutRegTile& tile, bool reorder) {
       if constexpr (gemm1NbWarpGrps == 1) {
         // swizzle in shared memory and write output global memory
@@ -2301,6 +2309,9 @@ CUBIN_EXPORT __global__
 
       // merge if we are the last CTA.
       const bool isLastCta = mbsmem.isLastCta;
+    #if defined(XQA_PAGED_INT4)
+      __syncthreads();
+    #endif
       if (isLastCta) {
         MultiBlockSMem::MBBuf& mbbuf = mbsmem.storage[warpIdx.y];
         SMemWarpRowMax& smemRowMax = reinterpret_cast<SMemWarpRowMax&>(smem);
@@ -2315,6 +2326,9 @@ CUBIN_EXPORT __global__
         // rescale and accumulate
         auto getTileBuf = [&](auto& buffers, uint32_t d) -> decltype(buffers[0][0][0])& { return buffers[warpGrpIdx][warpIdxInGrp][d]; };
         auto loadBufAsync = [&](uint32_t n) {
+#if defined(XQA_PAGED_INT4)
+          __syncwarp();
+#endif
           const uint32_t d = n / gemm1NbWarpGrps % nbTileBuffers;
           SharedMem::XSmemBuffer& dstTile = getTileBuf(mbbuf.tiles, d);
           SMemWarpRowMax& dstRowSum = getTileBuf(mbbuf.tileRowSums, d);
@@ -2339,6 +2353,9 @@ CUBIN_EXPORT __global__
           }
           ldgsts::commitGroup();
           ldgsts::waitGroup<1>();
+#if defined(XQA_PAGED_INT4)
+          __syncwarp();
+#endif
           const uint32_t d = n / gemm1NbWarpGrps % nbTileBuffers;
           WarpAcc tile = toWarpAcc(loadGemmOutTile(warp, mbbuf.tiles[warpGrpIdx][warpIdxInGrp][d]));
           const ThrdRegRowMax tileRowMax = getTileBuf(mbbuf.tileRowMax, d).loadToReg<false>(warp);

--- a/onnxruntime/contrib_ops/cuda/bert/xqa/xqa_loader.h
+++ b/onnxruntime/contrib_ops/cuda/bert/xqa/xqa_loader.h
@@ -15,7 +15,8 @@ namespace cuda {
 enum class XqaQuantType {
   kNone = 0,  // no quantization, use FP16/BF16
   kInt8 = 1,
-  kFp8 = 2
+  kFp8 = 2,
+  kInt4 = 3
 };
 
 // Wrapper for XQA MHA launch

--- a/onnxruntime/contrib_ops/cuda/bert/xqa/xqa_paged_fp16_int4_256.cu
+++ b/onnxruntime/contrib_ops/cuda/bert/xqa/xqa_paged_fp16_int4_256.cu
@@ -1,0 +1,13 @@
+#if defined(USE_INT4_KV_CACHE)
+#define HEAD_ELEMS 256
+#define HEAD_DIM_NAMESPACE H256
+#define XQA_PAGED_CACHE_ELEM 0
+#define XQA_PAGED_INT4 1
+#define XQA_PAGED_GROUP6_ONLY 1
+#define XQA_PAGED_INPUT_FP16 1
+#define XQA_PAGED_QUERY_T half
+#define XQA_PAGED_FAMILY fp16_int4
+#define XQA_PAGED_LAUNCH_FN LaunchXQAPagedInt4Kernel
+
+#include "xqa_paged_loader_impl.cuh"
+#endif

--- a/onnxruntime/contrib_ops/cuda/bert/xqa/xqa_paged_loader.cu
+++ b/onnxruntime/contrib_ops/cuda/bert/xqa/xqa_paged_loader.cu
@@ -64,6 +64,9 @@ XQA_PAGED_DECL(LaunchXQAPagedFp8KernelBF16);
 
 namespace H256 {
 XQA_PAGED_DECL(LaunchXQAPagedFp16Kernel);
+#ifdef USE_INT4_KV_CACHE
+XQA_PAGED_DECL(LaunchXQAPagedInt4Kernel);
+#endif
 XQA_PAGED_DECL(LaunchXQAPagedInt8Kernel);
 XQA_PAGED_DECL(LaunchXQAPagedInt8KernelBF16);
 #ifdef USE_FP8_KV_CACHE
@@ -103,6 +106,9 @@ XQA_PAGED_DECL(LaunchXQAPagedFp8KernelBF16);
 XQA_PAGED_SPEC_DEC_DECL(LaunchXQAPagedSpecDecFp16Kernel);
 XQA_PAGED_SPEC_DEC_DECL(LaunchXQAPagedSpecDecBf16Kernel);
 XQA_PAGED_SPEC_DEC_DECL(LaunchXQAPagedSpecDecInt8Kernel);
+#ifdef USE_INT4_KV_CACHE
+XQA_PAGED_SPEC_DEC_DECL(LaunchXQAPagedSpecDecInt4Kernel);
+#endif
 #ifdef USE_FP8_KV_CACHE
 XQA_PAGED_SPEC_DEC_DECL(LaunchXQAPagedSpecDecFp8Kernel);
 #endif
@@ -136,6 +142,14 @@ Status LaunchXQAPagedKernel(
     return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL, "XQA is only supported on Ampere (SM80) or newer GPUs.");
   }
 
+#ifdef USE_INT4_KV_CACHE
+  if (kv_quant_type == XqaQuantType::kInt4) {
+    // Null scales are the PER_CHANNEL case: the caller folded them into Q and the output.
+    ORT_RETURN_IF_NOT(head_size == 256 && !is_bf16 && kv_num_heads > 0 && num_heads == 6 * kv_num_heads,
+                      "INT4 paged XQA requires FP16 queries, head_size 256, and group size 6.");
+    return H256::LaunchXQAPagedInt4Kernel(XQA_PAGED_ARGS);
+  }
+#endif
   if (kv_quant_type == XqaQuantType::kNone) {
     if (head_size == 256 && !is_bf16) {
       return H256::LaunchXQAPagedFp16Kernel(XQA_PAGED_ARGS);
@@ -226,6 +240,11 @@ Status LaunchXQAPagedSpecDecKernel(
   if (kv_quant_type == XqaQuantType::kInt8) {
     return H256::LaunchXQAPagedSpecDecInt8Kernel(XQA_PAGED_SPEC_DEC_ARGS);
   }
+#ifdef USE_INT4_KV_CACHE
+  if (kv_quant_type == XqaQuantType::kInt4) {
+    return H256::LaunchXQAPagedSpecDecInt4Kernel(XQA_PAGED_SPEC_DEC_ARGS);
+  }
+#endif
 #ifdef USE_FP8_KV_CACHE
   if (kv_quant_type == XqaQuantType::kFp8) {
     return H256::LaunchXQAPagedSpecDecFp8Kernel(XQA_PAGED_SPEC_DEC_ARGS);
@@ -243,6 +262,12 @@ size_t GetXQAPagedSpecDecWorkspaceSize(
     int max_pages_per_seq,
     int max_query_len,
     XqaQuantType kv_quant_type) {
+#ifdef USE_INT4_KV_CACHE
+  if (kv_quant_type == XqaQuantType::kInt4) {
+    return H256::LaunchXQAPagedSpecDecInt4Kernel_WorkspaceSize(
+        device_prop, batch_size, kv_num_heads, max_pages_per_seq, max_query_len);
+  }
+#endif
   if (kv_quant_type == XqaQuantType::kNone) {
     return H256::LaunchXQAPagedSpecDecFp16Kernel_WorkspaceSize(
         device_prop, batch_size, kv_num_heads, max_pages_per_seq, max_query_len);
@@ -261,6 +286,11 @@ size_t GetXQAPagedSpecDecWorkspaceSize(
 }
 
 size_t GetXQAPagedSpecDecRequiredSharedMemoryBytes(XqaQuantType kv_quant_type) {
+#ifdef USE_INT4_KV_CACHE
+  if (kv_quant_type == XqaQuantType::kInt4) {
+    return H256::LaunchXQAPagedSpecDecInt4Kernel_SmemSize(6, 1);
+  }
+#endif
   if (kv_quant_type == XqaQuantType::kNone) {
     return H256::LaunchXQAPagedSpecDecFp16Kernel_SmemSize(6, 1);
   }
@@ -285,6 +315,13 @@ size_t GetXQAPagedRequiredSharedMemoryBytes(
   if (device_prop.major < 8 || kv_num_heads <= 0) {
     return 0;
   }
+#ifdef USE_INT4_KV_CACHE
+  if (kv_quant_type == XqaQuantType::kInt4) {
+    return head_size == 256 && !is_bf16 && num_heads == 6 * kv_num_heads
+               ? H256::LaunchXQAPagedInt4Kernel_SmemSize(num_heads, kv_num_heads)
+               : 0;
+  }
+#endif
   // FP16 and BF16 kernels have identical shared-memory footprints (both 2-byte elements), so the
   // FP16 instantiation is queried for both.
   if (kv_quant_type == XqaQuantType::kNone) {

--- a/onnxruntime/contrib_ops/cuda/bert/xqa/xqa_paged_loader.h
+++ b/onnxruntime/contrib_ops/cuda/bert/xqa/xqa_paged_loader.h
@@ -25,6 +25,9 @@ constexpr int kXqaTokensPerPage = 128;
 
 // Paged-KV XQA decode launcher. Unlike LaunchXQAKernel (contiguous per-request cache) this reads
 // K and V from a shared block pool addressed through a page table.
+// kInt4 uses packed UINT8 heads and FP16 per-token/head scales, passed through the scale pointers.
+// It supports FP16 query/output, head_size 256, and group_size 6 only. Other quantized types use
+// FP32 per-tensor scales. The INT4 shared-memory and scratch layouts match native FP16 XQA.
 //
 // Preconditions: one query token per sequence, head_size in {64, 128, 256}, group_size in
 // {4, 6, 8, 16, 32}, supported FP16/INT8/FP8 cache, block_size % kXqaTokensPerPage == 0.
@@ -55,7 +58,7 @@ Status LaunchXQAPagedKernel(
 
 // Multi-token speculative-verification launcher. The implementation is deliberately limited to
 // the DFlash2 target geometry: FP16/BF16 query/output, H256, group size 6, and matching native or
-// INT8/FP8 paged KV.
+// INT8/FP8 paged KV, or packed INT4 with the FP16 token-scale contract above.
 Status LaunchXQAPagedSpecDecKernel(
     const cudaDeviceProp& device_prop,
     cudaStream_t stream,

--- a/onnxruntime/contrib_ops/cuda/bert/xqa/xqa_paged_spec_dec_fp16_int4_256.cu
+++ b/onnxruntime/contrib_ops/cuda/bert/xqa/xqa_paged_spec_dec_fp16_int4_256.cu
@@ -1,0 +1,18 @@
+#if defined(USE_INT4_KV_CACHE)
+#define HEAD_ELEMS 256
+#define HEAD_DIM_NAMESPACE H256
+#define XQA_PAGED_CACHE_ELEM 0
+#define XQA_PAGED_INT4 1
+#define XQA_PAGED_INPUT_FP16 1
+#define XQA_PAGED_QUERY_T half
+#define XQA_PAGED_FAMILY fp16_int4_spec_dec
+#define XQA_PAGED_LAUNCH_FN LaunchXQAPagedSpecDecInt4Kernel
+#define XQA_PAGED_GROUP6_ONLY 1
+#define XQA_PAGED_SPEC_DEC 1
+
+#ifdef _MSC_VER
+#pragma warning(disable : 4459)
+#endif
+
+#include "xqa_paged_loader_impl.cuh"
+#endif

--- a/onnxruntime/contrib_ops/cuda/cuda_contrib_kernels.cc
+++ b/onnxruntime/contrib_ops/cuda/cuda_contrib_kernels.cc
@@ -125,6 +125,10 @@ class CUDA_MS_OP_TYPED_CLASS_NAME(1, MLFloat16_MLFloat16, PagedAttention);
 class CUDA_MS_OP_TYPED_CLASS_NAME(1, BFloat16_BFloat16, PagedAttention);
 class CUDA_MS_OP_TYPED_CLASS_NAME(1, MLFloat16_int8_t, PagedAttention);
 class CUDA_MS_OP_TYPED_CLASS_NAME(1, BFloat16_int8_t, PagedAttention);
+#ifdef USE_INT4_KV_CACHE
+class CUDA_MS_OP_TYPED_CLASS_NAME(1, MLFloat16_uint8_t, PagedAttention);
+class CUDA_MS_OP_TYPED_CLASS_NAME(1, BFloat16_uint8_t, PagedAttention);
+#endif
 #if defined(USE_FP8_KV_CACHE) && !defined(DISABLE_FLOAT8_TYPES)
 class CUDA_MS_OP_TYPED_CLASS_NAME(1, MLFloat16_Float8E4M3FN, PagedAttention);
 class CUDA_MS_OP_TYPED_CLASS_NAME(1, BFloat16_Float8E4M3FN, PagedAttention);
@@ -421,6 +425,10 @@ Status RegisterCudaContribKernels(KernelRegistry& kernel_registry) {
       BuildKernelCreateInfo<CUDA_MS_OP_TYPED_CLASS_NAME(1, BFloat16_BFloat16, PagedAttention)>,
       BuildKernelCreateInfo<CUDA_MS_OP_TYPED_CLASS_NAME(1, MLFloat16_int8_t, PagedAttention)>,
       BuildKernelCreateInfo<CUDA_MS_OP_TYPED_CLASS_NAME(1, BFloat16_int8_t, PagedAttention)>,
+#ifdef USE_INT4_KV_CACHE
+      BuildKernelCreateInfo<CUDA_MS_OP_TYPED_CLASS_NAME(1, MLFloat16_uint8_t, PagedAttention)>,
+      BuildKernelCreateInfo<CUDA_MS_OP_TYPED_CLASS_NAME(1, BFloat16_uint8_t, PagedAttention)>,
+#endif
 #if defined(USE_FP8_KV_CACHE) && !defined(DISABLE_FLOAT8_TYPES)
       BuildKernelCreateInfo<CUDA_MS_OP_TYPED_CLASS_NAME(1, MLFloat16_Float8E4M3FN, PagedAttention)>,
       BuildKernelCreateInfo<CUDA_MS_OP_TYPED_CLASS_NAME(1, BFloat16_Float8E4M3FN, PagedAttention)>,

--- a/onnxruntime/contrib_ops/webgpu/bert/paged_attention.cc
+++ b/onnxruntime/contrib_ops/webgpu/bert/paged_attention.cc
@@ -496,8 +496,9 @@ Status PagedAttention::ComputeInternal(onnxruntime::webgpu::ComputeContext& cont
   const Tensor* attention_metadata = context.InputCount() > 16 ? context.Input<Tensor>(16) : nullptr;
 
   PagedAttentionParameters parameters{};
-  const KVQuantizationType k_quant_type = StringToKVQuantizationType(k_quant_type_);
-  const KVQuantizationType v_quant_type = StringToKVQuantizationType(v_quant_type_);
+  // PER_TOKEN is a valid PagedAttention attribute value; the quantized-cache guard below rejects it.
+  const KVQuantizationType k_quant_type = StringToKVQuantizationType(k_quant_type_, true);
+  const KVQuantizationType v_quant_type = StringToKVQuantizationType(v_quant_type_, true);
   const KVCacheDataType k_cache_dtype = StringToKVCacheDataType(k_cache_dtype_);
   const KVCacheDataType v_cache_dtype = StringToKVCacheDataType(v_cache_dtype_);
   const bool is_latent_kv = (kv_cache_layout_ == "LATENT");

--- a/onnxruntime/core/graph/contrib_ops/bert_defs.cc
+++ b/onnxruntime/core/graph/contrib_ops/bert_defs.cc
@@ -1521,7 +1521,7 @@ void PagedAttentionTypeAndShapeInference(ONNX_NAMESPACE::InferenceContext& ctx) 
       if (ctx.getNumOutputs() > 2) {
         fail_shape_inference("value_cache_out must be absent when kv_cache_layout is 'LATENT'.");
       }
-    } else if (ctx.getNumOutputs() != 3) {
+    } else if (ctx.getNumOutputs() < 3) {
       fail_shape_inference("Key cache and value cache output tensors must be both present or both absent.");
     } else if (!ctx.hasInput(4)) {
       // value_cache is schema-optional (it must be absent for LATENT), so a SEPARATE node could omit it
@@ -1545,6 +1545,16 @@ void PagedAttentionTypeAndShapeInference(ONNX_NAMESPACE::InferenceContext& ctx) 
     if (ctx.getNumOutputs() > 2) {
       ONNX_NAMESPACE::propagateElemTypeFromInputToOutput(ctx, 4, 2);
       ONNX_NAMESPACE::propagateShapeFromInputToOutput(ctx, 4, 2);
+    }
+  }
+  for (size_t output_index = 3; output_index < ctx.getNumOutputs(); ++output_index) {
+    const size_t input_index = output_index + 14;
+    if (!ctx.hasInput(input_index)) {
+      continue;
+    }
+    ONNX_NAMESPACE::propagateElemTypeFromInputToOutput(ctx, input_index, output_index);
+    if (hasInputShape(ctx, input_index)) {
+      ONNX_NAMESPACE::propagateShapeFromInputToOutput(ctx, input_index, output_index);
     }
   }
 }
@@ -1587,17 +1597,28 @@ ONNX_MS_OPERATOR_SET_SCHEMA(
               AttributeProto::FLOAT,
               OPTIONAL_VALUE)
         .Attr("k_quant_type",
-              "Quantization granularity of the key cache: 'NONE', 'PER_TENSOR' or 'PER_CHANNEL'. "
+              "Quantization granularity of the key cache: 'NONE', 'PER_TENSOR', 'PER_CHANNEL' or 'PER_TOKEN'. "
               "Must be non-'NONE' exactly when 'key_cache' has a quantized element type, and then "
-              "'k_scale' is required. Default value is 'NONE'.",
+              "'k_scale' is required except for PER_TOKEN, which requires 'key_scale_cache' and forbids 'k_scale'. "
+              "Default value is 'NONE'.",
               AttributeProto::STRING,
               std::string("NONE"))
         .Attr("v_quant_type",
-              "Quantization granularity of the value cache: 'NONE', 'PER_TENSOR' or 'PER_CHANNEL'. "
+              "Quantization granularity of the value cache: 'NONE', 'PER_TENSOR', 'PER_CHANNEL' or 'PER_TOKEN'. "
               "Must be non-'NONE' exactly when 'value_cache' has a quantized element type, and then "
-              "'v_scale' is required. Default value is 'NONE'.",
+              "'v_scale' is required except for PER_TOKEN, which requires 'value_scale_cache' and forbids 'v_scale'. "
+              "Default value is 'NONE'.",
               AttributeProto::STRING,
               std::string("NONE"))
+        .Attr("qk_rotation",
+              "NONE or HADAMARD. Apply a per-head orthonormal Walsh-Hadamard transform to Q and K after "
+              "QK-Norm and rotary embedding. Requires a power-of-two head_size in [16, 256], SEPARATE layout, "
+              "and no PER_CHANNEL key quantization.",
+              AttributeProto::STRING, std::string("NONE"))
+        .Attr("v_rotation",
+              "NONE or HADAMARD. Rotate V before caching and invert the transform on the attention output. "
+              "Requires a power-of-two v_head_size in [16, 256], SEPARATE layout, and no PER_CHANNEL value quantization.",
+              AttributeProto::STRING, std::string("NONE"))
         .Attr("k_cache_dtype",
               "Logical element type stored in 'key_cache', named after the ONNX element type it denotes: '' "
               "(the default) means the cache tensor's own element type is also the logical type. 'float16', "
@@ -1752,6 +1773,14 @@ ONNX_MS_OPERATOR_SET_SCHEMA(
                "attention work.",
                "S",
                OpSchema::Optional)
+        .Input(17, "key_scale_cache",
+               "In-place dynamic key scales with shape (num_blocks, block_size, kv_num_heads). Required only "
+               "for PER_TOKEN quantization. Uses the same slot_mapping and block_table as key_cache.",
+               "T_SCALE_CACHE", OpSchema::Optional)
+        .Input(18, "value_scale_cache",
+               "In-place dynamic value scales with shape (num_blocks, block_size, kv_num_heads). Required only "
+               "for PER_TOKEN quantization. Uses the same slot_mapping and block_table as value_cache.",
+               "T_SCALE_CACHE", OpSchema::Optional)
         .Output(0,
                 "output",
                 "2D output tensor with shape (num_tokens, num_heads * v_head_size), which is "
@@ -1768,10 +1797,15 @@ ONNX_MS_OPERATOR_SET_SCHEMA(
                 "Must be absent when 'kv_cache_layout' is 'LATENT'.",
                 "T_CACHE",
                 OpSchema::Optional)
+        .Output(3, "key_scale_cache_out", "Aliases key_scale_cache with the same shape and element type.",
+                "T_SCALE_CACHE", OpSchema::Optional)
+        .Output(4, "value_scale_cache_out", "Aliases value_scale_cache with the same shape and element type.",
+                "T_SCALE_CACHE", OpSchema::Optional)
         .TypeConstraint("T", {"tensor(float16)", "tensor(bfloat16)"}, "Constrain input and output to float tensors.")
         .TypeConstraint("T_CACHE",
                         {"tensor(float16)", "tensor(bfloat16)", "tensor(int8)", "tensor(float8e4m3fn)", "tensor(uint8)"},
                         "Constrain the KV cache to float or quantized tensors.")
+        .TypeConstraint("T_SCALE_CACHE", {"tensor(float16)", "tensor(float)"}, "Dynamic paged quantization scales.")
         .TypeConstraint("T_KV_SCALE", {"tensor(float)"}, "Constrain KV cache scales to float tensors.")
         .TypeConstraint("S", {"tensor(int32)"}, "Constrain Positional inputs to int tensor.")
         .TypeAndShapeInferenceFunction([](ONNX_NAMESPACE::InferenceContext& ctx) {

--- a/onnxruntime/core/graph/contrib_ops/bert_defs.cc
+++ b/onnxruntime/core/graph/contrib_ops/bert_defs.cc
@@ -1653,13 +1653,15 @@ ONNX_MS_OPERATOR_SET_SCHEMA(
                OpSchema::Optional)
         .Input(3,
                "key_cache",
-               "Block-based key cache with shape (num_blocks, block_size, kv_num_heads, head_size). This is updated in "
+               "Block-based key cache with shape (num_blocks, block_size, kv_num_heads, cache_head_size), where "
+               "cache_head_size is (head_size + 1) / 2 for packed INT4 and head_size otherwise. This is updated in "
                "place within the op. When 'kv_cache_layout' is 'LATENT' this is the only cache, and V is read from its "
                "leading v_head_size channels.",
                "T_CACHE")
         .Input(4,
                "value_cache",
-               "Block-based value cache with shape (num_blocks, block_size, kv_num_heads, head_size). This is updated "
+               "Block-based value cache with shape (num_blocks, block_size, kv_num_heads, cache_head_size), where "
+               "cache_head_size is (head_size + 1) / 2 for packed INT4 and head_size otherwise. This is updated "
                "in place within the op. This should be the same shape as key_cache. Must be absent when "
                "'kv_cache_layout' is 'LATENT'.",
                "T_CACHE",
@@ -1757,19 +1759,18 @@ ONNX_MS_OPERATOR_SET_SCHEMA(
                 "T")
         .Output(1,
                 "key_cache_out",
-                "Block-based key cache with shape (num_blocks, block_size, kv_num_heads, head_size). This is always "
-                "the same tensor as key_cache.",
+                "Aliases key_cache with the same shape and element type, including its packed dimension for INT4.",
                 "T_CACHE",
                 OpSchema::Optional)
         .Output(2,
                 "value_cache_out",
-                "Block-based value cache with shape (num_blocks, block_size, kv_num_heads, head_size). This is always "
-                "the same tensor as value_cache. Must be absent when 'kv_cache_layout' is 'LATENT'.",
+                "Aliases value_cache with the same shape and element type, including its packed dimension for INT4. "
+                "Must be absent when 'kv_cache_layout' is 'LATENT'.",
                 "T_CACHE",
                 OpSchema::Optional)
         .TypeConstraint("T", {"tensor(float16)", "tensor(bfloat16)"}, "Constrain input and output to float tensors.")
         .TypeConstraint("T_CACHE",
-                        {"tensor(float16)", "tensor(bfloat16)", "tensor(int8)", "tensor(float8e4m3fn)"},
+                        {"tensor(float16)", "tensor(bfloat16)", "tensor(int8)", "tensor(float8e4m3fn)", "tensor(uint8)"},
                         "Constrain the KV cache to float or quantized tensors.")
         .TypeConstraint("T_KV_SCALE", {"tensor(float)"}, "Constrain KV cache scales to float tensors.")
         .TypeConstraint("S", {"tensor(int32)"}, "Constrain Positional inputs to int tensor.")

--- a/onnxruntime/test/python/transformers/test_paged_attention_int4.py
+++ b/onnxruntime/test/python/transformers/test_paged_attention_int4.py
@@ -1,0 +1,687 @@
+import os
+import pathlib
+import subprocess
+import tempfile
+import unittest
+from unittest.mock import patch
+
+import ml_dtypes
+import numpy as np
+import onnx
+from onnx import helper
+
+import onnxruntime as ort
+from onnxruntime.capi import _pybind_state
+
+
+def int4_kernel_available():
+    if os.getenv("ORT_PAGED_ATTENTION_TEST_RUNNER"):
+        return True
+    try:
+        return any(
+            kernel.op_name == "PagedAttention"
+            and kernel.provider == "CUDAExecutionProvider"
+            and "tensor(uint8)" in kernel.type_constraints.get("T_CACHE", [])
+            for kernel in _pybind_state.get_all_opkernel_def()
+        )
+    except (ImportError, AttributeError):
+        return False
+
+
+def set_attribute(model, name, value):
+    node = model.graph.node[0]
+    retained = [attribute for attribute in node.attribute if attribute.name != name]
+    del node.attribute[:]
+    node.attribute.extend([*retained, helper.make_attribute(name, value)])
+
+
+def replace_input(model, feeds, name, values):
+    feeds[name] = values
+    for value_info in model.graph.input:
+        if value_info.name == name:
+            value_info.CopyFrom(
+                helper.make_tensor_value_info(name, helper.np_dtype_to_tensor_dtype(values.dtype), values.shape)
+            )
+            return
+    model.graph.input.append(
+        helper.make_tensor_value_info(name, helper.np_dtype_to_tensor_dtype(values.dtype), values.shape)
+    )
+
+
+def remove_input(model, feeds, name):
+    feeds.pop(name)
+    remaining = [value_info for value_info in model.graph.input if value_info.name != name]
+    del model.graph.input[:]
+    model.graph.input.extend(remaining)
+    node = model.graph.node[0]
+    for index, input_name in enumerate(node.input):
+        if input_name == name:
+            node.input[index] = ""
+
+
+def static_scale(quant_type, kv_heads, width):
+    """Schema scale shape per granularity: (1,) for PER_TENSOR, (kv_num_heads, 1, head_size) otherwise."""
+    if quant_type == "PER_TENSOR":
+        return np.array([0.2], dtype=np.float32)
+    return np.linspace(0.05, 0.25, kv_heads * width, dtype=np.float32).reshape(kv_heads, 1, width)
+
+
+def quantize(values, scale):
+    """Signed INT4 codes in [-8, 7] stored biased by +8, two per byte, even channel in the low nibble."""
+    values = values.astype(np.float32)
+    scaled = np.divide(values, scale, out=np.zeros_like(values), where=scale != 0)
+    biased = (np.clip(np.rint(scaled), -8, 7).astype(np.int8) + 8).astype(np.uint8)
+    return biased[..., ::2] | (biased[..., 1::2] << 4)
+
+
+def unpack(packed, scale):
+    values = np.empty((*packed.shape[:-1], packed.shape[-1] * 2), dtype=np.float32)
+    values[..., ::2] = (packed & 15).astype(np.float32) - 8
+    values[..., 1::2] = (packed >> 4).astype(np.float32) - 8
+    return values * scale
+
+
+def make_case(
+    width=64,
+    lengths=(1, 1),
+    past=(19, 7),
+    int4=True,
+    quant_type="PER_CHANNEL",
+    packed=False,
+    skip=False,
+    sink=False,
+    softcap=0.0,
+    window=-1,
+    activation_dtype=np.float16,
+    heads=4,
+    kv_heads=2,
+    block_size=16,
+):
+    rng = np.random.default_rng(1234)
+    batch = len(lengths)
+    tokens = sum(lengths)
+    max_blocks = max((old + new + block_size - 1) // block_size for old, new in zip(past, lengths, strict=True))
+    num_blocks = batch * max_blocks + 1
+    block_table = rng.permutation(num_blocks - 1).astype(np.int32).reshape(batch, max_blocks)
+    cumulative = np.array([0, *np.cumsum(lengths)], dtype=np.int32)
+    query = rng.normal(0, 0.2, (tokens, heads, width)).astype(activation_dtype)
+    key = rng.normal(0, 0.4, (tokens, kv_heads, width)).astype(activation_dtype)
+    value = rng.normal(0, 0.6, (tokens, kv_heads, width)).astype(activation_dtype)
+    if tokens:
+        key[0, 0] = 0
+        value[0, 0] = 0
+    cache_inputs = {}
+    expected_cache = {}
+    logical_cache = {}
+    slots = []
+    for sequence, (old, new) in enumerate(zip(past, lengths, strict=True)):
+        for offset in range(new):
+            position = old + offset
+            slots.append(block_table[sequence, position // block_size] * block_size + position % block_size)
+    slots = np.array(slots, dtype=np.int32)
+    if skip and tokens:
+        slots[-1] = -1
+    for name, prefix, current in (("key", "k", key), ("value", "v", value)):
+        dense = rng.normal(0, 0.5, (num_blocks, block_size, kv_heads, width)).astype(np.float16).astype(np.float32)
+        dense[-1] = 0
+        broadcast = None
+        if int4:
+            scale = static_scale(quant_type, kv_heads, width)
+            broadcast = scale.reshape(kv_heads, width) if quant_type == "PER_CHANNEL" else scale
+            cache_inputs[f"{prefix}_scale"] = scale
+            cache = quantize(dense, broadcast)
+        else:
+            cache = dense.astype(np.float16)
+        cache_inputs[f"{name}_cache"] = cache.copy()
+        for token, slot in enumerate(slots):
+            if slot < 0:
+                continue
+            page, offset = divmod(int(slot), block_size)
+            if int4:
+                cache[page, offset] = quantize(current[token], broadcast)
+            else:
+                cache[page, offset] = current[token].astype(np.float16)
+        expected_cache[f"{name}_cache_out"] = cache
+        logical_cache[name] = unpack(cache, broadcast) if int4 else cache.astype(np.float32)
+
+    feeds = {
+        "query": query.reshape(tokens, heads * width),
+        "key": key.reshape(tokens, kv_heads * width),
+        "value": value.reshape(tokens, kv_heads * width),
+        **cache_inputs,
+        "cumulative_sequence_length": cumulative,
+        "past_seqlens": np.array(past, dtype=np.int32),
+        "block_table": block_table,
+        "slot_mapping": slots,
+        "attention_metadata": np.array([max(lengths), max(np.array(past) + lengths), 1], dtype=np.int32),
+    }
+    if sink:
+        feeds["head_sink"] = np.linspace(-0.5, 0.5, heads).astype(np.float16)
+    if packed:
+        feeds["query"] = np.concatenate([feeds["query"], feeds.pop("key"), feeds.pop("value")], axis=1)
+    inputs = [
+        "query",
+        "" if packed else "key",
+        "" if packed else "value",
+        "key_cache",
+        "value_cache",
+        "cumulative_sequence_length",
+        "past_seqlens",
+        "block_table",
+        "",
+        "",
+        "slot_mapping",
+        "head_sink" if sink else "",
+        "",
+        "",
+        "k_scale" if int4 else "",
+        "v_scale" if int4 else "",
+        "attention_metadata",
+    ]
+    output_info = [("output", activation_dtype, (tokens, heads * width))]
+    output_info.extend((name, values.dtype, values.shape) for name, values in expected_cache.items())
+    output_order = ["output", "key_cache_out", "value_cache_out"]
+    output_info.sort(key=lambda info: output_order.index(info[0]))
+    attributes = {
+        "num_heads": heads,
+        "kv_num_heads": kv_heads,
+        "k_cache_dtype": "int4" if int4 else "",
+        "v_cache_dtype": "int4" if int4 else "",
+        "k_quant_type": quant_type if int4 else "NONE",
+        "v_quant_type": quant_type if int4 else "NONE",
+        "softcap": softcap,
+        "local_window_size": window,
+    }
+    node = helper.make_node("PagedAttention", inputs, output_order, domain="com.microsoft", **attributes)
+    graph = helper.make_graph(
+        [node],
+        "int4_paged_attention",
+        [
+            helper.make_tensor_value_info(name, helper.np_dtype_to_tensor_dtype(values.dtype), values.shape)
+            for name, values in feeds.items()
+        ],
+        [
+            helper.make_tensor_value_info(name, helper.np_dtype_to_tensor_dtype(np.dtype(dtype)), shape)
+            for name, dtype, shape in output_info
+        ],
+    )
+    model = helper.make_model(
+        graph, opset_imports=[helper.make_opsetid("", 21), helper.make_opsetid("com.microsoft", 1)]
+    )
+    model.ir_version = 10
+    expected_output = np.zeros_like(query, dtype=np.float32)
+    for sequence, (old, new) in enumerate(zip(past, lengths, strict=True)):
+        for offset in range(new):
+            token = cumulative[sequence] + offset
+            end = old + offset + 1
+            begin = max(0, end - window) if window > 0 else 0
+            positions = np.arange(begin, end)
+            pages = block_table[sequence, positions // block_size]
+            for head in range(heads):
+                kv_head = head // (heads // kv_heads)
+                keys = logical_cache["key"][pages, positions % block_size, kv_head]
+                values = logical_cache["value"][pages, positions % block_size, kv_head]
+                logits = keys @ query[token, head].astype(np.float32) / np.sqrt(width)
+                if softcap:
+                    logits = softcap * np.tanh(logits / softcap)
+                maximum = max(np.max(logits), float(feeds["head_sink"][head]) if sink else -np.inf)
+                probabilities = np.exp(logits - maximum)
+                denominator = probabilities.sum() + (np.exp(float(feeds["head_sink"][head]) - maximum) if sink else 0)
+                expected_output[token, head] = probabilities @ values / denominator
+    expected_output = expected_output.astype(activation_dtype)
+    return model, feeds, {"output": expected_output.reshape(tokens, heads * width), **expected_cache}
+
+
+def run_case(model, feeds, steps=1, updates=None, cuda_graph=False):
+    updates = updates or {}
+    runner = os.getenv("ORT_PAGED_ATTENTION_TEST_RUNNER")
+    if runner:
+        with tempfile.TemporaryDirectory() as temporary:
+            directory = pathlib.Path(temporary)
+            onnx.save(model, directory / "model.onnx")
+            for name, values in feeds.items():
+                values.tofile(directory / f"{name}.bin")
+            for step, values in updates.items():
+                for name, array in values.items():
+                    array.tofile(directory / f"{name}.{step}.bin")
+            result = subprocess.run(
+                [runner, str(directory), str(steps), str(int(cuda_graph))], capture_output=True, text=True, check=False
+            )
+            if result.returncode:
+                raise RuntimeError(result.stdout + result.stderr)
+            results = []
+            for step in range(steps):
+                outputs = {}
+                for output in model.graph.output:
+                    tensor = output.type.tensor_type
+                    shape = [dimension.dim_value for dimension in tensor.shape.dim]
+                    dtype = helper.tensor_dtype_to_np_dtype(tensor.elem_type)
+                    outputs[output.name] = np.fromfile(directory / f"{output.name}.{step}.bin", dtype=dtype).reshape(
+                        shape
+                    )
+                results.append(outputs)
+            return results
+    options = ort.SessionOptions()
+    options.graph_optimization_level = ort.GraphOptimizationLevel.ORT_DISABLE_ALL
+    options.intra_op_num_threads = 1
+    session = ort.InferenceSession(
+        model.SerializeToString(),
+        options,
+        providers=[("CUDAExecutionProvider", {"enable_cuda_graph": int(cuda_graph)})],
+    )
+    binding = session.io_binding()
+
+    def storage(array):
+        if array.dtype == np.dtype(ml_dtypes.bfloat16):
+            return array.view(np.uint16)
+        if array.dtype == np.dtype(ml_dtypes.float8_e4m3fn):
+            return array.view(np.uint8)
+        return array
+
+    values = {
+        name: ort.OrtValue.ortvalue_from_numpy(storage(array), "cpu" if name == "attention_metadata" else "cuda", 0)
+        for name, array in feeds.items()
+    }
+    for input_info in model.graph.input:
+        name = input_info.name
+        binding.bind_input(
+            name,
+            "cpu" if name == "attention_metadata" else "cuda",
+            0,
+            input_info.type.tensor_type.elem_type,
+            feeds[name].shape,
+            values[name].data_ptr(),
+        )
+    outputs = {}
+    for output in model.graph.output:
+        tensor = output.type.tensor_type
+        shape = [dimension.dim_value for dimension in tensor.shape.dim]
+        if output.name.endswith("_out") and output.name[:-4] in values:
+            outputs[output.name] = values[output.name[:-4]]
+        else:
+            dtype = helper.tensor_dtype_to_np_dtype(tensor.elem_type)
+            outputs[output.name] = ort.OrtValue.ortvalue_from_numpy(storage(np.zeros(shape, dtype=dtype)), "cuda", 0)
+        binding.bind_output(output.name, "cuda", 0, tensor.elem_type, shape, outputs[output.name].data_ptr())
+    results = []
+    for step in range(steps):
+        for name, array in updates.get(step, {}).items():
+            values[name].update_inplace(storage(array))
+        session.run_with_iobinding(binding)
+        binding.synchronize_outputs()
+        results.append(
+            {
+                output.name: outputs[output.name]
+                .numpy()
+                .view(helper.tensor_dtype_to_np_dtype(output.type.tensor_type.elem_type))
+                .copy()
+                for output in model.graph.output
+            }
+        )
+    return results
+
+
+@unittest.skipUnless(int4_kernel_available(), "Requires CUDA PagedAttention built with USE_INT4_KV_CACHE")
+class TestPagedAttentionInt4(unittest.TestCase):
+    def setUp(self):
+        self.environment = patch.dict(os.environ, {"ORT_ENABLE_XQA": "0"})
+        self.environment.start()
+        self.addCleanup(self.environment.stop)
+
+    def check_case(self, **kwargs):
+        model, feeds, expected = make_case(**kwargs)
+        actual = run_case(model, feeds)[0]
+        for name, reference in expected.items():
+            if name == "output":
+                tolerance = 6e-3 if str(reference.dtype) == "bfloat16" else 8e-4
+                np.testing.assert_allclose(
+                    actual[name].astype(np.float32), reference.astype(np.float32), atol=tolerance, rtol=5e-3
+                )
+            elif reference.dtype == np.float16:
+                np.testing.assert_allclose(actual[name], reference, atol=1e-6, rtol=1e-3)
+            else:
+                np.testing.assert_array_equal(actual[name], reference)
+        return actual
+
+    def test_int4_decode_pack(self):
+        for width in (16, 32, 64, 128, 256):
+            for quant_type in ("PER_CHANNEL", "PER_TENSOR"):
+                with self.subTest(width=width, quant_type=quant_type):
+                    self.check_case(width=width, quant_type=quant_type)
+
+    def test_int4_packed_qkv_and_skipped_slot(self):
+        self.check_case(width=128, lengths=(3, 0, 2), past=(15, 7, 31), packed=True, skip=True)
+
+    def test_int4_prefill(self):
+        self.check_case(width=128, lengths=(65, 33), past=(0, 0))
+
+    def test_int4_chunked_prefill(self):
+        self.check_case(width=128, lengths=(33, 17), past=(23, 7))
+
+    def test_int4_speculative_decode(self):
+        self.check_case(width=256, lengths=(8, 3), past=(31, 7), sink=True, softcap=2.0, window=23)
+        self.check_case(width=128, lengths=(8, 3), past=(257, 7))
+        self.check_case(width=256, lengths=(8, 3), past=(31, 7), heads=24, kv_heads=4)
+
+    def test_int4_splitkv_and_derived_slots(self):
+        model, feeds, expected = make_case(width=128, past=(513, 0))
+        remove_input(model, feeds, "slot_mapping")
+        actual = run_case(model, feeds)[0]
+        for name, reference in expected.items():
+            if name == "output":
+                np.testing.assert_allclose(actual[name], reference, atol=8e-4, rtol=5e-3)
+            else:
+                np.testing.assert_array_equal(actual[name], reference)
+
+    def test_int4_xqa_decode(self):
+        with patch.dict(os.environ, {"ORT_ENABLE_XQA": "1"}):
+            for block_size in (128, 256):
+                for window in (-1, 129):
+                    with self.subTest(block_size=block_size, window=window):
+                        self.check_case(
+                            width=256,
+                            heads=24,
+                            kv_heads=4,
+                            past=(513, 138),
+                            block_size=block_size,
+                            window=window,
+                            sink=True,
+                        )
+
+    def test_int4_xqa_unsupported_scales_fall_back(self):
+        # INT4 XQA only covers PER_CHANNEL scales, so PER_TENSOR must take the portable kernel.
+        with patch.dict(os.environ, {"ORT_ENABLE_XQA": "1"}):
+            self.check_case(width=256, heads=24, kv_heads=4, past=(513, 138), block_size=256, quant_type="PER_TENSOR")
+
+    def test_int4_xqa_speculative_decode(self):
+        with patch.dict(os.environ, {"ORT_ENABLE_XQA": "1"}):
+            for lengths in ((2, 1), (8, 3), (0, 8)):
+                for window in (-1, 129):
+                    with self.subTest(lengths=lengths, window=window):
+                        self.check_case(
+                            width=256,
+                            heads=24,
+                            kv_heads=4,
+                            past=(513, 138),
+                            lengths=lengths,
+                            block_size=256,
+                            window=window,
+                            sink=True,
+                        )
+
+    def test_int4_xqa_cuda_graph_replay(self):
+        with patch.dict(os.environ, {"ORT_ENABLE_XQA": "1"}):
+            model, feeds, _ = make_case(
+                width=256, heads=24, kv_heads=4, block_size=256, lengths=(8, 3), past=(513, 138)
+            )
+            changed = {"key": feeds["key"] * np.float16(3), "value": feeds["value"] * np.float16(0.25)}
+            actual = run_case(model, feeds, steps=3, updates={1: changed}, cuda_graph=True)
+            reference = run_case(model, {**feeds, **changed})[0]
+            self.assertFalse(np.array_equal(actual[0]["value_cache_out"], actual[1]["value_cache_out"]))
+            for name in reference:
+                np.testing.assert_array_equal(actual[1][name], actual[2][name])
+                np.testing.assert_allclose(actual[1][name], reference[name], atol=8e-4, rtol=5e-3)
+
+    def test_int4_cuda_graph_replay(self):
+        model, feeds, _ = make_case(width=128)
+        changed = {"key": feeds["key"] * np.float16(3), "value": feeds["value"] * np.float16(0.25)}
+        actual = run_case(model, feeds, steps=3, updates={1: changed}, cuda_graph=True)
+        reference = run_case(model, {**feeds, **changed})[0]
+        self.assertFalse(np.array_equal(actual[0]["value_cache_out"], actual[1]["value_cache_out"]))
+        for name in reference:
+            np.testing.assert_array_equal(actual[1][name], actual[2][name])
+            np.testing.assert_allclose(actual[1][name], reference[name], atol=8e-4, rtol=5e-3)
+
+    def test_cache_write_follows_norm_and_partial_rope(self):
+        for interleaved in (False, True):
+            with self.subTest(interleaved=interleaved):
+                model, feeds, _ = make_case(width=64, lengths=(5,), past=(0,), int4=False)
+                reference_model, reference_feeds, _ = make_case(width=64, lengths=(5,), past=(0,), int4=False)
+                width, rotary_width = 64, 32
+                positions = np.arange(5, dtype=np.float32)
+                angles = positions[:, None] * np.linspace(0.01, 0.4, rotary_width // 2, dtype=np.float32)
+                cos = np.cos(angles).astype(np.float16)
+                sin = np.sin(angles).astype(np.float16)
+                for name, heads, input_index in (("query", 4, 12), ("key", 2, 13)):
+                    weight_name = "q_norm_weight" if name == "query" else "k_norm_weight"
+                    weight = np.linspace(0.8, 1.2, width, dtype=np.float16)
+                    values = feeds[name].reshape(5, heads, width).astype(np.float32)
+                    normalized = (
+                        values / np.sqrt(np.mean(values * values, axis=-1, keepdims=True) + 1e-6) * weight
+                    ).astype(np.float16)
+                    channels = np.arange(rotary_width)
+                    partner = channels ^ 1 if interleaved else (channels + rotary_width // 2) % rotary_width
+                    cache_index = channels // 2 if interleaved else channels % (rotary_width // 2)
+                    sign = np.where(channels % 2 == 0 if interleaved else channels < rotary_width // 2, -1, 1)
+                    result = normalized.copy()
+                    result[..., :rotary_width] = (
+                        normalized[..., :rotary_width] * cos[:, None, cache_index]
+                        + (normalized[..., partner] * sign.astype(np.float16)) * sin[:, None, cache_index]
+                    )
+                    reference_feeds[name] = result.reshape(5, heads * width)
+                    replace_input(model, feeds, weight_name, weight)
+                    model.graph.node[0].input[input_index] = weight_name
+                for index, name, values in ((8, "cos_cache", cos), (9, "sin_cache", sin)):
+                    replace_input(model, feeds, name, values)
+                    model.graph.node[0].input[index] = name
+                set_attribute(model, "do_rotary", 1)
+                set_attribute(model, "rotary_interleaved", int(interleaved))
+                actual = run_case(model, feeds)[0]
+                reference = run_case(reference_model, reference_feeds)[0]
+                for name in reference:
+                    np.testing.assert_allclose(actual[name], reference[name], atol=8e-4, rtol=5e-3)
+
+    def test_optional_cache_outputs(self):
+        for output_count in (1, 3):
+            with self.subTest(output_count=output_count):
+                model, feeds, expected = make_case()
+                del model.graph.node[0].output[output_count:]
+                del model.graph.output[output_count:]
+                actual = run_case(model, feeds)[0]
+                for name in actual:
+                    np.testing.assert_allclose(actual[name], expected[name], atol=8e-4, rtol=5e-3)
+
+    def test_invalid_contracts(self):
+        cases = []
+        for side in ("key", "value"):
+            prefix = "k" if side == "key" else "v"
+            cases.extend(
+                [
+                    (f"{side}_ambiguous_uint8", (f"{prefix}_cache_dtype", ""), "explicit int4"),
+                    (f"{side}_wrong_dtype", (f"{prefix}_cache_dtype", "float4e2m1"), "explicit int4"),
+                ]
+            )
+        for label, attribute, message in cases:
+            with self.subTest(case=label):
+                model, feeds, _ = make_case(width=64)
+                set_attribute(model, *attribute)
+                del model.graph.node[0].output[1:]
+                del model.graph.output[1:]
+                with self.assertRaisesRegex(Exception, message):
+                    run_case(model, feeds)
+
+    def test_invalid_packed_dimensions(self):
+        for side in ("key", "value"):
+            with self.subTest(side=side):
+                model, feeds, _ = make_case()
+                name = f"{side}_cache"
+                replace_input(model, feeds, name, np.repeat(feeds[name], 2, axis=-1))
+                del model.graph.node[0].output[1:]
+                del model.graph.output[1:]
+                with self.assertRaisesRegex(Exception, "dimension 3"):
+                    run_case(model, feeds)
+
+    def test_int4_bfloat16_activations(self):
+        for width in (16, 32, 128, 256):
+            with self.subTest(width=width):
+                self.check_case(width=width, activation_dtype=ml_dtypes.bfloat16)
+
+    def test_int4_known_packing_and_padding(self):
+        model, feeds, _ = make_case(width=32, lengths=(1,), past=(0,), quant_type="PER_TENSOR")
+        pattern = np.array(
+            [
+                -9,
+                -8,
+                -7,
+                -6,
+                -5,
+                -4,
+                -3,
+                -2,
+                -1,
+                0,
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                -2.5,
+                -1.5,
+                -0.5,
+                0.5,
+                1.5,
+                2.5,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+            ],
+            dtype=np.float16,
+        )
+        signed = np.clip(np.rint(pattern), -8, 7).astype(np.int8)
+        biased = (signed + 8).astype(np.uint8)
+        packed = biased[::2] | (biased[1::2] << 4)
+        expected = {}
+        slot = int(feeds["slot_mapping"][0])
+        for side, prefix in (("key", "k"), ("value", "v")):
+            feeds[side][:] = np.tile(pattern, 2)
+            feeds[f"{side}_cache"][:] = 0x88
+            replace_input(model, feeds, f"{prefix}_scale", np.ones(1, dtype=np.float32))
+            cache = feeds[f"{side}_cache"].copy()
+            cache.reshape(-1, 2, 16)[slot] = packed
+            expected[f"{side}_cache_out"] = cache
+        actual = run_case(model, feeds)[0]
+        for name, values in expected.items():
+            np.testing.assert_array_equal(actual[name], values)
+        np.testing.assert_array_equal(actual["output"], np.tile(signed, 4).reshape(1, -1).astype(np.float16))
+
+    def test_int4_per_channel_xqa_matches_portable(self):
+        # A PER_CHANNEL scale is folded into Q and the output, so XQA has to agree with the
+        # portable kernel. lengths (2, 1) also covers the speculative INT4 kernel.
+        for lengths in ((1, 1), (2, 1)):
+            with self.subTest(lengths=lengths):
+                model, feeds, _ = make_case(
+                    width=256, heads=24, kv_heads=4, past=(513, 138), block_size=256, lengths=lengths
+                )
+                with patch.dict(os.environ, {"ORT_ENABLE_XQA": "0"}):
+                    portable = run_case(model, feeds)[0]
+                with patch.dict(os.environ, {"ORT_ENABLE_XQA": "1"}):
+                    accelerated = run_case(model, feeds)[0]
+                np.testing.assert_allclose(
+                    accelerated["output"].astype(np.float32),
+                    portable["output"].astype(np.float32),
+                    atol=8e-4,
+                    rtol=5e-3,
+                )
+                for name in ("key_cache_out", "value_cache_out"):
+                    np.testing.assert_array_equal(accelerated[name], portable[name])
+
+    def test_int4_scale_extremes(self):
+        for magnitude in (2.0**-24, 1e10):
+            with self.subTest(magnitude=magnitude):
+                model, feeds, _ = make_case(
+                    width=32,
+                    lengths=(1,),
+                    past=(0,),
+                    quant_type="PER_TENSOR",
+                    activation_dtype=ml_dtypes.bfloat16,
+                )
+                pattern = np.tile(np.array([-magnitude, magnitude], dtype=ml_dtypes.bfloat16), 32).reshape(1, 64)
+                for side, prefix in (("key", "k"), ("value", "v")):
+                    feeds[side][:] = pattern
+                    replace_input(model, feeds, f"{prefix}_scale", np.array([1e-6], dtype=np.float32))
+                actual = run_case(model, feeds)[0]
+                raw = pattern.reshape(2, 32).astype(np.float32)
+                biased = (np.clip(np.rint(raw / np.float32(1e-6)), -8, 7).astype(np.int8) + 8).astype(np.uint8)
+                packed = biased[:, ::2] | (biased[:, 1::2] << 4)
+                page, offset = divmod(int(feeds["slot_mapping"][0]), 16)
+                for side in ("key", "value"):
+                    np.testing.assert_array_equal(actual[f"{side}_cache_out"][page, offset], packed)
+
+    def test_reject_latent_int4(self):
+        model, feeds, _ = make_case(width=64, lengths=(1,), past=(0,), heads=4, kv_heads=1)
+        set_attribute(model, "kv_cache_layout", "LATENT")
+        set_attribute(model, "v_quant_type", "NONE")
+        set_attribute(model, "v_cache_dtype", "")
+        remove_input(model, feeds, "value")
+        remove_input(model, feeds, "value_cache")
+        remove_input(model, feeds, "v_scale")
+        del model.graph.node[0].output[1:]
+        del model.graph.output[1:]
+        with self.assertRaisesRegex(Exception, "LATENT"):
+            run_case(model, feeds)
+
+    def test_int8_fp8_cache_regression(self):
+        for cache_dtype, qmax in ((np.int8, 127), (ml_dtypes.float8_e4m3fn, 448)):
+            for mode in ("PER_TENSOR", "PER_CHANNEL"):
+                for lengths in ((1, 1), (33, 17)):
+                    with self.subTest(cache_dtype=cache_dtype, mode=mode, lengths=lengths):
+                        model, feeds, _ = make_case(width=128, lengths=lengths, int4=False)
+                        reference_model = onnx.ModelProto.FromString(model.SerializeToString())
+                        reference_feeds = {name: array.copy() for name, array in feeds.items()}
+                        reference_feeds["slot_mapping"][:] = -1
+                        expected_cache = {}
+                        for side, prefix, index in (("key", "k", 14), ("value", "v", 15)):
+                            cache_name = f"{side}_cache"
+                            dense = feeds[cache_name].astype(np.float32)
+                            current = feeds[side].reshape(-1, 2, 128).astype(np.float32)
+                            scale = (
+                                np.array([0.03125], dtype=np.float32)
+                                if mode == "PER_TENSOR"
+                                else np.linspace(0.02, 0.06, 256, dtype=np.float32).reshape(2, 1, 128)
+                            )
+                            scale_name = f"{prefix}_scale"
+                            replace_input(model, feeds, scale_name, scale)
+                            model.graph.node[0].input[index] = scale_name
+                            divisor = scale.reshape(2, 128) if mode == "PER_CHANNEL" else scale
+
+                            def encode(array, scale, cache_dtype=cache_dtype, qmax=qmax):
+                                scaled = np.divide(array, scale, out=np.zeros_like(array), where=scale != 0)
+                                if cache_dtype == np.int8:
+                                    scaled = np.rint(scaled)
+                                return np.clip(scaled, -qmax, qmax).astype(cache_dtype)
+
+                            cache = encode(dense, divisor)
+                            replace_input(model, feeds, cache_name, cache.copy())
+                            cache_type = helper.np_dtype_to_tensor_dtype(np.dtype(cache_dtype))
+                            for output in model.graph.output:
+                                if output.name == f"{cache_name}_out":
+                                    output.type.tensor_type.elem_type = cache_type
+                            encoded_current = encode(current, divisor)
+                            for token, slot in enumerate(feeds["slot_mapping"]):
+                                page, offset = divmod(int(slot), 16)
+                                cache[page, offset] = encoded_current[token]
+                            expected_cache[f"{cache_name}_out"] = cache
+                            reference_feeds[cache_name] = (cache.astype(np.float32) * divisor).astype(np.float16)
+                            set_attribute(model, f"{prefix}_quant_type", mode)
+                        actual = run_case(model, feeds)[0]
+                        reference = run_case(reference_model, reference_feeds)[0]
+                        np.testing.assert_allclose(actual["output"], reference["output"], atol=8e-4, rtol=5e-3)
+                        for name, expected in expected_cache.items():
+                            if cache_dtype == np.int8:
+                                np.testing.assert_allclose(actual[name], expected, atol=1, rtol=0)
+                            else:
+                                lower = np.nextafter(expected, np.array(-448, dtype=cache_dtype)).astype(np.float32)
+                                upper = np.nextafter(expected, np.array(448, dtype=cache_dtype)).astype(np.float32)
+                                self.assertTrue(np.all(actual[name].astype(np.float32) >= lower))
+                                self.assertTrue(np.all(actual[name].astype(np.float32) <= upper))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/onnxruntime/test/python/transformers/test_paged_attention_int4.py
+++ b/onnxruntime/test/python/transformers/test_paged_attention_int4.py
@@ -8,10 +8,10 @@ from unittest.mock import patch
 import ml_dtypes
 import numpy as np
 import onnx
-from onnx import helper
+from onnx import TensorProto, helper
+from onnxruntime.capi import _pybind_state
 
 import onnxruntime as ort
-from onnxruntime.capi import _pybind_state
 
 
 def int4_kernel_available():
@@ -59,26 +59,34 @@ def remove_input(model, feeds, name):
             node.input[index] = ""
 
 
-def static_scale(quant_type, kv_heads, width):
-    """Schema scale shape per granularity: (1,) for PER_TENSOR, (kv_num_heads, 1, head_size) otherwise."""
-    if quant_type == "PER_TENSOR":
-        return np.array([0.2], dtype=np.float32)
-    return np.linspace(0.05, 0.25, kv_heads * width, dtype=np.float32).reshape(kv_heads, 1, width)
+def hadamard_matrix(width):
+    matrix = np.ones((1, 1), dtype=np.float32)
+    while matrix.shape[0] < width:
+        matrix = np.block([[matrix, matrix], [matrix, -matrix]])
+    return matrix / np.sqrt(np.float32(width))
 
 
-def quantize(values, scale):
-    """Signed INT4 codes in [-8, 7] stored biased by +8, two per byte, even channel in the low nibble."""
-    values = values.astype(np.float32)
-    scaled = np.divide(values, scale, out=np.zeros_like(values), where=scale != 0)
-    biased = (np.clip(np.rint(scaled), -8, 7).astype(np.int8) + 8).astype(np.uint8)
-    return biased[..., ::2] | (biased[..., 1::2] << 4)
+def rotate(values):
+    return values.astype(np.float32) @ hadamard_matrix(values.shape[-1])
 
 
-def unpack(packed, scale):
+def quantize(values, scale_dtype):
+    scales = np.max(np.abs(values), axis=-1) / 7.0
+    if scale_dtype == np.float16:
+        scales = np.where(scales == 0, 0, np.clip(scales, 2.0**-24, 65504))
+    scales = scales.astype(scale_dtype)
+    scaled = np.divide(values, scales[..., None], out=np.zeros_like(values), where=scales[..., None] != 0)
+    signed = np.clip(np.rint(scaled), -8, 7).astype(np.int8)
+    biased = (signed + 8).astype(np.uint8)
+    packed = biased[..., ::2] | (biased[..., 1::2] << 4)
+    return packed, scales
+
+
+def unpack(packed, scales):
     values = np.empty((*packed.shape[:-1], packed.shape[-1] * 2), dtype=np.float32)
     values[..., ::2] = (packed & 15).astype(np.float32) - 8
     values[..., 1::2] = (packed >> 4).astype(np.float32) - 8
-    return values * scale
+    return values * scales[..., None]
 
 
 def make_case(
@@ -86,7 +94,9 @@ def make_case(
     lengths=(1, 1),
     past=(19, 7),
     int4=True,
-    quant_type="PER_CHANNEL",
+    qk_rotation=True,
+    v_rotation=True,
+    scale_dtype=np.float16,
     packed=False,
     skip=False,
     sink=False,
@@ -121,28 +131,31 @@ def make_case(
     slots = np.array(slots, dtype=np.int32)
     if skip and tokens:
         slots[-1] = -1
-    for name, prefix, current in (("key", "k", key), ("value", "v", value)):
+    for name, current, rotation in (("key", key, qk_rotation), ("value", value, v_rotation)):
         dense = rng.normal(0, 0.5, (num_blocks, block_size, kv_heads, width)).astype(np.float16).astype(np.float32)
         dense[-1] = 0
-        broadcast = None
+        stored = rotate(dense) if rotation else dense
         if int4:
-            scale = static_scale(quant_type, kv_heads, width)
-            broadcast = scale.reshape(kv_heads, width) if quant_type == "PER_CHANNEL" else scale
-            cache_inputs[f"{prefix}_scale"] = scale
-            cache = quantize(dense, broadcast)
+            cache, scales = quantize(stored, scale_dtype)
+            cache_inputs[f"{name}_scale_cache"] = scales.copy()
         else:
-            cache = dense.astype(np.float16)
+            cache = stored.astype(np.float16)
         cache_inputs[f"{name}_cache"] = cache.copy()
+        transformed = rotate(current) if rotation else current.astype(np.float32)
         for token, slot in enumerate(slots):
             if slot < 0:
                 continue
             page, offset = divmod(int(slot), block_size)
             if int4:
-                cache[page, offset] = quantize(current[token], broadcast)
+                cache[page, offset], scales[page, offset] = quantize(transformed[token], scale_dtype)
             else:
-                cache[page, offset] = current[token].astype(np.float16)
+                cache[page, offset] = transformed[token].astype(np.float16)
         expected_cache[f"{name}_cache_out"] = cache
-        logical_cache[name] = unpack(cache, broadcast) if int4 else cache.astype(np.float32)
+        if int4:
+            expected_cache[f"{name}_scale_cache_out"] = scales
+            logical_cache[name] = unpack(cache, scales)
+        else:
+            logical_cache[name] = cache.astype(np.float32)
 
     feeds = {
         "query": query.reshape(tokens, heads * width),
@@ -174,21 +187,27 @@ def make_case(
         "head_sink" if sink else "",
         "",
         "",
-        "k_scale" if int4 else "",
-        "v_scale" if int4 else "",
+        "",
+        "",
         "attention_metadata",
+        "key_scale_cache" if int4 else "",
+        "value_scale_cache" if int4 else "",
     ]
     output_info = [("output", activation_dtype, (tokens, heads * width))]
     output_info.extend((name, values.dtype, values.shape) for name, values in expected_cache.items())
     output_order = ["output", "key_cache_out", "value_cache_out"]
+    if int4:
+        output_order += ["key_scale_cache_out", "value_scale_cache_out"]
     output_info.sort(key=lambda info: output_order.index(info[0]))
     attributes = {
         "num_heads": heads,
         "kv_num_heads": kv_heads,
+        "qk_rotation": "HADAMARD" if qk_rotation else "NONE",
+        "v_rotation": "HADAMARD" if v_rotation else "NONE",
         "k_cache_dtype": "int4" if int4 else "",
         "v_cache_dtype": "int4" if int4 else "",
-        "k_quant_type": quant_type if int4 else "NONE",
-        "v_quant_type": quant_type if int4 else "NONE",
+        "k_quant_type": "PER_TOKEN" if int4 else "NONE",
+        "v_quant_type": "PER_TOKEN" if int4 else "NONE",
         "softcap": softcap,
         "local_window_size": window,
     }
@@ -209,6 +228,7 @@ def make_case(
         graph, opset_imports=[helper.make_opsetid("", 21), helper.make_opsetid("com.microsoft", 1)]
     )
     model.ir_version = 10
+    transformed_query = (rotate(query).astype(activation_dtype) if qk_rotation else query).astype(np.float32)
     expected_output = np.zeros_like(query, dtype=np.float32)
     for sequence, (old, new) in enumerate(zip(past, lengths, strict=True)):
         for offset in range(new):
@@ -221,7 +241,7 @@ def make_case(
                 kv_head = head // (heads // kv_heads)
                 keys = logical_cache["key"][pages, positions % block_size, kv_head]
                 values = logical_cache["value"][pages, positions % block_size, kv_head]
-                logits = keys @ query[token, head].astype(np.float32) / np.sqrt(width)
+                logits = keys @ transformed_query[token, head] / np.sqrt(width)
                 if softcap:
                     logits = softcap * np.tanh(logits / softcap)
                 maximum = max(np.max(logits), float(feeds["head_sink"][head]) if sink else -np.inf)
@@ -229,6 +249,8 @@ def make_case(
                 denominator = probabilities.sum() + (np.exp(float(feeds["head_sink"][head]) - maximum) if sink else 0)
                 expected_output[token, head] = probabilities @ values / denominator
     expected_output = expected_output.astype(activation_dtype)
+    if v_rotation:
+        expected_output = rotate(expected_output).astype(activation_dtype)
     return model, feeds, {"output": expected_output.reshape(tokens, heads * width), **expected_cache}
 
 
@@ -320,6 +342,22 @@ def run_case(model, feeds, steps=1, updates=None, cuda_graph=False):
     return results
 
 
+def per_channel_int4_case(**kwargs):
+    """Both cache sides PER_CHANNEL, which forbids rotation and replaces the scale caches."""
+    model, feeds, _ = make_case(qk_rotation=False, v_rotation=False, **kwargs)
+    node = model.graph.node[0]
+    kv_heads, width = kwargs["kv_heads"], kwargs["width"]
+    for side, index, cache_name in (("k", 14, "key_scale_cache"), ("v", 15, "value_scale_cache")):
+        scale = np.linspace(0.02, 0.15, kv_heads * width, dtype=np.float32).reshape(kv_heads, 1, width)
+        remove_input(model, feeds, cache_name)
+        replace_input(model, feeds, f"{side}_scale", scale)
+        node.input[index] = f"{side}_scale"
+        set_attribute(model, f"{side}_quant_type", "PER_CHANNEL")
+    del node.output[3:]
+    del model.graph.output[3:]
+    return model, feeds
+
+
 @unittest.skipUnless(int4_kernel_available(), "Requires CUDA PagedAttention built with USE_INT4_KV_CACHE")
 class TestPagedAttentionInt4(unittest.TestCase):
     def setUp(self):
@@ -336,17 +374,26 @@ class TestPagedAttentionInt4(unittest.TestCase):
                 np.testing.assert_allclose(
                     actual[name].astype(np.float32), reference.astype(np.float32), atol=tolerance, rtol=5e-3
                 )
+            elif "scale" in name:
+                np.testing.assert_allclose(actual[name], reference, atol=1e-6, rtol=1e-3)
             elif reference.dtype == np.float16:
                 np.testing.assert_allclose(actual[name], reference, atol=1e-6, rtol=1e-3)
             else:
                 np.testing.assert_array_equal(actual[name], reference)
         return actual
 
-    def test_int4_decode_pack(self):
+    def test_hadamard_rotation_is_output_neutral(self):
         for width in (16, 32, 64, 128, 256):
-            for quant_type in ("PER_CHANNEL", "PER_TENSOR"):
-                with self.subTest(width=width, quant_type=quant_type):
-                    self.check_case(width=width, quant_type=quant_type)
+            with self.subTest(width=width):
+                rotated = self.check_case(width=width, int4=False)
+                plain = self.check_case(width=width, int4=False, qk_rotation=False, v_rotation=False)
+                np.testing.assert_allclose(rotated["output"], plain["output"], atol=8e-4, rtol=5e-3)
+
+    def test_int4_decode_pack_and_scale_cache(self):
+        for width in (16, 32, 64, 128, 256):
+            for dtype in (np.float16, np.float32):
+                with self.subTest(width=width, scale_dtype=dtype):
+                    self.check_case(width=width, scale_dtype=dtype)
 
     def test_int4_packed_qkv_and_skipped_slot(self):
         self.check_case(width=128, lengths=(3, 0, 2), past=(15, 7, 31), packed=True, skip=True)
@@ -388,9 +435,8 @@ class TestPagedAttentionInt4(unittest.TestCase):
                         )
 
     def test_int4_xqa_unsupported_scales_fall_back(self):
-        # INT4 XQA only covers PER_CHANNEL scales, so PER_TENSOR must take the portable kernel.
         with patch.dict(os.environ, {"ORT_ENABLE_XQA": "1"}):
-            self.check_case(width=256, heads=24, kv_heads=4, past=(513, 138), block_size=256, quant_type="PER_TENSOR")
+            self.check_case(width=256, heads=24, kv_heads=4, past=(513, 138), block_size=256, scale_dtype=np.float32)
 
     def test_int4_xqa_speculative_decode(self):
         with patch.dict(os.environ, {"ORT_ENABLE_XQA": "1"}):
@@ -416,22 +462,26 @@ class TestPagedAttentionInt4(unittest.TestCase):
             changed = {"key": feeds["key"] * np.float16(3), "value": feeds["value"] * np.float16(0.25)}
             actual = run_case(model, feeds, steps=3, updates={1: changed}, cuda_graph=True)
             reference = run_case(model, {**feeds, **changed})[0]
-            self.assertFalse(np.array_equal(actual[0]["value_cache_out"], actual[1]["value_cache_out"]))
+            self.assertFalse(np.array_equal(actual[0]["value_scale_cache_out"], actual[1]["value_scale_cache_out"]))
             for name in reference:
                 np.testing.assert_array_equal(actual[1][name], actual[2][name])
                 np.testing.assert_allclose(actual[1][name], reference[name], atol=8e-4, rtol=5e-3)
+
+    def test_int4_without_rotation_and_k_only(self):
+        self.check_case(qk_rotation=False, v_rotation=False)
+        self.check_case(v_rotation=False)
 
     def test_int4_cuda_graph_replay(self):
         model, feeds, _ = make_case(width=128)
         changed = {"key": feeds["key"] * np.float16(3), "value": feeds["value"] * np.float16(0.25)}
         actual = run_case(model, feeds, steps=3, updates={1: changed}, cuda_graph=True)
         reference = run_case(model, {**feeds, **changed})[0]
-        self.assertFalse(np.array_equal(actual[0]["value_cache_out"], actual[1]["value_cache_out"]))
+        self.assertFalse(np.array_equal(actual[0]["value_scale_cache_out"], actual[1]["value_scale_cache_out"]))
         for name in reference:
             np.testing.assert_array_equal(actual[1][name], actual[2][name])
             np.testing.assert_allclose(actual[1][name], reference[name], atol=8e-4, rtol=5e-3)
 
-    def test_cache_write_follows_norm_and_partial_rope(self):
+    def test_hadamard_follows_norm_and_partial_rope(self):
         for interleaved in (False, True):
             with self.subTest(interleaved=interleaved):
                 model, feeds, _ = make_case(width=64, lengths=(5,), past=(0,), int4=False)
@@ -470,8 +520,8 @@ class TestPagedAttentionInt4(unittest.TestCase):
                 for name in reference:
                     np.testing.assert_allclose(actual[name], reference[name], atol=8e-4, rtol=5e-3)
 
-    def test_optional_cache_outputs(self):
-        for output_count in (1, 3):
+    def test_optional_scale_outputs(self):
+        for output_count in (1, 3, 4, 5):
             with self.subTest(output_count=output_count):
                 model, feeds, expected = make_case()
                 del model.graph.node[0].output[output_count:]
@@ -484,19 +534,94 @@ class TestPagedAttentionInt4(unittest.TestCase):
         cases = []
         for side in ("key", "value"):
             prefix = "k" if side == "key" else "v"
+            for dimension in range(3):
+                cases.append((f"{side}_scale_dim_{dimension}", side, "shape", dimension, "Scale cache must have shape"))
             cases.extend(
                 [
-                    (f"{side}_ambiguous_uint8", (f"{prefix}_cache_dtype", ""), "explicit int4"),
-                    (f"{side}_wrong_dtype", (f"{prefix}_cache_dtype", "float4e2m1"), "explicit int4"),
+                    (f"{side}_missing_scale", side, "missing", None, "PER_TOKEN requires"),
+                    (f"{side}_static_scale", side, "static", None, "PER_TOKEN requires"),
+                    (f"{side}_ambiguous_uint8", side, "attribute", (f"{prefix}_cache_dtype", ""), "explicit int4"),
+                    (
+                        f"{side}_wrong_dtype",
+                        side,
+                        "attribute",
+                        (f"{prefix}_cache_dtype", "float4e2m1"),
+                        "explicit int4",
+                    ),
+                    (
+                        f"{side}_wrong_mode",
+                        side,
+                        "attribute",
+                        (f"{prefix}_quant_type", "PER_TENSOR"),
+                        "only allowed with PER_TOKEN",
+                    ),
+                    (
+                        f"{side}_rotation_channel",
+                        side,
+                        "attribute",
+                        (f"{prefix}_quant_type", "PER_CHANNEL"),
+                        "PER_CHANNEL",
+                    ),
                 ]
             )
-        for label, attribute, message in cases:
+        cases.extend(
+            [
+                ("invalid_rotation", "key", "attribute", ("qk_rotation", "BAD"), "must be NONE or HADAMARD"),
+                ("invalid_v_rotation", "value", "attribute", ("v_rotation", "BAD"), "must be NONE or HADAMARD"),
+                ("invalid_width", "key", "width", 24, "power-of-two"),
+                ("too_small_width", "key", "width", 8, "power-of-two"),
+                ("too_large_width", "key", "width", 512, "power-of-two"),
+            ]
+        )
+        for label, side, operation, value, message in cases:
             with self.subTest(case=label):
-                model, feeds, _ = make_case(width=64)
-                set_attribute(model, *attribute)
+                model, feeds, _ = make_case(
+                    width=value if operation == "width" else 64,
+                    qk_rotation=operation != "width",
+                    v_rotation=operation != "width",
+                )
+                if operation == "width":
+                    set_attribute(model, "qk_rotation", "HADAMARD")
+                if operation == "attribute":
+                    set_attribute(model, *value)
+                elif operation == "shape":
+                    name = f"{side}_scale_cache"
+                    shape = list(feeds[name].shape)
+                    shape[value] += 1
+                    replace_input(model, feeds, name, np.ones(shape, dtype=np.float16))
+                elif operation == "missing":
+                    remove_input(model, feeds, f"{side}_scale_cache")
+                elif operation == "static":
+                    name, index = ("k_scale", 14) if side == "key" else ("v_scale", 15)
+                    replace_input(model, feeds, name, np.ones(1, dtype=np.float32))
+                    model.graph.node[0].input[index] = name
                 del model.graph.node[0].output[1:]
                 del model.graph.output[1:]
                 with self.assertRaisesRegex(Exception, message):
+                    run_case(model, feeds)
+
+    def test_optional_scale_output_holes(self):
+        for side, prefix, input_index, output_index in (("key", "k", 14, 3), ("value", "v", 15, 4)):
+            with self.subTest(side=side):
+                model, feeds, _ = make_case()
+                remove_input(model, feeds, f"{side}_scale_cache")
+                set_attribute(model, f"{prefix}_quant_type", "PER_TENSOR")
+                replace_input(model, feeds, f"{prefix}_scale", np.array([0.125], dtype=np.float32))
+                model.graph.node[0].input[input_index] = f"{prefix}_scale"
+                missing_output = model.graph.node[0].output[output_index]
+                model.graph.node[0].output[output_index] = ""
+                del model.graph.output[output_index]
+                actual = run_case(model, feeds)[0]
+                reference_model = onnx.ModelProto.FromString(model.SerializeToString())
+                del reference_model.graph.node[0].output[3:]
+                del reference_model.graph.output[3:]
+                reference = run_case(reference_model, feeds)[0]
+                np.testing.assert_array_equal(actual["output"], reference["output"])
+                model.graph.node[0].output[output_index] = missing_output
+                model.graph.output.append(
+                    helper.make_tensor_value_info(missing_output, TensorProto.FLOAT16, feeds[f"{side}_cache"].shape[:3])
+                )
+                with self.assertRaisesRegex(Exception, "Scale cache output requires"):
                     run_case(model, feeds)
 
     def test_invalid_packed_dimensions(self):
@@ -516,7 +641,7 @@ class TestPagedAttentionInt4(unittest.TestCase):
                 self.check_case(width=width, activation_dtype=ml_dtypes.bfloat16)
 
     def test_int4_known_packing_and_padding(self):
-        model, feeds, _ = make_case(width=32, lengths=(1,), past=(0,), quant_type="PER_TENSOR")
+        model, feeds, _ = make_case(width=32, lengths=(1,), past=(0,), qk_rotation=False, v_rotation=False)
         pattern = np.array(
             [
                 -9,
@@ -559,24 +684,46 @@ class TestPagedAttentionInt4(unittest.TestCase):
         packed = biased[::2] | (biased[1::2] << 4)
         expected = {}
         slot = int(feeds["slot_mapping"][0])
-        for side, prefix in (("key", "k"), ("value", "v")):
+        for side, prefix, index in (("key", "k", 14), ("value", "v", 15)):
             feeds[side][:] = np.tile(pattern, 2)
             feeds[f"{side}_cache"][:] = 0x88
+            remove_input(model, feeds, f"{side}_scale_cache")
             replace_input(model, feeds, f"{prefix}_scale", np.ones(1, dtype=np.float32))
+            model.graph.node[0].input[index] = f"{prefix}_scale"
+            set_attribute(model, f"{prefix}_quant_type", "PER_TENSOR")
             cache = feeds[f"{side}_cache"].copy()
             cache.reshape(-1, 2, 16)[slot] = packed
             expected[f"{side}_cache_out"] = cache
+        del model.graph.node[0].output[3:]
+        del model.graph.output[3:]
         actual = run_case(model, feeds)[0]
         for name, values in expected.items():
             np.testing.assert_array_equal(actual[name], values)
         np.testing.assert_array_equal(actual["output"], np.tile(signed, 4).reshape(1, -1).astype(np.float16))
+
+    def test_int4_k_per_token_v_per_channel(self):
+        model, feeds, expected = make_case(width=32, lengths=(1,), past=(0,), v_rotation=False)
+        scale = np.linspace(0.02, 0.15, 64, dtype=np.float32).reshape(2, 1, 32)
+        remove_input(model, feeds, "value_scale_cache")
+        replace_input(model, feeds, "v_scale", scale)
+        model.graph.node[0].input[15] = "v_scale"
+        set_attribute(model, "v_quant_type", "PER_CHANNEL")
+        del model.graph.node[0].output[4:]
+        del model.graph.output[4:]
+        scaled = feeds["value"].reshape(2, 32).astype(np.float32) / scale.reshape(2, 32)
+        quantized = np.clip(np.rint(scaled), -8, 7)
+        decoded = quantized * scale.reshape(2, 32)
+        actual = run_case(model, feeds)[0]
+        np.testing.assert_allclose(actual["output"], np.repeat(decoded, 2, axis=0).reshape(1, -1), atol=5e-4, rtol=1e-3)
+        np.testing.assert_array_equal(actual["key_cache_out"], expected["key_cache_out"])
+        np.testing.assert_array_equal(actual["key_scale_cache_out"], expected["key_scale_cache_out"])
 
     def test_int4_per_channel_xqa_matches_portable(self):
         # A PER_CHANNEL scale is folded into Q and the output, so XQA has to agree with the
         # portable kernel. lengths (2, 1) also covers the speculative INT4 kernel.
         for lengths in ((1, 1), (2, 1)):
             with self.subTest(lengths=lengths):
-                model, feeds, _ = make_case(
+                model, feeds = per_channel_int4_case(
                     width=256, heads=24, kv_heads=4, past=(513, 138), block_size=256, lengths=lengths
                 )
                 with patch.dict(os.environ, {"ORT_ENABLE_XQA": "0"}):
@@ -593,46 +740,79 @@ class TestPagedAttentionInt4(unittest.TestCase):
                     np.testing.assert_array_equal(accelerated[name], portable[name])
 
     def test_int4_scale_extremes(self):
-        for magnitude in (2.0**-24, 1e10):
-            with self.subTest(magnitude=magnitude):
-                model, feeds, _ = make_case(
-                    width=32,
-                    lengths=(1,),
-                    past=(0,),
-                    quant_type="PER_TENSOR",
-                    activation_dtype=ml_dtypes.bfloat16,
-                )
-                pattern = np.tile(np.array([-magnitude, magnitude], dtype=ml_dtypes.bfloat16), 32).reshape(1, 64)
-                for side, prefix in (("key", "k"), ("value", "v")):
-                    feeds[side][:] = pattern
-                    replace_input(model, feeds, f"{prefix}_scale", np.array([1e-6], dtype=np.float32))
-                actual = run_case(model, feeds)[0]
-                raw = pattern.reshape(2, 32).astype(np.float32)
-                biased = (np.clip(np.rint(raw / np.float32(1e-6)), -8, 7).astype(np.int8) + 8).astype(np.uint8)
-                packed = biased[:, ::2] | (biased[:, 1::2] << 4)
-                page, offset = divmod(int(feeds["slot_mapping"][0]), 16)
-                for side in ("key", "value"):
-                    np.testing.assert_array_equal(actual[f"{side}_cache_out"][page, offset], packed)
+        for dynamic in (False, True):
+            for magnitude in (2.0**-24, 1e10):
+                with self.subTest(dynamic=dynamic, magnitude=magnitude):
+                    model, feeds, _ = make_case(
+                        width=32,
+                        lengths=(1,),
+                        past=(0,),
+                        qk_rotation=False,
+                        v_rotation=False,
+                        activation_dtype=ml_dtypes.bfloat16,
+                    )
+                    pattern = np.tile(np.array([-magnitude, magnitude], dtype=ml_dtypes.bfloat16), 32).reshape(1, 64)
+                    for side, prefix, index in (("key", "k", 14), ("value", "v", 15)):
+                        feeds[side][:] = pattern
+                        if not dynamic:
+                            remove_input(model, feeds, f"{side}_scale_cache")
+                            replace_input(model, feeds, f"{prefix}_scale", np.array([1e-6], dtype=np.float32))
+                            model.graph.node[0].input[index] = f"{prefix}_scale"
+                            set_attribute(model, f"{prefix}_quant_type", "PER_TENSOR")
+                    if not dynamic:
+                        del model.graph.node[0].output[3:]
+                        del model.graph.output[3:]
+                    actual = run_case(model, feeds)[0]
+                    raw = pattern.reshape(2, 32).astype(np.float32)
+                    if dynamic:
+                        packed, scales = quantize(raw, np.float16)
+                    else:
+                        signed = np.clip(np.rint(raw / np.float32(1e-6)), -8, 7).astype(np.int8)
+                        biased = (signed + 8).astype(np.uint8)
+                        packed = biased[:, ::2] | (biased[:, 1::2] << 4)
+                    page, offset = divmod(int(feeds["slot_mapping"][0]), 16)
+                    for side in ("key", "value"):
+                        np.testing.assert_array_equal(actual[f"{side}_cache_out"][page, offset], packed)
+                        if dynamic:
+                            np.testing.assert_array_equal(actual[f"{side}_scale_cache_out"][page, offset], scales)
 
-    def test_reject_latent_int4(self):
-        model, feeds, _ = make_case(width=64, lengths=(1,), past=(0,), heads=4, kv_heads=1)
-        set_attribute(model, "kv_cache_layout", "LATENT")
-        set_attribute(model, "v_quant_type", "NONE")
-        set_attribute(model, "v_cache_dtype", "")
-        remove_input(model, feeds, "value")
-        remove_input(model, feeds, "value_cache")
-        remove_input(model, feeds, "v_scale")
-        del model.graph.node[0].output[1:]
-        del model.graph.output[1:]
-        with self.assertRaisesRegex(Exception, "LATENT"):
-            run_case(model, feeds)
+    def test_reject_scale_rank_dtype_and_latent_rotation(self):
+        for operation, message in (
+            ("rank", "Scale cache must have shape"),
+            ("dtype", "invalid"),
+            ("mixed_dtype", "bound to different types"),
+            ("latent", "LATENT"),
+        ):
+            with self.subTest(operation=operation):
+                model, feeds, _ = make_case()
+                if operation == "rank":
+                    replace_input(model, feeds, "key_scale_cache", feeds["key_scale_cache"].reshape(-1, 2))
+                elif operation == "dtype":
+                    replace_input(model, feeds, "key_scale_cache", feeds["key_scale_cache"].astype(np.int32))
+                elif operation == "mixed_dtype":
+                    replace_input(model, feeds, "key_scale_cache", feeds["key_scale_cache"].astype(np.float32))
+                else:
+                    model, feeds, _ = make_case(int4=False)
+                    set_attribute(model, "kv_cache_layout", "LATENT")
+                    remove_input(model, feeds, "value")
+                    remove_input(model, feeds, "value_cache")
+                    set_attribute(model, "kv_num_heads", 1)
+                    replace_input(model, feeds, "key", feeds["key"][:, :64])
+                    replace_input(model, feeds, "key_cache", feeds["key_cache"][:, :, :1, :].copy())
+                del model.graph.node[0].output[1:]
+                del model.graph.output[1:]
+                with self.assertRaisesRegex(Exception, message):
+                    run_case(model, feeds)
 
     def test_int8_fp8_cache_regression(self):
         for cache_dtype, qmax in ((np.int8, 127), (ml_dtypes.float8_e4m3fn, 448)):
-            for mode in ("PER_TENSOR", "PER_CHANNEL"):
+            for mode in ("PER_TENSOR", "PER_CHANNEL", "PER_TOKEN"):
                 for lengths in ((1, 1), (33, 17)):
                     with self.subTest(cache_dtype=cache_dtype, mode=mode, lengths=lengths):
-                        model, feeds, _ = make_case(width=128, lengths=lengths, int4=False)
+                        rotated = mode == "PER_TOKEN"
+                        model, feeds, _ = make_case(
+                            width=128, lengths=lengths, int4=False, qk_rotation=rotated, v_rotation=rotated
+                        )
                         reference_model = onnx.ModelProto.FromString(model.SerializeToString())
                         reference_feeds = {name: array.copy() for name, array in feeds.items()}
                         reference_feeds["slot_mapping"][:] = -1
@@ -641,15 +821,33 @@ class TestPagedAttentionInt4(unittest.TestCase):
                             cache_name = f"{side}_cache"
                             dense = feeds[cache_name].astype(np.float32)
                             current = feeds[side].reshape(-1, 2, 128).astype(np.float32)
-                            scale = (
-                                np.array([0.03125], dtype=np.float32)
-                                if mode == "PER_TENSOR"
-                                else np.linspace(0.02, 0.06, 256, dtype=np.float32).reshape(2, 1, 128)
-                            )
-                            scale_name = f"{prefix}_scale"
-                            replace_input(model, feeds, scale_name, scale)
-                            model.graph.node[0].input[index] = scale_name
-                            divisor = scale.reshape(2, 128) if mode == "PER_CHANNEL" else scale
+                            if rotated:
+                                current = rotate(current)
+                            if mode == "PER_TOKEN":
+                                scales = (np.max(np.abs(dense), axis=-1) / qmax).astype(np.float16)
+                                current_scales = (np.max(np.abs(current), axis=-1) / qmax).astype(np.float16)
+                                scale_name = f"{side}_scale_cache"
+                                replace_input(model, feeds, scale_name, scales.copy())
+                                model.graph.node[0].input[index + 3] = scale_name
+                                model.graph.node[0].output.append(f"{scale_name}_out")
+                                model.graph.output.append(
+                                    helper.make_tensor_value_info(
+                                        f"{scale_name}_out", TensorProto.FLOAT16, scales.shape
+                                    )
+                                )
+                                divisor = scales[..., None]
+                                current_divisor = current_scales[..., None]
+                            else:
+                                scale = (
+                                    np.array([0.03125], dtype=np.float32)
+                                    if mode == "PER_TENSOR"
+                                    else np.linspace(0.02, 0.06, 256, dtype=np.float32).reshape(2, 1, 128)
+                                )
+                                scale_name = f"{prefix}_scale"
+                                replace_input(model, feeds, scale_name, scale)
+                                model.graph.node[0].input[index] = scale_name
+                                divisor = scale.reshape(2, 128) if mode == "PER_CHANNEL" else scale
+                                current_divisor = divisor
 
                             def encode(array, scale, cache_dtype=cache_dtype, qmax=qmax):
                                 scaled = np.divide(array, scale, out=np.zeros_like(array), where=scale != 0)
@@ -663,18 +861,24 @@ class TestPagedAttentionInt4(unittest.TestCase):
                             for output in model.graph.output:
                                 if output.name == f"{cache_name}_out":
                                     output.type.tensor_type.elem_type = cache_type
-                            encoded_current = encode(current, divisor)
+                            encoded_current = encode(current, current_divisor)
                             for token, slot in enumerate(feeds["slot_mapping"]):
                                 page, offset = divmod(int(slot), 16)
                                 cache[page, offset] = encoded_current[token]
+                                if mode == "PER_TOKEN":
+                                    scales[page, offset] = current_scales[token]
                             expected_cache[f"{cache_name}_out"] = cache
+                            if mode == "PER_TOKEN":
+                                expected_cache[f"{scale_name}_out"] = scales
                             reference_feeds[cache_name] = (cache.astype(np.float32) * divisor).astype(np.float16)
                             set_attribute(model, f"{prefix}_quant_type", mode)
                         actual = run_case(model, feeds)[0]
                         reference = run_case(reference_model, reference_feeds)[0]
                         np.testing.assert_allclose(actual["output"], reference["output"], atol=8e-4, rtol=5e-3)
                         for name, expected in expected_cache.items():
-                            if cache_dtype == np.int8:
+                            if "scale" in name:
+                                np.testing.assert_allclose(actual[name], expected, atol=1e-6, rtol=1e-3)
+                            elif cache_dtype == np.int8:
                                 np.testing.assert_allclose(actual[name], expected, atol=1, rtol=0)
                             else:
                                 lower = np.nextafter(expected, np.array(-448, dtype=cache_dtype)).astype(np.float32)


### PR DESCRIPTION
### Description

Stacked on #32515 — **please review that one first; this PR targets its branch, not `main`.**

Adds the two pieces the rotated INT4 configuration needs on top of the per-channel INT4 paged KV cache.

**PER_TOKEN quantization.** Each cached token gets its own scale, computed from that token's own amax during the cache write and stored in new in-place scale caches (inputs 17/18, outputs 3/4) that reuse the `slot_mapping` and `block_table` of the KV caches. Unlike a static scale this granularity adapts to outliers, which is what makes 4-bit viable for a rotated cache.

**Hadamard rotation.** `qk_rotation` / `v_rotation` apply a per-head orthonormal Walsh-Hadamard transform: Q and K are rotated after QK-Norm and rotary, V is rotated before caching, and the transform is inverted on the attention output. Because the transform is orthonormal it leaves attention mathematically unchanged (`(QH)(KH)^T = QK^T` and `softmax(S)(VH) = (softmax(S)V)H`) while spreading each head's energy across channels, which shrinks the per-token quantization range.

The rotation is incompatible with `PER_CHANNEL` on the rotated side, because a static per-channel scale is not preserved by mixing channels, so validation rejects that combination and the rotated path uses `PER_TOKEN`.

The XQA INT4 loader now takes an optional per-token FP16 scale array. A null pointer keeps the `PER_CHANNEL` behaviour from #32515, where the scale is folded into Q and the output and the kernel runs at unit scale, so that path is unchanged bit-for-bit.

### Motivation and Context

INT4 KV halves the cache against INT8 and is what makes a 256K context fit on 24 GB alongside a speculative drafter. Per-token scales plus the rotation are the accuracy insurance for that: on a 27B model the rotation lifts INT4 K SNR from 11.67 dB to 19.66 dB in simulation, and the two 4-bit variants land within noise of the INT8 baseline on GPQA-diamond and MMLU-Pro.

### Notes for reviewers

- Everything new is behind the existing `onnxruntime_USE_INT4_KV_CACHE` CMake option (default OFF). With the option off, `int4_xqa_eligible` is a `constexpr false` and the dispatch is unchanged.
- The only WebGPU change is passing the new `allow_per_token` argument when parsing the quantization-type attribute, so a `PER_TOKEN` node reports the existing "not supported yet" path instead of claiming the attribute value is invalid. The WebGPU kernel still rejects any quantized cache.
- `docs/ContribOperators.md` is generated; its diff is the schema change rendered by `tools/python/gen_contrib_doc.py`.
- Validated with the CUDA EP built both with and without `onnxruntime_USE_INT4_KV_CACHE`. The WebGPU EP was not built locally.
