### PR TITLE
Fix heap overflow

### DIFF
--- a/onnxruntime/contrib_ops/cpu/transformers/generation_device_helper.cc
+++ b/onnxruntime/contrib_ops/cpu/transformers/generation_device_helper.cc
@@ -87,6 +87,9 @@ Status ExpandBuffer(Stream* stream,
   bool is_kv_cache = input_shape.NumDimensions() == 4;
   if (max_sequence_length > 0 && is_kv_cache) {
     sequence_length = input_shape[2];
+    ORT_RETURN_IF(sequence_length > max_sequence_length,
+                  "Input sequence length (", sequence_length,
+                  ") exceeds max sequence length (", max_sequence_length, ").");
     dims[2] = max_sequence_length;
   }
   TensorShape expanded_shape(dims);

--- a/onnxruntime/contrib_ops/cuda/transformers/generation_device_helper.cc
+++ b/onnxruntime/contrib_ops/cuda/transformers/generation_device_helper.cc
@@ -1380,6 +1380,9 @@ Status ExpandBuffer(Stream* ort_stream,
   bool is_kv_cache = input_shape.NumDimensions() == 4;
   if (max_sequence_length > 0 && is_kv_cache) {
     sequence_length = input_shape[2];
+    ORT_RETURN_IF(sequence_length > max_sequence_length,
+                  "Input sequence length (", sequence_length,
+                  ") exceeds max sequence length (", max_sequence_length, ").");
     dims[2] = max_sequence_length;
   }
   TensorShape expanded_shape(&dims[0], input_shape.NumDimensions());

--- a/onnxruntime/test/contrib_ops/beam_search_test.cc
+++ b/onnxruntime/test/contrib_ops/beam_search_test.cc
@@ -127,6 +127,19 @@ TEST(BeamSearchTest, ExpandBufferSupportsRankGreaterThanFour) {
   EXPECT_EQ(expanded.Get<Tensor>().Shape(), TensorShape({2, 2, 3, 4, 5}));
 }
 
+TEST(BeamSearchTest, ExpandBufferRejectsSequenceLengthExceedingMaximum) {
+  AllocatorPtr allocator = CPUAllocator::DefaultInstance();
+  OrtValue input;
+  Tensor::InitOrtValue(DataTypeImpl::GetType<float>(), TensorShape({1, 1, 5, 1}), allocator, input);
+
+  OrtValue expanded;
+  const Status status = contrib::GenerationCpuDeviceHelper::ExpandBuffer<float>(
+      nullptr, input, 2, allocator, expanded, false, 4);
+
+  ASSERT_FALSE(status.IsOK());
+  EXPECT_THAT(status.ErrorMessage(), testing::HasSubstr("Input sequence length (5) exceeds max sequence length (4)"));
+}
+
 namespace {
 
 class TestSubgraph final : public contrib::transformers::Subgraph {

--- a/onnxruntime/test/providers/cuda/test_cases/generation_cuda_impl_test.cc
+++ b/onnxruntime/test/providers/cuda/test_cases/generation_cuda_impl_test.cc
@@ -8,6 +8,8 @@
 
 #include "contrib_ops/cuda/transformers/generation_device_helper.h"
 #include "contrib_ops/cuda/transformers/generation_cuda_impl.h"
+#include "core/framework/allocator.h"
+#include "core/framework/tensor.h"
 #include "core/providers/cuda/shared_inc/cuda_call.h"
 #include "test/util/include/asserts.h"
 
@@ -46,6 +48,20 @@ TEST(GenerationCudaImplTest, EmptyCrossQKPairsSkipLaunches) {
 
   LaunchFinalizeCrossQK(nullptr, 2, 1, 1, 1, 1, 0, nullptr, 1, nullptr, nullptr, 1, nullptr, {});
   CUDA_CALL_THROW(cudaGetLastError());
+}
+
+TEST(GenerationCudaImplTest, ExpandBufferRejectsSequenceLengthExceedingMaximum) {
+  AllocatorPtr allocator = CPUAllocator::DefaultInstance();
+  OrtValue input;
+  Tensor::InitOrtValue(DataTypeImpl::GetType<float>(), TensorShape({1, 1, 5, 1}), allocator, input);
+
+  OrtValue expanded;
+  const Status status = GenerationCudaDeviceHelper::ExpandBuffer<float>(
+      nullptr, input, 2, allocator, expanded, false, 4);
+
+  ASSERT_FALSE(status.IsOK());
+  EXPECT_NE(status.ErrorMessage().find("Input sequence length (5) exceeds max sequence length (4)"),
+            std::string::npos);
 }
 
 TEST(GenerationCudaImplTest, CrossQKPairsAllowDuplicatesAndZeroInvalidIndices) {


### PR DESCRIPTION
This pull request adds input validation to the `ExpandBuffer` helper functions for both CPU and CUDA implementations, ensuring that the input sequence length does not exceed the specified maximum sequence length. It also introduces corresponding unit tests to verify this validation logic.

**Input validation improvements:**

* Added a check in both `GenerationCpuDeviceHelper::ExpandBuffer` (`generation_device_helper.cc`) and `GenerationCudaDeviceHelper::ExpandBuffer` (`generation_device_helper.cc`) to return an error if the input sequence length exceeds the maximum allowed sequence length. [[1]](diffhunk://#diff-05f42129bada251309af13af30447e4805aeea155ce165efa8094fd63ef438d6R90-R92) [[2]](diffhunk://#diff-a1e55fcadd7c5108d7cf89e5c813c787e625c9e9a5e727d8f8f4c67fc56d4f25R1383-R1385)

**Testing enhancements:**

* Added a new test `ExpandBufferRejectsSequenceLengthExceedingMaximum` to `beam_search_test.cc` for CPU, which verifies that the function properly rejects inputs with sequence length greater than the maximum.
* Added a similar test `ExpandBufferRejectsSequenceLengthExceedingMaximum` to `generation_cuda_impl_test.cc` for CUDA, ensuring the same validation logic is enforced for CUDA.
* Included necessary headers in `generation_cuda_impl_test.cc` to support the new test.