### PR TITLE
Fix localized DirectML adapter errors in Python

### DIFF
--- a/onnxruntime/core/providers/dml/dml_provider_factory.cc
+++ b/onnxruntime/core/providers/dml/dml_provider_factory.cc
@@ -512,7 +512,13 @@ Microsoft::WRL::ComPtr<ID3D12Device> DMLProviderFactoryCreator::CreateD3D12Devic
     ORT_THROW_IF_FAILED(CreateDXGIFactory2(0, IID_GRAPHICS_PPV_ARGS(dxgi_factory.ReleaseAndGetAddressOf())));
 
     ComPtr<IDXGIAdapter1> adapter;
-    ORT_THROW_IF_FAILED(dxgi_factory->EnumAdapters1(device_id, &adapter));
+    const HRESULT enumerate_adapter_hr = dxgi_factory->EnumAdapters1(device_id, &adapter);
+    if (FAILED(enumerate_adapter_hr)) {
+      // WIL includes the localized system message in exceptions from ORT_THROW_IF_FAILED. Those messages may use
+      // the active Windows code page, while Python exception messages must be UTF-8.
+      ORT_THROW("Failed to enumerate DirectML adapter with device_id ", device_id,
+                ". HRESULT: ", static_cast<uint32_t>(enumerate_adapter_hr));
+    }
 
     // Disallow using DML with the software adapter (Microsoft Basic Display Adapter) because CPU evaluations are much
     // faster. Some scenarios though call for EP initialization without this check (as execution will not actually occur

--- a/onnxruntime/test/python/onnxruntime_test_python.py
+++ b/onnxruntime/test/python/onnxruntime_test_python.py
@@ -284,6 +284,21 @@ class TestInferenceSession(unittest.TestCase):
         sess = onnxrt.InferenceSession(get_name("mul_1.onnx"), providers=onnxrt.get_available_providers())
         self.assertTrue("CPUExecutionProvider" in sess.get_providers())
 
+    @unittest.skipUnless(
+        sys.platform == "win32" and "DmlExecutionProvider" in onnxrt.get_available_providers(),
+        "requires the DirectML execution provider on Windows",
+    )
+    def test_invalid_dml_device_id_returns_readable_error(self):
+        invalid_device_id = 2**31 - 1
+        with self.assertRaisesRegex(
+            RuntimeError, f"Failed to enumerate DirectML adapter with device_id {invalid_device_id}"
+        ):
+            onnxrt.InferenceSession(
+                get_name("mul_1.onnx"),
+                providers=[("DmlExecutionProvider", {"device_id": str(invalid_device_id)})],
+                enable_fallback=False,
+            )
+
     def test_enabling_and_disabling_telemetry(self):
         onnxrt.disable_telemetry_events()
 


### PR DESCRIPTION
## Summary
- Report invalid DirectML adapter requests with a stable ASCII message before the error crosses the Python boundary.
- Add a Windows + DirectML regression test for an invalid device ID.

Fixes #32082

## Testing
- `python3 -m py_compile onnxruntime/test/python/onnxruntime_test_python.py`
- `git diff --check`
- Not run: the regression test requires Windows with DirectML; pytest is unavailable in this environment.