### PR TITLE
Fix Normalizer overflow and underflow

### DIFF
--- a/onnxruntime/core/providers/cpu/ml/normalizer.cc
+++ b/onnxruntime/core/providers/cpu/ml/normalizer.cc
@@ -43,21 +43,21 @@ ONNX_CPU_OPERATOR_ML_KERNEL(
 
 template <typename T>
 void NormalizeMax(const T* in, float* out, int64_t num_batches, int64_t batch_size) {
-  for (int b = 0; b < num_batches; ++b) {
-    float max = std::numeric_limits<float>::lowest();
+  for (int64_t b = 0; b < num_batches; ++b) {
+    double max = std::numeric_limits<double>::lowest();
 
-    for (int i = 0; i < batch_size; ++i) {
-      max = std::max(max, static_cast<float>(*in++));
+    for (int64_t i = 0; i < batch_size; ++i) {
+      max = std::max(max, static_cast<double>(*in++));
     }
 
     in -= batch_size;
 
-    if (max != 0.f) {
-      for (int i = 0; i < batch_size; ++i) {
-        *out++ = static_cast<float>(*in++) / max;
+    if (max != 0.0) {
+      for (int64_t i = 0; i < batch_size; ++i) {
+        *out++ = static_cast<float>(static_cast<double>(*in++) / max);
       }
     } else {
-      for (int i = 0; i < batch_size; ++i) {
+      for (int64_t i = 0; i < batch_size; ++i) {
         *out++ = static_cast<float>(*in++);
       }
     }
@@ -66,21 +66,27 @@ void NormalizeMax(const T* in, float* out, int64_t num_batches, int64_t batch_si
 
 template <typename T>
 static void NormalizeL1(const T* in, float* out, int64_t num_batches, int64_t batch_size) {
-  for (int b = 0; b < num_batches; ++b) {
-    float sum = 0.f;
+  for (int64_t b = 0; b < num_batches; ++b) {
+    double scale = 0.0;
 
-    for (int i = 0; i < batch_size; ++i) {
-      sum += static_cast<float>(std::abs(*in++));
+    for (int64_t i = 0; i < batch_size; ++i) {
+      scale = std::max(scale, std::abs(static_cast<double>(*in++)));
     }
 
     in -= batch_size;
 
-    if (sum != 0.f) {
-      for (int i = 0; i < batch_size; ++i) {
-        *out++ = static_cast<float>(*in++) / sum;
+    if (scale != 0.0) {
+      double scaled_sum = 0.0;
+      for (int64_t i = 0; i < batch_size; ++i) {
+        scaled_sum += std::abs(static_cast<double>(*in++) / scale);
+      }
+
+      in -= batch_size;
+      for (int64_t i = 0; i < batch_size; ++i) {
+        *out++ = static_cast<float>((static_cast<double>(*in++) / scale) / scaled_sum);
       }
     } else {
-      for (int i = 0; i < batch_size; ++i) {
+      for (int64_t i = 0; i < batch_size; ++i) {
         *out++ = static_cast<float>(*in++);
       }
     }
@@ -89,28 +95,28 @@ static void NormalizeL1(const T* in, float* out, int64_t num_batches, int64_t ba
 
 template <typename T>
 void NormalizeL2(const T* in, float* out, int64_t num_batches, int64_t batch_size) {
-  for (int b = 0; b < num_batches; ++b) {
-    float sum = 0.f;
+  for (int64_t b = 0; b < num_batches; ++b) {
+    double scale = 0.0;
 
-    for (int i = 0; i < batch_size; ++i) {
-      auto x = *in++;
-      auto x_sq = static_cast<float>(x * x);
-      *out++ = x_sq;
-      sum += x_sq;
+    for (int64_t i = 0; i < batch_size; ++i) {
+      scale = std::max(scale, std::abs(static_cast<double>(*in++)));
     }
 
     in -= batch_size;
-    out -= batch_size;
+    if (scale != 0.0) {
+      double scaled_sum_squares = 0.0;
+      for (int64_t i = 0; i < batch_size; ++i) {
+        const double scaled = static_cast<double>(*in++) / scale;
+        scaled_sum_squares += scaled * scaled;
+      }
 
-    if (sum != 0.f) {
-      for (int i = 0; i < batch_size; ++i) {
-        auto x = *in++;
-        auto x_sq = *out;
-
-        *out++ = (x < 0) ? std::sqrt(x_sq / sum) * -1 : std::sqrt(x_sq / sum);
+      in -= batch_size;
+      const double scaled_norm = std::sqrt(scaled_sum_squares);
+      for (int64_t i = 0; i < batch_size; ++i) {
+        *out++ = static_cast<float>((static_cast<double>(*in++) / scale) / scaled_norm);
       }
     } else {
-      for (int i = 0; i < batch_size; ++i) {
+      for (int64_t i = 0; i < batch_size; ++i) {
         *out++ = static_cast<float>(*in++);
       }
     }

--- a/onnxruntime/test/providers/cpu/ml/normalizer_test.cc
+++ b/onnxruntime/test/providers/cpu/ml/normalizer_test.cc
@@ -156,6 +156,33 @@ TEST(Normalizer, TwoDimensionDouble) {
   RunTests(input, dims, max_output, l1_output, l2_output);
 }
 
+TEST(Normalizer, ExtremeMagnitudeDouble) {
+  std::vector<int64_t> dims = {2, 2};
+  std::vector<double> input = {1e300, 1e300,
+                               1e-300, -1e-300};
+
+  std::vector<float> max_output{1.f, 1.f,
+                                1.f, -1.f};
+
+  std::vector<float> l1_output{0.5f, 0.5f,
+                               0.5f, -0.5f};
+
+  std::vector<float> l2_output{0.70710677f, 0.70710677f,
+                               0.70710677f, -0.70710677f};
+
+  RunTests(input, dims, max_output, l1_output, l2_output);
+}
+
+TEST(Normalizer, ExtremeMagnitudeFloatL2) {
+  std::vector<int64_t> dims = {2, 2};
+  std::vector<float> input = {1e30f, 1e30f,
+                              1e-30f, -1e-30f};
+  std::vector<float> output{0.70710677f, 0.70710677f,
+                            0.70710677f, -0.70710677f};
+
+  RunTest(input, dims, output, "L2");
+}
+
 #if defined(_M_AMD64) || defined(__x86_64__)
 TEST(Normalizer, TwoDimensionInt) {
   std::vector<int64_t> dims = {3, 2};


### PR DESCRIPTION
### Description

Make the CPU `ai.onnx.ml::Normalizer` kernel stable across the finite input range accepted by the operator.

- compute `MAX` normalization in `double` before casting the result to the required `float` output;
- compute L1 and L2 norms with max-magnitude scaling, avoiding overflow and underflow in the sum;
- use `int64_t` loop counters to match tensor dimensions;
- add regression coverage for finite `float` and `double` values from `1e-300` through `1e300`.

For example, the previous L2 implementation returned `NaN` for `[1e30, 1e30]` and left `[1e-30, -1e-30]` effectively unchanged. Both now produce the normalized result `[0.70710677, ±0.70710677]`.

Zero-vector behavior and the existing `MAX` semantics are unchanged.

### Motivation and Context

The previous implementation narrowed values or their sums to `float`, and L2 formed `x * x` before normalization. Consequently, valid finite inputs could overflow to infinity or underflow to zero even though their normalized outputs are ordinary finite values.

The scaled formulas compute, for `s = max(abs(x))`:

- L1: `(x / s) / sum(abs(x / s))`
- L2: `(x / s) / sqrt(sum((x / s)^2))`

This keeps intermediate values bounded while producing the same result for the existing test range.

Validation on macOS arm64:

- built `onnxruntime_provider_test` from source;
- `onnxruntime_provider_test --gtest_filter='Normalizer.*'`: 7/7 passed;
- mutation check: restoring the previous implementation makes both new extreme-magnitude tests fail with `NaN`, zero, or unnormalized outputs;
- official `lintrunner` on both changed files: no lint issues.
