### PR TITLE
Validate LayerNormalization axis bounds

### DIFF
--- a/cmake/patches/onnx/onnx.patch
+++ b/cmake/patches/onnx/onnx.patch
@@ -46,3 +46,16 @@ index 3887169..8432613 100644
          .SetDoc(GroupNormalization_ver18_doc)
          .Attr("epsilon", "The epsilon value to use to avoid division by zero.", AttributeProto::FLOAT, 1e-5f)
          .Attr(
+diff --git a/onnx/defs/nn/defs.cc b/onnx/defs/nn/defs.cc
+index 0c271d5..6d64da7 100644
+--- a/onnx/defs/nn/defs.cc
++++ b/onnx/defs/nn/defs.cc
+@@ -2670,7 +2670,7 @@ ONNX_OPERATOR_SET_SCHEMA(
+                               // positive value.
+                               axis += input_ndim;
+                          }
+-          if (axis < 0) {
++          if (axis < 0 || axis >= input_ndim) {
+                               fail_shape_inference(
+                                         "Unexpected axis value (",
+                                         axis,

--- a/cmake/vcpkg-ports/onnx/binskim.patch
+++ b/cmake/vcpkg-ports/onnx/binskim.patch
@@ -46,3 +46,16 @@ index 3887169..8432613 100644
          .SetDoc(GroupNormalization_ver18_doc)
          .Attr("epsilon", "The epsilon value to use to avoid division by zero.", AttributeProto::FLOAT, 1e-5f)
          .Attr(
+diff --git a/onnx/defs/nn/defs.cc b/onnx/defs/nn/defs.cc
+index 0c271d5..6d64da7 100644
+--- a/onnx/defs/nn/defs.cc
++++ b/onnx/defs/nn/defs.cc
+@@ -2670,7 +2670,7 @@ ONNX_OPERATOR_SET_SCHEMA(
+                               // positive value.
+                               axis += input_ndim;
+                          }
+-          if (axis < 0) {
++          if (axis < 0 || axis >= input_ndim) {
+                               fail_shape_inference(
+                                         "Unexpected axis value (",
+                                         axis,

--- a/onnxruntime/test/contrib_ops/layer_norm_op_test.cc
+++ b/onnxruntime/test/contrib_ops/layer_norm_op_test.cc
@@ -855,6 +855,17 @@ TEST(LayerNormTest, LayerNorm_ZeroVariance) {
   test.Run();
 }
 
+TEST(LayerNormTest, LayerNorm_AxisExceedsRank) {
+  OpTester test("LayerNormalization", 17);
+  test.AddAttribute<int64_t>("axis", 0xFFFFFFFFLL);
+  test.AddInput<float>("X", {1, 2}, {1.0f, 2.0f});
+  test.AddInput<float>("Scale", {2}, {1.0f, 1.0f});
+  test.AddOutput<float>("Y", {1, 2}, {0.0f, 0.0f});
+  test.AddOutput<float>("Mean", {1, 1}, {0.0f});
+
+  test.Run(OpTester::ExpectResult::kExpectFailure, "Unexpected axis value");
+}
+
 // Edge case: constant weights (as in issue #20429)
 TEST(LayerNormTest, LayerNorm_ConstantWeights_LargeInput) {
   OpTester test("LayerNormalization", 17);


### PR DESCRIPTION
This pull request addresses validation and testing improvements for the `LayerNormalization` operator, specifically handling invalid axis values. The main change ensures that the operator correctly detects and reports an error when the `axis` attribute exceeds the input tensor's rank. Additionally, a new unit test is added to verify this behavior.

**Validation logic update:**

* Updated the axis validation in `onnx/defs/nn/defs.cc` to check if `axis` is less than 0 or greater than or equal to the input tensor rank, and to fail shape inference with an appropriate error message if so.

**Unit testing:**

* Added a new test case `LayerNorm_AxisExceedsRank` in `onnxruntime/test/contrib_ops/layer_norm_op_test.cc` to ensure that providing an out-of-bounds axis value results in a failure with the expected error message.