### PR TITLE
[MIGraphX EP] Parse output indices >= 10 from MIGraphX output names

### DIFF
--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
@@ -1554,18 +1554,7 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
           }
           // It is an output argument
           else {
-            auto compute_output_index = [](const std::string_view sv) -> int {
-              constexpr std::string_view out_name_prefix = "#output_";
-              const auto pos = sv.find(out_name_prefix);
-              if (pos == std::string_view::npos) {
-                return -1;
-              }
-
-              const auto index_str = sv.substr(pos + out_name_prefix.length());
-              return ToInteger(Trim(index_str, std::isdigit));
-            };
-
-            int output_index = compute_output_index(name);
+            int output_index = ParseOutputIndex(name);
             if (output_index != -1) {
               prog_output_indices.push_back(output_index);
               auto mgx_output_shape = prog_output_shapes[output_index];

--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider_utils.h
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider_utils.h
@@ -327,28 +327,23 @@ inline std::string GenerateGraphId(const GraphViewer& graph_viewer) {
   return std::string{s.data(), ptr};
 }
 
-inline std::string_view TrimLeft(std::string_view sv, int (*fn)(int) = std::isspace) {
-  return sv.substr(0, sv.end() - std::find_if(sv.begin(), sv.end(), [fn](int ch) {
-                        return fn(ch);
-                      }));
-}
-
-inline std::string_view TrimRight(std::string_view sv, int (*fn)(int) = std::isspace) {
-  return sv.substr(sv.end() - std::find_if(sv.rbegin(), sv.rend(), [fn](int ch) {
-                                return fn(ch);
-                              }).base());
-}
-
-inline std::string_view Trim(std::string_view sv, int (*fn)(int) = std::isspace) {
-  return TrimRight(TrimLeft(sv, fn), fn);
-}
-
 inline int ToInteger(const std::string_view sv) {
   int result = 0;
   if (auto [_, ec] = std::from_chars(sv.data(), sv.data() + sv.length(), result); ec == std::errc()) {
     return result;
   }
   ORT_THROW("invalid input for conversion to integer");
+}
+
+// MIGraphX names outputs "<module>:#output_<i>"; from i = 10 the index is ':' plus zero-padded digits.
+inline int ParseOutputIndex(std::string_view name) {
+  constexpr std::string_view prefix = "#output_";
+  const auto pos = name.find(prefix);
+  if (pos == std::string_view::npos) {
+    return -1;
+  }
+  const auto digits = name.find_first_of("0123456789", pos + prefix.length());
+  return ToInteger(digits == std::string_view::npos ? std::string_view{} : name.substr(digits));
 }
 
 }  // namespace onnxruntime

--- a/onnxruntime/test/providers/migraphx/migraphx_basic_test.cc
+++ b/onnxruntime/test/providers/migraphx/migraphx_basic_test.cc
@@ -188,6 +188,17 @@ TEST(MIGraphXExecutionProviderTest, canEvalArgument) {
   ASSERT_EQ(canEvalNodeArgument(gv, node2, {1}, input_nodes), true);
 }
 
+TEST(MIGraphXExecutionProviderTest, ParseOutputIndex) {
+  EXPECT_EQ(ParseOutputIndex("main:#output_0"), 0);
+  EXPECT_EQ(ParseOutputIndex("main:#output_9"), 9);
+  // MIGraphX writes indices >= 10 as ':' plus zero-padded digits.
+  EXPECT_EQ(ParseOutputIndex("main:#output_:00010"), 10);
+  EXPECT_EQ(ParseOutputIndex("main:#output_:00123"), 123);
+  EXPECT_EQ(ParseOutputIndex("main:#output_12"), 12);
+  EXPECT_EQ(ParseOutputIndex("x"), -1);
+  EXPECT_THROW(ParseOutputIndex("main:#output_"), OnnxRuntimeException);
+}
+
 #if defined(WIN32)
 static bool SessionHasEp(Ort::Session& session, const char* ep_name) {
   // Access the underlying InferenceSession.


### PR DESCRIPTION
### Description

From index 10 on, MIGraphX names outputs like `main:#output_:00010`. `TrimLeft` cut the wrong end of that name, so `ToInteger` threw. `ParseOutputIndex` now reads from the first digit after `#output_`, and the unused `Trim` helpers are gone.

Added a gtest. I couldn't run it (no ROCm, and no CI builds MIGraphX), but the same cases pass in a g++ harness built on the header code.

### Motivation and Context

Fixes #32567
