### PR TITLE
Validate NCHWc convolution layouts

### DIFF
--- a/onnxruntime/contrib_ops/cpu/nchwc_ops.cc
+++ b/onnxruntime/contrib_ops/cpu/nchwc_ops.cc
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+#include <limits>
+
 #include "nchwc_ops.h"
 #include "core/common/narrow.h"
 #include "core/common/safeint.h"
@@ -156,14 +158,33 @@ Status NchwcConv::Compute(OpKernelContext* context) const {
   const auto* B = context->Input<Tensor>(2);
   const auto* Sum = context->Input<Tensor>(3);
 
-  ORT_RETURN_IF_ERROR(conv_attrs_.ValidateInputShape(X, W));
-
   const auto& X_shape = X->Shape();
   const auto& W_shape = W->Shape();
-  ORT_ENFORCE(X_shape.NumDimensions() == 4);
+  ORT_RETURN_IF_NOT(conv_attrs_.group > 0, "NCHWc Conv group must be greater than 0.");
+  ORT_RETURN_IF_NOT(X_shape.NumDimensions() == 4 && W_shape.NumDimensions() == 4,
+                    "NCHWc Conv input and filter must be rank 4.");
 
-  const size_t nchwc_block_size = MlasNchwcGetBlockSize();
-  ORT_ENFORCE((static_cast<size_t>(X_shape[1]) < nchwc_block_size) || ((X_shape[1] % nchwc_block_size) == 0));
+  const int64_t input_channels_per_group = W_shape[1];
+  const int64_t output_channels = W_shape[0];
+  ORT_RETURN_IF_NOT(input_channels_per_group > 0 && output_channels > 0,
+                    "NCHWc Conv input and output channels must be greater than 0.");
+  ORT_RETURN_IF_NOT(input_channels_per_group <= std::numeric_limits<int64_t>::max() / conv_attrs_.group,
+                    "NCHWc Conv input channels per group is too large.");
+
+  ORT_RETURN_IF_ERROR(conv_attrs_.ValidateInputShape(X, W));
+
+  const int64_t nchwc_block_size = static_cast<int64_t>(MlasNchwcGetBlockSize());
+  const int64_t output_channels_per_group = output_channels / conv_attrs_.group;
+  const bool is_nchw_input = conv_attrs_.group == 1 && input_channels_per_group < nchwc_block_size;
+  const bool is_depthwise = input_channels_per_group == 1 && output_channels_per_group == 1;
+  const bool is_nchwc_input = input_channels_per_group % nchwc_block_size == 0 &&
+                              output_channels_per_group % nchwc_block_size == 0;
+
+  ORT_RETURN_IF_NOT(output_channels % nchwc_block_size == 0 &&
+                        (is_nchw_input || is_depthwise || is_nchwc_input),
+                    "NCHWc Conv input and filter shapes do not match a supported blocked layout.");
+  ORT_RETURN_IF_NOT(B == nullptr || (B->Shape().NumDimensions() == 1 && B->Shape().Size() == output_channels),
+                    "NCHWc Conv bias must be a 1D tensor matching the physical output channels.");
 
   TensorShapeVector kernel_shape;
   ORT_RETURN_IF_ERROR(conv_attrs_.ComputeKernelShape(W_shape, kernel_shape));

--- a/onnxruntime/test/contrib_ops/nchwc_ops_test.cc
+++ b/onnxruntime/test/contrib_ops/nchwc_ops_test.cc
@@ -1,0 +1,102 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "gtest/gtest.h"
+
+#include "core/mlas/inc/mlas.h"
+#include "test/providers/provider_test_utils.h"
+#include "test/util/include/default_providers.h"
+
+namespace onnxruntime {
+namespace test {
+namespace {
+
+void RunInvalidNchwcConvTest(const std::vector<int64_t>& input_shape,
+                             const std::vector<int64_t>& filter_shape,
+                             const std::vector<int64_t>* bias_shape,
+                             int64_t group,
+                             const std::string& expected_error) {
+  OpTester test("Conv", 1, kMSNchwcDomain);
+  test.AddAttribute("group", group);
+  test.AddInput<float>("X", input_shape, {});
+  test.AddInput<float>("W", filter_shape,
+                       std::vector<float>(static_cast<size_t>(TensorShape(filter_shape).Size()), 0.0f));
+  if (bias_shape != nullptr) {
+    test.AddInput<float>("B", *bias_shape,
+                         std::vector<float>(static_cast<size_t>(TensorShape(*bias_shape).Size()), 0.0f));
+  }
+  test.AddOutput<float>("Y", {0, filter_shape[0], 1, 1}, {});
+
+  test.Config(OpTester::ExpectResult::kExpectFailure, expected_error)
+      .ConfigEp(DefaultCpuExecutionProvider())
+      .RunWithConfig();
+}
+
+}  // namespace
+
+TEST(NchwcOpsTest, ConvRejectsUnalignedOutputChannels) {
+  const int64_t block_size = static_cast<int64_t>(MlasNchwcGetBlockSize());
+  if (block_size <= 1) {
+    GTEST_SKIP() << "NCHWc blocking is not enabled on this platform.";
+  }
+
+  RunInvalidNchwcConvTest({0, 1, 1, 1}, {block_size - 1, 1, 1, 1}, nullptr, 1,
+                          "NCHWc Conv input and filter shapes do not match a supported blocked layout.");
+}
+
+TEST(NchwcOpsTest, ConvRejectsInvalidGroup) {
+  const int64_t block_size = static_cast<int64_t>(MlasNchwcGetBlockSize());
+  if (block_size <= 1) {
+    GTEST_SKIP() << "NCHWc blocking is not enabled on this platform.";
+  }
+
+  RunInvalidNchwcConvTest({0, 1, 1, 1}, {block_size, 1, 1, 1}, nullptr, 0,
+                          "NCHWc Conv group must be greater than 0.");
+}
+
+TEST(NchwcOpsTest, ConvRejectsMismatchedBias) {
+  const int64_t block_size = static_cast<int64_t>(MlasNchwcGetBlockSize());
+  if (block_size <= 1) {
+    GTEST_SKIP() << "NCHWc blocking is not enabled on this platform.";
+  }
+
+  const std::vector<int64_t> bias_shape{block_size - 1};
+  RunInvalidNchwcConvTest({0, 1, 1, 1}, {block_size, 1, 1, 1}, &bias_shape, 1,
+                          "NCHWc Conv bias must be a 1D tensor matching the physical output channels.");
+}
+
+TEST(NchwcOpsTest, ConvRejectsNonVectorBias) {
+  const int64_t block_size = static_cast<int64_t>(MlasNchwcGetBlockSize());
+  if (block_size <= 1) {
+    GTEST_SKIP() << "NCHWc blocking is not enabled on this platform.";
+  }
+
+  const std::vector<int64_t> bias_shape{1, block_size};
+  RunInvalidNchwcConvTest({0, 1, 1, 1}, {block_size, 1, 1, 1}, &bias_shape, 1,
+                          "NCHWc Conv bias must be a 1D tensor matching the physical output channels.");
+}
+
+TEST(NchwcOpsTest, ConvRejectsUnsupportedGroupedLayout) {
+  const int64_t block_size = static_cast<int64_t>(MlasNchwcGetBlockSize());
+  if (block_size <= 1) {
+    GTEST_SKIP() << "NCHWc blocking is not enabled on this platform.";
+  }
+
+  const int64_t input_channels_per_group = block_size / 2;
+  RunInvalidNchwcConvTest({0, input_channels_per_group * 2, 1, 1},
+                          {block_size * 2, input_channels_per_group, 1, 1}, nullptr, 2,
+                          "NCHWc Conv input and filter shapes do not match a supported blocked layout.");
+}
+
+TEST(NchwcOpsTest, ConvRejectsUnalignedOutputChannelsPerGroup) {
+  const int64_t block_size = static_cast<int64_t>(MlasNchwcGetBlockSize());
+  if (block_size <= 1) {
+    GTEST_SKIP() << "NCHWc blocking is not enabled on this platform.";
+  }
+
+  RunInvalidNchwcConvTest({0, block_size * 2, 1, 1}, {block_size, block_size, 1, 1}, nullptr, 2,
+                          "NCHWc Conv input and filter shapes do not match a supported blocked layout.");
+}
+
+}  // namespace test
+}  // namespace onnxruntime


### PR DESCRIPTION
This pull request strengthens input validation for the NCHWc convolution operator and adds comprehensive unit tests to ensure invalid configurations are properly rejected. The main changes are improved error checking in the operator implementation and a new test suite covering various invalid input scenarios.

**Input validation improvements:**
- Enhanced validation in `NchwcConv::Compute` to check for valid group count, input/filter tensor ranks, positive channel sizes, channel size overflow, and correct blocked layout alignment. Also checks that the bias tensor (if present) is 1D and matches the number of output channels.
- Added `#include <limits>` to support overflow checks in the validation logic.

**Testing:**
- Introduced a new test file, `nchwc_ops_test.cc`, with unit tests that verify the operator correctly rejects various invalid input and filter shapes, group values, and bias tensor configurations.