### PR TITLE
[CUDA] Guard FP8 XQA test by compute capability

### DIFF
--- a/onnxruntime/test/python/transformers/test_paged_attention_int4.py
+++ b/onnxruntime/test/python/transformers/test_paged_attention_int4.py
@@ -23,6 +23,15 @@ def has_sm80_cuda():
     )
 
 
+def has_fp8_xqa_cuda():
+    if os.getenv("ORT_PAGED_ATTENTION_TEST_RUNNER"):
+        return True
+    if not torch.cuda.is_available():
+        return False
+    major, minor = torch.cuda.get_device_capability()
+    return major >= 9 or (major == 8 and minor == 9)
+
+
 def int4_kernel_available():
     if os.getenv("ORT_PAGED_ATTENTION_TEST_RUNNER"):
         return True
@@ -356,6 +365,16 @@ def run_with_kernel(model, feeds, expected_kernel, **kwargs):
 
 
 class TestPagedAttentionInt4Helpers(unittest.TestCase):
+    def test_fp8_xqa_cuda_capability(self):
+        for capability, expected in (((8, 6), False), ((8, 9), True), ((9, 0), True)):
+            with (
+                self.subTest(capability=capability),
+                patch.dict(os.environ, {"ORT_PAGED_ATTENTION_TEST_RUNNER": ""}),
+                patch.object(torch.cuda, "is_available", return_value=True),
+                patch.object(torch.cuda, "get_device_capability", return_value=capability),
+            ):
+                self.assertEqual(has_fp8_xqa_cuda(), expected)
+
     def test_dispatch_capture_accepts_xqa(self):
         result = [object()]
 
@@ -749,7 +768,10 @@ class TestPagedAttentionInt4(unittest.TestCase):
         # attention_scale * normalizer overflow fp32 and every logit NaN. The normalizer exponent is
         # bounded to prevent that, and this table spans one binade so it stays on XQA.
         heads, width = 6, 256
-        for cache_dtype in (np.uint8, np.int8, ml_dtypes.float8_e4m3fn):
+        cache_dtypes = (np.uint8, np.int8)
+        if has_fp8_xqa_cuda():
+            cache_dtypes += (ml_dtypes.float8_e4m3fn,)
+        for cache_dtype in cache_dtypes:
             for length in (1, 3):
                 with self.subTest(cache_dtype=cache_dtype, length=length):
                     model, feeds, _ = make_case(


### PR DESCRIPTION
### Description
The Windows CUDA CI runner for PR #32515 uses an SM86 A10-4Q. `PagedAttention` intentionally enables FP8 XQA only on SM89 or SM90+, so the FP8 cases in `test_xqa_large_attention_scale_and_k_scale` fell back to portable kernels and failed the XQA dispatch assertion.

Mirror the runtime capability predicate in the test and include the FP8 variant only on supported GPUs. UINT8 and INT8 remain covered on SM80 and newer devices. This is a capability guard, not a memory guard: the failed job completed pytest normally and reported two assertion failures rather than a CUDA allocation failure or process crash.

Failed job: https://github.com/microsoft/onnxruntime/actions/runs/34435175610/job/102757939916?pr=32515

### Motivation and Context
Fixes the Windows GPU CUDA CI regression introduced by #32515 without skipping valid XQA coverage on SM86.

### Testing
- `TestPagedAttentionInt4Helpers`: 4 tests passed, including simulated SM86, SM89, and SM90 capability cases.
- `lintrunner onnxruntime/test/python/transformers/test_paged_attention_int4.py`
- `python -m py_compile onnxruntime/test/python/transformers/test_paged_attention_int4.py`
- `git diff --check`