### PR TITLE
Fix duplicate script_params in the AzureML BERT notebook

### DIFF
--- a/onnxruntime/python/tools/transformers/notebooks/Inference_Bert_with_OnnxRuntime_on_AzureML.ipynb
+++ b/onnxruntime/python/tools/transformers/notebooks/Inference_Bert_with_OnnxRuntime_on_AzureML.ipynb
@@ -117,7 +117,6 @@
     "                    compute_target=gpu_compute_target,\n",
     "                    use_docker=True,\n",
     "                    custom_docker_image=image_name,\n",
-    "                    script_params = {...},\n",
     "                    entry_script='run_squad_azureml.py', # change here\n",
     "                    node_count=1,\n",
     "                    process_count_per_node=4,\n",


### PR DESCRIPTION
### Description

The PyTorch estimator cell in `Inference_Bert_with_OnnxRuntime_on_AzureML.ipynb` passes `script_params` twice — the second time as a leftover `{...}` placeholder:

```python
estimator = PyTorch(source_directory=project_roots,
                    script_params={'--output-dir': './outputs'},
                    compute_target=gpu_compute_target,
                    use_docker=True,
                    custom_docker_image=image_name,
                    script_params = {...},          # <- duplicate
                    entry_script='run_squad_azureml.py',
                    ...)
```

Python rejects a repeated keyword argument at compile time, so running that cell raises

```
SyntaxError: keyword argument repeated: script_params
```

and the notebook cannot proceed past it. Note this is a *compile*-stage error, so `ast.parse()` accepts the source and only `compile()` surfaces it — which is likely why it went unnoticed.

### Change

Remove the placeholder line and keep the real value. One line deleted, no other cells or metadata touched.

Verified afterwards by extracting the cell source and calling `compile(src, "<cell>", "exec")`, which now succeeds.
