### PR TITLE
[WebGPU] Fix out-of-bounds writes in SubgroupMatrixMatMulNBits

### DIFF
--- a/onnxruntime/contrib_ops/webgpu/quantization/matmul_nbits.cc
+++ b/onnxruntime/contrib_ops/webgpu/quantization/matmul_nbits.cc
@@ -234,7 +234,8 @@ Status ApplyMatMulNBits(const Tensor* a, const Tensor* b, const Tensor* scales, 
                                         y->DataType() == DataTypeImpl::GetType<MLFloat16>(),
                                         subgroup_matrix_config_index,
                                         M,
-                                        has_weight_idx_indirect)) {
+                                        has_weight_idx_indirect,
+                                        has_bias)) {
     return ApplySubgroupMatrixMatMulNBits(a, b, scales, zero_points, bias, M, N, K, static_cast<uint32_t>(nbits), zero_blocks_per_col, subgroup_matrix_config_index, context, y, weight_index, weight_index_indirect);
   }
 

--- a/onnxruntime/contrib_ops/webgpu/quantization/matmul_nbits_mlp.cc
+++ b/onnxruntime/contrib_ops/webgpu/quantization/matmul_nbits_mlp.cc
@@ -308,7 +308,9 @@ Status MatMulNBitsMlp::ComputeInternal(onnxruntime::webgpu::ComputeContext& cont
                                         static_cast<uint32_t>(bits_),
                                         y->DataType() == DataTypeImpl::GetType<MLFloat16>(),
                                         subgroup_matrix_config_index,
-                                        M);
+                                        M,
+                                        /*has_weight_idx_indirect=*/false,
+                                        /*has_bias=*/gate_bias != nullptr || up_bias != nullptr);
   const bool would_use_dp4a_unfused =
       CanApplyDP4AMatrixMatMulNBits(context, accuracy_level_, block_size, N, K, components_a,
                                     M, /*has_weight_idx_indirect=*/false, y);

--- a/onnxruntime/contrib_ops/webgpu/quantization/subgroup_matrix_matmul_nbits.cc
+++ b/onnxruntime/contrib_ops/webgpu/quantization/subgroup_matrix_matmul_nbits.cc
@@ -4,7 +4,6 @@
 #include "contrib_ops/webgpu/quantization/subgroup_matrix_matmul_nbits.h"
 #include "contrib_ops/webgpu/quantization/matmul_nbits_common.h"
 #include "core/providers/webgpu/math/subgroup_matrix_config.h"
-#include "core/providers/webgpu/vendor/intel/intel_device_info.h"
 
 namespace onnxruntime {
 namespace contrib {
@@ -14,6 +13,7 @@ namespace webgpu {
 // shared core header (core/providers/webgpu/math/subgroup_matrix_config.h) so both this contrib
 // kernel and the core subgroup-matrix MatMul share them.
 using onnxruntime::webgpu::IsSubgroupMatrixConfigSupported;
+using onnxruntime::webgpu::SupportedSubgroupMatrixConfig;
 using onnxruntime::webgpu::supported_subgroup_matrix_configs;
 
 // This program optimizes the layout of input matrix A(MxK) for SubgroupMatrixLoad, so that all elements of each
@@ -147,6 +147,39 @@ Status SubgroupMatrixMatMulNBitsProgram::GenerateShaderCode(ShaderHelper& shader
   }
 }
 
+// Full workgroup/tile/dispatch layout for a subgroup matrix config and M/N shape: output tile
+// size, workgroup size, and dispatch grouping. Each workgroup handles exactly one (M-tile,
+// N-tile) pair. Shared between ApplySubgroupMatrixMatMulNBits (actual dispatch/prepack sizing)
+// and CanApplySubgroupMatrixMatMulNBits (shape pre-check), so the two can't drift out of sync.
+struct SubgroupMatrixTiling {
+  uint32_t tile_size_a;
+  uint32_t tile_size_b;
+  uint32_t work_group_size;
+  uint32_t dispatch_x;
+  uint32_t dispatch_y;
+};
+
+SubgroupMatrixTiling GetSubgroupMatrixTiling(const SupportedSubgroupMatrixConfig& config, uint32_t M, uint32_t N) {
+  SubgroupMatrixTiling tiling{};
+  tiling.tile_size_a = 32;
+  tiling.tile_size_b = 64;
+  tiling.work_group_size = 128;
+  if (config.Is(8, 16, 16)) {
+    // 8x16x16 config: 8 subgroups, 256 threads, 64x64 tiles
+    tiling.tile_size_a = 64;
+    tiling.work_group_size = 256;
+  } else if (config.Is(16, 16, 16)) {
+    // 16x16x16 config: 4 subgroups, 128 threads, 128x128 tiles
+    tiling.tile_size_a = 128;
+    tiling.tile_size_b = 128;
+    tiling.work_group_size = 128;
+  }
+
+  tiling.dispatch_x = (N + tiling.tile_size_b - 1) / tiling.tile_size_b;
+  tiling.dispatch_y = (M + tiling.tile_size_a - 1) / tiling.tile_size_a;
+  return tiling;
+}
+
 Status ApplySubgroupMatrixMatMulNBits(const Tensor* a, const Tensor* b, const Tensor* scales,
                                       const Tensor* zero_points, const Tensor* bias,
                                       uint32_t M,
@@ -159,21 +192,10 @@ Status ApplySubgroupMatrixMatMulNBits(const Tensor* a, const Tensor* b, const Te
                                       Tensor* y,
                                       const uint32_t weight_index,
                                       const Tensor* weight_index_indirect) {
-  // Determine tile sizes first (needed for prepack padding).
+  // Determine the full tiling/dispatch layout first (needed for prepack padding).
   const auto& config = supported_subgroup_matrix_configs[config_index];
-  uint32_t tile_size_a = 32;
-  uint32_t tile_size_b = 64;
-  uint32_t work_group_size = 128;
-  if (config.Is(8, 16, 16)) {
-    // 8x16x16 config: 8 subgroups, 256 threads, 64x64 tiles
-    tile_size_a = 64;
-    work_group_size = 256;
-  } else if (config.Is(16, 16, 16)) {
-    // 16x16x16 config: 4 subgroups, 128 threads, 128x128 tiles
-    tile_size_a = 128;
-    tile_size_b = 128;
-    work_group_size = 128;
-  }
+  const auto tiling = GetSubgroupMatrixTiling(config, M, N);
+  const uint32_t tile_size_a = tiling.tile_size_a;
 
   // If applicable, layout optimization of input matrix A(MxK) can be used for SubgroupMatrixLoad.
   Tensor a_prepack;
@@ -211,7 +233,7 @@ Status ApplySubgroupMatrixMatMulNBits(const Tensor* a, const Tensor* b, const Te
   const bool has_weight_idx_indirect = weight_index_indirect != nullptr;
   const bool has_weight_idx = weight_index > 0 || has_weight_idx_indirect;
   SubgroupMatrixMatMulNBitsProgram mul_program{nbits, config_index, has_zero_points, has_bias, has_weight_idx, has_weight_idx_indirect};
-  mul_program.SetWorkgroupSize(work_group_size);
+  mul_program.SetWorkgroupSize(tiling.work_group_size);
 
   // On Intel, use a fixed subgroup size of 32 for better performance.
   if (context.AdapterInfo().vendor == std::string_view{"intel"} &&
@@ -219,26 +241,11 @@ Status ApplySubgroupMatrixMatMulNBits(const Tensor* a, const Tensor* b, const Te
     mul_program.SetSubgroupSize(32);
   }
 
-  uint32_t dispatch_x = (N + tile_size_b - 1) / tile_size_b;
-  uint32_t num_m_tiles = (M + tile_size_a - 1) / tile_size_a;
-  uint32_t dispatch_y = num_m_tiles;
-  // For large M on Intel Xe, cap dispatch_y so each workgroup processes multiple
-  // M-tiles sequentially, reducing scheduling overhead.
-  if (M > 2048 && context.AdapterInfo().vendor == std::string_view{"intel"}) {
-    const uint32_t hw_subgroups =
-        ::onnxruntime::webgpu::intel::HwSubgroups(std::string_view{context.AdapterInfo().architecture});
-    if (hw_subgroups > 0) {
-      constexpr uint32_t kOccupancyFactor = 16;  // empirically tuned on Xe2/Xe3 devices
-      uint32_t target_wgs = hw_subgroups * kOccupancyFactor / (work_group_size / 32);
-      dispatch_y = std::min(dispatch_y, (target_wgs + dispatch_x - 1) / dispatch_x);
-    }
-  }
-  uint32_t m_tiles_per_wg = (num_m_tiles + dispatch_y - 1) / dispatch_y;
-  mul_program.SetDispatchGroupSize(dispatch_x, dispatch_y, 1);
+  mul_program.SetDispatchGroupSize(tiling.dispatch_x, tiling.dispatch_y, 1);
   mul_program.AddInputs({{a, ProgramTensorMetadataDependency::TypeAndRank, 1},
                          {b, ProgramTensorMetadataDependency::TypeAndRank, static_cast<int>(nbits == 4 ? kU32Components : 2 * kU32Components)},
                          {scales, ProgramTensorMetadataDependency::TypeAndRank, 1}})
-      .AddUniformVariables({{M}, {N}, {K}, {zero_blocks_per_col}, {weight_index}, {m_tiles_per_wg}})
+      .AddUniformVariables({{M}, {N}, {K}, {zero_blocks_per_col}, {weight_index}})
       .AddOutput({y, ProgramTensorMetadataDependency::TypeAndRank, y_shape, 1})
       .CacheHint(nbits, has_zero_points, has_bias, has_weight_idx, has_weight_idx_indirect);
   if (has_zero_points) {
@@ -263,7 +270,8 @@ bool CanApplySubgroupMatrixMatMulNBits(onnxruntime::webgpu::ComputeContext& cont
                                        bool is_fp16,
                                        int32_t& config_index,
                                        uint32_t M,
-                                       bool has_weight_idx_indirect) {
+                                       bool has_weight_idx_indirect,
+                                       bool has_bias) {
   // Subgroup matrix kernels only support 4-bit/8-bit quantization.
   if (nbits != 4 && nbits != 8) {
     return false;
@@ -286,6 +294,17 @@ bool CanApplySubgroupMatrixMatMulNBits(onnxruntime::webgpu::ComputeContext& cont
         // by setting compute_precision to Fp32, but that will be slower. For 1K token prefill FP16 Phi 3.5 is around 5s,
         // FP32 is around 7s.
         has_subgroup_matrix = accuracy_level == 4;
+      }
+
+      if (has_subgroup_matrix && !has_bias && supported_subgroup_matrix_configs[config_index].Is(8, 16, 16)) {
+        // The 8x16x16 kernel's non-bias output-store path (subgroup_matrix_matmul_nbits_8x16x16.wgsl.template)
+        // writes whole subgroup-matrix output tiles with no per-element bounds check, unlike the bias path
+        // (and unlike the 8x8x8 / 16x16x16 kernels, which bounds-check every write regardless of M/N
+        // alignment). It must not be dispatched for an M or N that isn't an exact multiple of the tile size
+        // ApplySubgroupMatrixMatMulNBits will actually use, or the edge tiles write past the end of the
+        // output tensor. The bias path already bounds-checks every write, so it's exempt.
+        const auto tiling = GetSubgroupMatrixTiling(supported_subgroup_matrix_configs[config_index], M, N);
+        has_subgroup_matrix = M % tiling.tile_size_a == 0 && N % tiling.tile_size_b == 0;
       }
     }
   }

--- a/onnxruntime/contrib_ops/webgpu/quantization/subgroup_matrix_matmul_nbits.h
+++ b/onnxruntime/contrib_ops/webgpu/quantization/subgroup_matrix_matmul_nbits.h
@@ -32,8 +32,7 @@ class SubgroupMatrixMatMulNBitsProgram final : public Program<SubgroupMatrixMatM
       {"N", ProgramUniformVariableDataType::Uint32},
       {"K", ProgramUniformVariableDataType::Uint32},
       {"zero_blocks_per_col", ProgramUniformVariableDataType::Uint32},
-      {"weight_idx", ProgramUniformVariableDataType::Uint32},
-      {"m_tiles_per_wg", ProgramUniformVariableDataType::Uint32});
+      {"weight_idx", ProgramUniformVariableDataType::Uint32});
 
  private:
   uint32_t nbits_;
@@ -67,7 +66,8 @@ bool CanApplySubgroupMatrixMatMulNBits(onnxruntime::webgpu::ComputeContext& cont
                                        bool is_fp16,
                                        int32_t& config_index,
                                        uint32_t M = std::numeric_limits<uint32_t>::max(),
-                                       bool has_weight_idx_indirect = false);
+                                       bool has_weight_idx_indirect = false,
+                                       bool has_bias = false);
 
 }  // namespace webgpu
 }  // namespace contrib

--- a/onnxruntime/contrib_ops/webgpu/quantization/subgroup_matrix_matmul_nbits_8x16x16.wgsl.template
+++ b/onnxruntime/contrib_ops/webgpu/quantization/subgroup_matrix_matmul_nbits_8x16x16.wgsl.template
@@ -133,106 +133,96 @@ fn dequant_b_to_tile(n_base: u32, k_idx: u32, n_idx: u32, k_chunk_idx: u32) {
 
 $MAIN {
     let global_base_b = workgroup_id.x * kTileN;
+    let global_base_a = workgroup_id.y * kTileM;
     let sg_idx = u32(local_idx / sg_size);
     let sg_mat_count_k = uniforms.K / kSgMatK;
-    let num_tiles_m = (uniforms.M + kTileM - 1) / kTileM;
+    let sg_mat_idx = (workgroup_id.y * kSgMatCountM + sg_idx) * sg_mat_count_k;
 
-    // Zero-initialized accumulator template (used to reset per M-tile iteration).
-    var sg_mat_zero: subgroup_matrix_result<f16, sg_mat_n, sg_mat_m>;
+    var sg_mat_offset_a = sg_mat_idx * kSgMatSizeLeft;
 
-    // Sequential M-loop: each workgroup processes a contiguous block of M-tiles.
-    let m_start = workgroup_id.y * uniforms.m_tiles_per_wg;
-    let m_end = min(m_start + uniforms.m_tiles_per_wg, num_tiles_m);
-    for (var m_tile: u32 = m_start; m_tile < m_end; m_tile++) {
-        let global_base_a = m_tile * kTileM;
-        let sg_mat_idx = (m_tile * kSgMatCountM + sg_idx) * sg_mat_count_k;
-
-        var sg_mat_offset_a = sg_mat_idx * kSgMatSizeLeft;
-
-        var sg_mat_c0 = sg_mat_zero;
-        var sg_mat_c1 = sg_mat_zero;
-        var sg_mat_c2 = sg_mat_zero;
-        var sg_mat_c3 = sg_mat_zero;
-        for (var k_idx: u32 = 0; k_idx < uniforms.K; k_idx += kTileK) {
-            // Load Phase
-            dequant_b_to_tile(global_base_b, k_idx, local_idx / 4, local_idx % 4);
-            workgroupBarrier();
-
-            for (var sg_mat_k_idx: u32 = 0; sg_mat_k_idx < kTileK; sg_mat_k_idx += kSgMatK)
-            {
-                // Load A from global memory (prepacked layout).
-                // Syntax: subgroupMatrixLoad<type, majorness>(src_ptr, src_offset, src_stride)
-                var sg_mat_a0: subgroup_matrix_left<f16, sg_mat_k, sg_mat_m> =
-                    subgroupMatrixLoad<subgroup_matrix_left<f16, sg_mat_k, sg_mat_m>, row_major>(
-                        &input_a, sg_mat_offset_a, kSgMatK);
-                sg_mat_offset_a += kSgMatSizeLeft;
-
-                // Load B from shared local memory.
-                // tile_b [kTileN, kTileK] is stored as column major.
-                var sg_mat_b0: subgroup_matrix_right<f16, sg_mat_n, sg_mat_k> =
-                    subgroupMatrixLoad<subgroup_matrix_right<f16, sg_mat_n, sg_mat_k>, col_major>(
-                        &tile_b, sg_mat_k_idx, kTileK);
-                var sg_mat_b1: subgroup_matrix_right<f16, sg_mat_n, sg_mat_k> =
-                    subgroupMatrixLoad<subgroup_matrix_right<f16, sg_mat_n, sg_mat_k>, col_major>(
-                        &tile_b, sg_mat_k_idx + kSgMatStrideN, kTileK);
-                var sg_mat_b2: subgroup_matrix_right<f16, sg_mat_n, sg_mat_k> =
-                    subgroupMatrixLoad<subgroup_matrix_right<f16, sg_mat_n, sg_mat_k>, col_major>(
-                        &tile_b, sg_mat_k_idx + 2 * kSgMatStrideN, kTileK);
-                var sg_mat_b3: subgroup_matrix_right<f16, sg_mat_n, sg_mat_k> =
-                    subgroupMatrixLoad<subgroup_matrix_right<f16, sg_mat_n, sg_mat_k>, col_major>(
-                        &tile_b, sg_mat_k_idx + 3 * kSgMatStrideN, kTileK);
-
-                // Compute Phase
-                // Syntax: subgroupMatrixMultiplyAccumulate left, right, accumulate -> accumulate
-                sg_mat_c0 = subgroupMatrixMultiplyAccumulate(sg_mat_a0, sg_mat_b0, sg_mat_c0);
-                sg_mat_c1 = subgroupMatrixMultiplyAccumulate(sg_mat_a0, sg_mat_b1, sg_mat_c1);
-                sg_mat_c2 = subgroupMatrixMultiplyAccumulate(sg_mat_a0, sg_mat_b2, sg_mat_c2);
-                sg_mat_c3 = subgroupMatrixMultiplyAccumulate(sg_mat_a0, sg_mat_b3, sg_mat_c3);
-            }
-            workgroupBarrier();
-        }
-
-        // Write out
-#if has_bias
-        // Store results to scratch workgroup memory, then add bias and write to output.
-        // scratch layout: [kTileM, kTileN] row-major
-        let scratch_m_base = sg_idx * kSgMatM;
-        subgroupMatrixStore<row_major>(&scratch, scratch_m_base * kTileN, sg_mat_c0, kTileN);
-        subgroupMatrixStore<row_major>(&scratch, scratch_m_base * kTileN + kSgMatN, sg_mat_c1, kTileN);
-        subgroupMatrixStore<row_major>(&scratch, scratch_m_base * kTileN + 2 * kSgMatN, sg_mat_c2, kTileN);
-        subgroupMatrixStore<row_major>(&scratch, scratch_m_base * kTileN + 3 * kSgMatN, sg_mat_c3, kTileN);
+    var sg_mat_c0: subgroup_matrix_result<f16, sg_mat_n, sg_mat_m>;
+    var sg_mat_c1: subgroup_matrix_result<f16, sg_mat_n, sg_mat_m>;
+    var sg_mat_c2: subgroup_matrix_result<f16, sg_mat_n, sg_mat_m>;
+    var sg_mat_c3: subgroup_matrix_result<f16, sg_mat_n, sg_mat_m>;
+    for (var k_idx: u32 = 0; k_idx < uniforms.K; k_idx += kTileK) {
+        // Load Phase
+        dequant_b_to_tile(global_base_b, k_idx, local_idx / 4, local_idx % 4);
         workgroupBarrier();
 
-        // 256 threads write 64x64 = 4096 elements. Each thread handles 16 elements.
-        // Thread mapping: m = local_idx / 4, n_base = (local_idx % 4) * 16
-        let out_m = local_idx / 4;
-        let out_n_base = (local_idx % 4) * 16;
-        let global_m = global_base_a + out_m;
-        if (global_m < uniforms.M) {
-            let global_n_base = global_base_b + out_n_base;
-            let scratch_base = out_m * kTileN + out_n_base;
-            let out_base = global_m * uniforms.N + global_n_base;
+        for (var sg_mat_k_idx: u32 = 0; sg_mat_k_idx < kTileK; sg_mat_k_idx += kSgMatK)
+        {
+            // Load A from global memory (prepacked layout).
+            // Syntax: subgroupMatrixLoad<type, majorness>(src_ptr, src_offset, src_stride)
+            var sg_mat_a0: subgroup_matrix_left<f16, sg_mat_k, sg_mat_m> =
+                subgroupMatrixLoad<subgroup_matrix_left<f16, sg_mat_k, sg_mat_m>, row_major>(
+                    &input_a, sg_mat_offset_a, kSgMatK);
+            sg_mat_offset_a += kSgMatSizeLeft;
+
+            // Load B from shared local memory.
+            // tile_b [kTileN, kTileK] is stored as column major.
+            var sg_mat_b0: subgroup_matrix_right<f16, sg_mat_n, sg_mat_k> =
+                subgroupMatrixLoad<subgroup_matrix_right<f16, sg_mat_n, sg_mat_k>, col_major>(
+                    &tile_b, sg_mat_k_idx, kTileK);
+            var sg_mat_b1: subgroup_matrix_right<f16, sg_mat_n, sg_mat_k> =
+                subgroupMatrixLoad<subgroup_matrix_right<f16, sg_mat_n, sg_mat_k>, col_major>(
+                    &tile_b, sg_mat_k_idx + kSgMatStrideN, kTileK);
+            var sg_mat_b2: subgroup_matrix_right<f16, sg_mat_n, sg_mat_k> =
+                subgroupMatrixLoad<subgroup_matrix_right<f16, sg_mat_n, sg_mat_k>, col_major>(
+                    &tile_b, sg_mat_k_idx + 2 * kSgMatStrideN, kTileK);
+            var sg_mat_b3: subgroup_matrix_right<f16, sg_mat_n, sg_mat_k> =
+                subgroupMatrixLoad<subgroup_matrix_right<f16, sg_mat_n, sg_mat_k>, col_major>(
+                    &tile_b, sg_mat_k_idx + 3 * kSgMatStrideN, kTileK);
+
+            // Compute Phase
+            // Syntax: subgroupMatrixMultiplyAccumulate left, right, accumulate -> accumulate
+            sg_mat_c0 = subgroupMatrixMultiplyAccumulate(sg_mat_a0, sg_mat_b0, sg_mat_c0);
+            sg_mat_c1 = subgroupMatrixMultiplyAccumulate(sg_mat_a0, sg_mat_b1, sg_mat_c1);
+            sg_mat_c2 = subgroupMatrixMultiplyAccumulate(sg_mat_a0, sg_mat_b2, sg_mat_c2);
+            sg_mat_c3 = subgroupMatrixMultiplyAccumulate(sg_mat_a0, sg_mat_b3, sg_mat_c3);
+        }
+        workgroupBarrier();
+    }
+
+    // Write out
+#if has_bias
+    // Store results to scratch workgroup memory, then add bias and write to output.
+    // scratch layout: [kTileM, kTileN] row-major
+    let scratch_m_base = sg_idx * kSgMatM;
+    subgroupMatrixStore<row_major>(&scratch, scratch_m_base * kTileN, sg_mat_c0, kTileN);
+    subgroupMatrixStore<row_major>(&scratch, scratch_m_base * kTileN + kSgMatN, sg_mat_c1, kTileN);
+    subgroupMatrixStore<row_major>(&scratch, scratch_m_base * kTileN + 2 * kSgMatN, sg_mat_c2, kTileN);
+    subgroupMatrixStore<row_major>(&scratch, scratch_m_base * kTileN + 3 * kSgMatN, sg_mat_c3, kTileN);
+    workgroupBarrier();
+
+    // 256 threads write 64x64 = 4096 elements. Each thread handles 16 elements.
+    // Thread mapping: m = local_idx / 4, n_base = (local_idx % 4) * 16
+    let out_m = local_idx / 4;
+    let out_n_base = (local_idx % 4) * 16;
+    let global_m = global_base_a + out_m;
+    if (global_m < uniforms.M) {
+        let global_n_base = global_base_b + out_n_base;
+        let scratch_base = out_m * kTileN + out_n_base;
+        let out_base = global_m * uniforms.N + global_n_base;
 #if has_weight_idx_indirect
-            let bias_offset = weight_index_indirect[uniforms.weight_idx] * uniforms.N;
+        let bias_offset = weight_index_indirect[uniforms.weight_idx] * uniforms.N;
 #elif has_weight_idx
-            let bias_offset = uniforms.weight_idx * uniforms.N;
+        let bias_offset = uniforms.weight_idx * uniforms.N;
 #else
-            const bias_offset: u32 = 0;
+        const bias_offset: u32 = 0;
 #endif
-            for (var i: u32 = 0; i < 16; i++) {
-                if (global_n_base + i < uniforms.N) {
-                    let val = output_element_t(scratch[scratch_base + i])
-                        + bias[bias_offset + global_n_base + i];
-                    output.setByOffset(out_base + i, val);
-                }
+        for (var i: u32 = 0; i < 16; i++) {
+            if (global_n_base + i < uniforms.N) {
+                let val = output_element_t(scratch[scratch_base + i])
+                    + bias[bias_offset + global_n_base + i];
+                output.setByOffset(out_base + i, val);
             }
         }
+    }
 #else
-        let sg_mat_offset_c = global_base_a * uniforms.N + global_base_b + sg_idx * kSgMatM * uniforms.N;
-        subgroupMatrixStore<row_major>(&output, sg_mat_offset_c, sg_mat_c0, uniforms.N);
-        subgroupMatrixStore<row_major>(&output, sg_mat_offset_c + kSgMatN, sg_mat_c1, uniforms.N);
-        subgroupMatrixStore<row_major>(&output, sg_mat_offset_c + 2 * kSgMatN, sg_mat_c2, uniforms.N);
-        subgroupMatrixStore<row_major>(&output, sg_mat_offset_c + 3 * kSgMatN, sg_mat_c3, uniforms.N);
+    let sg_mat_offset_c = global_base_a * uniforms.N + global_base_b + sg_idx * kSgMatM * uniforms.N;
+    subgroupMatrixStore<row_major>(&output, sg_mat_offset_c, sg_mat_c0, uniforms.N);
+    subgroupMatrixStore<row_major>(&output, sg_mat_offset_c + kSgMatN, sg_mat_c1, uniforms.N);
+    subgroupMatrixStore<row_major>(&output, sg_mat_offset_c + 2 * kSgMatN, sg_mat_c2, uniforms.N);
+    subgroupMatrixStore<row_major>(&output, sg_mat_offset_c + 3 * kSgMatN, sg_mat_c3, uniforms.N);
 #endif
-    } // end M-tile loop
 }  // MAIN


### PR DESCRIPTION
### Description
The 8x16x16 kernel's non-bias output-store path writes whole subgroup-matrix tiles with no per-element bounds check, unlike the bias path and unlike the 8x8x8 / 16x16x16 kernels (which bounds-check every write regardless of M/N alignment). For an M or N that isn't an exact multiple of the kernel's tile size, this wrote past the end of the output tensor.

CanApplySubgroupMatrixMatMulNBits now rejects (falls back to DP4A) unaligned shapes for the non-bias path only; the bias path is unaffected since it's already safe for any M/N. Tile-size/dispatch computation is consolidated into GetSubgroupMatrixTiling, shared between Apply and CanApply so they can't drift out of sync.

Also drops the Intel-specific m_tiles_per_wg dispatch_y capping (each workgroup now processes exactly one M-tile again, matching the other kernels), simplifying the host and shader code together.


### Motivation and Context
See above.
