### PR TITLE
Add contributor sorting option to compile_contributors.py

### DIFF
--- a/tools/python/compile_contributors.py
+++ b/tools/python/compile_contributors.py
@@ -12,9 +12,14 @@ Description:
 Usage:
     python compile_contributors.py [--base <base_branch>] [--target <target_branch>] [--dir <output_dir>]
                                    [--paths <path> [<path> ...]] [--paths-file <file>]
+                                   [--sort-by {contributions,contributor}]
 
 Example:
     python compile_contributors.py --base origin/rel-1.23.2 --target origin/rel-1.24.1 --dir rel-1.24.1_report
+
+    # Sort the release-note contributor list alphabetically (case-insensitive):
+    python compile_contributors.py --base origin/rel-1.28.0 --target origin/rel-1.29.0 \
+        --dir rel-1.29.0_report --sort-by contributor
 
     # Limit to commits that touch selected areas (replace with your paths):
     # Using git pathspec syntax, ":(top)" anchors each path at repository root.
@@ -330,12 +335,25 @@ def read_pathspecs_file(pathspecs_file):
     return pathspecs
 
 
+def sort_contributors(contributors, sort_by):
+    """Sort (lowercase identity, contribution count) pairs for summary output."""
+    if sort_by == "contributor":
+        return sorted(contributors.items(), key=lambda item: item[0])
+    return sorted(contributors.items(), key=lambda item: (-item[1], item[0]))
+
+
 def main():
     parser = argparse.ArgumentParser(description="Compile contributor list from Git log comparison.")
     parser.add_argument("--base", default="origin/rel-1.23.2", help="Base branch/commit to compare from")
     parser.add_argument("--target", default="origin/rel-1.24.1", help="Target branch/commit to compare to")
     parser.add_argument("--dir", default="contributors", help="Output directory for reports and logs")
     parser.add_argument("--scan-depth", type=int, default=200, help="Depth to scan base/meta-PRs for deduplication")
+    parser.add_argument(
+        "--sort-by",
+        choices=("contributions", "contributor"),
+        default="contributions",
+        help="Sort the summary by contribution count (default) or contributor name (case-insensitive)",
+    )
     parser.add_argument(
         "--paths",
         nargs="+",
@@ -466,8 +484,7 @@ def main():
                 if not is_bot(final_author) and not is_invalid(final_author):
                     consolidated_contributors[author_lower] = consolidated_contributors.get(author_lower, 0) + count
 
-        # Sort human contributors by count descending, then alphabetically by identity for determinism
-        sorted_contributors = sorted(consolidated_contributors.items(), key=lambda x: (-x[1], x[0]))
+        sorted_contributors = sort_contributors(consolidated_contributors, args.sort_by)
 
         log_event("\n--- Summary ---", log_file)
         # Prefix only identified github logins and format as markdown links

--- a/tools/python/compile_contributors.py
+++ b/tools/python/compile_contributors.py
@@ -146,6 +146,7 @@ def extract_authors_from_commit(commit_id):
 # Bots to exclude from contributor lists
 BOT_NAMES = {
     "Copilot",
+    "claude",
     "dependabot[bot]",
     "app/dependabot",
     "github-actions[bot]",

--- a/tools/python/test_compile_contributors.py
+++ b/tools/python/test_compile_contributors.py
@@ -3,7 +3,20 @@
 
 import unittest
 
-from compile_contributors import sort_contributors
+from compile_contributors import is_bot, is_invalid, sort_contributors
+
+
+class ContributorFilteringTest(unittest.TestCase):
+    def test_is_bot_excludes_claude(self):
+        for name in ("claude", "@claude", " @claude "):
+            with self.subTest(name=name):
+                self.assertTrue(is_bot(name))
+
+    def test_is_bot_preserves_similar_human_login(self):
+        self.assertFalse(is_bot("claudette"))
+
+    def test_is_invalid_preserves_claude_for_csv(self):
+        self.assertFalse(is_invalid("claude"))
 
 
 class SortContributorsTest(unittest.TestCase):

--- a/tools/python/test_compile_contributors.py
+++ b/tools/python/test_compile_contributors.py
@@ -1,0 +1,28 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+import unittest
+
+from compile_contributors import sort_contributors
+
+
+class SortContributorsTest(unittest.TestCase):
+    def test_sort_by_contributions_orders_by_count_then_contributor(self):
+        contributors = {"charlie": 1, "bravo": 3, "alpha": 3}
+
+        self.assertEqual(
+            sort_contributors(contributors, "contributions"),
+            [("alpha", 3), ("bravo", 3), ("charlie", 1)],
+        )
+
+    def test_sort_by_contributor_orders_alphabetically(self):
+        contributors = {"charlie": 3, "bravo": 2, "alpha": 1}
+
+        self.assertEqual(
+            sort_contributors(contributors, "contributor"),
+            [("alpha", 1), ("bravo", 2), ("charlie", 3)],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Description

- Add `--sort-by` to order the contributor summary by contribution count or contributor name.
- Preserve contribution-count ordering as the default, with a deterministic contributor-name tie-breaker.
- Add focused unit tests for both sorting modes.
- Add claude to bot list

### Motivation and Context

Release-note contributor acknowledgments should be alphabetized, while existing workflows can continue sorting by contribution count.

### Testing

- `.venv\Scripts\python.exe tools\python\test_compile_contributors.py`
- `.venv\Scripts\python.exe -m ruff check --config pyproject.toml tools/python/compile_contributors.py tools/python/test_compile_contributors.py`
- `.venv\Scripts\python.exe -m ruff format --check --config pyproject.toml tools/python/compile_contributors.py tools/python/test_compile_contributors.py`