### PR TITLE
Fix TensorRT engine cache shape collisions

### DIFF
--- a/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider_utils.h
+++ b/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider_utils.h
@@ -553,9 +553,13 @@ HashValue TRTGenerateId(const GraphViewer& graph_viewer, std::string trt_version
     LOGS_DEFAULT(INFO) << "[TensorRT EP] Model path is empty";
   }
 
-  // fingerprint current graph by hashing graph inputs
+  // Fingerprint graph inputs, including their type and shape. The engine cache must not reuse an
+  // engine built for a model with different static input shapes.
   for (const auto* node_arg : graph_viewer.GetInputsIncludingInitializers()) {
     hash_str(node_arg->Name());
+    if (const auto* type_proto = node_arg->TypeAsProto()) {
+      hash_str(type_proto->SerializeAsString());
+    }
   }
 
   // hashing output of each node

--- a/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider_utils.h
+++ b/onnxruntime/core/providers/tensorrt/tensorrt_execution_provider_utils.h
@@ -553,12 +553,19 @@ HashValue TRTGenerateId(const GraphViewer& graph_viewer, std::string trt_version
     LOGS_DEFAULT(INFO) << "[TensorRT EP] Model path is empty";
   }
 
-  // Fingerprint graph inputs, including their type and shape. The engine cache must not reuse an
+  // Fingerprint graph inputs, including their shapes. The engine cache must not reuse an
   // engine built for a model with different static input shapes.
   for (const auto* node_arg : graph_viewer.GetInputsIncludingInitializers()) {
     hash_str(node_arg->Name());
-    if (const auto* type_proto = node_arg->TypeAsProto()) {
-      hash_str(type_proto->SerializeAsString());
+    if (const auto* shape = node_arg->Shape()) {
+      std::string shape_string = "[";
+      for (const auto& dim : shape->dim()) {
+        // Symbolic names and dimension denotations do not change the static shape.
+        shape_string += dim.has_dim_value() ? std::to_string(dim.dim_value()) : "?";
+        shape_string += ",";
+      }
+      shape_string += "]";
+      hash_str(shape_string);
     }
   }
 

--- a/onnxruntime/test/providers/tensorrt/tensorrt_basic_test.cc
+++ b/onnxruntime/test/providers/tensorrt/tensorrt_basic_test.cc
@@ -378,6 +378,29 @@ TEST(TensorrtExecutionProviderTest, TRTModelIdGeneratorUsingModelHashing) {
   GraphViewer viewer3(graph3);
   HashValue model_hash3 = TRTGenerateId(viewer3, trt_version, cuda_version);
   ASSERT_EQ(model_hash, model_hash3) << "model 1&3 are same models and they have same hash, no matter where they are loaded";
+
+  // Models with the same name and graph structure, but different static input shapes, must not
+  // share an engine cache entry.
+  const PathString shape_test_model_path = ORT_TSTR("trt_model_id_shape_test.onnx");
+  const std::string shape_test_graph_name = "trt_model_id_shape_test";
+  CreateBaseModel(shape_test_model_path, shape_test_graph_name, {3, 3});
+
+  std::shared_ptr<Model> model_with_3x3_input;
+  ASSERT_TRUE(Model::Load(shape_test_model_path, model_with_3x3_input, nullptr,
+                          DefaultLoggingManager().DefaultLogger())
+                  .IsOK());
+
+  CreateBaseModel(shape_test_model_path, shape_test_graph_name, {4, 4});
+
+  std::shared_ptr<Model> model_with_4x4_input;
+  ASSERT_TRUE(Model::Load(shape_test_model_path, model_with_4x4_input, nullptr,
+                          DefaultLoggingManager().DefaultLogger())
+                  .IsOK());
+
+  GraphViewer viewer_with_3x3_input(model_with_3x3_input->MainGraph());
+  GraphViewer viewer_with_4x4_input(model_with_4x4_input->MainGraph());
+  ASSERT_NE(TRTGenerateId(viewer_with_3x3_input, trt_version, cuda_version),
+            TRTGenerateId(viewer_with_4x4_input, trt_version, cuda_version));
 }
 
 TEST(TensorrtExecutionProviderTest, EPContextNode) {

--- a/onnxruntime/test/providers/tensorrt/tensorrt_basic_test.cc
+++ b/onnxruntime/test/providers/tensorrt/tensorrt_basic_test.cc
@@ -378,29 +378,63 @@ TEST(TensorrtExecutionProviderTest, TRTModelIdGeneratorUsingModelHashing) {
   GraphViewer viewer3(graph3);
   HashValue model_hash3 = TRTGenerateId(viewer3, trt_version, cuda_version);
   ASSERT_EQ(model_hash, model_hash3) << "model 1&3 are same models and they have same hash, no matter where they are loaded";
+}
 
-  // Models with the same name and graph structure, but different static input shapes, must not
-  // share an engine cache entry.
-  const PathString shape_test_model_path = ORT_TSTR("trt_model_id_shape_test.onnx");
-  const std::string shape_test_graph_name = "trt_model_id_shape_test";
-  CreateBaseModel(shape_test_model_path, shape_test_graph_name, {3, 3});
+TEST(TensorrtExecutionProviderTest, TRTModelIdGeneratorUsingInputShapes) {
+  const std::string trt_version = std::to_string(NV_TENSORRT_MAJOR) + "." + std::to_string(NV_TENSORRT_MINOR);
+  const std::string cuda_version = std::to_string(CUDA_VERSION);
+  auto generate_id = [&](const TypeProto& input_type) {
+    Model model("main_graph", false, DefaultLoggingManager().DefaultLogger());
+    auto& graph = model.MainGraph();
+    auto& x = graph.GetOrCreateNodeArg("x", &input_type);
+    auto& y = graph.GetOrCreateNodeArg("y", &input_type);
+    auto& z = graph.GetOrCreateNodeArg("z", &input_type);
+    graph.AddNode("add", "Add", "", {&x, &y}, {&z});
+    ORT_THROW_IF_ERROR(graph.Resolve());
 
-  std::shared_ptr<Model> model_with_3x3_input;
-  ASSERT_TRUE(Model::Load(shape_test_model_path, model_with_3x3_input, nullptr,
-                          DefaultLoggingManager().DefaultLogger())
-                  .IsOK());
+    // Match the reported collision: same graph name and structure, loaded from bytes without a path.
+    std::string model_bytes = model.ToProto().SerializeAsString();
+    std::shared_ptr<Model> loaded_model;
+    ORT_THROW_IF_ERROR(Model::LoadFromBytes(static_cast<int>(model_bytes.size()), model_bytes.data(),
+                                            loaded_model, nullptr, DefaultLoggingManager().DefaultLogger()));
+    return TRTGenerateId(GraphViewer(loaded_model->MainGraph()), trt_version, cuda_version);
+  };
 
-  CreateBaseModel(shape_test_model_path, shape_test_graph_name, {4, 4});
+  const InlinedVector<TensorShapeVector> shapes = {
+      {3, 3}, {4, 4}, {3, 4}, {4, 3}, {9}, {}, {0}, {0, 3}, {0, 4}, {3, 0}, {3, -1}, {4, -1}, {-1, 3}, {1, 23}, {12, 3}, {4294967299LL, 3}};
+  InlinedVector<HashValue> hashes;
+  hashes.reserve(shapes.size());
+  for (const auto& dims : shapes) {
+    SCOPED_TRACE(::testing::PrintToString(dims));
+    TypeProto input_type;
+    auto* tensor_type = input_type.mutable_tensor_type();
+    tensor_type->set_elem_type(TensorProto_DataType_FLOAT);
+    auto* shape = tensor_type->mutable_shape();
+    for (int64_t dim : dims) {
+      auto* dimension = shape->add_dim();
+      if (dim < 0) {
+        dimension->set_dim_param("batch");
+      } else {
+        dimension->set_dim_value(dim);
+      }
+    }
 
-  std::shared_ptr<Model> model_with_4x4_input;
-  ASSERT_TRUE(Model::Load(shape_test_model_path, model_with_4x4_input, nullptr,
-                          DefaultLoggingManager().DefaultLogger())
-                  .IsOK());
+    const HashValue hash = generate_id(input_type);
+    EXPECT_EQ(hash, generate_id(input_type)) << "Identical models must retain the same cache ID";
+    for (HashValue previous_hash : hashes) {
+      EXPECT_NE(hash, previous_hash) << "Different static shapes or ranks must not share a cache ID";
+    }
+    hashes.push_back(hash);
 
-  GraphViewer viewer_with_3x3_input(model_with_3x3_input->MainGraph());
-  GraphViewer viewer_with_4x4_input(model_with_4x4_input->MainGraph());
-  ASSERT_NE(TRTGenerateId(viewer_with_3x3_input, trt_version, cuda_version),
-            TRTGenerateId(viewer_with_4x4_input, trt_version, cuda_version));
+    input_type.set_denotation("IMAGE");
+    for (auto& dim : *shape->mutable_dim()) {
+      dim.set_denotation("DATA_BATCH");
+      if (dim.has_dim_param()) {
+        dim.set_dim_param("renamed_batch");
+      }
+    }
+    EXPECT_EQ(hash, generate_id(input_type)) << "Shape annotations must not invalidate the cache";
+  }
 }
 
 TEST(TensorrtExecutionProviderTest, EPContextNode) {


### PR DESCRIPTION
## Description

Fixes #32254.

Include graph input shapes in the TensorRT model/cache identifier so otherwise identical graphs with different static input shapes do not reuse an incompatible engine.

The fingerprint uses rank, ordered static dimensions, and a marker for dynamic dimensions. It uses methods exposed by the shared-provider bridge and deliberately ignores type/dimension denotations and symbolic dimension names. No execution kernels, graph partitioning decisions, public APIs, or provider options are changed.

Add an in-memory Add-model regression test covering 16 shapes (including the reported 3x3 versus 4x4 case), repeated-model ID stability, and annotation-only changes. Existing model-path tests remain unchanged.

Existing TensorRT cache IDs change for shaped inputs, so cached engines may be rebuilt once after adopting this change.

## Validation

- Lint and `git diff --check` pass for the two changed C++ files.
- A local isolated C++ harness compiled the actual `TRTGenerateId` function and repository MurmurHash implementation with lightweight graph stand-ins. It reproduced the collision on the original code and passed 16 shape/rank separation cases, repeated-input stability, directory-independent IDs, and byte-loaded versus file-loaded ID separation with the revised code. This is not a provider build or inference test.
- The TensorRT provider and new regression test have not been built/run locally: this macOS host has no CUDA/TensorRT toolchain. TensorRT CI validation is still required.
