### PR TITLE
Validate CUDA Split dimension products

### DIFF
--- a/onnxruntime/core/providers/cuda/tensor/split.cc
+++ b/onnxruntime/core/providers/cuda/tensor/split.cc
@@ -64,11 +64,11 @@ Status SplitKernel::PrepareForComputeLocal(const TensorShape& input_shape,
   axis = HandleNegativeAxis(axis_, num_dimensions);
   const int64_t split_dim_size = input_dims[onnxruntime::narrow<size_t>(axis)];
 
-  before_dims = gsl::narrow_cast<int>(input_shape.SizeToDimension(onnxruntime::narrow<size_t>(axis)));
-  after_dims_including_split_axis = gsl::narrow_cast<int>(input_shape.SizeFromDimension(onnxruntime::narrow<size_t>(axis)));
+  before_dims = onnxruntime::narrow<int>(input_shape.SizeToDimension(onnxruntime::narrow<size_t>(axis)));
+  after_dims_including_split_axis = onnxruntime::narrow<int>(input_shape.SizeFromDimension(onnxruntime::narrow<size_t>(axis)));
   after_dims_excluding_split = (axis + 1 == num_dimensions)
                                    ? 1
-                                   : gsl::narrow_cast<int>(input_shape.SizeFromDimension(onnxruntime::narrow<size_t>(axis + 1)));
+                                   : onnxruntime::narrow<int>(input_shape.SizeFromDimension(onnxruntime::narrow<size_t>(axis + 1)));
 
   if (num_outputs_ != -1) {
     if (num_outputs_ > split_dim_size) {

--- a/onnxruntime/test/providers/cpu/tensor/split_op_test.cc
+++ b/onnxruntime/test/providers/cpu/tensor/split_op_test.cc
@@ -422,6 +422,21 @@ TEST(SplitOperatorTest, ZeroSizeInput) {
   RunTest<float>(axis, {}, input, outputs, {kTensorrtExecutionProvider, kQnnExecutionProvider, kCoreMLExecutionProvider});
 }
 
+#ifdef USE_CUDA
+TEST(SplitOperatorTest, CudaDimensionProductExceedsIntMax) {
+  OpTester test("Split", 13);
+  test.AddAttribute("axis", int64_t{1});
+  test.AddInput<float>("input", {0, 46341, 46341}, {});
+  test.AddInput<int64_t>("split", {2}, {23170, 23171});
+  test.AddOutput<float>("output0", {0, 23170, 46341}, {});
+  test.AddOutput<float>("output1", {0, 23171, 46341}, {});
+
+  test.Config(ExpectResult::kExpectFailure, "narrowing_error")
+      .ConfigEp(DefaultCudaExecutionProvider())
+      .RunWithConfig();
+}
+#endif
+
 TEST(SplitOperatorTest, ZeroSizeOutput) {
   constexpr int64_t axis = 1;
   std::vector<ShapeAndFloatData> outputs;


### PR DESCRIPTION
This pull request makes improvements to the CUDA provider's handling of tensor dimension conversions in the `split` operator and adds a new unit test to cover edge cases where dimension products could exceed the maximum value of an `int`. The changes help prevent narrowing errors and improve test coverage for CUDA-specific scenarios.

**CUDA kernel improvements:**

* Replaced `gsl::narrow_cast<int>` with `onnxruntime::narrow<int>` for converting tensor dimensions to `int` in `split.cc`, ensuring consistent and safer narrowing conversions.

**Test coverage enhancements:**

* Added a CUDA-specific unit test (`CudaDimensionProductExceedsIntMax`) to verify that the split operator correctly handles cases where the product of dimensions exceeds the maximum value for an `int`, expecting a narrowing error.