### PR TITLE
Avoid telemetry session sidecar for in-memory storage

### DIFF
--- a/cmake/patches/cpp_client_telemetry/cpp_client_telemetry.patch
+++ b/cmake/patches/cpp_client_telemetry/cpp_client_telemetry.patch
@@ -125,3 +125,25 @@
      return {EMPTY_GUID};
 +#endif
  }
+
+--- a/lib/offline/LogSessionDataProvider.cpp
++++ b/lib/offline/LogSessionDataProvider.cpp
+@@ -91,7 +91,8 @@
+     void LogSessionDataProvider::DeleteLogSessionDataFromFile()
+     {
+-        std::string sessionPath = m_cacheFilePath.empty() ? "" : (m_cacheFilePath + ".ses").c_str();
++        std::string sessionPath =
++            (m_cacheFilePath.empty() || m_cacheFilePath == ":memory:") ? "" : m_cacheFilePath + ".ses";
+         if (!sessionPath.empty() && MAT::FileExists(sessionPath.c_str()))
+         {
+             MAT::FileDelete(sessionPath.c_str());
+@@ -104,7 +105,8 @@
+     {
+         uint64_t sessionFirstTimeLaunch = 0;
+         std::string sessionSDKUid;
+-        std::string sessionPath = m_cacheFilePath.empty() ? "" : (m_cacheFilePath + ".ses").c_str();
++        std::string sessionPath =
++            (m_cacheFilePath.empty() || m_cacheFilePath == ":memory:") ? "" : m_cacheFilePath + ".ses";
+         if (!sessionPath.empty()) 
+         {
+             if (MAT::FileExists(sessionPath.c_str())) 

--- a/cmake/patches/cpp_client_telemetry/cpp_client_telemetry.patch
+++ b/cmake/patches/cpp_client_telemetry/cpp_client_telemetry.patch
@@ -128,7 +128,8 @@
 
 --- a/lib/offline/LogSessionDataProvider.cpp
 +++ b/lib/offline/LogSessionDataProvider.cpp
-@@ -91,7 +91,8 @@
+@@ -97,7 +97,8 @@
+ 
      void LogSessionDataProvider::DeleteLogSessionDataFromFile()
      {
 -        std::string sessionPath = m_cacheFilePath.empty() ? "" : (m_cacheFilePath + ".ses").c_str();
@@ -137,7 +138,7 @@
          if (!sessionPath.empty() && MAT::FileExists(sessionPath.c_str()))
          {
              MAT::FileDelete(sessionPath.c_str());
-@@ -104,7 +105,8 @@
+@@ -108,7 +109,8 @@
      {
          uint64_t sessionFirstTimeLaunch = 0;
          std::string sessionSDKUid;
@@ -147,3 +148,46 @@
          if (!sessionPath.empty()) 
          {
              if (MAT::FileExists(sessionPath.c_str())) 
+--- a/tests/functests/LogSessionDataFuncTests.cpp
++++ b/tests/functests/LogSessionDataFuncTests.cpp
+@@ -14,14 +14,18 @@
+ 
+ const std::string SessionFileArgument = "test";
+ const char* const SessionFile = "test.ses";
++const char* const MemorySessionFile = ":memory:.ses";
+ 
+ class LogSessionDataFuncTests : public ::testing::Test
+ {
+     void CleanupLocalSessionFile()
+     {
+-        if (MAT::FileExists(SessionFile))
++        for (const auto* sessionFile : {SessionFile, MemorySessionFile})
+         {
+-            MAT::FileDelete(SessionFile);
++            if (MAT::FileExists(sessionFile))
++            {
++                MAT::FileDelete(sessionFile);
++            }
+         }
+     }
+ 
+@@ -76,6 +80,19 @@
+     ASSERT_TRUE(MAT::FileExists(SessionFile));
+ }
+ 
++TEST_F(LogSessionDataFuncTests, Constructor_InMemoryCache_NoSessionFileCreated)
++{
++    auto logSessionDataProvider = LogSessionDataProvider(":memory:");
++    logSessionDataProvider.CreateLogSessionData();
++    ASSERT_NE(logSessionDataProvider.GetLogSessionData(), nullptr);
++    EXPECT_FALSE(MAT::FileExists(MemorySessionFile));
++
++    logSessionDataProvider.ResetLogSessionData();
++    EXPECT_FALSE(MAT::FileExists(MemorySessionFile));
++    logSessionDataProvider.DeleteLogSessionData();
++    EXPECT_FALSE(MAT::FileExists(MemorySessionFile));
++}
++
+ TEST_F(LogSessionDataFuncTests, Constructor_ValidSessionFileExists_MembersSetToExistingFile)
+ {
+     const std::string validSessionFirstTime{ "123456" };


### PR DESCRIPTION
### Description

Fixes #32476.

When telemetry falls back to SQLite's `:memory:` database, the session-data code still appends `.ses` to the cache path and creates a real `:memory:.ses` file in the working directory.

Treat `:memory:` like an empty cache path for the file-backed session sidecar. Normal file-backed telemetry behavior is unchanged.

### Testing

- Regenerated the patch hunks against the pinned `cpp_client_telemetry` v3.10.173.1 dependency and verified patch application.
- Added `Constructor_InMemoryCache_NoSessionFileCreated`, covering create, reset, and delete.
- The new regression fails with the original provider and passes with the fix.
- Built the patched dependency on macOS arm64 and ran `LogSessionDataFuncTests.*`: all 5 passed, including existing file-backed behavior.

The full dependency functional suite and upstream CI matrix were not run locally.
