### PR TITLE
[MLAS] Riscv64 rvv kernel optimizations

### DIFF
--- a/cmake/onnxruntime_mlas.cmake
+++ b/cmake/onnxruntime_mlas.cmake
@@ -1160,6 +1160,7 @@ else()
               ${MLAS_SRC_DIR}/riscv64/layernorm_kernel_rvv.cpp
               ${MLAS_SRC_DIR}/riscv64/qgemm_kernel_rvv.cpp
               ${MLAS_SRC_DIR}/riscv64/activation_kernel_rvv.cpp
+              ${MLAS_SRC_DIR}/riscv64/conv_activation_kernel_rvv.cpp
               ${MLAS_SRC_DIR}/riscv64/qnbitgemm_kernel_rvv.cpp
             )
             list(REMOVE_ITEM mlas_platform_srcs
@@ -1174,6 +1175,7 @@ else()
               ${MLAS_SRC_DIR}/riscv64/layernorm_kernel_rvv.cpp
               ${MLAS_SRC_DIR}/riscv64/qgemm_kernel_rvv.cpp
               ${MLAS_SRC_DIR}/riscv64/activation_kernel_rvv.cpp
+              ${MLAS_SRC_DIR}/riscv64/conv_activation_kernel_rvv.cpp
               ${MLAS_SRC_DIR}/riscv64/qnbitgemm_kernel_rvv.cpp
               PROPERTIES COMPILE_FLAGS "-march=rv64gcv -mabi=lp64d")
             list(APPEND mlas_private_compile_definitions MLAS_USE_RVV=1)

--- a/onnxruntime/core/mlas/lib/activate.cpp
+++ b/onnxruntime/core/mlas/lib/activate.cpp
@@ -489,6 +489,16 @@ Return Value:
 
 --*/
 {
+#if defined(MLAS_TARGET_RISCV64) && defined(MLAS_USE_RVV)
+    // The platform routine covers the element-wise kinds and returns false for the
+    // rest, which fall through to the switch below.
+
+    if (GetMlasPlatform().ActivationRoutine != nullptr &&
+        GetMlasPlatform().ActivationRoutine(Activation, Buffer, Bias, M, N, ldc)) {
+        return;
+    }
+#endif
+
     switch (Activation->ActivationKind) {
 
         case MlasIdentityActivation:

--- a/onnxruntime/core/mlas/lib/convolve.cpp
+++ b/onnxruntime/core/mlas/lib/convolve.cpp
@@ -1747,6 +1747,31 @@ Return Value:
             return;
         }
 
+    #if defined(MLAS_TARGET_RISCV64) && defined(MLAS_USE_RVV)
+
+        // The riscv64 depthwise kernel covers kernel shapes beyond 3x3 and any
+        // stride; the alternative for those is im2col and a GEMM per channel.
+        // Routing widens only where the vector kernels are installed, since
+        // MlasConvDepthwiseFloat_CHW runs vector instructions and a build for the
+        // vector extension can still run on a part that does not implement it.
+
+        if (GetMlasPlatform().ConvNchwFloatKernel != nullptr
+                && Dimensions == 2
+                && Parameters->FilterCount == 1 && Parameters->InputChannels == 1
+                && Parameters->KernelShape[1] <= kDepthwiseGeneralMaxKernelWidth
+                && Parameters->Padding[0] < Parameters->KernelShape[0]
+                && Parameters->Padding[1] < Parameters->KernelShape[1]
+                && Parameters->Padding[2] < Parameters->KernelShape[0]
+                && Parameters->Padding[3] < Parameters->KernelShape[1]
+                && Parameters->DilationShape[0] == 1 && Parameters->DilationShape[1] == 1) {
+
+            *WorkingBufferSize = Parameters->InputShape[1] + 2;
+            Parameters->Algorithm = MlasConvAlgorithmDepthwise;
+            return;
+        }
+
+    #endif
+
 #endif
 
         //

--- a/onnxruntime/core/mlas/lib/mlasi.h
+++ b/onnxruntime/core/mlas/lib/mlasi.h
@@ -664,6 +664,17 @@ constexpr size_t kDepthwiseGeneralMaxKernelWidth = 16;
 #endif
 
 typedef
+bool
+(MLASCALL MLAS_ACTIVATION_ROUTINE)(
+    const MLAS_ACTIVATION* Activation,
+    float* Buffer,
+    const float* Bias,
+    size_t M,
+    size_t N,
+    size_t ldc
+    );
+
+typedef
 void
 (MLASCALL MLAS_COMPUTE_ERF_FP16_KERNEL)(
     const MLAS_FP16* Input,
@@ -1471,6 +1482,7 @@ MlasReorderOutputNchwBlock16Avx512F(
     MLAS_COMPUTE_UNARY_FLOAT_KERNEL MlasSiluKernelRvv;
     MLAS_COMPUTE_UNARY_FLOAT_KERNEL MlasTanhKernelRvv;
     MLAS_COMPUTE_UNARY_FLOAT_KERNEL MlasComputeExpF32KernelRvv;
+    MLAS_ACTIVATION_ROUTINE MlasActivationRvv;
 #endif
 #if defined(MLAS_TARGET_AMD64)
     MLAS_REDUCE_MAXIMUM_FLOAT_KERNEL MlasReduceMaximumF32KernelAvx;
@@ -1897,6 +1909,7 @@ struct MLAS_PLATFORM {
     MLAS_CONV_POINTWISE_FLOAT_KERNEL* ConvPointwiseFloatKernel;
     MLAS_POOL_FLOAT_KERNEL* PoolFloatKernel[MlasPoolingKindCount];
     uint32_t NchwcBlockSize;
+    MLAS_ACTIVATION_ROUTINE* ActivationRoutine;
 #endif
 
 MLAS_COMPUTE_ERF_FP16_KERNEL* ErfFP16KernelRoutine = nullptr;

--- a/onnxruntime/core/mlas/lib/mlasi.h
+++ b/onnxruntime/core/mlas/lib/mlasi.h
@@ -659,6 +659,10 @@ void
     size_t N
     );
 
+#if defined(MLAS_TARGET_RISCV64) && defined(MLAS_USE_RVV)
+constexpr size_t kDepthwiseGeneralMaxKernelWidth = 16;
+#endif
+
 typedef
 void
 (MLASCALL MLAS_COMPUTE_ERF_FP16_KERNEL)(

--- a/onnxruntime/core/mlas/lib/platform.cpp
+++ b/onnxruntime/core/mlas/lib/platform.cpp
@@ -346,6 +346,7 @@ Return Value:
     this->ComputeLogSoftmaxOutputF32Kernel = MlasComputeLogSoftmaxOutputF32Kernel;
 
 #if defined(MLAS_USE_RVV)
+    this->ActivationRoutine = nullptr;
     bool has_rvv = true;
 #if defined(__linux__)
     has_rvv = (getauxval(AT_HWCAP) & COMPAT_HWCAP_ISA_V) != 0;
@@ -364,6 +365,7 @@ Return Value:
         this->GeluErfKernelRoutine = MlasGeluErfKernelRvv;
         this->SiluKernelRoutine = MlasSiluKernelRvv;
         this->TanhKernelRoutine = MlasTanhKernelRvv;
+        this->ActivationRoutine = MlasActivationRvv;
         this->ComputeExpF32Kernel = MlasComputeExpF32KernelRvv;
         this->ReduceMaximumF32Kernel = MlasReduceMaximumF32KernelRvv;
         this->ComputeSumExpF32Kernel = MlasComputeSumExpF32KernelRvv;

--- a/onnxruntime/core/mlas/lib/riscv64/conv_activation_kernel_rvv.cpp
+++ b/onnxruntime/core/mlas/lib/riscv64/conv_activation_kernel_rvv.cpp
@@ -1,0 +1,291 @@
+/*++
+
+Copyright (c) Microsoft Corporation. All rights reserved.
+
+Licensed under the MIT License.
+
+Module Name:
+
+    conv_activation_kernel_rvv.cpp
+
+Abstract:
+
+    This module implements RVV kernels for the fused activations on riscv64.
+
+    The kinds that are pure element-wise arithmetic are covered here: Identity,
+    which only has to apply the bias, Relu, LeakyRelu, Clip and HardSigmoid. Tanh
+    and Logistic are not, because MlasActivation applies the bias and then routes
+    those two through MlasComputeTanh and MlasComputeLogistic, which have kernels
+    of their own.
+
+    Each kind reproduces the arithmetic of its MLAS_ACTIVATION_FUNCTION
+    specialization in activate.cpp, so the results are the same. The comparisons
+    are a compare plus a merge rather than vfmin/vfmax for the reason given in
+    unary_clamp_rvv.h; the bounds here are runtime values, so the clamps cannot
+    come from that header.
+
+    The generic kernel splits each row into a four wide vector body and a scalar
+    remainder. Both compute the same thing, so there is no separate tail here:
+    vsetvl covers the end of the row.
+
+--*/
+
+#include "mlasi.h"
+
+#if defined(MLAS_USE_RVV)
+
+#include <riscv_vector.h>
+
+namespace {
+
+//
+// Mirrors MlasMaximumFloat32x4(MlasBroadcastFloat32x4(Bound), Value):
+// (Bound > Value) ? Bound : Value, and Value when the compare is unordered.
+//
+MLAS_FORCEINLINE
+vfloat32m4_t
+ClampLower(
+    vfloat32m4_t Value,
+    float Bound,
+    size_t vl
+    )
+{
+    return __riscv_vfmerge_vfm_f32m4(Value, Bound,
+                                     __riscv_vmflt_vf_f32m4_b8(Value, Bound, vl), vl);
+}
+
+//
+// Mirrors MlasMinimumFloat32x4(MlasBroadcastFloat32x4(Bound), Value):
+// (Value > Bound) ? Bound : Value, and Value when the compare is unordered.
+//
+MLAS_FORCEINLINE
+vfloat32m4_t
+ClampUpper(
+    vfloat32m4_t Value,
+    float Bound,
+    size_t vl
+    )
+{
+    return __riscv_vfmerge_vfm_f32m4(Value, Bound,
+                                     __riscv_vmfgt_vf_f32m4_b8(Value, Bound, vl), vl);
+}
+
+//
+// One vector's worth of each activation. The parameters are read once by the
+// caller and passed in as scalars, matching the broadcasts the generic
+// MLAS_ACTIVATION_FUNCTION constructors set up.
+//
+
+struct ActivationIdentityRvv {
+    explicit ActivationIdentityRvv(const MLAS_ACTIVATION*) {}
+
+    MLAS_FORCEINLINE vfloat32m4_t Activate(vfloat32m4_t Value, size_t) const
+    {
+        return Value;
+    }
+};
+
+struct ActivationReluRvv {
+    explicit ActivationReluRvv(const MLAS_ACTIVATION*) {}
+
+    // MlasMaximumFloat32x4(Zero, Value)
+    MLAS_FORCEINLINE vfloat32m4_t Activate(vfloat32m4_t Value, size_t vl) const
+    {
+        return ClampLower(Value, 0.0f, vl);
+    }
+};
+
+struct ActivationLeakyReluRvv {
+    float Alpha;
+
+    explicit ActivationLeakyReluRvv(const MLAS_ACTIVATION* Activation)
+        : Alpha(Activation->Parameters.LeakyRelu.alpha)
+    {
+    }
+
+    // The form this target compiles, MlasBlendFloat32x4(ValueTimesAlpha, Value,
+    // Zero < Value), i.e. (0 < Value) ? Value : Value * Alpha. The comparison is
+    // the strict one, and being unordered it selects Value * Alpha for a NaN, the
+    // way every other implementation of this activation does.
+    MLAS_FORCEINLINE vfloat32m4_t Activate(vfloat32m4_t Value, size_t vl) const
+    {
+        const vfloat32m4_t ValueTimesAlpha = __riscv_vfmul_vf_f32m4(Value, Alpha, vl);
+        return __riscv_vmerge_vvm_f32m4(ValueTimesAlpha, Value,
+                                        __riscv_vmfgt_vf_f32m4_b8(Value, 0.0f, vl), vl);
+    }
+};
+
+struct ActivationClipRvv {
+    float Minimum;
+    float Maximum;
+
+    explicit ActivationClipRvv(const MLAS_ACTIVATION* Activation)
+        : Minimum(Activation->Parameters.Clip.minimum),
+          Maximum(Activation->Parameters.Clip.maximum)
+    {
+    }
+
+    MLAS_FORCEINLINE vfloat32m4_t Activate(vfloat32m4_t Value, size_t vl) const
+    {
+        return ClampUpper(ClampLower(Value, Minimum, vl), Maximum, vl);
+    }
+};
+
+struct ActivationHardSigmoidRvv {
+    float Alpha;
+    float Beta;
+
+    explicit ActivationHardSigmoidRvv(const MLAS_ACTIVATION* Activation)
+        : Alpha(Activation->Parameters.HardSigmoid.alpha),
+          Beta(Activation->Parameters.HardSigmoid.beta)
+    {
+    }
+
+    // Value * Alpha + Beta, then Minimum(1.0, .), then Maximum(0.0, .), in that
+    // order, as the generic specialization does.
+    MLAS_FORCEINLINE vfloat32m4_t Activate(vfloat32m4_t Value, size_t vl) const
+    {
+        Value = __riscv_vfmadd_vf_f32m4(Value, Alpha, __riscv_vfmv_v_f_f32m4(Beta, vl), vl);
+        return ClampLower(ClampUpper(Value, 1.0f, vl), 0.0f, vl);
+    }
+};
+
+//
+// Steps over the output matrix the same way MlasActivationKernel does: one row
+// at a time, with the bias broadcast from a single element per row.
+//
+template <typename ActivationType, bool AddBias>
+void
+ActivationLoopRvv(
+    const MLAS_ACTIVATION* Activation,
+    float* Buffer,
+    const float* Bias,
+    size_t M,
+    size_t N,
+    size_t ldc
+    )
+{
+    const ActivationType ActivationFunction(Activation);
+
+    while (M-- > 0) {
+        float* buffer = Buffer;
+        size_t n = N;
+
+        float bias = 0.0f;
+        if (AddBias) {
+            bias = *Bias++;
+        }
+
+        while (n > 0) {
+            const size_t vl = __riscv_vsetvl_e32m4(n);
+
+            vfloat32m4_t Vector = __riscv_vle32_v_f32m4(buffer, vl);
+            if (AddBias) {
+                Vector = __riscv_vfadd_vf_f32m4(Vector, bias, vl);
+            }
+            __riscv_vse32_v_f32m4(buffer, ActivationFunction.Activate(Vector, vl), vl);
+
+            buffer += vl;
+            n -= vl;
+        }
+
+        Buffer += ldc;
+    }
+}
+
+template <typename ActivationType>
+void
+ActivationDispatchBiasRvv(
+    const MLAS_ACTIVATION* Activation,
+    float* Buffer,
+    const float* Bias,
+    size_t M,
+    size_t N,
+    size_t ldc
+    )
+{
+    if (Bias != nullptr) {
+        ActivationLoopRvv<ActivationType, true>(Activation, Buffer, Bias, M, N, ldc);
+    } else {
+        ActivationLoopRvv<ActivationType, false>(Activation, Buffer, Bias, M, N, ldc);
+    }
+}
+
+}  // namespace
+
+bool
+MLASCALL
+MlasActivationRvv(
+    const MLAS_ACTIVATION* Activation,
+    float* Buffer,
+    const float* Bias,
+    size_t M,
+    size_t N,
+    size_t ldc
+    )
+/*++
+
+Routine Description:
+
+    This routine applies the bias and the activation using RVV, for the
+    activation kinds that are pure element-wise arithmetic.
+
+Arguments:
+
+    Activation - Supplies the parameters for the activation.
+
+    Buffer - Supplies the output matrix.
+
+    Bias - Supplies the optional bias vector, one element per row.
+
+    M - Supplies the number of rows in the output matrix, and the number of
+        elements of the bias vector.
+
+    N - Supplies the number of columns of the output matrix.
+
+    ldc - Supplies the number of elements per row of the output matrix.
+
+Return Value:
+
+    Returns true when this routine handled the activation. Returns false for
+    the kinds it does not cover, leaving them to the caller.
+
+--*/
+{
+    switch (Activation->ActivationKind) {
+        case MlasIdentityActivation:
+            // Without a bias there is nothing to apply, which is what the
+            // generic MlasActivationKernel<MlasIdentityActivation, false>
+            // specialization also does.
+            if (Bias != nullptr) {
+                ActivationLoopRvv<ActivationIdentityRvv, true>(
+                    Activation, Buffer, Bias, M, N, ldc);
+            }
+            return true;
+
+        case MlasReluActivation:
+            ActivationDispatchBiasRvv<ActivationReluRvv>(Activation, Buffer, Bias, M, N, ldc);
+            return true;
+
+        case MlasLeakyReluActivation:
+            ActivationDispatchBiasRvv<ActivationLeakyReluRvv>(Activation, Buffer, Bias, M, N, ldc);
+            return true;
+
+        case MlasClipActivation:
+            ActivationDispatchBiasRvv<ActivationClipRvv>(Activation, Buffer, Bias, M, N, ldc);
+            return true;
+
+        case MlasHardSigmoidActivation:
+            ActivationDispatchBiasRvv<ActivationHardSigmoidRvv>(
+                Activation, Buffer, Bias, M, N, ldc);
+            return true;
+
+        default:
+            // Tanh and Logistic apply the bias and then go through
+            // MlasComputeTanh/MlasComputeLogistic, which have their own
+            // kernels, so they are left to the generic path.
+            return false;
+    }
+}
+
+#endif  // MLAS_USE_RVV

--- a/onnxruntime/core/mlas/lib/riscv64/sconv_depthwise_kernel_rvv.cpp
+++ b/onnxruntime/core/mlas/lib/riscv64/sconv_depthwise_kernel_rvv.cpp
@@ -10,9 +10,68 @@ Module Name:
 
 Abstract:
 
-    This module implements an RVV kernel for the single precision depthwise
-    convolution operation (3x3 kernel, stride 1, dilation 1, padding <= 1)
-    on riscv64.
+    This module implements RVV kernels for the single precision NCHW depthwise
+    convolution that MlasConvPrepare() routes to MlasConvAlgorithmDepthwise: one
+    for the 3x3 kernel, dilation 1, padding at most 1 shape, and one for any other
+    kernel shape at dilation 1.
+
+    The second exists because the architecture independent kernel covers 3x3
+    alone, so every other kernel shape was left to im2col and a GEMM, once per
+    channel. A depthwise convolution gives that GEMM a single row, so almost all
+    of its time goes into building the column buffer and packing a panel for one
+    row of arithmetic.
+
+    The 3x3 body follows the shape of the kernel it replaces. The row pointers
+    that kernel keeps -- row0, row1 and row2, each biased by -pad_left and each
+    replaced by the caller's zero-filled buffer when it would fall outside the
+    image -- already make the three taps of a row contiguous, so the inner loop
+    vectorizes directly: one strided load per tap, nine multiply-accumulates and
+    one store produce vl output elements at a time. Only the interior of each
+    output row is vectorized; the pad_left and pad_right columns stay scalar and
+    keep the generic kernel's arithmetic, because they drop the taps that fall
+    outside the image rather than reading a zero for them.
+
+    The nine taps are accumulated left to right into a single accumulator and the
+    beta term is added last, which is the order the generic kernel's expression is
+    written in. The results are still not bit-identical to it and cannot be: the
+    generic kernel leaves that expression for the compiler to contract, and the
+    summation topology that produces differs. This is the same class of difference
+    the direct convolution path already introduces relative to the im2col path it
+    replaces.
+
+    Two loop bodies are emitted, one using unit-stride loads for stride_w == 1 and
+    one using strided loads otherwise; both strides appear in a depthwise separable
+    network.
+
+    The general body cannot borrow that shape, because a wider kernel loses too
+    much to the edges: on a seven by seven image a 5x5 kernel pads by two, so
+    leaving the padded columns scalar would leave four of seven columns scalar. It
+    vectorizes the whole row instead and asks, per tap, which output columns that
+    tap can reach. A tap reads its input columns at the convolution's stride, so
+    the answer is an interval, and the two ends are not alike:
+
+      starts before the image   only the leading output columns, whose lanes sit
+                                at the front of a vector where neither vl nor a
+                                pointer offset reaches them, so those columns are
+                                scalar - and there are at most pad_left of them
+      reaches past the image     the lanes lost are at the end of the vector, so
+                                shortening vl drops exactly those
+      row outside the image      the tap contributes nothing and is skipped, so
+                                the general body needs no zero-filled row
+
+    Two details of that cost more than the arithmetic on a small image, and both
+    are hoisted. The bound on how far a tap reaches is computed once per filter
+    column, not per tap, because deriving it needs a division. And the taps that
+    reach a full vector are a prefix of the filter columns, so the tap loop splits
+    there: the full ones use a plain multiply-add and the partial ones a tail
+    preserving one, which keeps the vector type from changing on every tap.
+
+    LMUL is chosen at run time, not fixed. A convolution's row is only as wide as
+    the image, and a vector operation costs what its LMUL says regardless of how
+    much of it the current vl actually uses, so a tile wider than the row wastes
+    most of the machine, and how wide a fixed LMUL is depends on VLEN. The body
+    below is written once and instantiated at LMUL 1, 2 and 4, and the dispatch
+    picks the smallest one whose vector still covers the row.
 
 --*/
 
@@ -21,132 +80,222 @@ Abstract:
 #if defined(MLAS_USE_RVV)
 
 #include <riscv_vector.h>
-#include <cassert>
+
+#include <algorithm>
 
 namespace {
 
+//
+// The LMUL of an RVV intrinsic is part of its name, so the three instantiations
+// need three sets of wrappers. They are generated rather than written out to
+// keep the arithmetic in one place.
+//
+
+#define MLAS_DEPTHWISE_RVV_TRAITS(TraitsName, Suffix)                                        \
+    struct TraitsName {                                                                      \
+        using Vector = vfloat32##Suffix##_t;                                                 \
+                                                                                             \
+        static MLAS_FORCEINLINE size_t MaxVectorLength()                                     \
+        {                                                                                    \
+            return __riscv_vsetvlmax_e32##Suffix();                                          \
+        }                                                                                    \
+                                                                                             \
+        static MLAS_FORCEINLINE size_t VectorLength(size_t Count)                            \
+        {                                                                                    \
+            return __riscv_vsetvl_e32##Suffix(Count);                                        \
+        }                                                                                    \
+                                                                                             \
+        static MLAS_FORCEINLINE Vector Load(const float* Address, size_t vl)                 \
+        {                                                                                    \
+            return __riscv_vle32_v_f32##Suffix(Address, vl);                                 \
+        }                                                                                    \
+                                                                                             \
+        static MLAS_FORCEINLINE Vector                                                       \
+        LoadStrided(const float* Address, ptrdiff_t ByteStride, size_t vl)                   \
+        {                                                                                    \
+            return __riscv_vlse32_v_f32##Suffix(Address, ByteStride, vl);                    \
+        }                                                                                    \
+                                                                                             \
+        static MLAS_FORCEINLINE void Store(float* Address, Vector Value, size_t vl)          \
+        {                                                                                    \
+            __riscv_vse32_v_f32##Suffix(Address, Value, vl);                                 \
+        }                                                                                    \
+                                                                                             \
+        static MLAS_FORCEINLINE Vector Multiply(Vector Value, float Scalar, size_t vl)       \
+        {                                                                                    \
+            return __riscv_vfmul_vf_f32##Suffix(Value, Scalar, vl);                          \
+        }                                                                                    \
+                                                                                             \
+        static MLAS_FORCEINLINE Vector                                                       \
+        MultiplyAdd(Vector Accumulator, float Scalar, Vector Value, size_t vl)               \
+        {                                                                                    \
+            return __riscv_vfmacc_vf_f32##Suffix(Accumulator, Scalar, Value, vl);            \
+        }                                                                                    \
+                                                                                             \
+        static MLAS_FORCEINLINE Vector Zero(size_t vl)                                       \
+        {                                                                                    \
+            return __riscv_vfmv_v_f_f32##Suffix(0.0f, vl);                                   \
+        }                                                                                    \
+                                                                                             \
+        /* Leaves the elements past vl in the accumulator alone, which is what */            \
+        /* lets a tap that runs out of input columns simply shorten vl. */                   \
+        static MLAS_FORCEINLINE Vector                                                       \
+        MultiplyAddPartial(Vector Accumulator, float Scalar, Vector Value, size_t vl)         \
+        {                                                                                    \
+            return __riscv_vfmacc_vf_f32##Suffix##_tu(Accumulator, Scalar, Value, vl);        \
+        }                                                                                    \
+    }
+
+MLAS_DEPTHWISE_RVV_TRAITS(MlasDepthwiseRvvM1, m1);
+MLAS_DEPTHWISE_RVV_TRAITS(MlasDepthwiseRvvM2, m2);
+MLAS_DEPTHWISE_RVV_TRAITS(MlasDepthwiseRvvM4, m4);
+
+#undef MLAS_DEPTHWISE_RVV_TRAITS
+
+//
+// Accumulates the nine taps for one chunk of an output row.
+//
+// Row0, Row1 and Row2 point at the first tap of the chunk for each of the
+// three filter rows, already biased by -pad_left by the caller. ByteStride is
+// the distance in bytes between the elements that consecutive output columns
+// read, that is stride_w * sizeof(float).
+//
+
+template <typename Traits>
 MLAS_FORCEINLINE
-void
-DepthwiseAccumulateRowRvv(
-    vfloat32m4_t& acc,
-    const float* row,
-    size_t base,
-    float w0,
-    float w1,
-    float w2,
+typename Traits::Vector
+MlasConvDepthwise3x3AccumulateRvv(
+    const float* Row0,
+    const float* Row1,
+    const float* Row2,
+    ptrdiff_t ByteStride,
+    float w00,
+    float w01,
+    float w02,
+    float w10,
+    float w11,
+    float w12,
+    float w20,
+    float w21,
+    float w22,
     size_t vl
     )
 {
-    if (row == nullptr) {
-        return;
-    }
+    typename Traits::Vector Accumulator =
+        Traits::Multiply(Traits::LoadStrided(Row0, ByteStride, vl), w00, vl);
 
-    const float* r = row + base;
-    vfloat32m4_t c0 = __riscv_vle32_v_f32m4(r, vl);
-    vfloat32m4_t c1 = __riscv_vle32_v_f32m4(r + 1, vl);
-    vfloat32m4_t c2 = __riscv_vle32_v_f32m4(r + 2, vl);
+    Accumulator =
+        Traits::MultiplyAdd(Accumulator, w01, Traits::LoadStrided(Row0 + 1, ByteStride, vl), vl);
+    Accumulator =
+        Traits::MultiplyAdd(Accumulator, w02, Traits::LoadStrided(Row0 + 2, ByteStride, vl), vl);
 
-    acc = __riscv_vfmacc_vf_f32m4(acc, w0, c0, vl);
-    acc = __riscv_vfmacc_vf_f32m4(acc, w1, c1, vl);
-    acc = __riscv_vfmacc_vf_f32m4(acc, w2, c2, vl);
+    Accumulator =
+        Traits::MultiplyAdd(Accumulator, w10, Traits::LoadStrided(Row1, ByteStride, vl), vl);
+    Accumulator =
+        Traits::MultiplyAdd(Accumulator, w11, Traits::LoadStrided(Row1 + 1, ByteStride, vl), vl);
+    Accumulator =
+        Traits::MultiplyAdd(Accumulator, w12, Traits::LoadStrided(Row1 + 2, ByteStride, vl), vl);
+
+    Accumulator =
+        Traits::MultiplyAdd(Accumulator, w20, Traits::LoadStrided(Row2, ByteStride, vl), vl);
+    Accumulator =
+        Traits::MultiplyAdd(Accumulator, w21, Traits::LoadStrided(Row2 + 1, ByteStride, vl), vl);
+    Accumulator =
+        Traits::MultiplyAdd(Accumulator, w22, Traits::LoadStrided(Row2 + 2, ByteStride, vl), vl);
+
+    return Accumulator;
 }
 
+//
+// The unit-stride form of the above. Kept separate so that the common
+// stride_w == 1 case uses vle32 rather than vlse32.
+//
+
+template <typename Traits>
 MLAS_FORCEINLINE
-float
-DepthwiseSampleValue(
-    const float* row,
-    ptrdiff_t col,
-    size_t width
+typename Traits::Vector
+MlasConvDepthwise3x3AccumulateUnitStrideRvv(
+    const float* Row0,
+    const float* Row1,
+    const float* Row2,
+    float w00,
+    float w01,
+    float w02,
+    float w10,
+    float w11,
+    float w12,
+    float w20,
+    float w21,
+    float w22,
+    size_t vl
     )
 {
-    if (row == nullptr || col < 0 || col >= static_cast<ptrdiff_t>(width)) {
-        return 0.0f;
-    }
-    return row[col];
+    typename Traits::Vector Accumulator = Traits::Multiply(Traits::Load(Row0, vl), w00, vl);
+
+    Accumulator = Traits::MultiplyAdd(Accumulator, w01, Traits::Load(Row0 + 1, vl), vl);
+    Accumulator = Traits::MultiplyAdd(Accumulator, w02, Traits::Load(Row0 + 2, vl), vl);
+
+    Accumulator = Traits::MultiplyAdd(Accumulator, w10, Traits::Load(Row1, vl), vl);
+    Accumulator = Traits::MultiplyAdd(Accumulator, w11, Traits::Load(Row1 + 1, vl), vl);
+    Accumulator = Traits::MultiplyAdd(Accumulator, w12, Traits::Load(Row1 + 2, vl), vl);
+
+    Accumulator = Traits::MultiplyAdd(Accumulator, w20, Traits::Load(Row2, vl), vl);
+    Accumulator = Traits::MultiplyAdd(Accumulator, w21, Traits::Load(Row2 + 1, vl), vl);
+    Accumulator = Traits::MultiplyAdd(Accumulator, w22, Traits::Load(Row2 + 2, vl), vl);
+
+    return Accumulator;
 }
+
+//
+// The trailing padding is derived rather than read from Parameters, because
+// pad_right and pad_bottom are allowed not to match the other parameters
+// exactly. This mirrors the generic kernel.
+//
 
 MLAS_FORCEINLINE
-float
-DepthwiseComputeEdge(
-    const float* row0,
-    const float* row1,
-    const float* row2,
-    ptrdiff_t iw,
-    size_t width,
-    float w00, float w01, float w02,
-    float w10, float w11, float w12,
-    float w20, float w21, float w22
+size_t
+MlasConvDepthwisePadRight(
+    size_t OutputWidth,
+    size_t StrideWidth,
+    size_t PadLeft,
+    size_t InputWidth
     )
 {
-    float acc = 0.0f;
-    const ptrdiff_t c0 = iw;
-    const ptrdiff_t c1 = iw + 1;
-    const ptrdiff_t c2 = iw + 2;
-
-    acc += DepthwiseSampleValue(row0, c0, width) * w00;
-    acc += DepthwiseSampleValue(row0, c1, width) * w01;
-    acc += DepthwiseSampleValue(row0, c2, width) * w02;
-    acc += DepthwiseSampleValue(row1, c0, width) * w10;
-    acc += DepthwiseSampleValue(row1, c1, width) * w11;
-    acc += DepthwiseSampleValue(row1, c2, width) * w12;
-    acc += DepthwiseSampleValue(row2, c0, width) * w20;
-    acc += DepthwiseSampleValue(row2, c1, width) * w21;
-    acc += DepthwiseSampleValue(row2, c2, width) * w22;
-
-    return acc;
-}
-
-MLAS_FORCEINLINE
-float
-DepthwiseAccumulateRowScalar(
-    float acc,
-    const float* row,
-    size_t base,
-    float w0,
-    float w1,
-    float w2
-    )
-{
-    if (row == nullptr) {
-        return acc;
+    if (OutputWidth == 0) {
+        return 0;
     }
 
-    acc += row[base] * w0;
-    acc += row[base + 1] * w1;
-    acc += row[base + 2] * w2;
-    return acc;
+    return (((OutputWidth - 1) * StrideWidth + 3) > (PadLeft + InputWidth)) ? 1 : 0;
 }
 
-}  // namespace
+//
+// Number of columns in an output row that have all nine taps inside the image
+// or inside the caller's zero-filled buffer. Every output row has the same
+// count, so the dispatch can use it to choose LMUL once.
+//
 
-static
+MLAS_FORCEINLINE
+size_t
+MlasConvDepthwiseInteriorColumns(
+    size_t OutputWidth,
+    size_t PadLeft,
+    size_t PadRight
+    )
+{
+    const size_t AfterPadLeft = (PadLeft == 1 && OutputWidth > 0) ? OutputWidth - 1 : OutputWidth;
+    return (AfterPadLeft > PadRight) ? (AfterPadLeft - PadRight) : 0;
+}
+
+template <typename Traits>
 void
-MlasConv2dSingleChannel_CHW_Kernel3x3_Pad01_Dilation1(
+MlasConvDepthwiseFloat_CHW_RvvImpl(
     const MLAS_CONV_PARAMETERS* Parameters,
     const float* Input,
     const float* Filter,
-    float* Output
+    float* Output,
+    const float* Zeros
     )
 {
-    const size_t H = Parameters->InputShape[0];
-    const size_t W = Parameters->InputShape[1];
-    const size_t out_rows = Parameters->OutputShape[0];
-    const size_t out_cols = Parameters->OutputShape[1];
-
-    const size_t pad_top = Parameters->Padding[0];
-    const size_t pad_left = Parameters->Padding[1];
-    [[maybe_unused]] const size_t pad_bottom = Parameters->Padding[2];
-    const size_t pad_right = Parameters->Padding[3];
-
-    assert(pad_top <= 1);
-    assert(pad_bottom <= 1);
-    assert(pad_left <= 1);
-    assert(pad_right <= 1);
-    MLAS_UNREFERENCED_PARAMETER(pad_bottom);
-
-    const float beta = Parameters->Beta;
-    const bool accumulate_output = beta != 0.0f;
-
     const float w00 = Filter[0];
     const float w01 = Filter[1];
     const float w02 = Filter[2];
@@ -157,126 +306,426 @@ MlasConv2dSingleChannel_CHW_Kernel3x3_Pad01_Dilation1(
     const float w21 = Filter[7];
     const float w22 = Filter[8];
 
-    for (size_t oh = 0; oh < out_rows; ++oh) {
-        const ptrdiff_t ih = static_cast<ptrdiff_t>(oh) - static_cast<ptrdiff_t>(pad_top);
+    const size_t H = Parameters->InputShape[0];
+    const size_t W = Parameters->InputShape[1];
+    const size_t out_rows = Parameters->OutputShape[0];
+    const size_t out_cols = Parameters->OutputShape[1];
+    const size_t pad_top = Parameters->Padding[0];
+    const size_t pad_left = Parameters->Padding[1];
+    const size_t stride_h = Parameters->StrideShape[0];
+    const size_t stride_w = Parameters->StrideShape[1];
 
-        const ptrdiff_t row0_index = ih;
-        const ptrdiff_t row1_index = ih + 1;
-        const ptrdiff_t row2_index = ih + 2;
+    const float beta = Parameters->Beta;
+    const bool accumulate = beta != 0.0f;
 
-        const float* row0 = nullptr;
-        const float* row1 = nullptr;
-        const float* row2 = nullptr;
+    const size_t pad_right = MlasConvDepthwisePadRight(out_cols, stride_w, pad_left, W);
+    const size_t interior_columns = MlasConvDepthwiseInteriorColumns(out_cols, pad_left, pad_right);
 
-        if (row0_index >= 0 && row0_index < static_cast<ptrdiff_t>(H)) {
-            row0 = Input + static_cast<size_t>(row0_index) * W;
+    //
+    // Row pointer bookkeeping, taken from the generic kernel unchanged.
+    //
+
+    const float* row0 = (pad_top > 0) ? Zeros : (Input - pad_left);
+    const float* row1 = (H + pad_top <= 1) ? Zeros : (Input + (1 - pad_top) * W) - pad_left;
+    const float* row2 = (H + pad_top <= 2) ? Zeros : (row1 + W);
+
+    const ptrdiff_t byte_stride = static_cast<ptrdiff_t>(stride_w * sizeof(float));
+
+    for (size_t h = 0, out_row = out_rows; out_row > 0; --out_row) {
+        size_t out_col = out_cols;
+
+        if (pad_left == 1) {
+            float dotsum = w01 * row0[1] + w02 * row0[2] + w11 * row1[1] + w12 * row1[2] +
+                           w21 * row2[1] + w22 * row2[2] + (accumulate ? *Output * beta : 0.f);
+            *Output++ = dotsum;
+            out_col--;
+            row0 += stride_w;
+            row1 += stride_w;
+            row2 += stride_w;
         }
-        if (row1_index >= 0 && row1_index < static_cast<ptrdiff_t>(H)) {
-            row1 = Input + static_cast<size_t>(row1_index) * W;
-        }
-        if (row2_index >= 0 && row2_index < static_cast<ptrdiff_t>(H)) {
-            row2 = Input + static_cast<size_t>(row2_index) * W;
+
+        size_t interior = interior_columns;
+        out_col -= interior;
+
+        if (stride_w == 1) {
+            while (interior > 0) {
+                const size_t vl = Traits::VectorLength(interior);
+
+                typename Traits::Vector Accumulator =
+                    MlasConvDepthwise3x3AccumulateUnitStrideRvv<Traits>(
+                        row0, row1, row2, w00, w01, w02, w10, w11, w12, w20, w21, w22, vl);
+
+                if (accumulate) {
+                    Accumulator =
+                        Traits::MultiplyAdd(Accumulator, beta, Traits::Load(Output, vl), vl);
+                }
+
+                Traits::Store(Output, Accumulator, vl);
+
+                Output += vl;
+                row0 += vl;
+                row1 += vl;
+                row2 += vl;
+                interior -= vl;
+            }
+        } else {
+            while (interior > 0) {
+                const size_t vl = Traits::VectorLength(interior);
+
+                typename Traits::Vector Accumulator = MlasConvDepthwise3x3AccumulateRvv<Traits>(
+                    row0, row1, row2, byte_stride, w00, w01, w02, w10, w11, w12, w20, w21, w22,
+                    vl);
+
+                if (accumulate) {
+                    Accumulator =
+                        Traits::MultiplyAdd(Accumulator, beta, Traits::Load(Output, vl), vl);
+                }
+
+                Traits::Store(Output, Accumulator, vl);
+
+                Output += vl;
+                row0 += vl * stride_w;
+                row1 += vl * stride_w;
+                row2 += vl * stride_w;
+                interior -= vl;
+            }
         }
 
+        if (out_col == 1) {  // pad_right == 1
+            float dotsum = w00 * row0[0] + w01 * row0[1] + w10 * row1[0] + w11 * row1[1] +
+                           w20 * row2[0] + w21 * row2[1] + (accumulate ? *Output * beta : 0.f);
+            *Output++ = dotsum;
+        }
+
+        h += stride_h;
+        row0 = (Input + (h - pad_top) * W) - pad_left;
+        row1 = row0 + W;
+        row2 = (h + 2 >= H + pad_top) ? Zeros : (row1 + W);
+    }
+}
+
+//
+// One output column of any kernel shape, computed with scalars.
+//
+// Only the leading columns need this: those are the ones whose leftmost taps
+// fall outside the image, and the lanes they would occupy sit at the front of a
+// vector, where neither vl nor a pointer offset can reach them. The trailing
+// columns do not, because the taps they lose are at the end of the vector and
+// shortening vl drops exactly those.
+//
+// Which taps a column keeps is decided once, as a range of filter columns,
+// rather than tested per tap: consecutive filter columns read consecutive input
+// columns, so the taps a column keeps are exactly the ones whose filter column
+// lands inside the image, and that is an interval.
+//
+
+MLAS_FORCEINLINE
+float
+MlasConvDepthwiseLeadingColumnRvv(
+    const float* Input,
+    const float* Filter,
+    size_t H,
+    size_t W,
+    size_t KernelHeight,
+    size_t KernelWidth,
+    ptrdiff_t InputRow,
+    ptrdiff_t InputColumn,
+    float Initial
+    )
+{
+    const size_t FilterBegin =
+        (InputColumn < 0) ? static_cast<size_t>(-InputColumn) : 0;
+    const size_t Reach = static_cast<size_t>(static_cast<ptrdiff_t>(W) - InputColumn);
+    const size_t FilterEnd = std::min(KernelWidth, Reach);
+
+    float Accumulator = Initial;
+
+    for (size_t kh = 0; kh < KernelHeight; kh++) {
+        const ptrdiff_t ih = InputRow + static_cast<ptrdiff_t>(kh);
+
+        if (ih < 0 || static_cast<size_t>(ih) >= H) {
+            continue;
+        }
+
+        const float* InputRowBase =
+            Input + static_cast<size_t>(ih) * W + static_cast<size_t>(InputColumn + ptrdiff_t(FilterBegin));
+        const float* FilterRow = Filter + kh * KernelWidth + FilterBegin;
+
+        for (size_t kw = FilterBegin; kw < FilterEnd; kw++) {
+            Accumulator += *FilterRow++ * *InputRowBase++;
+        }
+    }
+
+    return Accumulator;
+}
+
+//
+// Any kernel shape, dilation 1.
+//
+// An output row is taken in one pass per vector's worth of columns, and every
+// tap accumulates into that vector before it is stored, so the output row is
+// written once no matter how many taps the kernel has. That is what separates
+// this from the path it replaces: routing a depthwise convolution through im2col
+// and a GEMM gives that GEMM a single row, so it spends its time building the
+// column buffer and packing a panel for one row of arithmetic.
+//
+// A tap reads a run of input columns whose stride is the convolution's, so the
+// only shape questions are where that run starts and how far it reaches:
+//
+//   starts before the image   the leading output columns, handled as scalars
+//                             above, because those lanes are at the front
+//   reaches past the image    handled here by shortening vl, because those
+//                             lanes are at the end
+//   row outside the image     the whole tap contributes nothing and is skipped,
+//                             so no zero-filled row is needed
+//
+
+//
+// The general body keeps one bound per filter column on the stack, sized by the
+// shared kDepthwiseGeneralMaxKernelWidth, which is what removes the division
+// from the tap loop.
+//
+
+template <typename Traits>
+void
+MlasConvDepthwiseGeneralRvvImpl(
+    const MLAS_CONV_PARAMETERS* Parameters,
+    const float* Input,
+    const float* Filter,
+    float* Output
+    )
+{
+    const size_t H = Parameters->InputShape[0];
+    const size_t W = Parameters->InputShape[1];
+    const size_t KernelHeight = Parameters->KernelShape[0];
+    const size_t KernelWidth = Parameters->KernelShape[1];
+    const size_t out_rows = Parameters->OutputShape[0];
+    const size_t out_cols = Parameters->OutputShape[1];
+    const size_t pad_top = Parameters->Padding[0];
+    const size_t pad_left = Parameters->Padding[1];
+    const size_t stride_h = Parameters->StrideShape[0];
+    const size_t stride_w = Parameters->StrideShape[1];
+
+    const float beta = Parameters->Beta;
+    const bool accumulate = beta != 0.0f;
+
+    //
+    // The columns whose leftmost tap starts before the image. Every later
+    // column has all of its taps at or after column zero, which is what lets
+    // the vectorized body below drop the left hand test entirely.
+    //
+
+    const size_t leading_columns =
+        std::min(out_cols, (pad_left + stride_w - 1) / stride_w);
+
+    //
+    // The last output column each filter column can still read, so that the tap
+    // loop shortens vl with a comparison rather than a division. A division per
+    // tap is what a first revision of this did, and on a 7x7 image with a 5x5
+    // kernel it cost more than the arithmetic.
+    //
+    // A negative bound means the filter column never lands inside the image,
+    // which happens once the padding exceeds the image width.
+    //
+
+    ptrdiff_t last_column[kDepthwiseGeneralMaxKernelWidth];
+
+    for (size_t kw = 0; kw < KernelWidth; kw++) {
+        const ptrdiff_t reach =
+            static_cast<ptrdiff_t>(W - 1 + pad_left) - static_cast<ptrdiff_t>(kw);
+
+        last_column[kw] = (reach < 0) ? -1 : (reach / static_cast<ptrdiff_t>(stride_w));
+    }
+
+    const ptrdiff_t byte_stride = static_cast<ptrdiff_t>(stride_w * sizeof(float));
+
+    for (size_t oh = 0; oh < out_rows; oh++) {
+        const ptrdiff_t input_row =
+            static_cast<ptrdiff_t>(oh * stride_h) - static_cast<ptrdiff_t>(pad_top);
         float* out_row = Output + oh * out_cols;
-        size_t ow = 0;
 
-        if (pad_left && ow < out_cols) {
-            const ptrdiff_t iw = static_cast<ptrdiff_t>(ow) - static_cast<ptrdiff_t>(pad_left);
-            float acc = DepthwiseComputeEdge(
-                row0, row1, row2, iw, W,
-                w00, w01, w02, w10, w11, w12, w20, w21, w22
-            );
-            if (accumulate_output) {
-                acc += beta * out_row[ow];
-            }
-            out_row[ow++] = acc;
+        for (size_t oc = 0; oc < leading_columns; oc++) {
+            const ptrdiff_t input_column =
+                static_cast<ptrdiff_t>(oc * stride_w) - static_cast<ptrdiff_t>(pad_left);
+
+            out_row[oc] = MlasConvDepthwiseLeadingColumnRvv(
+                Input, Filter, H, W, KernelHeight, KernelWidth, input_row, input_column,
+                accumulate ? out_row[oc] * beta : 0.0f);
         }
 
-        size_t interior_cols = 0;
-        if (out_cols > pad_left + pad_right) {
-            interior_cols = out_cols - pad_left - pad_right;
-        }
+        size_t oc = leading_columns;
 
-        size_t processed = 0;
-        while (processed < interior_cols) {
-            const ptrdiff_t iw = static_cast<ptrdiff_t>(ow) - static_cast<ptrdiff_t>(pad_left);
-            const size_t base = static_cast<size_t>(iw);
+        while (oc < out_cols) {
+            const size_t vl = Traits::VectorLength(out_cols - oc);
 
-            size_t remaining = interior_cols - processed;
-            if ((base + remaining + 2) > W) {
-                remaining = (W > base + 2) ? W - base - 2 : 0;
+            typename Traits::Vector Accumulator =
+                accumulate ? Traits::Multiply(Traits::Load(out_row + oc, vl), beta, vl)
+                           : Traits::Zero(vl);
+
+            //
+            // How many of this chunk's taps read a full vector. Reach shrinks as
+            // the filter column grows, so those are a prefix, and splitting the
+            // tap loop there is what keeps the common tap free of a bound, a
+            // branch, and a vector type change: a full width load next to a tail
+            // preserving multiply-add toggles the type on every tap, which cost
+            // more than the arithmetic on a small image.
+            //
+
+            size_t taps_full = 0;
+
+            while (taps_full < KernelWidth &&
+                   last_column[taps_full] >= static_cast<ptrdiff_t>(oc + vl - 1)) {
+                taps_full++;
             }
 
-            if (remaining == 0) {
-                break;
+            for (size_t kh = 0; kh < KernelHeight; kh++) {
+                const ptrdiff_t ih = input_row + static_cast<ptrdiff_t>(kh);
+
+                if (ih < 0 || static_cast<size_t>(ih) >= H) {
+                    continue;
+                }
+
+                //
+                // The first input column of this filter row's leftmost tap. It
+                // cannot be negative here: oc is at least leading_columns.
+                //
+
+                const float* TapBase =
+                    Input + static_cast<size_t>(ih) * W + (oc * stride_w - pad_left);
+                const float* FilterRow = Filter + kh * KernelWidth;
+
+                if (stride_w == 1) {
+                    for (size_t kw = 0; kw < taps_full; kw++) {
+                        Accumulator = Traits::MultiplyAdd(Accumulator, FilterRow[kw],
+                                                         Traits::Load(TapBase + kw, vl), vl);
+                    }
+                } else {
+                    for (size_t kw = 0; kw < taps_full; kw++) {
+                        Accumulator =
+                            Traits::MultiplyAdd(Accumulator, FilterRow[kw],
+                                                Traits::LoadStrided(TapBase + kw, byte_stride, vl),
+                                                vl);
+                    }
+                }
+
+                for (size_t kw = taps_full; kw < KernelWidth; kw++) {
+                    const ptrdiff_t remaining = last_column[kw] - static_cast<ptrdiff_t>(oc) + 1;
+
+                    if (remaining <= 0) {
+                        continue;
+                    }
+
+                    const size_t count = std::min(vl, static_cast<size_t>(remaining));
+
+                    const typename Traits::Vector Values =
+                        (stride_w == 1) ? Traits::Load(TapBase + kw, count)
+                                        : Traits::LoadStrided(TapBase + kw, byte_stride, count);
+
+                    Accumulator =
+                        Traits::MultiplyAddPartial(Accumulator, FilterRow[kw], Values, count);
+                }
             }
 
-            size_t vl = __riscv_vsetvl_e32m4(remaining);
-
-            vfloat32m4_t acc = __riscv_vfmv_v_f_f32m4(0.0f, vl);
-
-            DepthwiseAccumulateRowRvv(acc, row0, base, w00, w01, w02, vl);
-            DepthwiseAccumulateRowRvv(acc, row1, base, w10, w11, w12, vl);
-            DepthwiseAccumulateRowRvv(acc, row2, base, w20, w21, w22, vl);
-
-            if (accumulate_output) {
-                vfloat32m4_t prev = __riscv_vle32_v_f32m4(out_row + ow, vl);
-                acc = __riscv_vfmacc_vf_f32m4(acc, beta, prev, vl);
-            }
-
-            __riscv_vse32_v_f32m4(out_row + ow, acc, vl);
-            ow += vl;
-            processed += vl;
-        }
-
-        for (; processed < interior_cols; ++processed) {
-            const ptrdiff_t iw = static_cast<ptrdiff_t>(ow) - static_cast<ptrdiff_t>(pad_left);
-            const size_t base = static_cast<size_t>(iw);
-
-            float acc = 0.0f;
-            acc = DepthwiseAccumulateRowScalar(acc, row0, base, w00, w01, w02);
-            acc = DepthwiseAccumulateRowScalar(acc, row1, base, w10, w11, w12);
-            acc = DepthwiseAccumulateRowScalar(acc, row2, base, w20, w21, w22);
-
-            if (accumulate_output) {
-                acc += beta * out_row[ow];
-            }
-            out_row[ow++] = acc;
-        }
-
-        if (pad_right && ow < out_cols) {
-            const ptrdiff_t iw = static_cast<ptrdiff_t>(ow) - static_cast<ptrdiff_t>(pad_left);
-            float acc = DepthwiseComputeEdge(
-                row0, row1, row2, iw, W,
-                w00, w01, w02, w10, w11, w12, w20, w21, w22
-            );
-            if (accumulate_output) {
-                acc += beta * out_row[ow];
-            }
-            out_row[ow++] = acc;
+            Traits::Store(out_row + oc, Accumulator, vl);
+            oc += vl;
         }
     }
 }
 
-void MlasConvDepthwiseFloat_CHW(
+}  // namespace
+
+void
+MLASCALL
+MlasConvDepthwiseFloat_CHW(
     const MLAS_CONV_PARAMETERS* Parameters,
     const float* Input,
     const float* Filter,
     float* Output,
     const float* Zeros
     )
+/*++
+
+Routine Description:
+
+    Computes one channel of a depthwise convolution using RVV, at the smallest
+    LMUL whose vector still covers an output row.
+
+    The 3x3 / padding <= 1 shape has its own body; every other kernel shape goes
+    to the general one.
+
+Arguments:
+
+    Parameters - Supplies the prepared convolution parameters.
+
+    Input - Supplies one input channel slice in H x W layout.
+
+    Filter - Supplies that channel's filter, in KH x KW layout.
+
+    Output - Supplies one output channel slice in OH x OW layout.
+
+    Zeros - Supplies the caller's zero-filled buffer of InputShape[1] + 2
+        elements, used in place of a row that falls outside the image. The
+        general body skips such a row instead, so it does not read this.
+
+--*/
 {
-    MLAS_UNREFERENCED_PARAMETER(Zeros);
+    const size_t W = Parameters->InputShape[1];
+    const size_t out_cols = Parameters->OutputShape[1];
+    const size_t pad_left = Parameters->Padding[1];
+    const size_t stride_w = Parameters->StrideShape[1];
 
-    assert(Parameters->Dimensions == 2);
-    assert(Parameters->FilterCount == 1);
-    assert(Parameters->InputChannels == 1);
-    assert(Parameters->KernelShape[0] == 3 && Parameters->KernelShape[1] == 3);
-    assert(Parameters->StrideShape[0] == 1 && Parameters->StrideShape[1] == 1);
-    assert(Parameters->DilationShape[0] == 1 && Parameters->DilationShape[1] == 1);
+    //
+    // Any shape other than the 3x3 one below goes to the general body, which
+    // covers every kernel shape MlasConvPrepare admits: it routes only shapes
+    // whose kernel width is at most kDepthwiseGeneralMaxKernelWidth.
+    //
 
-    MlasConv2dSingleChannel_CHW_Kernel3x3_Pad01_Dilation1(Parameters, Input, Filter, Output);
+    if (Parameters->KernelShape[0] != 3 || Parameters->KernelShape[1] != 3 ||
+        Parameters->Padding[0] > 1 || Parameters->Padding[1] > 1 ||
+        Parameters->Padding[2] > 1 || Parameters->Padding[3] > 1 ||
+        W <= 1) {
+
+        const size_t leading_columns =
+            std::min(out_cols, (pad_left + stride_w - 1) / stride_w);
+        const size_t vector_columns = out_cols - leading_columns;
+        const size_t vlmax_m1 = MlasDepthwiseRvvM1::MaxVectorLength();
+
+        if (vector_columns <= vlmax_m1) {
+            MlasConvDepthwiseGeneralRvvImpl<MlasDepthwiseRvvM1>(Parameters, Input, Filter, Output);
+        } else if (vector_columns <= 2 * vlmax_m1) {
+            MlasConvDepthwiseGeneralRvvImpl<MlasDepthwiseRvvM2>(Parameters, Input, Filter, Output);
+        } else {
+            MlasConvDepthwiseGeneralRvvImpl<MlasDepthwiseRvvM4>(Parameters, Input, Filter, Output);
+        }
+
+        return;
+    }
+
+    const size_t pad_right = MlasConvDepthwisePadRight(out_cols, stride_w, pad_left, W);
+    const size_t interior_columns = MlasConvDepthwiseInteriorColumns(out_cols, pad_left, pad_right);
+
+    //
+    // Pick the smallest LMUL whose vector holds the whole interior, so that a
+    // narrow row does not pay for a wide tile. A row too wide for LMUL=4 is
+    // taken in several LMUL=4 passes, where only the last one is partial and
+    // the waste is amortized.
+    //
+    // vlmax is queried rather than derived from a VLEN constant, which keeps
+    // this correct on any VLEN.
+    //
+
+    const size_t vlmax_m1 = MlasDepthwiseRvvM1::MaxVectorLength();
+
+    if (interior_columns <= vlmax_m1) {
+        MlasConvDepthwiseFloat_CHW_RvvImpl<MlasDepthwiseRvvM1>(Parameters, Input, Filter, Output,
+                                                               Zeros);
+    } else if (interior_columns <= 2 * vlmax_m1) {
+        MlasConvDepthwiseFloat_CHW_RvvImpl<MlasDepthwiseRvvM2>(Parameters, Input, Filter, Output,
+                                                               Zeros);
+    } else {
+        MlasConvDepthwiseFloat_CHW_RvvImpl<MlasDepthwiseRvvM4>(Parameters, Input, Filter, Output,
+                                                               Zeros);
+    }
 }
 
-#endif  // MLAS_USE_RVV
+#endif  // defined(MLAS_USE_RVV)

--- a/onnxruntime/core/mlas/lib/riscv64/sconv_nchwc_kernel_rvv.cpp
+++ b/onnxruntime/core/mlas/lib/riscv64/sconv_nchwc_kernel_rvv.cpp
@@ -14,8 +14,9 @@ Abstract:
     convolution operations on riscv64: direct NCHW, direct NCHWc,
     depthwise, and pointwise convolution.
 
-    BlockSize is fixed at 16, matching the ARM64 NEON NCHWc layout.
-    With VLEN>=128 and LMUL=4, a single vfloat32m4_t holds 16 floats.
+    BlockSize is fixed at 16, matching the ARM64 NEON NCHWc layout, so a channel
+    block is held in one register group and the multiplier that group needs
+    follows the vector length: four registers at 128 bits, two at 256, one at 512.
 
 --*/
 
@@ -37,6 +38,90 @@ namespace {
 constexpr size_t BlockSize = 16;
 
 //
+// A channel block has to fit in one register group and the group should be no
+// wider: the cost of a vector instruction follows the multiplier it was issued
+// with, not the number of elements asked for. Which multiplier that is depends on
+// the vector length, so the kernels are written once against these accessors.
+//
+
+template <size_t Lmul>
+struct MLAS_RVV_BLOCK;
+
+#define MLAS_RVV_BLOCK_FOR_LMUL(Lmul, Suffix)                                                  \
+    template <>                                                                                \
+    struct MLAS_RVV_BLOCK<Lmul> {                                                              \
+        using Vector = vfloat32##Suffix##_t;                                                   \
+        static MLAS_FORCEINLINE size_t VectorLength()                                          \
+            { return __riscv_vsetvl_e32##Suffix(BlockSize); }                                  \
+        static MLAS_FORCEINLINE Vector Broadcast(float Value, size_t vl)                       \
+            { return __riscv_vfmv_v_f_f32##Suffix(Value, vl); }                                \
+        static MLAS_FORCEINLINE Vector Load(const float* Address, size_t vl)                   \
+            { return __riscv_vle32_v_f32##Suffix(Address, vl); }                               \
+        static MLAS_FORCEINLINE void Store(float* Address, Vector Value, size_t vl)            \
+            { __riscv_vse32_v_f32##Suffix(Address, Value, vl); }                               \
+        static MLAS_FORCEINLINE Vector MultiplyAdd(Vector Accumulator, float Multiplicand,     \
+                                                   Vector Multiplier, size_t vl)               \
+            { return __riscv_vfmacc_vf_f32##Suffix(Accumulator, Multiplicand, Multiplier, vl); }\
+        static MLAS_FORCEINLINE Vector MultiplyAdd(Vector Accumulator, Vector Multiplicand,    \
+                                                   Vector Multiplier, size_t vl)               \
+            { return __riscv_vfmacc_vv_f32##Suffix(Accumulator, Multiplicand, Multiplier, vl); }\
+        static MLAS_FORCEINLINE Vector Add(Vector First, Vector Second, size_t vl)             \
+            { return __riscv_vfadd_vv_f32##Suffix(First, Second, vl); }                        \
+        static MLAS_FORCEINLINE Vector Maximum(Vector First, Vector Second, size_t vl)         \
+            { return __riscv_vfmax_vv_f32##Suffix(First, Second, vl); }                        \
+        static MLAS_FORCEINLINE Vector Divide(Vector Dividend, Vector Divisor, size_t vl)      \
+            { return __riscv_vfdiv_vv_f32##Suffix(Dividend, Divisor, vl); }                    \
+    }
+
+MLAS_RVV_BLOCK_FOR_LMUL(1, m1);
+MLAS_RVV_BLOCK_FOR_LMUL(2, m2);
+MLAS_RVV_BLOCK_FOR_LMUL(4, m4);
+
+#undef MLAS_RVV_BLOCK_FOR_LMUL
+
+//
+// Smallest multiplier whose register group still holds a block.
+//
+
+MLAS_FORCEINLINE
+size_t
+MlasConvNchwcLmulRvv(
+    void
+    )
+{
+    const size_t BlockBytes = BlockSize * sizeof(float);
+    const size_t RegisterBytes = __riscv_vlenb();
+
+    if (RegisterBytes >= BlockBytes) {
+        return 1;
+    }
+
+    if (2 * RegisterBytes >= BlockBytes) {
+        return 2;
+    }
+
+    return 4;
+}
+
+//
+// Enters Body at the multiplier this part wants. A kernel is entered once per
+// output row, so asking each time costs a control status register read.
+//
+
+#define MLAS_RVV_DISPATCH_ON_LMUL(Body, ...)     \
+    switch (MlasConvNchwcLmulRvv()) {            \
+        case 1:                                  \
+            Body<1>(__VA_ARGS__);                \
+            break;                               \
+        case 2:                                  \
+            Body<2>(__VA_ARGS__);                \
+            break;                               \
+        default:                                 \
+            Body<4>(__VA_ARGS__);                \
+            break;                               \
+    }
+
+//
 // Number of output positions a kernel accumulates at once.
 //
 // A block of channels fills a register group, so no parallelism is left inside
@@ -51,30 +136,34 @@ constexpr size_t BlockSize = 16;
 //
 constexpr size_t OutputStep = 4;
 
+template <size_t Lmul>
 MLAS_FORCEINLINE
 void
 ApplyPostProcessing(
-    vfloat32m4_t& acc,
+    typename MLAS_RVV_BLOCK<Lmul>::Vector& acc,
     const float* Output,
     const float* Bias,
     unsigned KernelFlags,
     size_t vl
     )
 {
+    using Block = MLAS_RVV_BLOCK<Lmul>;
+    using Vector = typename Block::Vector;
+
     if (KernelFlags & MLAS_CONV_KERNEL_FLAG_ACCUMULATE_OUTPUT) {
-        vfloat32m4_t old_output = __riscv_vle32_v_f32m4(Output, vl);
-        acc = __riscv_vfadd_vv_f32m4(acc, old_output, vl);
+        Vector old_output = Block::Load(Output, vl);
+        acc = Block::Add(acc, old_output, vl);
     }
 
     if (KernelFlags & MLAS_CONV_KERNEL_FLAG_BIAS_ADDITION) {
         assert(Bias != nullptr);
-        vfloat32m4_t bias_vec = __riscv_vle32_v_f32m4(Bias, vl);
-        acc = __riscv_vfadd_vv_f32m4(acc, bias_vec, vl);
+        Vector bias_vec = Block::Load(Bias, vl);
+        acc = Block::Add(acc, bias_vec, vl);
     }
 
     if (KernelFlags & MLAS_CONV_KERNEL_FLAG_RELU_ACTIVATION) {
-        vfloat32m4_t zero = __riscv_vfmv_v_f_f32m4(0.0f, vl);
-        acc = __riscv_vfmax_vv_f32m4(acc, zero, vl);
+        Vector zero = Block::Broadcast(0.0f, vl);
+        acc = Block::Maximum(acc, zero, vl);
     }
 }
 
@@ -94,6 +183,7 @@ LoadInRange(
 // and Output address the first of them; the filter is already at its block.
 //
 
+template <size_t Lmul>
 MLAS_FORCEINLINE
 void
 MlasConvNchwFloatGroupRvv(
@@ -113,16 +203,19 @@ MlasConvNchwFloatGroupRvv(
     size_t OutputCountThisIteration
     )
 {
+    using Block = MLAS_RVV_BLOCK<Lmul>;
+    using Vector = typename Block::Vector;
+
     const size_t offset1 = (OutputCountThisIteration > 1 ? 1 : 0) * StrideWidthElements;
     const size_t offset2 = (OutputCountThisIteration > 2 ? 2 : 0) * StrideWidthElements;
     const size_t offset3 = (OutputCountThisIteration > 3 ? 3 : 0) * StrideWidthElements;
 
     const size_t offset_last = (OutputCountThisIteration - 1) * StrideWidthElements;
 
-    vfloat32m4_t acc0 = __riscv_vfmv_v_f_f32m4(0.0f, vl);
-    vfloat32m4_t acc1 = acc0;
-    vfloat32m4_t acc2 = acc0;
-    vfloat32m4_t acc3 = acc0;
+    Vector acc0 = Block::Broadcast(0.0f, vl);
+    Vector acc1 = acc0;
+    Vector acc2 = acc0;
+    Vector acc3 = acc0;
 
     for (size_t kh = 0; kh < KernelHeight; kh++) {
 
@@ -134,50 +227,48 @@ MlasConvNchwFloatGroupRvv(
             const float* input_pos =
                 Input + kh * DilatedInputWidthElements + kw * DilationWidthElements;
 
-            vfloat32m4_t filt =
-                __riscv_vle32_v_f32m4(&Filter[(kh * KernelWidth + kw) * BlockSize], vl);
+            Vector filt =
+                Block::Load(&Filter[(kh * KernelWidth + kw) * BlockSize], vl);
 
             if (input_pos >= input_row_start && (input_pos + offset_last) < input_row_end) {
-                acc0 = __riscv_vfmacc_vf_f32m4(acc0, input_pos[0], filt, vl);
-                acc1 = __riscv_vfmacc_vf_f32m4(acc1, input_pos[offset1], filt, vl);
-                acc2 = __riscv_vfmacc_vf_f32m4(acc2, input_pos[offset2], filt, vl);
-                acc3 = __riscv_vfmacc_vf_f32m4(acc3, input_pos[offset3], filt, vl);
+                acc0 = Block::MultiplyAdd(acc0, input_pos[0], filt, vl);
+                acc1 = Block::MultiplyAdd(acc1, input_pos[offset1], filt, vl);
+                acc2 = Block::MultiplyAdd(acc2, input_pos[offset2], filt, vl);
+                acc3 = Block::MultiplyAdd(acc3, input_pos[offset3], filt, vl);
             } else {
-                acc0 = __riscv_vfmacc_vf_f32m4(
+                acc0 = Block::MultiplyAdd(
                     acc0, LoadInRange(input_pos, input_row_start, input_row_end), filt, vl);
-                acc1 = __riscv_vfmacc_vf_f32m4(
+                acc1 = Block::MultiplyAdd(
                     acc1, LoadInRange(input_pos + offset1, input_row_start, input_row_end),
                     filt, vl);
-                acc2 = __riscv_vfmacc_vf_f32m4(
+                acc2 = Block::MultiplyAdd(
                     acc2, LoadInRange(input_pos + offset2, input_row_start, input_row_end),
                     filt, vl);
-                acc3 = __riscv_vfmacc_vf_f32m4(
+                acc3 = Block::MultiplyAdd(
                     acc3, LoadInRange(input_pos + offset3, input_row_start, input_row_end),
                     filt, vl);
             }
         }
     }
 
-    ApplyPostProcessing(acc0, &Output[0], Bias, KernelFlags, vl);
-    __riscv_vse32_v_f32m4(&Output[0], acc0, vl);
+    ApplyPostProcessing<Lmul>(acc0, &Output[0], Bias, KernelFlags, vl);
+    Block::Store(&Output[0], acc0, vl);
 
     if (OutputCountThisIteration > 1) {
-        ApplyPostProcessing(acc1, &Output[BlockSize], Bias, KernelFlags, vl);
-        __riscv_vse32_v_f32m4(&Output[BlockSize], acc1, vl);
+        ApplyPostProcessing<Lmul>(acc1, &Output[BlockSize], Bias, KernelFlags, vl);
+        Block::Store(&Output[BlockSize], acc1, vl);
     }
 
     if (OutputCountThisIteration > 2) {
-        ApplyPostProcessing(acc2, &Output[2 * BlockSize], Bias, KernelFlags, vl);
-        __riscv_vse32_v_f32m4(&Output[2 * BlockSize], acc2, vl);
+        ApplyPostProcessing<Lmul>(acc2, &Output[2 * BlockSize], Bias, KernelFlags, vl);
+        Block::Store(&Output[2 * BlockSize], acc2, vl);
     }
 
     if (OutputCountThisIteration > 3) {
-        ApplyPostProcessing(acc3, &Output[3 * BlockSize], Bias, KernelFlags, vl);
-        __riscv_vse32_v_f32m4(&Output[3 * BlockSize], acc3, vl);
+        ApplyPostProcessing<Lmul>(acc3, &Output[3 * BlockSize], Bias, KernelFlags, vl);
+        Block::Store(&Output[3 * BlockSize], acc3, vl);
     }
 }
-
-}  // namespace
 
 //
 // Direct NCHW convolution kernel.
@@ -187,6 +278,72 @@ MlasConvNchwFloatGroupRvv(
 // broadcast and multiplied with BlockSize filter values.
 // Output is in NCHWc (BlockSize channels interleaved).
 //
+
+template <size_t Lmul>
+void
+MlasConvNchwFloatKernelRvvImpl(
+    const float* Input,
+    const float* Filter,
+    float* Output,
+    size_t StrideWidth,
+    size_t DilationWidth,
+    size_t FilterCount,
+    size_t InputStride,
+    size_t FilterStride,
+    size_t OutputStride,
+    size_t KernelHeight,
+    size_t KernelWidth,
+    const float* InputBase,
+    size_t InputWidth,
+    size_t DilatedInputWidth,
+    size_t OutputCountLeftPad,
+    size_t OutputCount,
+    size_t OutputCountRightPad,
+    const float* Bias,
+    unsigned KernelFlags
+    )
+{
+    MLAS_UNREFERENCED_PARAMETER(InputStride);
+
+    using Block = MLAS_RVV_BLOCK<Lmul>;
+
+    const size_t vl = Block::VectorLength();
+    const size_t StrideWidthElements = StrideWidth / sizeof(float);
+    const size_t DilationWidthElements = DilationWidth / sizeof(float);
+    const size_t FilterStrideElements = FilterStride / sizeof(float);
+    const size_t OutputStrideElements = OutputStride / sizeof(float);
+    const size_t InputWidthElements = InputWidth / sizeof(float);
+    const size_t DilatedInputWidthElements = DilatedInputWidth / sizeof(float);
+
+    const size_t TotalOutputCount = OutputCountLeftPad + OutputCount + OutputCountRightPad;
+
+    for (size_t filterSetBlock = 0; filterSetBlock < FilterCount; filterSetBlock++) {
+
+        const float* filter = Filter + filterSetBlock * FilterStrideElements;
+        float* output = Output + filterSetBlock * OutputStrideElements;
+        const float* bias = (Bias != nullptr) ? &Bias[filterSetBlock * BlockSize] : nullptr;
+
+        size_t output_idx = 0;
+
+        for (; output_idx + OutputStep <= TotalOutputCount; output_idx += OutputStep) {
+            MlasConvNchwFloatGroupRvv<Lmul>(
+                Input + output_idx * StrideWidthElements, filter, &output[output_idx * BlockSize],
+                StrideWidthElements, DilationWidthElements, InputWidthElements,
+                DilatedInputWidthElements, KernelHeight, KernelWidth, InputBase, bias,
+                KernelFlags, vl, OutputStep);
+        }
+
+        if (output_idx < TotalOutputCount) {
+            MlasConvNchwFloatGroupRvv<Lmul>(
+                Input + output_idx * StrideWidthElements, filter, &output[output_idx * BlockSize],
+                StrideWidthElements, DilationWidthElements, InputWidthElements,
+                DilatedInputWidthElements, KernelHeight, KernelWidth, InputBase, bias,
+                KernelFlags, vl, TotalOutputCount - output_idx);
+        }
+    }
+}
+
+}  // namespace
 
 void
 MLASCALL
@@ -212,42 +369,11 @@ MlasConvNchwFloatKernelRvv(
     unsigned KernelFlags
     )
 {
-    MLAS_UNREFERENCED_PARAMETER(InputStride);
-
-    const size_t vl = __riscv_vsetvl_e32m4(BlockSize);
-    const size_t StrideWidthElements = StrideWidth / sizeof(float);
-    const size_t DilationWidthElements = DilationWidth / sizeof(float);
-    const size_t FilterStrideElements = FilterStride / sizeof(float);
-    const size_t OutputStrideElements = OutputStride / sizeof(float);
-    const size_t InputWidthElements = InputWidth / sizeof(float);
-    const size_t DilatedInputWidthElements = DilatedInputWidth / sizeof(float);
-
-    const size_t TotalOutputCount = OutputCountLeftPad + OutputCount + OutputCountRightPad;
-
-    for (size_t filterSetBlock = 0; filterSetBlock < FilterCount; filterSetBlock++) {
-
-        const float* filter = Filter + filterSetBlock * FilterStrideElements;
-        float* output = Output + filterSetBlock * OutputStrideElements;
-        const float* bias = (Bias != nullptr) ? &Bias[filterSetBlock * BlockSize] : nullptr;
-
-        size_t output_idx = 0;
-
-        for (; output_idx + OutputStep <= TotalOutputCount; output_idx += OutputStep) {
-            MlasConvNchwFloatGroupRvv(
-                Input + output_idx * StrideWidthElements, filter, &output[output_idx * BlockSize],
-                StrideWidthElements, DilationWidthElements, InputWidthElements,
-                DilatedInputWidthElements, KernelHeight, KernelWidth, InputBase, bias,
-                KernelFlags, vl, OutputStep);
-        }
-
-        if (output_idx < TotalOutputCount) {
-            MlasConvNchwFloatGroupRvv(
-                Input + output_idx * StrideWidthElements, filter, &output[output_idx * BlockSize],
-                StrideWidthElements, DilationWidthElements, InputWidthElements,
-                DilatedInputWidthElements, KernelHeight, KernelWidth, InputBase, bias,
-                KernelFlags, vl, TotalOutputCount - output_idx);
-        }
-    }
+    MLAS_RVV_DISPATCH_ON_LMUL(MlasConvNchwFloatKernelRvvImpl, Input, Filter, Output, StrideWidth,
+                              DilationWidth, FilterCount, InputStride, FilterStride, OutputStride,
+                              KernelHeight, KernelWidth, InputBase, InputWidth, DilatedInputWidth,
+                              OutputCountLeftPad, OutputCount, OutputCountRightPad, Bias,
+                              KernelFlags)
 }
 
 namespace {
@@ -257,6 +383,7 @@ namespace {
 // and Output address the first of them; the filter is already at its block.
 //
 
+template <size_t Lmul>
 MLAS_FORCEINLINE
 void
 MlasConvNchwcFloatGroupRvv(
@@ -276,6 +403,9 @@ MlasConvNchwcFloatGroupRvv(
     size_t OutputCountThisIteration
     )
 {
+    using Block = MLAS_RVV_BLOCK<Lmul>;
+    using Vector = typename Block::Vector;
+
     const size_t offset1 = (OutputCountThisIteration > 1 ? 1 : 0) * StrideWidthElements;
     const size_t offset2 = (OutputCountThisIteration > 2 ? 2 : 0) * StrideWidthElements;
     const size_t offset3 = (OutputCountThisIteration > 3 ? 3 : 0) * StrideWidthElements;
@@ -283,10 +413,10 @@ MlasConvNchwcFloatGroupRvv(
     // Furthest position the group stores; the slots it does not use sit at zero.
     const size_t offset_last = (OutputCountThisIteration - 1) * StrideWidthElements;
 
-    vfloat32m4_t acc0 = __riscv_vfmv_v_f_f32m4(0.0f, vl);
-    vfloat32m4_t acc1 = acc0;
-    vfloat32m4_t acc2 = acc0;
-    vfloat32m4_t acc3 = acc0;
+    Vector acc0 = Block::Broadcast(0.0f, vl);
+    Vector acc1 = acc0;
+    Vector acc2 = acc0;
+    Vector acc3 = acc0;
 
     for (size_t kh = 0; kh < KernelHeight; kh++) {
 
@@ -310,27 +440,27 @@ MlasConvNchwcFloatGroupRvv(
 
             if (all_in_bounds) {
                 for (size_t ic = 0; ic < BlockSize; ic++) {
-                    vfloat32m4_t filt =
-                        __riscv_vle32_v_f32m4(&filter_position[ic * BlockSize], vl);
-                    acc0 = __riscv_vfmacc_vf_f32m4(acc0, input_base0[ic], filt, vl);
-                    acc1 = __riscv_vfmacc_vf_f32m4(acc1, input_base1[ic], filt, vl);
-                    acc2 = __riscv_vfmacc_vf_f32m4(acc2, input_base2[ic], filt, vl);
-                    acc3 = __riscv_vfmacc_vf_f32m4(acc3, input_base3[ic], filt, vl);
+                    Vector filt =
+                        Block::Load(&filter_position[ic * BlockSize], vl);
+                    acc0 = Block::MultiplyAdd(acc0, input_base0[ic], filt, vl);
+                    acc1 = Block::MultiplyAdd(acc1, input_base1[ic], filt, vl);
+                    acc2 = Block::MultiplyAdd(acc2, input_base2[ic], filt, vl);
+                    acc3 = Block::MultiplyAdd(acc3, input_base3[ic], filt, vl);
                 }
             } else {
                 for (size_t ic = 0; ic < BlockSize; ic++) {
-                    vfloat32m4_t filt =
-                        __riscv_vle32_v_f32m4(&filter_position[ic * BlockSize], vl);
-                    acc0 = __riscv_vfmacc_vf_f32m4(
+                    Vector filt =
+                        Block::Load(&filter_position[ic * BlockSize], vl);
+                    acc0 = Block::MultiplyAdd(
                         acc0, LoadInRange(input_base0 + ic, input_row_start, input_row_end),
                         filt, vl);
-                    acc1 = __riscv_vfmacc_vf_f32m4(
+                    acc1 = Block::MultiplyAdd(
                         acc1, LoadInRange(input_base1 + ic, input_row_start, input_row_end),
                         filt, vl);
-                    acc2 = __riscv_vfmacc_vf_f32m4(
+                    acc2 = Block::MultiplyAdd(
                         acc2, LoadInRange(input_base2 + ic, input_row_start, input_row_end),
                         filt, vl);
-                    acc3 = __riscv_vfmacc_vf_f32m4(
+                    acc3 = Block::MultiplyAdd(
                         acc3, LoadInRange(input_base3 + ic, input_row_start, input_row_end),
                         filt, vl);
                 }
@@ -338,26 +468,24 @@ MlasConvNchwcFloatGroupRvv(
         }
     }
 
-    ApplyPostProcessing(acc0, &Output[0], Bias, KernelFlags, vl);
-    __riscv_vse32_v_f32m4(&Output[0], acc0, vl);
+    ApplyPostProcessing<Lmul>(acc0, &Output[0], Bias, KernelFlags, vl);
+    Block::Store(&Output[0], acc0, vl);
 
     if (OutputCountThisIteration > 1) {
-        ApplyPostProcessing(acc1, &Output[BlockSize], Bias, KernelFlags, vl);
-        __riscv_vse32_v_f32m4(&Output[BlockSize], acc1, vl);
+        ApplyPostProcessing<Lmul>(acc1, &Output[BlockSize], Bias, KernelFlags, vl);
+        Block::Store(&Output[BlockSize], acc1, vl);
     }
 
     if (OutputCountThisIteration > 2) {
-        ApplyPostProcessing(acc2, &Output[2 * BlockSize], Bias, KernelFlags, vl);
-        __riscv_vse32_v_f32m4(&Output[2 * BlockSize], acc2, vl);
+        ApplyPostProcessing<Lmul>(acc2, &Output[2 * BlockSize], Bias, KernelFlags, vl);
+        Block::Store(&Output[2 * BlockSize], acc2, vl);
     }
 
     if (OutputCountThisIteration > 3) {
-        ApplyPostProcessing(acc3, &Output[3 * BlockSize], Bias, KernelFlags, vl);
-        __riscv_vse32_v_f32m4(&Output[3 * BlockSize], acc3, vl);
+        ApplyPostProcessing<Lmul>(acc3, &Output[3 * BlockSize], Bias, KernelFlags, vl);
+        Block::Store(&Output[3 * BlockSize], acc3, vl);
     }
 }
-
-}  // namespace
 
 //
 // Direct NCHWc convolution kernel.
@@ -367,6 +495,72 @@ MlasConvNchwcFloatGroupRvv(
 // For each kernel position and input channel, one input scalar is broadcast
 // and multiplied with BlockSize output filter values.
 //
+
+template <size_t Lmul>
+void
+MlasConvNchwcFloatKernelRvvImpl(
+    const float* Input,
+    const float* Filter,
+    float* Output,
+    size_t StrideWidth,
+    size_t DilationWidth,
+    size_t FilterCount,
+    size_t InputStride,
+    size_t FilterStride,
+    size_t OutputStride,
+    size_t KernelHeight,
+    size_t KernelWidth,
+    const float* InputBase,
+    size_t InputWidth,
+    size_t DilatedInputWidth,
+    size_t OutputCountLeftPad,
+    size_t OutputCount,
+    size_t OutputCountRightPad,
+    const float* Bias,
+    unsigned KernelFlags
+    )
+{
+    MLAS_UNREFERENCED_PARAMETER(InputStride);
+
+    using Block = MLAS_RVV_BLOCK<Lmul>;
+
+    const size_t vl = Block::VectorLength();
+    const size_t StrideWidthElements = StrideWidth / sizeof(float);
+    const size_t DilationWidthElements = DilationWidth / sizeof(float);
+    const size_t FilterStrideElements = FilterStride / sizeof(float);
+    const size_t OutputStrideElements = OutputStride / sizeof(float);
+    const size_t InputWidthElements = InputWidth / sizeof(float);
+    const size_t DilatedInputWidthElements = DilatedInputWidth / sizeof(float);
+
+    const size_t TotalOutputCount = OutputCountLeftPad + OutputCount + OutputCountRightPad;
+
+    for (size_t filterSetBlock = 0; filterSetBlock < FilterCount; filterSetBlock++) {
+
+        const float* filter = Filter + filterSetBlock * FilterStrideElements;
+        float* output = Output + filterSetBlock * OutputStrideElements;
+        const float* bias = (Bias != nullptr) ? &Bias[filterSetBlock * BlockSize] : nullptr;
+
+        size_t output_idx = 0;
+
+        for (; output_idx + OutputStep <= TotalOutputCount; output_idx += OutputStep) {
+            MlasConvNchwcFloatGroupRvv<Lmul>(
+                Input + output_idx * StrideWidthElements, filter, &output[output_idx * BlockSize],
+                StrideWidthElements, DilationWidthElements, InputWidthElements,
+                DilatedInputWidthElements, KernelHeight, KernelWidth, InputBase, bias,
+                KernelFlags, vl, OutputStep);
+        }
+
+        if (output_idx < TotalOutputCount) {
+            MlasConvNchwcFloatGroupRvv<Lmul>(
+                Input + output_idx * StrideWidthElements, filter, &output[output_idx * BlockSize],
+                StrideWidthElements, DilationWidthElements, InputWidthElements,
+                DilatedInputWidthElements, KernelHeight, KernelWidth, InputBase, bias,
+                KernelFlags, vl, TotalOutputCount - output_idx);
+        }
+    }
+}
+
+}  // namespace
 
 void
 MLASCALL
@@ -392,48 +586,18 @@ MlasConvNchwcFloatKernelRvv(
     unsigned KernelFlags
     )
 {
-    MLAS_UNREFERENCED_PARAMETER(InputStride);
-
-    const size_t vl = __riscv_vsetvl_e32m4(BlockSize);
-    const size_t StrideWidthElements = StrideWidth / sizeof(float);
-    const size_t DilationWidthElements = DilationWidth / sizeof(float);
-    const size_t FilterStrideElements = FilterStride / sizeof(float);
-    const size_t OutputStrideElements = OutputStride / sizeof(float);
-    const size_t InputWidthElements = InputWidth / sizeof(float);
-    const size_t DilatedInputWidthElements = DilatedInputWidth / sizeof(float);
-
-    const size_t TotalOutputCount = OutputCountLeftPad + OutputCount + OutputCountRightPad;
-
-    for (size_t filterSetBlock = 0; filterSetBlock < FilterCount; filterSetBlock++) {
-
-        const float* filter = Filter + filterSetBlock * FilterStrideElements;
-        float* output = Output + filterSetBlock * OutputStrideElements;
-        const float* bias = (Bias != nullptr) ? &Bias[filterSetBlock * BlockSize] : nullptr;
-
-        size_t output_idx = 0;
-
-        for (; output_idx + OutputStep <= TotalOutputCount; output_idx += OutputStep) {
-            MlasConvNchwcFloatGroupRvv(
-                Input + output_idx * StrideWidthElements, filter, &output[output_idx * BlockSize],
-                StrideWidthElements, DilationWidthElements, InputWidthElements,
-                DilatedInputWidthElements, KernelHeight, KernelWidth, InputBase, bias,
-                KernelFlags, vl, OutputStep);
-        }
-
-        if (output_idx < TotalOutputCount) {
-            MlasConvNchwcFloatGroupRvv(
-                Input + output_idx * StrideWidthElements, filter, &output[output_idx * BlockSize],
-                StrideWidthElements, DilationWidthElements, InputWidthElements,
-                DilatedInputWidthElements, KernelHeight, KernelWidth, InputBase, bias,
-                KernelFlags, vl, TotalOutputCount - output_idx);
-        }
-    }
+    MLAS_RVV_DISPATCH_ON_LMUL(MlasConvNchwcFloatKernelRvvImpl, Input, Filter, Output, StrideWidth,
+                              DilationWidth, FilterCount, InputStride, FilterStride, OutputStride,
+                              KernelHeight, KernelWidth, InputBase, InputWidth, DilatedInputWidth,
+                              OutputCountLeftPad, OutputCount, OutputCountRightPad, Bias,
+                              KernelFlags)
 }
 
 namespace {
 
+template <size_t Lmul>
 MLAS_FORCEINLINE
-vfloat32m4_t
+typename MLAS_RVV_BLOCK<Lmul>::Vector
 LoadBlockInRange(
     const float* Address,
     const float* RowStart,
@@ -441,17 +605,20 @@ LoadBlockInRange(
     size_t vl
     )
 {
+    using Block = MLAS_RVV_BLOCK<Lmul>;
+
     if (Address >= RowStart && (Address + BlockSize - 1) < RowEnd) {
-        return __riscv_vle32_v_f32m4(Address, vl);
+        return Block::Load(Address, vl);
     }
 
-    return __riscv_vfmv_v_f_f32m4(0.0f, vl);
+    return Block::Broadcast(0.0f, vl);
 }
 
 //
 // Accumulates a group of output positions of the depthwise convolution.
 //
 
+template <size_t Lmul>
 MLAS_FORCEINLINE
 void
 MlasConvDepthwiseFloatGroupRvv(
@@ -471,16 +638,19 @@ MlasConvDepthwiseFloatGroupRvv(
     size_t OutputCountThisIteration
     )
 {
+    using Block = MLAS_RVV_BLOCK<Lmul>;
+    using Vector = typename Block::Vector;
+
     const size_t offset1 = (OutputCountThisIteration > 1 ? 1 : 0) * StrideWidthElements;
     const size_t offset2 = (OutputCountThisIteration > 2 ? 2 : 0) * StrideWidthElements;
     const size_t offset3 = (OutputCountThisIteration > 3 ? 3 : 0) * StrideWidthElements;
 
     const size_t offset_last = (OutputCountThisIteration - 1) * StrideWidthElements;
 
-    vfloat32m4_t acc0 = __riscv_vfmv_v_f_f32m4(0.0f, vl);
-    vfloat32m4_t acc1 = acc0;
-    vfloat32m4_t acc2 = acc0;
-    vfloat32m4_t acc3 = acc0;
+    Vector acc0 = Block::Broadcast(0.0f, vl);
+    Vector acc1 = acc0;
+    Vector acc2 = acc0;
+    Vector acc3 = acc0;
 
     for (size_t kh = 0; kh < KernelHeight; kh++) {
 
@@ -492,59 +662,50 @@ MlasConvDepthwiseFloatGroupRvv(
             const float* input_base =
                 Input + kh * DilatedInputWidthElements + kw * DilationWidthElements;
 
-            vfloat32m4_t filt =
-                __riscv_vle32_v_f32m4(&Filter[(kh * KernelWidth + kw) * BlockSize], vl);
+            const float* input_base0 = input_base;
+            const float* input_base1 = input_base + offset1;
+            const float* input_base2 = input_base + offset2;
+            const float* input_base3 = input_base + offset3;
 
-            if (input_base >= input_row_start &&
+            Vector filt = Block::Load(&Filter[(kh * KernelWidth + kw) * BlockSize], vl);
+
+            if (input_base0 >= input_row_start &&
                 (input_base + offset_last + BlockSize - 1) < input_row_end) {
-                acc0 = __riscv_vfmacc_vv_f32m4(
-                    acc0, __riscv_vle32_v_f32m4(input_base, vl), filt, vl);
-                acc1 = __riscv_vfmacc_vv_f32m4(
-                    acc1, __riscv_vle32_v_f32m4(input_base + offset1, vl), filt, vl);
-                acc2 = __riscv_vfmacc_vv_f32m4(
-                    acc2, __riscv_vle32_v_f32m4(input_base + offset2, vl), filt, vl);
-                acc3 = __riscv_vfmacc_vv_f32m4(
-                    acc3, __riscv_vle32_v_f32m4(input_base + offset3, vl), filt, vl);
+                acc0 = Block::MultiplyAdd(acc0, Block::Load(input_base0, vl), filt, vl);
+                acc1 = Block::MultiplyAdd(acc1, Block::Load(input_base1, vl), filt, vl);
+                acc2 = Block::MultiplyAdd(acc2, Block::Load(input_base2, vl), filt, vl);
+                acc3 = Block::MultiplyAdd(acc3, Block::Load(input_base3, vl), filt, vl);
             } else {
-                acc0 = __riscv_vfmacc_vv_f32m4(
-                    acc0, LoadBlockInRange(input_base, input_row_start, input_row_end, vl),
-                    filt, vl);
-                acc1 = __riscv_vfmacc_vv_f32m4(
-                    acc1,
-                    LoadBlockInRange(input_base + offset1, input_row_start, input_row_end, vl),
-                    filt, vl);
-                acc2 = __riscv_vfmacc_vv_f32m4(
-                    acc2,
-                    LoadBlockInRange(input_base + offset2, input_row_start, input_row_end, vl),
-                    filt, vl);
-                acc3 = __riscv_vfmacc_vv_f32m4(
-                    acc3,
-                    LoadBlockInRange(input_base + offset3, input_row_start, input_row_end, vl),
-                    filt, vl);
+                acc0 = Block::MultiplyAdd(
+                    acc0, LoadBlockInRange<Lmul>(input_base0, input_row_start, input_row_end, vl), filt, vl);
+                acc1 = Block::MultiplyAdd(
+                    acc1, LoadBlockInRange<Lmul>(input_base1, input_row_start, input_row_end, vl), filt, vl);
+                acc2 = Block::MultiplyAdd(
+                    acc2, LoadBlockInRange<Lmul>(input_base2, input_row_start, input_row_end, vl), filt, vl);
+                acc3 = Block::MultiplyAdd(
+                    acc3, LoadBlockInRange<Lmul>(input_base3, input_row_start, input_row_end, vl), filt, vl);
             }
         }
     }
 
-    ApplyPostProcessing(acc0, &Output[0], Bias, KernelFlags, vl);
-    __riscv_vse32_v_f32m4(&Output[0], acc0, vl);
+    ApplyPostProcessing<Lmul>(acc0, &Output[0], Bias, KernelFlags, vl);
+    Block::Store(&Output[0], acc0, vl);
 
     if (OutputCountThisIteration > 1) {
-        ApplyPostProcessing(acc1, &Output[BlockSize], Bias, KernelFlags, vl);
-        __riscv_vse32_v_f32m4(&Output[BlockSize], acc1, vl);
+        ApplyPostProcessing<Lmul>(acc1, &Output[BlockSize], Bias, KernelFlags, vl);
+        Block::Store(&Output[BlockSize], acc1, vl);
     }
 
     if (OutputCountThisIteration > 2) {
-        ApplyPostProcessing(acc2, &Output[2 * BlockSize], Bias, KernelFlags, vl);
-        __riscv_vse32_v_f32m4(&Output[2 * BlockSize], acc2, vl);
+        ApplyPostProcessing<Lmul>(acc2, &Output[2 * BlockSize], Bias, KernelFlags, vl);
+        Block::Store(&Output[2 * BlockSize], acc2, vl);
     }
 
     if (OutputCountThisIteration > 3) {
-        ApplyPostProcessing(acc3, &Output[3 * BlockSize], Bias, KernelFlags, vl);
-        __riscv_vse32_v_f32m4(&Output[3 * BlockSize], acc3, vl);
+        ApplyPostProcessing<Lmul>(acc3, &Output[3 * BlockSize], Bias, KernelFlags, vl);
+        Block::Store(&Output[3 * BlockSize], acc3, vl);
     }
 }
-
-}  // namespace
 
 //
 // Depthwise NCHWc convolution kernel.
@@ -552,6 +713,60 @@ MlasConvDepthwiseFloatGroupRvv(
 // Each channel is convolved with its own filter (element-wise).
 // Input is NCHWc, filter is [KH][KW][BlockSize].
 //
+
+template <size_t Lmul>
+void
+MlasConvDepthwiseFloatKernelRvvImpl(
+    const float* Input,
+    const float* Filter,
+    float* Output,
+    size_t StrideWidth,
+    size_t DilationWidth,
+    size_t InputStride,
+    size_t KernelHeight,
+    size_t KernelWidth,
+    const float* InputBase,
+    size_t InputWidth,
+    size_t DilatedInputWidth,
+    size_t OutputCountLeftPad,
+    size_t OutputCount,
+    size_t OutputCountRightPad,
+    const float* Bias,
+    unsigned KernelFlags
+    )
+{
+    MLAS_UNREFERENCED_PARAMETER(InputStride);
+
+    using Block = MLAS_RVV_BLOCK<Lmul>;
+
+    const size_t vl = Block::VectorLength();
+    const size_t StrideWidthElements = StrideWidth / sizeof(float);
+    const size_t DilationWidthElements = DilationWidth / sizeof(float);
+    const size_t InputWidthElements = InputWidth / sizeof(float);
+    const size_t DilatedInputWidthElements = DilatedInputWidth / sizeof(float);
+
+    const size_t TotalOutputCount = OutputCountLeftPad + OutputCount + OutputCountRightPad;
+
+    size_t output_idx = 0;
+
+    for (; output_idx + OutputStep <= TotalOutputCount; output_idx += OutputStep) {
+        MlasConvDepthwiseFloatGroupRvv<Lmul>(
+            Input + output_idx * StrideWidthElements, Filter, &Output[output_idx * BlockSize],
+            StrideWidthElements, DilationWidthElements, InputWidthElements,
+            DilatedInputWidthElements, KernelHeight, KernelWidth, InputBase, Bias, KernelFlags,
+            vl, OutputStep);
+    }
+
+    if (output_idx < TotalOutputCount) {
+        MlasConvDepthwiseFloatGroupRvv<Lmul>(
+            Input + output_idx * StrideWidthElements, Filter, &Output[output_idx * BlockSize],
+            StrideWidthElements, DilationWidthElements, InputWidthElements,
+            DilatedInputWidthElements, KernelHeight, KernelWidth, InputBase, Bias, KernelFlags,
+            vl, TotalOutputCount - output_idx);
+    }
+}
+
+}  // namespace
 
 void
 MLASCALL
@@ -574,33 +789,10 @@ MlasConvDepthwiseFloatKernelRvv(
     unsigned KernelFlags
     )
 {
-    MLAS_UNREFERENCED_PARAMETER(InputStride);
-
-    const size_t vl = __riscv_vsetvl_e32m4(BlockSize);
-    const size_t StrideWidthElements = StrideWidth / sizeof(float);
-    const size_t DilationWidthElements = DilationWidth / sizeof(float);
-    const size_t InputWidthElements = InputWidth / sizeof(float);
-    const size_t DilatedInputWidthElements = DilatedInputWidth / sizeof(float);
-
-    const size_t TotalOutputCount = OutputCountLeftPad + OutputCount + OutputCountRightPad;
-
-    size_t output_idx = 0;
-
-    for (; output_idx + OutputStep <= TotalOutputCount; output_idx += OutputStep) {
-        MlasConvDepthwiseFloatGroupRvv(
-            Input + output_idx * StrideWidthElements, Filter, &Output[output_idx * BlockSize],
-            StrideWidthElements, DilationWidthElements, InputWidthElements,
-            DilatedInputWidthElements, KernelHeight, KernelWidth, InputBase, Bias, KernelFlags,
-            vl, OutputStep);
-    }
-
-    if (output_idx < TotalOutputCount) {
-        MlasConvDepthwiseFloatGroupRvv(
-            Input + output_idx * StrideWidthElements, Filter, &Output[output_idx * BlockSize],
-            StrideWidthElements, DilationWidthElements, InputWidthElements,
-            DilatedInputWidthElements, KernelHeight, KernelWidth, InputBase, Bias, KernelFlags,
-            vl, TotalOutputCount - output_idx);
-    }
+    MLAS_RVV_DISPATCH_ON_LMUL(MlasConvDepthwiseFloatKernelRvvImpl, Input, Filter, Output,
+                              StrideWidth, DilationWidth, InputStride, KernelHeight, KernelWidth,
+                              InputBase, InputWidth, DilatedInputWidth, OutputCountLeftPad,
+                              OutputCount, OutputCountRightPad, Bias, KernelFlags)
 }
 
 namespace {
@@ -610,6 +802,7 @@ namespace {
 // is padded here, so no position needs a range test.
 //
 
+template <size_t Lmul>
 MLAS_FORCEINLINE
 void
 MlasConvPointwiseFloatGroupRvv(
@@ -625,14 +818,17 @@ MlasConvPointwiseFloatGroupRvv(
     size_t OutputCountThisIteration
     )
 {
+    using Block = MLAS_RVV_BLOCK<Lmul>;
+    using Vector = typename Block::Vector;
+
     const size_t offset1 = (OutputCountThisIteration > 1 ? 1 : 0) * StrideWidthElements;
     const size_t offset2 = (OutputCountThisIteration > 2 ? 2 : 0) * StrideWidthElements;
     const size_t offset3 = (OutputCountThisIteration > 3 ? 3 : 0) * StrideWidthElements;
 
-    vfloat32m4_t acc0 = __riscv_vfmv_v_f_f32m4(0.0f, vl);
-    vfloat32m4_t acc1 = acc0;
-    vfloat32m4_t acc2 = acc0;
-    vfloat32m4_t acc3 = acc0;
+    Vector acc0 = Block::Broadcast(0.0f, vl);
+    Vector acc1 = acc0;
+    Vector acc2 = acc0;
+    Vector acc3 = acc0;
 
     for (size_t ic = 0; ic < InputChannels; ic++) {
 
@@ -640,34 +836,32 @@ MlasConvPointwiseFloatGroupRvv(
         const float* filter = Filter + ic * BlockSize * BlockSize;
 
         for (size_t j = 0; j < BlockSize; j++) {
-            vfloat32m4_t filt = __riscv_vle32_v_f32m4(&filter[j * BlockSize], vl);
-            acc0 = __riscv_vfmacc_vf_f32m4(acc0, input[j], filt, vl);
-            acc1 = __riscv_vfmacc_vf_f32m4(acc1, input[offset1 + j], filt, vl);
-            acc2 = __riscv_vfmacc_vf_f32m4(acc2, input[offset2 + j], filt, vl);
-            acc3 = __riscv_vfmacc_vf_f32m4(acc3, input[offset3 + j], filt, vl);
+            Vector filt = Block::Load(&filter[j * BlockSize], vl);
+            acc0 = Block::MultiplyAdd(acc0, input[j], filt, vl);
+            acc1 = Block::MultiplyAdd(acc1, input[offset1 + j], filt, vl);
+            acc2 = Block::MultiplyAdd(acc2, input[offset2 + j], filt, vl);
+            acc3 = Block::MultiplyAdd(acc3, input[offset3 + j], filt, vl);
         }
     }
 
-    ApplyPostProcessing(acc0, &Output[0], Bias, KernelFlags, vl);
-    __riscv_vse32_v_f32m4(&Output[0], acc0, vl);
+    ApplyPostProcessing<Lmul>(acc0, &Output[0], Bias, KernelFlags, vl);
+    Block::Store(&Output[0], acc0, vl);
 
     if (OutputCountThisIteration > 1) {
-        ApplyPostProcessing(acc1, &Output[BlockSize], Bias, KernelFlags, vl);
-        __riscv_vse32_v_f32m4(&Output[BlockSize], acc1, vl);
+        ApplyPostProcessing<Lmul>(acc1, &Output[BlockSize], Bias, KernelFlags, vl);
+        Block::Store(&Output[BlockSize], acc1, vl);
     }
 
     if (OutputCountThisIteration > 2) {
-        ApplyPostProcessing(acc2, &Output[2 * BlockSize], Bias, KernelFlags, vl);
-        __riscv_vse32_v_f32m4(&Output[2 * BlockSize], acc2, vl);
+        ApplyPostProcessing<Lmul>(acc2, &Output[2 * BlockSize], Bias, KernelFlags, vl);
+        Block::Store(&Output[2 * BlockSize], acc2, vl);
     }
 
     if (OutputCountThisIteration > 3) {
-        ApplyPostProcessing(acc3, &Output[3 * BlockSize], Bias, KernelFlags, vl);
-        __riscv_vse32_v_f32m4(&Output[3 * BlockSize], acc3, vl);
+        ApplyPostProcessing<Lmul>(acc3, &Output[3 * BlockSize], Bias, KernelFlags, vl);
+        Block::Store(&Output[3 * BlockSize], acc3, vl);
     }
 }
-
-}  // namespace
 
 //
 // Pointwise (1x1) NCHWc convolution kernel.
@@ -676,6 +870,57 @@ MlasConvPointwiseFloatGroupRvv(
 // Processes OutputCount output positions, accumulating over InputChannels
 // (counted in blocks of BlockSize).
 //
+
+template <size_t Lmul>
+void
+MlasConvPointwiseFloatKernelRvvImpl(
+    const float* Input,
+    const float* Filter,
+    float* Output,
+    size_t StrideWidth,
+    size_t InputChannels,
+    size_t FilterCount,
+    size_t InputStride,
+    size_t FilterStride,
+    size_t OutputStride,
+    size_t OutputCount,
+    const float* Bias,
+    unsigned KernelFlags
+    )
+{
+    using Block = MLAS_RVV_BLOCK<Lmul>;
+
+    const size_t vl = Block::VectorLength();
+    const size_t StrideWidthElements = StrideWidth / sizeof(float);
+    const size_t InputStrideElements = InputStride / sizeof(float);
+    const size_t FilterStrideElements = FilterStride / sizeof(float);
+    const size_t OutputStrideElements = OutputStride / sizeof(float);
+
+    for (size_t f = 0; f < FilterCount; f++) {
+
+        const float* filter = Filter + f * FilterStrideElements;
+        float* output = Output + f * OutputStrideElements;
+        const float* bias = (Bias != nullptr) ? &Bias[f * BlockSize] : nullptr;
+
+        size_t out = 0;
+
+        for (; out + OutputStep <= OutputCount; out += OutputStep) {
+            MlasConvPointwiseFloatGroupRvv<Lmul>(
+                Input + out * StrideWidthElements, filter, &output[out * BlockSize],
+                StrideWidthElements, InputStrideElements, InputChannels, bias, KernelFlags, vl,
+                OutputStep);
+        }
+
+        if (out < OutputCount) {
+            MlasConvPointwiseFloatGroupRvv<Lmul>(
+                Input + out * StrideWidthElements, filter, &output[out * BlockSize],
+                StrideWidthElements, InputStrideElements, InputChannels, bias, KernelFlags, vl,
+                OutputCount - out);
+        }
+    }
+}
+
+}  // namespace
 
 void
 MLASCALL
@@ -694,39 +939,83 @@ MlasConvPointwiseFloatKernelRvv(
     unsigned KernelFlags
     )
 {
-    const size_t vl = __riscv_vsetvl_e32m4(BlockSize);
-    const size_t StrideWidthElements = StrideWidth / sizeof(float);
-    const size_t InputStrideElements = InputStride / sizeof(float);
-    const size_t FilterStrideElements = FilterStride / sizeof(float);
-    const size_t OutputStrideElements = OutputStride / sizeof(float);
-
-    for (size_t f = 0; f < FilterCount; f++) {
-
-        const float* filter = Filter + f * FilterStrideElements;
-        float* output = Output + f * OutputStrideElements;
-        const float* bias = (Bias != nullptr) ? &Bias[f * BlockSize] : nullptr;
-
-        size_t out = 0;
-
-        for (; out + OutputStep <= OutputCount; out += OutputStep) {
-            MlasConvPointwiseFloatGroupRvv(
-                Input + out * StrideWidthElements, filter, &output[out * BlockSize],
-                StrideWidthElements, InputStrideElements, InputChannels, bias, KernelFlags, vl,
-                OutputStep);
-        }
-
-        if (out < OutputCount) {
-            MlasConvPointwiseFloatGroupRvv(
-                Input + out * StrideWidthElements, filter, &output[out * BlockSize],
-                StrideWidthElements, InputStrideElements, InputChannels, bias, KernelFlags, vl,
-                OutputCount - out);
-        }
-    }
+    MLAS_RVV_DISPATCH_ON_LMUL(MlasConvPointwiseFloatKernelRvvImpl, Input, Filter, Output,
+                              StrideWidth, InputChannels, FilterCount, InputStride, FilterStride,
+                              OutputStride, OutputCount, Bias, KernelFlags)
 }
 
 //
 // Max pooling kernel for NCHWc format.
 //
+
+namespace {
+
+template <size_t Lmul>
+void
+MlasPoolMaximumFloatKernelRvvImpl(
+    const float* Input,
+    float* Output,
+    size_t StrideWidth,
+    size_t DilationWidth,
+    size_t InputStride,
+    size_t ActualKernelSize,
+    size_t KernelHeight,
+    size_t KernelWidth,
+    const float* InputBase,
+    size_t InputWidth,
+    size_t DilatedInputWidth,
+    size_t OutputCountLeftPad,
+    size_t OutputCount,
+    size_t OutputCountRightPad
+    )
+{
+    MLAS_UNREFERENCED_PARAMETER(ActualKernelSize);
+    MLAS_UNREFERENCED_PARAMETER(InputStride);
+
+    using Block = MLAS_RVV_BLOCK<Lmul>;
+    using Vector = typename Block::Vector;
+
+    const size_t vl = Block::VectorLength();
+    const size_t StrideWidthElements = StrideWidth / sizeof(float);
+    const size_t DilationWidthElements = DilationWidth / sizeof(float);
+    const size_t InputWidthElements = InputWidth / sizeof(float);
+    const size_t DilatedInputWidthElements = DilatedInputWidth / sizeof(float);
+    const size_t TotalOutputCount = OutputCountLeftPad + OutputCount + OutputCountRightPad;
+
+    const float PadValue = std::numeric_limits<float>::lowest();
+
+    for (size_t output_idx = 0; output_idx < TotalOutputCount; output_idx++) {
+
+        Vector max_vec = Block::Broadcast(PadValue, vl);
+
+        for (size_t kh = 0; kh < KernelHeight; kh++) {
+            const float* row_start = InputBase + kh * DilatedInputWidthElements;
+            const float* row_end = row_start + InputWidthElements;
+
+            for (size_t kw = 0; kw < KernelWidth; kw++) {
+                const float* input_ptr = Input + output_idx * StrideWidthElements +
+                                         kh * DilatedInputWidthElements + kw * DilationWidthElements;
+
+                if (input_ptr >= row_start && (input_ptr + BlockSize) <= row_end) {
+                    Vector inp = Block::Load(input_ptr, vl);
+                    max_vec = Block::Maximum(max_vec, inp, vl);
+                } else {
+                    float values[BlockSize];
+                    for (size_t i = 0; i < BlockSize; i++) {
+                        const float* ep = input_ptr + i;
+                        values[i] = (ep >= row_start && ep < row_end) ? *ep : PadValue;
+                    }
+                    Vector inp = Block::Load(values, vl);
+                    max_vec = Block::Maximum(max_vec, inp, vl);
+                }
+            }
+        }
+
+        Block::Store(&Output[output_idx * BlockSize], max_vec, vl);
+    }
+}
+
+}  // namespace
 
 void
 MLASCALL
@@ -747,47 +1036,10 @@ MlasPoolMaximumFloatKernelRvv(
     size_t OutputCountRightPad
     )
 {
-    MLAS_UNREFERENCED_PARAMETER(ActualKernelSize);
-    MLAS_UNREFERENCED_PARAMETER(InputStride);
-
-    const size_t vl = __riscv_vsetvl_e32m4(BlockSize);
-    const size_t StrideWidthElements = StrideWidth / sizeof(float);
-    const size_t DilationWidthElements = DilationWidth / sizeof(float);
-    const size_t InputWidthElements = InputWidth / sizeof(float);
-    const size_t DilatedInputWidthElements = DilatedInputWidth / sizeof(float);
-    const size_t TotalOutputCount = OutputCountLeftPad + OutputCount + OutputCountRightPad;
-
-    const float PadValue = std::numeric_limits<float>::lowest();
-
-    for (size_t output_idx = 0; output_idx < TotalOutputCount; output_idx++) {
-
-        vfloat32m4_t max_vec = __riscv_vfmv_v_f_f32m4(PadValue, vl);
-
-        for (size_t kh = 0; kh < KernelHeight; kh++) {
-            const float* row_start = InputBase + kh * DilatedInputWidthElements;
-            const float* row_end = row_start + InputWidthElements;
-
-            for (size_t kw = 0; kw < KernelWidth; kw++) {
-                const float* input_ptr = Input + output_idx * StrideWidthElements +
-                                         kh * DilatedInputWidthElements + kw * DilationWidthElements;
-
-                if (input_ptr >= row_start && (input_ptr + BlockSize) <= row_end) {
-                    vfloat32m4_t inp = __riscv_vle32_v_f32m4(input_ptr, vl);
-                    max_vec = __riscv_vfmax_vv_f32m4(max_vec, inp, vl);
-                } else {
-                    float values[BlockSize];
-                    for (size_t i = 0; i < BlockSize; i++) {
-                        const float* ep = input_ptr + i;
-                        values[i] = (ep >= row_start && ep < row_end) ? *ep : PadValue;
-                    }
-                    vfloat32m4_t inp = __riscv_vle32_v_f32m4(values, vl);
-                    max_vec = __riscv_vfmax_vv_f32m4(max_vec, inp, vl);
-                }
-            }
-        }
-
-        __riscv_vse32_v_f32m4(&Output[output_idx * BlockSize], max_vec, vl);
-    }
+    MLAS_RVV_DISPATCH_ON_LMUL(MlasPoolMaximumFloatKernelRvvImpl, Input, Output, StrideWidth,
+                              DilationWidth, InputStride, ActualKernelSize, KernelHeight,
+                              KernelWidth, InputBase, InputWidth, DilatedInputWidth,
+                              OutputCountLeftPad, OutputCount, OutputCountRightPad)
 }
 
 //
@@ -796,6 +1048,7 @@ MlasPoolMaximumFloatKernelRvv(
 
 namespace {
 
+template <size_t Lmul>
 MLAS_FORCEINLINE
 void
 MlasPoolAverageFloatKernelRvvImpl(
@@ -815,7 +1068,10 @@ MlasPoolAverageFloatKernelRvvImpl(
     bool ExcludePad
     )
 {
-    const size_t vl = __riscv_vsetvl_e32m4(BlockSize);
+    using Block = MLAS_RVV_BLOCK<Lmul>;
+    using Vector = typename Block::Vector;
+
+    const size_t vl = Block::VectorLength();
     const size_t StrideWidthElements = StrideWidth / sizeof(float);
     const size_t DilationWidthElements = DilationWidth / sizeof(float);
     const size_t InputWidthElements = InputWidth / sizeof(float);
@@ -824,7 +1080,7 @@ MlasPoolAverageFloatKernelRvvImpl(
 
     for (size_t output_idx = 0; output_idx < TotalOutputCount; output_idx++) {
 
-        vfloat32m4_t sum_vec = __riscv_vfmv_v_f_f32m4(0.0f, vl);
+        Vector sum_vec = Block::Broadcast(0.0f, vl);
         uint32_t valid_count[BlockSize];
 
         if (ExcludePad) {
@@ -842,8 +1098,8 @@ MlasPoolAverageFloatKernelRvvImpl(
                                          kh * DilatedInputWidthElements + kw * DilationWidthElements;
 
                 if (input_ptr >= row_start && (input_ptr + BlockSize) <= row_end) {
-                    vfloat32m4_t inp = __riscv_vle32_v_f32m4(input_ptr, vl);
-                    sum_vec = __riscv_vfadd_vv_f32m4(sum_vec, inp, vl);
+                    Vector inp = Block::Load(input_ptr, vl);
+                    sum_vec = Block::Add(sum_vec, inp, vl);
 
                     if (ExcludePad) {
                         for (size_t i = 0; i < BlockSize; i++) {
@@ -863,27 +1119,27 @@ MlasPoolAverageFloatKernelRvvImpl(
                             values[i] = 0.0f;
                         }
                     }
-                    vfloat32m4_t inp = __riscv_vle32_v_f32m4(values, vl);
-                    sum_vec = __riscv_vfadd_vv_f32m4(sum_vec, inp, vl);
+                    Vector inp = Block::Load(values, vl);
+                    sum_vec = Block::Add(sum_vec, inp, vl);
                 }
             }
         }
 
         if (ExcludePad) {
             float results[BlockSize];
-            __riscv_vse32_v_f32m4(results, sum_vec, vl);
+            Block::Store(results, sum_vec, vl);
             for (size_t i = 0; i < BlockSize; i++) {
                 results[i] = (valid_count[i] > 0)
                     ? results[i] / static_cast<float>(valid_count[i])
                     : 0.0f;
             }
-            vfloat32m4_t result_vec = __riscv_vle32_v_f32m4(results, vl);
-            __riscv_vse32_v_f32m4(&Output[output_idx * BlockSize], result_vec, vl);
+            Vector result_vec = Block::Load(results, vl);
+            Block::Store(&Output[output_idx * BlockSize], result_vec, vl);
         } else {
-            vfloat32m4_t divisor = __riscv_vfmv_v_f_f32m4(
+            Vector divisor = Block::Broadcast(
                 static_cast<float>(ActualKernelSize), vl);
-            vfloat32m4_t result_vec = __riscv_vfdiv_vv_f32m4(sum_vec, divisor, vl);
-            __riscv_vse32_v_f32m4(&Output[output_idx * BlockSize], result_vec, vl);
+            Vector result_vec = Block::Divide(sum_vec, divisor, vl);
+            Block::Store(&Output[output_idx * BlockSize], result_vec, vl);
         }
     }
 }
@@ -911,10 +1167,10 @@ MlasPoolAverageExcludePadFloatKernelRvv(
 {
     MLAS_UNREFERENCED_PARAMETER(InputStride);
 
-    MlasPoolAverageFloatKernelRvvImpl(
-        Input, Output, StrideWidth, DilationWidth, ActualKernelSize,
-        KernelHeight, KernelWidth, InputBase, InputWidth, DilatedInputWidth,
-        OutputCountLeftPad, OutputCount, OutputCountRightPad, true);
+    MLAS_RVV_DISPATCH_ON_LMUL(MlasPoolAverageFloatKernelRvvImpl, Input, Output, StrideWidth,
+                              DilationWidth, ActualKernelSize, KernelHeight, KernelWidth,
+                              InputBase, InputWidth, DilatedInputWidth, OutputCountLeftPad,
+                              OutputCount, OutputCountRightPad, true)
 }
 
 void
@@ -938,10 +1194,10 @@ MlasPoolAverageIncludePadFloatKernelRvv(
 {
     MLAS_UNREFERENCED_PARAMETER(InputStride);
 
-    MlasPoolAverageFloatKernelRvvImpl(
-        Input, Output, StrideWidth, DilationWidth, ActualKernelSize,
-        KernelHeight, KernelWidth, InputBase, InputWidth, DilatedInputWidth,
-        OutputCountLeftPad, OutputCount, OutputCountRightPad, false);
+    MLAS_RVV_DISPATCH_ON_LMUL(MlasPoolAverageFloatKernelRvvImpl, Input, Output, StrideWidth,
+                              DilationWidth, ActualKernelSize, KernelHeight, KernelWidth,
+                              InputBase, InputWidth, DilatedInputWidth, OutputCountLeftPad,
+                              OutputCount, OutputCountRightPad, false)
 }
 
 #endif  // MLAS_USE_RVV

--- a/onnxruntime/core/mlas/lib/riscv64/sconv_nchwc_kernel_rvv.cpp
+++ b/onnxruntime/core/mlas/lib/riscv64/sconv_nchwc_kernel_rvv.cpp
@@ -36,6 +36,21 @@ namespace {
 
 constexpr size_t BlockSize = 16;
 
+//
+// Number of output positions a kernel accumulates at once.
+//
+// A block of channels fills a register group, so no parallelism is left inside
+// one: the multiply accumulates for an output position form a chain. It comes
+// from the output positions instead, and they share one filter load. Four of
+// them plus that filter occupy twenty of the thirty two registers at LMUL 4.
+//
+// A register group cannot be held in an array, so the positions are spelled out,
+// and a group holding fewer than four repeats the first position in the slots it
+// does not use. Those slots are not stored, which lets one body serve both a
+// full group and the remainder.
+//
+constexpr size_t OutputStep = 4;
+
 MLAS_FORCEINLINE
 void
 ApplyPostProcessing(
@@ -60,6 +75,105 @@ ApplyPostProcessing(
     if (KernelFlags & MLAS_CONV_KERNEL_FLAG_RELU_ACTIVATION) {
         vfloat32m4_t zero = __riscv_vfmv_v_f_f32m4(0.0f, vl);
         acc = __riscv_vfmax_vv_f32m4(acc, zero, vl);
+    }
+}
+
+MLAS_FORCEINLINE
+float
+LoadInRange(
+    const float* Address,
+    const float* RowStart,
+    const float* RowEnd
+    )
+{
+    return (Address >= RowStart && Address < RowEnd) ? *Address : 0.0f;
+}
+
+//
+// Accumulates a group of output positions of the direct NCHW convolution. Input
+// and Output address the first of them; the filter is already at its block.
+//
+
+MLAS_FORCEINLINE
+void
+MlasConvNchwFloatGroupRvv(
+    const float* Input,
+    const float* Filter,
+    float* Output,
+    size_t StrideWidthElements,
+    size_t DilationWidthElements,
+    size_t InputWidthElements,
+    size_t DilatedInputWidthElements,
+    size_t KernelHeight,
+    size_t KernelWidth,
+    const float* InputBase,
+    const float* Bias,
+    unsigned KernelFlags,
+    size_t vl,
+    size_t OutputCountThisIteration
+    )
+{
+    const size_t offset1 = (OutputCountThisIteration > 1 ? 1 : 0) * StrideWidthElements;
+    const size_t offset2 = (OutputCountThisIteration > 2 ? 2 : 0) * StrideWidthElements;
+    const size_t offset3 = (OutputCountThisIteration > 3 ? 3 : 0) * StrideWidthElements;
+
+    const size_t offset_last = (OutputCountThisIteration - 1) * StrideWidthElements;
+
+    vfloat32m4_t acc0 = __riscv_vfmv_v_f_f32m4(0.0f, vl);
+    vfloat32m4_t acc1 = acc0;
+    vfloat32m4_t acc2 = acc0;
+    vfloat32m4_t acc3 = acc0;
+
+    for (size_t kh = 0; kh < KernelHeight; kh++) {
+
+        const float* input_row_start = InputBase + kh * DilatedInputWidthElements;
+        const float* input_row_end = input_row_start + InputWidthElements;
+
+        for (size_t kw = 0; kw < KernelWidth; kw++) {
+
+            const float* input_pos =
+                Input + kh * DilatedInputWidthElements + kw * DilationWidthElements;
+
+            vfloat32m4_t filt =
+                __riscv_vle32_v_f32m4(&Filter[(kh * KernelWidth + kw) * BlockSize], vl);
+
+            if (input_pos >= input_row_start && (input_pos + offset_last) < input_row_end) {
+                acc0 = __riscv_vfmacc_vf_f32m4(acc0, input_pos[0], filt, vl);
+                acc1 = __riscv_vfmacc_vf_f32m4(acc1, input_pos[offset1], filt, vl);
+                acc2 = __riscv_vfmacc_vf_f32m4(acc2, input_pos[offset2], filt, vl);
+                acc3 = __riscv_vfmacc_vf_f32m4(acc3, input_pos[offset3], filt, vl);
+            } else {
+                acc0 = __riscv_vfmacc_vf_f32m4(
+                    acc0, LoadInRange(input_pos, input_row_start, input_row_end), filt, vl);
+                acc1 = __riscv_vfmacc_vf_f32m4(
+                    acc1, LoadInRange(input_pos + offset1, input_row_start, input_row_end),
+                    filt, vl);
+                acc2 = __riscv_vfmacc_vf_f32m4(
+                    acc2, LoadInRange(input_pos + offset2, input_row_start, input_row_end),
+                    filt, vl);
+                acc3 = __riscv_vfmacc_vf_f32m4(
+                    acc3, LoadInRange(input_pos + offset3, input_row_start, input_row_end),
+                    filt, vl);
+            }
+        }
+    }
+
+    ApplyPostProcessing(acc0, &Output[0], Bias, KernelFlags, vl);
+    __riscv_vse32_v_f32m4(&Output[0], acc0, vl);
+
+    if (OutputCountThisIteration > 1) {
+        ApplyPostProcessing(acc1, &Output[BlockSize], Bias, KernelFlags, vl);
+        __riscv_vse32_v_f32m4(&Output[BlockSize], acc1, vl);
+    }
+
+    if (OutputCountThisIteration > 2) {
+        ApplyPostProcessing(acc2, &Output[2 * BlockSize], Bias, KernelFlags, vl);
+        __riscv_vse32_v_f32m4(&Output[2 * BlockSize], acc2, vl);
+    }
+
+    if (OutputCountThisIteration > 3) {
+        ApplyPostProcessing(acc3, &Output[3 * BlockSize], Bias, KernelFlags, vl);
+        __riscv_vse32_v_f32m4(&Output[3 * BlockSize], acc3, vl);
     }
 }
 
@@ -110,41 +224,140 @@ MlasConvNchwFloatKernelRvv(
 
     const size_t TotalOutputCount = OutputCountLeftPad + OutputCount + OutputCountRightPad;
 
-    for (size_t output_idx = 0; output_idx < TotalOutputCount; output_idx++) {
+    for (size_t filterSetBlock = 0; filterSetBlock < FilterCount; filterSetBlock++) {
 
-        for (size_t filterSetBlock = 0; filterSetBlock < FilterCount; filterSetBlock++) {
-            const float* filter = Filter + filterSetBlock * FilterStrideElements;
-            float* output = Output + filterSetBlock * OutputStrideElements;
+        const float* filter = Filter + filterSetBlock * FilterStrideElements;
+        float* output = Output + filterSetBlock * OutputStrideElements;
+        const float* bias = (Bias != nullptr) ? &Bias[filterSetBlock * BlockSize] : nullptr;
 
-            vfloat32m4_t acc = __riscv_vfmv_v_f_f32m4(0.0f, vl);
+        size_t output_idx = 0;
 
-            for (size_t kh = 0; kh < KernelHeight; kh++) {
-                for (size_t kw = 0; kw < KernelWidth; kw++) {
-                    const float* input_pos = Input + output_idx * StrideWidthElements +
-                                             kh * DilatedInputWidthElements + kw * DilationWidthElements;
+        for (; output_idx + OutputStep <= TotalOutputCount; output_idx += OutputStep) {
+            MlasConvNchwFloatGroupRvv(
+                Input + output_idx * StrideWidthElements, filter, &output[output_idx * BlockSize],
+                StrideWidthElements, DilationWidthElements, InputWidthElements,
+                DilatedInputWidthElements, KernelHeight, KernelWidth, InputBase, bias,
+                KernelFlags, vl, OutputStep);
+        }
 
-                    const float* input_row_start = InputBase + kh * DilatedInputWidthElements;
-                    const float* input_row_end = input_row_start + InputWidthElements;
-
-                    float input_value = 0.0f;
-                    if (input_pos >= input_row_start && input_pos < input_row_end) {
-                        input_value = *input_pos;
-                    }
-
-                    size_t kernel_base_pos = kh * KernelWidth + kw;
-                    vfloat32m4_t filt = __riscv_vle32_v_f32m4(&filter[kernel_base_pos * BlockSize], vl);
-                    acc = __riscv_vfmacc_vf_f32m4(acc, input_value, filt, vl);
-                }
-            }
-
-            ApplyPostProcessing(acc, &output[output_idx * BlockSize],
-                                Bias ? &Bias[filterSetBlock * BlockSize] : nullptr,
-                                KernelFlags, vl);
-
-            __riscv_vse32_v_f32m4(&output[output_idx * BlockSize], acc, vl);
+        if (output_idx < TotalOutputCount) {
+            MlasConvNchwFloatGroupRvv(
+                Input + output_idx * StrideWidthElements, filter, &output[output_idx * BlockSize],
+                StrideWidthElements, DilationWidthElements, InputWidthElements,
+                DilatedInputWidthElements, KernelHeight, KernelWidth, InputBase, bias,
+                KernelFlags, vl, TotalOutputCount - output_idx);
         }
     }
 }
+
+namespace {
+
+//
+// Accumulates a group of output positions of the direct NCHWc convolution. Input
+// and Output address the first of them; the filter is already at its block.
+//
+
+MLAS_FORCEINLINE
+void
+MlasConvNchwcFloatGroupRvv(
+    const float* Input,
+    const float* Filter,
+    float* Output,
+    size_t StrideWidthElements,
+    size_t DilationWidthElements,
+    size_t InputWidthElements,
+    size_t DilatedInputWidthElements,
+    size_t KernelHeight,
+    size_t KernelWidth,
+    const float* InputBase,
+    const float* Bias,
+    unsigned KernelFlags,
+    size_t vl,
+    size_t OutputCountThisIteration
+    )
+{
+    const size_t offset1 = (OutputCountThisIteration > 1 ? 1 : 0) * StrideWidthElements;
+    const size_t offset2 = (OutputCountThisIteration > 2 ? 2 : 0) * StrideWidthElements;
+    const size_t offset3 = (OutputCountThisIteration > 3 ? 3 : 0) * StrideWidthElements;
+
+    // Furthest position the group stores; the slots it does not use sit at zero.
+    const size_t offset_last = (OutputCountThisIteration - 1) * StrideWidthElements;
+
+    vfloat32m4_t acc0 = __riscv_vfmv_v_f_f32m4(0.0f, vl);
+    vfloat32m4_t acc1 = acc0;
+    vfloat32m4_t acc2 = acc0;
+    vfloat32m4_t acc3 = acc0;
+
+    for (size_t kh = 0; kh < KernelHeight; kh++) {
+
+        const float* input_row_start = InputBase + kh * DilatedInputWidthElements;
+        const float* input_row_end = input_row_start + InputWidthElements;
+
+        for (size_t kw = 0; kw < KernelWidth; kw++) {
+
+            const float* filter_position =
+                Filter + (kh * KernelWidth + kw) * BlockSize * BlockSize;
+
+            const float* input_base =
+                Input + kh * DilatedInputWidthElements + kw * DilationWidthElements;
+            const float* input_base0 = input_base;
+            const float* input_base1 = input_base + offset1;
+            const float* input_base2 = input_base + offset2;
+            const float* input_base3 = input_base + offset3;
+
+            const bool all_in_bounds = (input_base >= input_row_start) &&
+                                     ((input_base + offset_last + BlockSize) <= input_row_end);
+
+            if (all_in_bounds) {
+                for (size_t ic = 0; ic < BlockSize; ic++) {
+                    vfloat32m4_t filt =
+                        __riscv_vle32_v_f32m4(&filter_position[ic * BlockSize], vl);
+                    acc0 = __riscv_vfmacc_vf_f32m4(acc0, input_base0[ic], filt, vl);
+                    acc1 = __riscv_vfmacc_vf_f32m4(acc1, input_base1[ic], filt, vl);
+                    acc2 = __riscv_vfmacc_vf_f32m4(acc2, input_base2[ic], filt, vl);
+                    acc3 = __riscv_vfmacc_vf_f32m4(acc3, input_base3[ic], filt, vl);
+                }
+            } else {
+                for (size_t ic = 0; ic < BlockSize; ic++) {
+                    vfloat32m4_t filt =
+                        __riscv_vle32_v_f32m4(&filter_position[ic * BlockSize], vl);
+                    acc0 = __riscv_vfmacc_vf_f32m4(
+                        acc0, LoadInRange(input_base0 + ic, input_row_start, input_row_end),
+                        filt, vl);
+                    acc1 = __riscv_vfmacc_vf_f32m4(
+                        acc1, LoadInRange(input_base1 + ic, input_row_start, input_row_end),
+                        filt, vl);
+                    acc2 = __riscv_vfmacc_vf_f32m4(
+                        acc2, LoadInRange(input_base2 + ic, input_row_start, input_row_end),
+                        filt, vl);
+                    acc3 = __riscv_vfmacc_vf_f32m4(
+                        acc3, LoadInRange(input_base3 + ic, input_row_start, input_row_end),
+                        filt, vl);
+                }
+            }
+        }
+    }
+
+    ApplyPostProcessing(acc0, &Output[0], Bias, KernelFlags, vl);
+    __riscv_vse32_v_f32m4(&Output[0], acc0, vl);
+
+    if (OutputCountThisIteration > 1) {
+        ApplyPostProcessing(acc1, &Output[BlockSize], Bias, KernelFlags, vl);
+        __riscv_vse32_v_f32m4(&Output[BlockSize], acc1, vl);
+    }
+
+    if (OutputCountThisIteration > 2) {
+        ApplyPostProcessing(acc2, &Output[2 * BlockSize], Bias, KernelFlags, vl);
+        __riscv_vse32_v_f32m4(&Output[2 * BlockSize], acc2, vl);
+    }
+
+    if (OutputCountThisIteration > 3) {
+        ApplyPostProcessing(acc3, &Output[3 * BlockSize], Bias, KernelFlags, vl);
+        __riscv_vse32_v_f32m4(&Output[3 * BlockSize], acc3, vl);
+    }
+}
+
+}  // namespace
 
 //
 // Direct NCHWc convolution kernel.
@@ -191,57 +404,147 @@ MlasConvNchwcFloatKernelRvv(
 
     const size_t TotalOutputCount = OutputCountLeftPad + OutputCount + OutputCountRightPad;
 
-    for (size_t output_idx = 0; output_idx < TotalOutputCount; output_idx++) {
+    for (size_t filterSetBlock = 0; filterSetBlock < FilterCount; filterSetBlock++) {
 
-        for (size_t filterSetBlock = 0; filterSetBlock < FilterCount; filterSetBlock++) {
-            const float* filter = Filter + filterSetBlock * FilterStrideElements;
-            float* output = Output + filterSetBlock * OutputStrideElements;
+        const float* filter = Filter + filterSetBlock * FilterStrideElements;
+        float* output = Output + filterSetBlock * OutputStrideElements;
+        const float* bias = (Bias != nullptr) ? &Bias[filterSetBlock * BlockSize] : nullptr;
 
-            vfloat32m4_t acc = __riscv_vfmv_v_f_f32m4(0.0f, vl);
+        size_t output_idx = 0;
 
-            for (size_t kh = 0; kh < KernelHeight; kh++) {
-                for (size_t kw = 0; kw < KernelWidth; kw++) {
-                    const float* input_base = Input + output_idx * StrideWidthElements +
-                                              kh * DilatedInputWidthElements + kw * DilationWidthElements;
+        for (; output_idx + OutputStep <= TotalOutputCount; output_idx += OutputStep) {
+            MlasConvNchwcFloatGroupRvv(
+                Input + output_idx * StrideWidthElements, filter, &output[output_idx * BlockSize],
+                StrideWidthElements, DilationWidthElements, InputWidthElements,
+                DilatedInputWidthElements, KernelHeight, KernelWidth, InputBase, bias,
+                KernelFlags, vl, OutputStep);
+        }
 
-                    const float* input_row_start = InputBase + kh * DilatedInputWidthElements;
-                    const float* input_row_end = input_row_start + InputWidthElements;
-
-                    size_t kernel_pos = kh * KernelWidth + kw;
-
-                    bool in_bounds = (input_base >= input_row_start) &&
-                                     ((input_base + BlockSize) <= input_row_end);
-
-                    if (in_bounds) {
-                        for (size_t ic = 0; ic < BlockSize; ic++) {
-                            float input_value = input_base[ic];
-                            size_t filter_offset = kernel_pos * BlockSize * BlockSize + ic * BlockSize;
-                            vfloat32m4_t filt = __riscv_vle32_v_f32m4(&filter[filter_offset], vl);
-                            acc = __riscv_vfmacc_vf_f32m4(acc, input_value, filt, vl);
-                        }
-                    } else {
-                        for (size_t ic = 0; ic < BlockSize; ic++) {
-                            const float* input_element = input_base + ic;
-                            float input_value = 0.0f;
-                            if (input_element >= input_row_start && input_element < input_row_end) {
-                                input_value = *input_element;
-                            }
-                            size_t filter_offset = kernel_pos * BlockSize * BlockSize + ic * BlockSize;
-                            vfloat32m4_t filt = __riscv_vle32_v_f32m4(&filter[filter_offset], vl);
-                            acc = __riscv_vfmacc_vf_f32m4(acc, input_value, filt, vl);
-                        }
-                    }
-                }
-            }
-
-            ApplyPostProcessing(acc, &output[output_idx * BlockSize],
-                                Bias ? &Bias[filterSetBlock * BlockSize] : nullptr,
-                                KernelFlags, vl);
-
-            __riscv_vse32_v_f32m4(&output[output_idx * BlockSize], acc, vl);
+        if (output_idx < TotalOutputCount) {
+            MlasConvNchwcFloatGroupRvv(
+                Input + output_idx * StrideWidthElements, filter, &output[output_idx * BlockSize],
+                StrideWidthElements, DilationWidthElements, InputWidthElements,
+                DilatedInputWidthElements, KernelHeight, KernelWidth, InputBase, bias,
+                KernelFlags, vl, TotalOutputCount - output_idx);
         }
     }
 }
+
+namespace {
+
+MLAS_FORCEINLINE
+vfloat32m4_t
+LoadBlockInRange(
+    const float* Address,
+    const float* RowStart,
+    const float* RowEnd,
+    size_t vl
+    )
+{
+    if (Address >= RowStart && (Address + BlockSize - 1) < RowEnd) {
+        return __riscv_vle32_v_f32m4(Address, vl);
+    }
+
+    return __riscv_vfmv_v_f_f32m4(0.0f, vl);
+}
+
+//
+// Accumulates a group of output positions of the depthwise convolution.
+//
+
+MLAS_FORCEINLINE
+void
+MlasConvDepthwiseFloatGroupRvv(
+    const float* Input,
+    const float* Filter,
+    float* Output,
+    size_t StrideWidthElements,
+    size_t DilationWidthElements,
+    size_t InputWidthElements,
+    size_t DilatedInputWidthElements,
+    size_t KernelHeight,
+    size_t KernelWidth,
+    const float* InputBase,
+    const float* Bias,
+    unsigned KernelFlags,
+    size_t vl,
+    size_t OutputCountThisIteration
+    )
+{
+    const size_t offset1 = (OutputCountThisIteration > 1 ? 1 : 0) * StrideWidthElements;
+    const size_t offset2 = (OutputCountThisIteration > 2 ? 2 : 0) * StrideWidthElements;
+    const size_t offset3 = (OutputCountThisIteration > 3 ? 3 : 0) * StrideWidthElements;
+
+    const size_t offset_last = (OutputCountThisIteration - 1) * StrideWidthElements;
+
+    vfloat32m4_t acc0 = __riscv_vfmv_v_f_f32m4(0.0f, vl);
+    vfloat32m4_t acc1 = acc0;
+    vfloat32m4_t acc2 = acc0;
+    vfloat32m4_t acc3 = acc0;
+
+    for (size_t kh = 0; kh < KernelHeight; kh++) {
+
+        const float* input_row_start = InputBase + kh * DilatedInputWidthElements;
+        const float* input_row_end = input_row_start + InputWidthElements;
+
+        for (size_t kw = 0; kw < KernelWidth; kw++) {
+
+            const float* input_base =
+                Input + kh * DilatedInputWidthElements + kw * DilationWidthElements;
+
+            vfloat32m4_t filt =
+                __riscv_vle32_v_f32m4(&Filter[(kh * KernelWidth + kw) * BlockSize], vl);
+
+            if (input_base >= input_row_start &&
+                (input_base + offset_last + BlockSize - 1) < input_row_end) {
+                acc0 = __riscv_vfmacc_vv_f32m4(
+                    acc0, __riscv_vle32_v_f32m4(input_base, vl), filt, vl);
+                acc1 = __riscv_vfmacc_vv_f32m4(
+                    acc1, __riscv_vle32_v_f32m4(input_base + offset1, vl), filt, vl);
+                acc2 = __riscv_vfmacc_vv_f32m4(
+                    acc2, __riscv_vle32_v_f32m4(input_base + offset2, vl), filt, vl);
+                acc3 = __riscv_vfmacc_vv_f32m4(
+                    acc3, __riscv_vle32_v_f32m4(input_base + offset3, vl), filt, vl);
+            } else {
+                acc0 = __riscv_vfmacc_vv_f32m4(
+                    acc0, LoadBlockInRange(input_base, input_row_start, input_row_end, vl),
+                    filt, vl);
+                acc1 = __riscv_vfmacc_vv_f32m4(
+                    acc1,
+                    LoadBlockInRange(input_base + offset1, input_row_start, input_row_end, vl),
+                    filt, vl);
+                acc2 = __riscv_vfmacc_vv_f32m4(
+                    acc2,
+                    LoadBlockInRange(input_base + offset2, input_row_start, input_row_end, vl),
+                    filt, vl);
+                acc3 = __riscv_vfmacc_vv_f32m4(
+                    acc3,
+                    LoadBlockInRange(input_base + offset3, input_row_start, input_row_end, vl),
+                    filt, vl);
+            }
+        }
+    }
+
+    ApplyPostProcessing(acc0, &Output[0], Bias, KernelFlags, vl);
+    __riscv_vse32_v_f32m4(&Output[0], acc0, vl);
+
+    if (OutputCountThisIteration > 1) {
+        ApplyPostProcessing(acc1, &Output[BlockSize], Bias, KernelFlags, vl);
+        __riscv_vse32_v_f32m4(&Output[BlockSize], acc1, vl);
+    }
+
+    if (OutputCountThisIteration > 2) {
+        ApplyPostProcessing(acc2, &Output[2 * BlockSize], Bias, KernelFlags, vl);
+        __riscv_vse32_v_f32m4(&Output[2 * BlockSize], acc2, vl);
+    }
+
+    if (OutputCountThisIteration > 3) {
+        ApplyPostProcessing(acc3, &Output[3 * BlockSize], Bias, KernelFlags, vl);
+        __riscv_vse32_v_f32m4(&Output[3 * BlockSize], acc3, vl);
+    }
+}
+
+}  // namespace
 
 //
 // Depthwise NCHWc convolution kernel.
@@ -280,38 +583,91 @@ MlasConvDepthwiseFloatKernelRvv(
     const size_t DilatedInputWidthElements = DilatedInputWidth / sizeof(float);
 
     const size_t TotalOutputCount = OutputCountLeftPad + OutputCount + OutputCountRightPad;
-    const size_t KernelSize = KernelHeight * KernelWidth;
 
-    for (size_t output_idx = 0; output_idx < TotalOutputCount; output_idx++) {
+    size_t output_idx = 0;
 
-        vfloat32m4_t acc = __riscv_vfmv_v_f_f32m4(0.0f, vl);
+    for (; output_idx + OutputStep <= TotalOutputCount; output_idx += OutputStep) {
+        MlasConvDepthwiseFloatGroupRvv(
+            Input + output_idx * StrideWidthElements, Filter, &Output[output_idx * BlockSize],
+            StrideWidthElements, DilationWidthElements, InputWidthElements,
+            DilatedInputWidthElements, KernelHeight, KernelWidth, InputBase, Bias, KernelFlags,
+            vl, OutputStep);
+    }
 
-        for (size_t kpos = 0; kpos < KernelSize; kpos++) {
-            size_t kh = kpos / KernelWidth;
-            size_t kw = kpos % KernelWidth;
-
-            const float* input_base = Input + output_idx * StrideWidthElements +
-                                      kh * DilatedInputWidthElements + kw * DilationWidthElements;
-
-            const float* input_row_start = InputBase + kh * DilatedInputWidthElements;
-            const float* input_row_end = input_row_start + InputWidthElements;
-
-            vfloat32m4_t input_vec;
-            if (input_base >= input_row_start && (input_base + BlockSize - 1) < input_row_end) {
-                input_vec = __riscv_vle32_v_f32m4(input_base, vl);
-            } else {
-                input_vec = __riscv_vfmv_v_f_f32m4(0.0f, vl);
-            }
-
-            vfloat32m4_t filt = __riscv_vle32_v_f32m4(&Filter[kpos * BlockSize], vl);
-            acc = __riscv_vfmacc_vv_f32m4(acc, input_vec, filt, vl);
-        }
-
-        ApplyPostProcessing(acc, &Output[output_idx * BlockSize], Bias, KernelFlags, vl);
-
-        __riscv_vse32_v_f32m4(&Output[output_idx * BlockSize], acc, vl);
+    if (output_idx < TotalOutputCount) {
+        MlasConvDepthwiseFloatGroupRvv(
+            Input + output_idx * StrideWidthElements, Filter, &Output[output_idx * BlockSize],
+            StrideWidthElements, DilationWidthElements, InputWidthElements,
+            DilatedInputWidthElements, KernelHeight, KernelWidth, InputBase, Bias, KernelFlags,
+            vl, TotalOutputCount - output_idx);
     }
 }
+
+namespace {
+
+//
+// Accumulates a group of output positions of the pointwise convolution. Nothing
+// is padded here, so no position needs a range test.
+//
+
+MLAS_FORCEINLINE
+void
+MlasConvPointwiseFloatGroupRvv(
+    const float* Input,
+    const float* Filter,
+    float* Output,
+    size_t StrideWidthElements,
+    size_t InputStrideElements,
+    size_t InputChannels,
+    const float* Bias,
+    unsigned KernelFlags,
+    size_t vl,
+    size_t OutputCountThisIteration
+    )
+{
+    const size_t offset1 = (OutputCountThisIteration > 1 ? 1 : 0) * StrideWidthElements;
+    const size_t offset2 = (OutputCountThisIteration > 2 ? 2 : 0) * StrideWidthElements;
+    const size_t offset3 = (OutputCountThisIteration > 3 ? 3 : 0) * StrideWidthElements;
+
+    vfloat32m4_t acc0 = __riscv_vfmv_v_f_f32m4(0.0f, vl);
+    vfloat32m4_t acc1 = acc0;
+    vfloat32m4_t acc2 = acc0;
+    vfloat32m4_t acc3 = acc0;
+
+    for (size_t ic = 0; ic < InputChannels; ic++) {
+
+        const float* input = Input + ic * InputStrideElements;
+        const float* filter = Filter + ic * BlockSize * BlockSize;
+
+        for (size_t j = 0; j < BlockSize; j++) {
+            vfloat32m4_t filt = __riscv_vle32_v_f32m4(&filter[j * BlockSize], vl);
+            acc0 = __riscv_vfmacc_vf_f32m4(acc0, input[j], filt, vl);
+            acc1 = __riscv_vfmacc_vf_f32m4(acc1, input[offset1 + j], filt, vl);
+            acc2 = __riscv_vfmacc_vf_f32m4(acc2, input[offset2 + j], filt, vl);
+            acc3 = __riscv_vfmacc_vf_f32m4(acc3, input[offset3 + j], filt, vl);
+        }
+    }
+
+    ApplyPostProcessing(acc0, &Output[0], Bias, KernelFlags, vl);
+    __riscv_vse32_v_f32m4(&Output[0], acc0, vl);
+
+    if (OutputCountThisIteration > 1) {
+        ApplyPostProcessing(acc1, &Output[BlockSize], Bias, KernelFlags, vl);
+        __riscv_vse32_v_f32m4(&Output[BlockSize], acc1, vl);
+    }
+
+    if (OutputCountThisIteration > 2) {
+        ApplyPostProcessing(acc2, &Output[2 * BlockSize], Bias, KernelFlags, vl);
+        __riscv_vse32_v_f32m4(&Output[2 * BlockSize], acc2, vl);
+    }
+
+    if (OutputCountThisIteration > 3) {
+        ApplyPostProcessing(acc3, &Output[3 * BlockSize], Bias, KernelFlags, vl);
+        __riscv_vse32_v_f32m4(&Output[3 * BlockSize], acc3, vl);
+    }
+}
+
+}  // namespace
 
 //
 // Pointwise (1x1) NCHWc convolution kernel.
@@ -345,29 +701,25 @@ MlasConvPointwiseFloatKernelRvv(
     const size_t OutputStrideElements = OutputStride / sizeof(float);
 
     for (size_t f = 0; f < FilterCount; f++) {
+
         const float* filter = Filter + f * FilterStrideElements;
         float* output = Output + f * OutputStrideElements;
+        const float* bias = (Bias != nullptr) ? &Bias[f * BlockSize] : nullptr;
 
-        for (size_t out = 0; out < OutputCount; out++) {
+        size_t out = 0;
 
-            vfloat32m4_t acc = __riscv_vfmv_v_f_f32m4(0.0f, vl);
+        for (; out + OutputStep <= OutputCount; out += OutputStep) {
+            MlasConvPointwiseFloatGroupRvv(
+                Input + out * StrideWidthElements, filter, &output[out * BlockSize],
+                StrideWidthElements, InputStrideElements, InputChannels, bias, KernelFlags, vl,
+                OutputStep);
+        }
 
-            const float* input = Input + out * StrideWidthElements;
-
-            for (size_t ic = 0; ic < InputChannels; ic++) {
-                for (size_t j = 0; j < BlockSize; j++) {
-                    float input_value = input[ic * InputStrideElements + j];
-                    vfloat32m4_t filt = __riscv_vle32_v_f32m4(
-                        &filter[ic * BlockSize * BlockSize + j * BlockSize], vl);
-                    acc = __riscv_vfmacc_vf_f32m4(acc, input_value, filt, vl);
-                }
-            }
-
-            ApplyPostProcessing(acc, &output[out * BlockSize],
-                                Bias ? &Bias[f * BlockSize] : nullptr,
-                                KernelFlags, vl);
-
-            __riscv_vse32_v_f32m4(&output[out * BlockSize], acc, vl);
+        if (out < OutputCount) {
+            MlasConvPointwiseFloatGroupRvv(
+                Input + out * StrideWidthElements, filter, &output[out * BlockSize],
+                StrideWidthElements, InputStrideElements, InputChannels, bias, KernelFlags, vl,
+                OutputCount - out);
         }
     }
 }

--- a/onnxruntime/core/mlas/lib/riscv64/softmax_kernel_rvv.cpp
+++ b/onnxruntime/core/mlas/lib/riscv64/softmax_kernel_rvv.cpp
@@ -15,6 +15,16 @@ Abstract:
     focuses on the float32 primitives used by Softmax and LogSoftmax:
     reduction, sum-exp, normalization, and log-softmax output.
 
+    The two reducing kernels carry their result in a vector across the row and
+    reduce once at the end, which is what the generic implementations do. A
+    reduction costs several times what an add or a max costs, so issuing one per
+    group turns the row into a chain of them.
+
+    LMUL is 4 throughout. The polynomial in the exponential is a dependency
+    chain, so what the loop wants is a group wide enough to keep independent work
+    in flight across it rather than the widest group available: LMUL 8 leaves the
+    register file four names and spills.
+
 --*/
 
 #include "mlasi.h"
@@ -38,68 +48,76 @@ constexpr float kPoly4 = 0x1.fffff6p-2f;
 constexpr float kPoly56 = 0x1.000000p+0f;
 constexpr int32_t kMaximumExponentBits = 0x3F800000;
 
+//
+// The polynomial is a multiply and an add rather than a fused multiply add.
+// Horner's form wants the addend to be the constant, and the fused instruction
+// takes its addend from a vector, so every step would first have to broadcast
+// the constant into one. That is an instruction and a register group per step,
+// and it measures no faster than the pair it would replace.
+//
+
 MLAS_FORCEINLINE
-vfloat32m1_t
+vfloat32m4_t
 MlasComputeExpVectorRvv(
-    vfloat32m1_t value,
+    vfloat32m4_t value,
     size_t vl
     )
 {
-    value = __riscv_vfmax_vf_f32m1(value, kExpLowerRangeSumExp, vl);
+    value = __riscv_vfmax_vf_f32m4(value, kExpLowerRangeSumExp, vl);
 
-    vfloat32m1_t scaled = __riscv_vfmul_vf_f32m1(value, kLog2Reciprocal, vl);
-    vfloat32m1_t biased = __riscv_vfadd_vf_f32m1(scaled, kRoundingBias, vl);
-    vfloat32m1_t reduced_m = __riscv_vfsub_vf_f32m1(biased, kRoundingBias, vl);
-    vfloat32m1_t reduced = __riscv_vfadd_vv_f32m1(
-        __riscv_vfmul_vf_f32m1(reduced_m, kLog2High, vl), value, vl);
-    reduced = __riscv_vfadd_vv_f32m1(
-        __riscv_vfmul_vf_f32m1(reduced_m, kLog2Low, vl), reduced, vl);
+    vfloat32m4_t scaled = __riscv_vfmul_vf_f32m4(value, kLog2Reciprocal, vl);
+    vfloat32m4_t biased = __riscv_vfadd_vf_f32m4(scaled, kRoundingBias, vl);
+    vfloat32m4_t reduced_m = __riscv_vfsub_vf_f32m4(biased, kRoundingBias, vl);
+    vfloat32m4_t reduced = __riscv_vfadd_vv_f32m4(
+        __riscv_vfmul_vf_f32m4(reduced_m, kLog2High, vl), value, vl);
+    reduced = __riscv_vfadd_vv_f32m4(
+        __riscv_vfmul_vf_f32m4(reduced_m, kLog2Low, vl), reduced, vl);
 
-    vfloat32m1_t poly = __riscv_vfmv_v_f_f32m1(kPoly0, vl);
-    poly = __riscv_vfadd_vf_f32m1(
-        __riscv_vfmul_vv_f32m1(poly, reduced, vl), kPoly1, vl);
-    poly = __riscv_vfadd_vf_f32m1(
-        __riscv_vfmul_vv_f32m1(poly, reduced, vl), kPoly2, vl);
-    poly = __riscv_vfadd_vf_f32m1(
-        __riscv_vfmul_vv_f32m1(poly, reduced, vl), kPoly3, vl);
-    poly = __riscv_vfadd_vf_f32m1(
-        __riscv_vfmul_vv_f32m1(poly, reduced, vl), kPoly4, vl);
-    poly = __riscv_vfadd_vf_f32m1(
-        __riscv_vfmul_vv_f32m1(poly, reduced, vl), kPoly56, vl);
-    poly = __riscv_vfadd_vf_f32m1(
-        __riscv_vfmul_vv_f32m1(poly, reduced, vl), kPoly56, vl);
+    vfloat32m4_t poly = __riscv_vfmv_v_f_f32m4(kPoly0, vl);
+    poly = __riscv_vfadd_vf_f32m4(
+        __riscv_vfmul_vv_f32m4(poly, reduced, vl), kPoly1, vl);
+    poly = __riscv_vfadd_vf_f32m4(
+        __riscv_vfmul_vv_f32m4(poly, reduced, vl), kPoly2, vl);
+    poly = __riscv_vfadd_vf_f32m4(
+        __riscv_vfmul_vv_f32m4(poly, reduced, vl), kPoly3, vl);
+    poly = __riscv_vfadd_vf_f32m4(
+        __riscv_vfmul_vv_f32m4(poly, reduced, vl), kPoly4, vl);
+    poly = __riscv_vfadd_vf_f32m4(
+        __riscv_vfmul_vv_f32m4(poly, reduced, vl), kPoly56, vl);
+    poly = __riscv_vfadd_vf_f32m4(
+        __riscv_vfmul_vv_f32m4(poly, reduced, vl), kPoly56, vl);
 
-    vint32m1_t exponent_bits = __riscv_vreinterpret_v_f32m1_i32m1(biased);
-    exponent_bits = __riscv_vsll_vx_i32m1(exponent_bits, 23, vl);
-    exponent_bits = __riscv_vadd_vx_i32m1(exponent_bits, kMaximumExponentBits, vl);
-    vfloat32m1_t scale = __riscv_vreinterpret_v_i32m1_f32m1(exponent_bits);
+    vint32m4_t exponent_bits = __riscv_vreinterpret_v_f32m4_i32m4(biased);
+    exponent_bits = __riscv_vsll_vx_i32m4(exponent_bits, 23, vl);
+    exponent_bits = __riscv_vadd_vx_i32m4(exponent_bits, kMaximumExponentBits, vl);
+    vfloat32m4_t scale = __riscv_vreinterpret_v_i32m4_f32m4(exponent_bits);
 
-    return __riscv_vfmul_vv_f32m1(poly, scale, vl);
+    return __riscv_vfmul_vv_f32m4(poly, scale, vl);
 }
 
 MLAS_FORCEINLINE
 float
 MlasReduceSumRvv(
-    vfloat32m1_t value,
+    vfloat32m4_t value,
     size_t vl
     )
 {
-    vfloat32m1_t accumulator = __riscv_vfmv_s_f_f32m1(0.0f, 1);
-    accumulator = __riscv_vfredusum_vs_f32m1_f32m1(value, accumulator, vl);
-    return __riscv_vfmv_f_s_f32m1_f32(accumulator);
+    vfloat32m1_t accumulation = __riscv_vfmv_s_f_f32m1(0.0f, 1);
+    accumulation = __riscv_vfredusum_vs_f32m4_f32m1(value, accumulation, vl);
+    return __riscv_vfmv_f_s_f32m1_f32(accumulation);
 }
 
 MLAS_FORCEINLINE
 float
 MlasReduceMaxRvv(
-    vfloat32m1_t value,
+    vfloat32m4_t value,
     size_t vl
     )
 {
-    vfloat32m1_t accumulator =
+    vfloat32m1_t maximum =
         __riscv_vfmv_s_f_f32m1(std::numeric_limits<float>::lowest(), 1);
-    accumulator = __riscv_vfredmax_vs_f32m1_f32m1(value, accumulator, vl);
-    return __riscv_vfmv_f_s_f32m1_f32(accumulator);
+    maximum = __riscv_vfredmax_vs_f32m4_f32m1(value, maximum, vl);
+    return __riscv_vfmv_f_s_f32m1_f32(maximum);
 }
 
 }  // namespace
@@ -111,19 +129,28 @@ MlasReduceMaximumF32KernelRvv(
     size_t N
     )
 {
-    float maximum = std::numeric_limits<float>::lowest();
+    const size_t VectorLength = __riscv_vsetvlmax_e32m4();
+
+    //
+    // The accumulator starts at the identity and the groups are taken into it
+    // with the tail undisturbed, so a final group shorter than the rest leaves
+    // the lanes it does not reach at that identity.
+    //
+
+    vfloat32m4_t maximum =
+        __riscv_vfmv_v_f_f32m4(std::numeric_limits<float>::lowest(), VectorLength);
 
     while (N > 0) {
-        size_t vl = __riscv_vsetvl_e32m1(N);
-        vfloat32m1_t input = __riscv_vle32_v_f32m1(Input, vl);
-        input = __riscv_vfmax_vf_f32m1(input, maximum, vl);
-        maximum = MlasReduceMaxRvv(input, vl);
+        const size_t vl = __riscv_vsetvl_e32m4(N);
+
+        maximum = __riscv_vfmax_vv_f32m4_tu(maximum, maximum,
+                                            __riscv_vle32_v_f32m4(Input, vl), vl);
 
         Input += vl;
         N -= vl;
     }
 
-    return maximum;
+    return MlasReduceMaxRvv(maximum, VectorLength);
 }
 
 float
@@ -136,26 +163,28 @@ MlasComputeSumExpF32KernelRvv(
     )
 {
     const float negative_maximum = *NegativeMaximum;
-    float accumulation = 0.0f;
+    const size_t VectorLength = __riscv_vsetvlmax_e32m4();
+
+    vfloat32m4_t accumulation = __riscv_vfmv_v_f_f32m4(0.0f, VectorLength);
 
     while (N > 0) {
-        size_t vl = __riscv_vsetvl_e32m1(N);
-        vfloat32m1_t input = __riscv_vle32_v_f32m1(Input, vl);
-        vfloat32m1_t shifted = __riscv_vfadd_vf_f32m1(input, negative_maximum, vl);
-        vfloat32m1_t exp_value = MlasComputeExpVectorRvv(shifted, vl);
+        const size_t vl = __riscv_vsetvl_e32m4(N);
+        vfloat32m4_t input = __riscv_vle32_v_f32m4(Input, vl);
+        vfloat32m4_t shifted = __riscv_vfadd_vf_f32m4(input, negative_maximum, vl);
+        vfloat32m4_t exp_value = MlasComputeExpVectorRvv(shifted, vl);
 
         if (Output != nullptr) {
-            __riscv_vse32_v_f32m1(Output, exp_value, vl);
+            __riscv_vse32_v_f32m4(Output, exp_value, vl);
             Output += vl;
         }
 
-        accumulation += MlasReduceSumRvv(exp_value, vl);
+        accumulation = __riscv_vfadd_vv_f32m4_tu(accumulation, accumulation, exp_value, vl);
 
         Input += vl;
         N -= vl;
     }
 
-    return accumulation;
+    return MlasReduceSumRvv(accumulation, VectorLength);
 }
 
 void
@@ -169,10 +198,10 @@ MlasComputeSoftmaxOutputF32KernelRvv(
     const float scale = Parameters[0];
 
     while (N > 0) {
-        size_t vl = __riscv_vsetvl_e32m1(N);
-        vfloat32m1_t output = __riscv_vle32_v_f32m1(Output, vl);
-        output = __riscv_vfmul_vf_f32m1(output, scale, vl);
-        __riscv_vse32_v_f32m1(Output, output, vl);
+        const size_t vl = __riscv_vsetvl_e32m4(N);
+        vfloat32m4_t output = __riscv_vle32_v_f32m4(Output, vl);
+        output = __riscv_vfmul_vf_f32m4(output, scale, vl);
+        __riscv_vse32_v_f32m4(Output, output, vl);
 
         Output += vl;
         N -= vl;
@@ -192,11 +221,11 @@ MlasComputeLogSoftmaxOutputF32KernelRvv(
     const float logarithm = Parameters[1];
 
     while (N > 0) {
-        size_t vl = __riscv_vsetvl_e32m1(N);
-        vfloat32m1_t input = __riscv_vle32_v_f32m1(Input, vl);
-        input = __riscv_vfadd_vf_f32m1(input, negative_maximum, vl);
-        input = __riscv_vfsub_vf_f32m1(input, logarithm, vl);
-        __riscv_vse32_v_f32m1(Output, input, vl);
+        const size_t vl = __riscv_vsetvl_e32m4(N);
+        vfloat32m4_t input = __riscv_vle32_v_f32m4(Input, vl);
+        input = __riscv_vfadd_vf_f32m4(input, negative_maximum, vl);
+        input = __riscv_vfsub_vf_f32m4(input, logarithm, vl);
+        __riscv_vse32_v_f32m4(Output, input, vl);
 
         Input += vl;
         Output += vl;

--- a/onnxruntime/test/mlas/unittest/test_activation.cpp
+++ b/onnxruntime/test/mlas/unittest/test_activation.cpp
@@ -246,14 +246,16 @@ class MlasActivationTest : public MlasTestBase {
       }
 
       MlasActivation(&Activation, &Buffer[0].f, nullptr, 1, _countof(Buffer), _countof(Buffer));
-      // TODO: Fix the test once centos has updated to almalinux
-      //      for (unsigned i = 0; i < _countof(TestData); i++) {
-      //        // Sensitive to comparing positive/negative zero and NaNs.
-      //        EXPECT_TRUE(Buffer[i].u == TestData[i][kind].u || Buffer[i].f == TestData[i][kind].f)
-      //            << ", Vector Activation Kind:" << (int)kind << ", i=" << i << ", value:"
-      //            << std::setw(8) << std::setfill('0') << std::hex << Buffer[i].u << ", expecting:"
-      //            << std::setw(8) << std::setfill('0') << std::hex << TestData[i][kind].u;
-      //      }
+      for (unsigned i = 0; i < _countof(TestData); i++) {
+        const float actual = Buffer[i].f;
+        const float expected = TestData[i][kind].f;
+        // Match NaNs by classification and allow rounding differences and either sign of zero.
+        const float tolerance = 0.000001f * std::max(1.0f, std::fabs(expected));
+        EXPECT_TRUE(actual == expected || (std::isnan(actual) && std::isnan(expected)) ||
+                    (std::isfinite(actual) && std::isfinite(expected) && std::fabs(actual - expected) < tolerance))
+            << ", Vector Activation Kind:" << kind << ", i=" << i
+            << ", value:" << actual << ", expecting:" << expected;
+      }
 
       //
       // Test the scalar activations.
@@ -280,3 +282,69 @@ class MlasActivationTest : public MlasTestBase {
 static UNUSED_VARIABLE bool added_to_main = AddTestRegister([](bool is_short_execute) {
   return is_short_execute ? MlasDirectShortExecuteTests<MlasActivationTest>::RegisterShortExecute() : 0;
 });
+
+TEST(ActivationMatrix, BiasAndStride) {
+  constexpr MLAS_ACTIVATION_KIND kinds[] = {
+      MlasIdentityActivation, MlasReluActivation, MlasLeakyReluActivation,
+      MlasClipActivation, MlasHardSigmoidActivation};
+  constexpr float values[] = {-10.0f, -4.0f, -0.25f, 0.0f, 0.25f, 4.0f, 10.0f};
+  constexpr float expected[][_countof(values)] = {
+      {-10.0f, -4.0f, -0.25f, 0.0f, 0.25f, 4.0f, 10.0f},
+      {0.0f, 0.0f, 0.0f, 0.0f, 0.25f, 4.0f, 10.0f},
+      {-2.0f, -0.8f, -0.05f, 0.0f, 0.25f, 4.0f, 10.0f},
+      {0.0f, 0.0f, 0.0f, 0.0f, 0.25f, 4.0f, 6.0f},
+      {0.0f, 0.0f, 0.07f, 0.12f, 0.17f, 0.92f, 1.0f},
+  };
+  constexpr float bias[] = {-1.0f, 0.0f, 1.0f};
+  constexpr size_t widths[] = {0, 1, 3, 4, 5, 15, 16, 17, 31, 32, 33, 63, 64, 65, 127, 128, 129};
+  constexpr size_t paddings[] = {0, 5};
+  constexpr float sentinel = -12345.0f;
+  MatrixGuardBuffer<float> guarded_buffer;
+
+  for (size_t kind = 0; kind < _countof(kinds); ++kind) {
+    MLAS_ACTIVATION activation{};
+    activation.ActivationKind = kinds[kind];
+    if (activation.ActivationKind == MlasLeakyReluActivation) {
+      activation.Parameters.LeakyRelu.alpha = 0.2f;
+    } else if (activation.ActivationKind == MlasClipActivation) {
+      activation.Parameters.Clip.minimum = 0.0f;
+      activation.Parameters.Clip.maximum = 6.0f;
+    } else if (activation.ActivationKind == MlasHardSigmoidActivation) {
+      activation.Parameters.HardSigmoid.alpha = 0.2f;
+      activation.Parameters.HardSigmoid.beta = 0.12f;
+    }
+
+    for (bool add_bias : {false, true}) {
+      for (size_t n : widths) {
+        for (size_t padding : paddings) {
+          const size_t ldc = n + padding;
+          const size_t count = _countof(bias) * ldc;
+          float* buffer = guarded_buffer.GetBuffer(count + 1);
+          std::fill_n(buffer, count + 1, sentinel);
+          SCOPED_TRACE(::testing::Message() << "kind=" << kinds[kind] << ", bias=" << add_bias
+                                            << ", N=" << n << ", ldc=" << ldc);
+
+          for (size_t row = 0; row < _countof(bias); ++row) {
+            for (size_t col = 0; col < n; ++col) {
+              const size_t index = (row + col) % _countof(values);
+              buffer[row * ldc + col] = values[index] - (add_bias ? bias[row] : 0.0f);
+            }
+          }
+
+          MlasActivation(&activation, buffer, add_bias ? bias : nullptr, _countof(bias), n, ldc);
+
+          for (size_t row = 0; row < _countof(bias); ++row) {
+            for (size_t col = 0; col < n; ++col) {
+              EXPECT_NEAR(buffer[row * ldc + col], expected[kind][(row + col) % _countof(values)], 0.000001f)
+                  << "row=" << row << ", col=" << col;
+            }
+            for (size_t col = n; col < ldc; ++col) {
+              EXPECT_EQ(buffer[row * ldc + col], sentinel) << "row=" << row << ", padding=" << col;
+            }
+          }
+          EXPECT_EQ(buffer[count], sentinel);
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
### Description

Improve FP32 inference in the MLAS riscv64 RVV backend with five commits:

1. **Softmax:** accumulate across each row, reduce once at the end, and use LMUL 4.
2. **NCHWc convolution:** compute four adjacent outputs with independent accumulators and shared filter loads.
3. **NCHWc register groups:** select LMUL 1/2/4 from the vector length, preserving the sixteen-float block layout.
4. **Depthwise convolution:** extend the existing `sconv_depthwise_kernel_rvv.cpp` to additional shapes and strides,
   with unit dilation and kernel width up to sixteen. Enable the wider route only when RVV kernels are installed.
5. **Activation:** add an RVV `MlasActivation` routine, including the clamp used by ReLU6.

Changes are limited to MLAS and its CMake source list. Public interfaces remain unchanged.

**Performance**

A210/C920V2: VLEN=128; SpacemiT K3/X100: VLEN=256.
**Baseline** is unmodified upstream `main` at `9f913ae52`, which already includes #32406.
**Optimized** is that baseline with this PR's five RVV kernel changes.
Both use the CPU Execution Provider, `ORT_ENABLE_ALL`, and RVV kernels enabled, with the same toolchain
and build configuration. Runs use one pinned core, one thread, warmup, fixed frequency, and best of three.
Speedup is baseline latency divided by optimized latency. These measurements precede the final depthwise
file consolidation and latest rebase.

| Model | Input shape | C920V2 baseline (ms) | C920V2 optimized (ms) | Speedup | X100 baseline (ms) | X100 optimized (ms) | Speedup |
|---|---|---|---|---|---|---|---|
| [retinaface](https://github.com/serengil/retinaface) | 1x640x640x3 NHWC | 22300.2 | 7404.1 | **3.01x** | 11327.5 | 4037.0 | **2.81x** |
| [resnet50-v1-7](https://github.com/onnx/models/blob/main/validated/vision/classification/resnet/model/resnet50-v1-7.onnx) | 1x3x224x224 NCHW | 1398.1 | 567.3 | **2.46x** | 816.3 | 271.6 | **3.01x** |
| [mobilenetv2-12](https://github.com/onnx/models/blob/main/validated/vision/classification/mobilenet/model/mobilenetv2-12.onnx) | 1x3x224x224 NCHW | 148.2 | 70.7 | **2.10x** | 93.9 | 30.4 | **3.09x** |
| [mobilevit-s](https://github.com/andestech/ModelZoo/blob/master/MobileViT-Small/Model/mobilevit-s.onnx) | 1x3x256x256 NCHW | 845.8 | 419.7 | 2.02x | 356.8 | 200.2 | 1.78x |
| [shufflenet-v2-10](https://github.com/onnx/models/blob/main/validated/vision/classification/shufflenet/model/shufflenet-v2-10.onnx) | 1x3x224x224 NCHW | 68.5 | 47.2 | 1.45x | 41.9 | 20.3 | 2.06x |
| [efficientnet-b0](https://huggingface.co/qualcomm/EfficientNet-B0/blob/main/EfficientNet-B0.onnx) | 1x3x224x224 NCHW | 244.1 | 189.5 | 1.29x | 124.3 | 67.1 | 1.85x |

RetinaFace uses the official serengil TensorFlow/ResNet50 implementation and weights, exported with tf2onnx
at opset 13.

**Validation**

Before the latest rebase: XuanTie cross-compilation passed under `-Werror`. After depthwise consolidation,
the K3 convolution/activation subset passed **1109 tests with RVV** and **565 with forced scalar**,
with zero failures and three HalfConv skips in each mode. Softmax/log-softmax differential checks against
a double-precision reference passed on both boards.

### Motivation and Context

Follow-up to #28261 and #28411, building on the runtime gate restored in #32406.
The existing NCHWc kernels reached only 0.20x–0.84x of the alternative convolution path's throughput
across seven measured shapes. Independent accumulators and appropriately sized register groups address
these bottlenecks while preserving the blocked layout.

Broader depthwise routing avoids im2col plus a single-row GEMM per channel. It benefits convolutions
that cannot use NCHWc, including some ShuffleNet layers at the default optimization level, as well as
`ORT_ENABLE_EXTENDED`. Fewer softmax reductions and vectorized activation address the remaining overhead.
