### PR TITLE
Validate NCHWc reorder channel layout

### DIFF
--- a/onnxruntime/contrib_ops/cpu/nchwc_ops.cc
+++ b/onnxruntime/contrib_ops/cpu/nchwc_ops.cc
@@ -127,7 +127,10 @@ Status ReorderOutput::Compute(OpKernelContext* context) const {
   const auto& X_shape = X->Shape().GetDims();
   const auto X_rank = X_shape.size();
   ORT_ENFORCE(X_rank == 4);
-  ORT_ENFORCE(channels_ <= X_shape[1]);
+  const int64_t nchwc_block_size = static_cast<int64_t>(MlasNchwcGetBlockSize());
+  ORT_ENFORCE(X_shape[1] % nchwc_block_size == 0 &&
+                  channels_ <= X_shape[1] && X_shape[1] - channels_ < nchwc_block_size,
+              "Input channels must match the NCHWc block-aligned channel count.");
 
   // Build the output shape in NCHW or NHWC order.
   TensorShapeVector Y_shape(X_rank);

--- a/onnxruntime/test/contrib_ops/nchwc_ops_test.cc
+++ b/onnxruntime/test/contrib_ops/nchwc_ops_test.cc
@@ -1,0 +1,34 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "gtest/gtest.h"
+
+#include "core/mlas/inc/mlas.h"
+#include "test/providers/provider_test_utils.h"
+#include "test/util/include/default_providers.h"
+
+namespace onnxruntime {
+namespace test {
+
+TEST(NchwcOpsTest, ReorderOutputRejectsUnalignedInputChannels) {
+  const int64_t block_size = static_cast<int64_t>(MlasNchwcGetBlockSize());
+  if (block_size <= 1) {
+    GTEST_SKIP() << "NCHWc blocking is not enabled on this platform.";
+  }
+
+  const int64_t input_channels = block_size - 1;
+  OpTester test("ReorderOutput", 1, kMSNchwcDomain);
+  test.AddAttribute("channels", int64_t{1});
+  test.AddAttribute("channels_last", int64_t{0});
+  test.AddInput<float>("X", {1, input_channels, 2, 2},
+                       std::vector<float>(static_cast<size_t>(input_channels) * 4, 0.0f));
+  test.AddOutput<float>("Y", {1, 1, 2, 2}, {0.0f, 0.0f, 0.0f, 0.0f});
+
+  test.Config(OpTester::ExpectResult::kExpectFailure,
+              "Input channels must match the NCHWc block-aligned channel count.")
+      .ConfigEp(DefaultCpuExecutionProvider())
+      .RunWithConfig();
+}
+
+}  // namespace test
+}  // namespace onnxruntime


### PR DESCRIPTION
This pull request strengthens input validation in the `ReorderOutput` operator for NCHWc tensors and adds a new unit test to ensure correct error handling for misaligned input channels. The main focus is to enforce stricter requirements on input channel alignment and to verify this behavior with automated testing.

**Operator input validation improvements:**

* Updated `ReorderOutput::Compute` in `nchwc_ops.cc` to enforce that the input channel count is a multiple of the NCHWc block size, and that the number of channels requested is properly aligned. The error message was also improved for clarity.

**Testing enhancements:**

* Added a new unit test `ReorderOutputRejectsUnalignedInputChannels` in `nchwc_ops_test.cc` to verify that the operator correctly rejects inputs where the channel count is not NCHWc block-aligned, ensuring that the stricter validation is covered.