### PR TITLE
Preserve negative zero in CPU Where

### DIFF
--- a/onnxruntime/core/providers/cpu/tensor/where_op.cc
+++ b/onnxruntime/core/providers/cpu/tensor/where_op.cc
@@ -4,6 +4,7 @@
 #include "core/providers/cpu/tensor/where_op.h"
 
 #include <algorithm>
+#include <cmath>
 #include <type_traits>
 
 #include "core/providers/cpu/math/element_wise_ops.h"  // for broadcast utilities
@@ -149,8 +150,17 @@ EnableIfEigenNotScalar<T, ProcessBroadcastSpanFuncs> SelectBroadcastFuncs() {
 }
 
 template <typename T>
+bool WasSelected(const T& value) {
+  if constexpr (std::is_floating_point<T>::value) {
+    return value != T{} || std::signbit(value);
+  }
+
+  return value != T{};
+}
+
+template <typename T>
 void MergeScalarAndVector(EigenVectorMap<T> output, const T& scalar_value, ConstEigenVectorMap<T> vector_value) {
-  if (scalar_value != T{}) {
+  if (WasSelected(scalar_value)) {
     output = EigenVectorMap<T>::PlainObject::Constant(vector_value.size(), scalar_value);
   } else {
     output = vector_value;
@@ -175,7 +185,7 @@ EnableIfEigenScalar<T, ProcessBroadcastSpanFuncs> MergeBroadcastFuncs() {
         auto Y_selection = per_iter_bh.EigenInput1<T>();
         per_iter_bh.OutputEigen<T>() = X_selection.binaryExpr(Y_selection,
                                                               [](T x, T y) -> T {
-                                                                return x != T{} ? x : y;
+                                                                return WasSelected(x) ? x : y;
                                                               });
       }};
 }

--- a/onnxruntime/core/providers/cpu/tensor/where_op.cc
+++ b/onnxruntime/core/providers/cpu/tensor/where_op.cc
@@ -277,7 +277,8 @@ Status Where<T>::Compute(OpKernelContext* context) const {
   // These selections are handled within UntypedSelect.
   //
   // Finally, we broadcast over and merge X_selection and Y_selection:
-  //   output = (X_selection != default value) ? X_selection : Y_selection
+  //   output = WasSelected(X_selection) ? X_selection : Y_selection
+  // Floating-point negative zero counts as selected despite comparing equal to the default.
   //
   // The merging is handled within UntypedMerge.
   auto X_selection_tensor = UntypedSelect(*context, true, tensor_allocator, typed_tensor_allocation, funcs);

--- a/onnxruntime/test/providers/cpu/tensor/where_op_test.cc
+++ b/onnxruntime/test/providers/cpu/tensor/where_op_test.cc
@@ -3,6 +3,7 @@
 
 #include "gtest/gtest.h"
 
+#include <cmath>
 #include <gsl/gsl>
 
 #include "test/providers/provider_test_utils.h"
@@ -26,6 +27,47 @@ std::vector<TDest> CastVector(const std::vector<TSrc>& source) {
   std::transform(source.begin(), source.end(), std::back_inserter(target),
                  [](TSrc n) { return static_cast<TDest>(n); });
   return target;
+}
+
+template <typename T>
+void WherePreservesNegativeZeroTest() {
+  const auto verify_negative_zero = [](const std::vector<OrtValue>& fetches,
+                                       const std::string& /*provider_type*/) {
+    ASSERT_EQ(fetches.size(), 1u);
+    ASSERT_TRUE(fetches[0].IsTensor());
+
+    const auto& output_tensor = fetches[0].Get<Tensor>();
+    const auto* output = output_tensor.Data<T>();
+    for (int64_t i = 0; i < output_tensor.Shape().Size(); ++i) {
+      EXPECT_TRUE(std::signbit(output[i]));
+    }
+  };
+
+  {
+    OpTester test{kOpName, kOpVersion};
+    test.AddInput<bool>("condition", {1}, {true});
+    test.AddInput<T>("X", {1}, {-T{0}});
+    test.AddInput<T>("Y", {1}, {T{0}});
+    test.AddOutput<T>("output", {1}, {-T{0}});
+    test.SetCustomOutputVerifier(verify_negative_zero);
+
+    std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
+    execution_providers.push_back(DefaultCpuExecutionProvider());
+    test.Run(OpTester::ExpectResult::kExpectSuccess, "", {}, nullptr, &execution_providers);
+  }
+
+  {
+    OpTester test{kOpName, kOpVersion};
+    test.AddInput<bool>("condition", {1}, {false});
+    test.AddInput<T>("X", {4}, {T{1}, T{2}, T{3}, T{4}});
+    test.AddInput<T>("Y", {1}, {-T{0}});
+    test.AddOutput<T>("output", {4}, {-T{0}, -T{0}, -T{0}, -T{0}});
+    test.SetCustomOutputVerifier(verify_negative_zero);
+
+    std::vector<std::unique_ptr<IExecutionProvider>> execution_providers;
+    execution_providers.push_back(DefaultCpuExecutionProvider());
+    test.Run(OpTester::ExpectResult::kExpectSuccess, "", {}, nullptr, &execution_providers);
+  }
 }
 
 template <typename TNumeric>
@@ -104,6 +146,11 @@ void WhereBroadcastTest(const T& x_value, const T& y_value) {
 TEST(WhereOpTest, BasicNumeric) {
   WhereBasicNumericTest<float>();
   WhereBasicNumericTest<double>();
+}
+
+TEST(WhereOpTest, PreservesNegativeZero) {
+  WherePreservesNegativeZeroTest<float>();
+  WherePreservesNegativeZeroTest<double>();
 }
 
 TEST(WhereOpTest, BasicString) {

--- a/onnxruntime/test/providers/cpu/tensor/where_op_test.cc
+++ b/onnxruntime/test/providers/cpu/tensor/where_op_test.cc
@@ -7,9 +7,9 @@
 #include <gsl/gsl>
 
 #include "test/providers/provider_test_utils.h"
+#include "test/util/include/default_providers.h"
 
 #ifdef USE_WEBGPU
-#include "test/util/include/default_providers.h"
 #include "core/providers/webgpu/webgpu_provider_options.h"
 #endif
 
@@ -39,6 +39,7 @@ void WherePreservesNegativeZeroTest() {
     const auto& output_tensor = fetches[0].Get<Tensor>();
     const auto* output = output_tensor.Data<T>();
     for (int64_t i = 0; i < output_tensor.Shape().Size(); ++i) {
+      EXPECT_EQ(output[i], T{0});
       EXPECT_TRUE(std::signbit(output[i]));
     }
   };


### PR DESCRIPTION
### Description

Fixes #32191.

The CPU `Where` implementation uses zero-filled selection tensors and treats `value != 0` as the marker that an element was selected. A selected `-0.0` compares equal to the `+0.0` sentinel, so its sign bit is lost.

Preserve selected floating-point negative zero while keeping integer and string behavior unchanged. The algorithm comment now describes the signed-zero-aware selection rule.

### Testing

- Float/double regression coverage for direct X selection and broadcast Y selection.
- The custom verifier checks both equality to zero and the sign bit.
- Native macOS arm64 Release build completed; all 6 `WhereOpTest.*` cases passed.

Validation used a combined worktree on current main with the pending QuickGelu, DivMul, and Gelu fixes. This does not claim validation of the full upstream CI matrix.
