### PR TITLE
Fix CPU ReduceL2 finite-range handling

### DIFF
--- a/onnxruntime/core/providers/cpu/reduction/reduction_ops.h
+++ b/onnxruntime/core/providers/cpu/reduction/reduction_ops.h
@@ -1247,6 +1247,53 @@ class ReduceAggregatorL2 : public ReduceAggregator<T, T> {
   double double_accumulator_ = 0.0;
   double kahan_compensation_ = 0.0;  // Kahan compensation term for int64+
 
+  // For float and double, use the scaled sum-of-squares algorithm used by
+  // stable norm implementations. This avoids overflowing or underflowing the
+  // intermediate square when the final norm is representable.
+  double floating_scale_ = 0.0;
+  double floating_scaled_sum_squares_ = 0.0;
+  bool floating_has_infinity_ = false;
+  bool floating_has_nan_ = false;
+
+  static constexpr bool kUseScaledSumSquares = std::is_same_v<T, float> || std::is_same_v<T, double>;
+
+  inline void update_scaled_sum_squares(const T& v) {
+    const double magnitude = std::abs(static_cast<double>(v));
+    if (std::isnan(magnitude)) {
+      floating_has_nan_ = true;
+      return;
+    }
+    if (std::isinf(magnitude)) {
+      floating_has_infinity_ = true;
+      return;
+    }
+    if (magnitude == 0.0) {
+      return;
+    }
+
+    if (floating_scale_ < magnitude) {
+      const double ratio = floating_scale_ / magnitude;
+      floating_scaled_sum_squares_ = 1.0 + floating_scaled_sum_squares_ * ratio * ratio;
+      floating_scale_ = magnitude;
+    } else {
+      const double ratio = magnitude / floating_scale_;
+      floating_scaled_sum_squares_ += ratio * ratio;
+    }
+  }
+
+  inline T get_scaled_sum_squares_value() const {
+    if (floating_has_nan_) {
+      return std::numeric_limits<T>::quiet_NaN();
+    }
+    if (floating_has_infinity_) {
+      return std::numeric_limits<T>::infinity();
+    }
+    if (floating_scale_ == 0.0) {
+      return static_cast<T>(0);
+    }
+    return static_cast<T>(floating_scale_ * std::sqrt(floating_scaled_sum_squares_));
+  }
+
  public:
   inline ReduceAggregatorL2(int64_t N, const T&) : ReduceAggregator<T, T>(N, 0) {}
   inline T aggall(const T* from_data) {
@@ -1273,6 +1320,11 @@ class ReduceAggregatorL2 : public ReduceAggregator<T, T> {
       constexpr double max_val = static_cast<double>(std::numeric_limits<T>::max());
       if (result >= max_val) return std::numeric_limits<T>::max();
       return static_cast<T>(result);
+    } else if constexpr (kUseScaledSumSquares) {
+      for (size_t i = 0, n = onnxruntime::narrow<size_t>(this->N_); i < n; ++i) {
+        update_scaled_sum_squares(from_data[i]);
+      }
+      return get_scaled_sum_squares_value();
     } else {
       return Eigen::Map<const Eigen::Matrix<T, Eigen::Dynamic, 1>>(from_data, onnxruntime::narrow<size_t>(this->N_)).norm();
     }
@@ -1289,6 +1341,8 @@ class ReduceAggregatorL2 : public ReduceAggregator<T, T> {
       } else {
         double_accumulator_ += dv * dv;
       }
+    } else if constexpr (kUseScaledSumSquares) {
+      update_scaled_sum_squares(v);
     } else {
       this->accumulator_ += v * v;
     }
@@ -1300,6 +1354,8 @@ class ReduceAggregatorL2 : public ReduceAggregator<T, T> {
       constexpr double max_val = static_cast<double>(std::numeric_limits<T>::max());
       if (result >= max_val) return std::numeric_limits<T>::max();
       return static_cast<T>(result);
+    } else if constexpr (kUseScaledSumSquares) {
+      return get_scaled_sum_squares_value();
     } else {
       return reduce_sqrt<T>(this->accumulator_);
     }

--- a/onnxruntime/test/providers/cpu/reduction/reduction_ops_test.cc
+++ b/onnxruntime/test/providers/cpu/reduction/reduction_ops_test.cc
@@ -661,6 +661,57 @@ TEST(ReductionOpTest, ReduceL2_double) {
   test.Run();
 }
 
+TEST(ReductionOpTest, ReduceL2_float_preserves_finite_range) {
+  const float sqrt_two = std::sqrt(2.0f);
+
+  // Reducing one axis exercises the incremental aggregation path. Both
+  // results are representable even though squaring the inputs is not.
+  {
+    OpTester test("ReduceL2");
+    test.AddAttribute("axes", std::vector<int64_t>{1});
+    test.AddAttribute("keepdims", static_cast<int64_t>(0));
+    test.AddInput<float>("data", {2, 2}, {1.0e30f, 1.0e30f, 1.0e-30f, 1.0e-30f});
+    test.AddOutput<float>("reduced", {2}, {sqrt_two * 1.0e30f, sqrt_two * 1.0e-30f});
+    test.SetOutputAbsErr("reduced", 0.0f);
+    test.SetOutputRelErr("reduced", 1.0e-5f);
+    test.ConfigEp(DefaultCpuExecutionProvider()).RunWithConfig();
+  }
+
+  // Reducing all axes uses the contiguous aggregation path.
+  {
+    OpTester test("ReduceL2");
+    test.AddAttribute("keepdims", static_cast<int64_t>(0));
+    test.AddInput<float>("data", {2}, {1.0e30f, 1.0e30f});
+    test.AddOutput<float>("reduced", {}, {sqrt_two * 1.0e30f});
+    test.SetOutputRelErr("reduced", 1.0e-5f);
+    test.ConfigEp(DefaultCpuExecutionProvider()).RunWithConfig();
+  }
+}
+
+TEST(ReductionOpTest, ReduceL2_double_preserves_finite_range) {
+  const double sqrt_two = std::sqrt(2.0);
+
+  {
+    OpTester test("ReduceL2");
+    test.AddAttribute("axes", std::vector<int64_t>{1});
+    test.AddAttribute("keepdims", static_cast<int64_t>(0));
+    test.AddInput<double>("data", {2, 2}, {1.0e200, 1.0e200, 1.0e-200, 1.0e-200});
+    test.AddOutput<double>("reduced", {2}, {sqrt_two * 1.0e200, sqrt_two * 1.0e-200});
+    test.SetOutputAbsErr("reduced", 0.0f);
+    test.SetOutputRelErr("reduced", 1.0e-12f);
+    test.ConfigEp(DefaultCpuExecutionProvider()).RunWithConfig();
+  }
+
+  {
+    OpTester test("ReduceL2");
+    test.AddAttribute("keepdims", static_cast<int64_t>(0));
+    test.AddInput<double>("data", {2}, {1.0e200, 1.0e200});
+    test.AddOutput<double>("reduced", {}, {sqrt_two * 1.0e200});
+    test.SetOutputRelErr("reduced", 1.0e-12f);
+    test.ConfigEp(DefaultCpuExecutionProvider()).RunWithConfig();
+  }
+}
+
 #if defined(USE_DNNL)
 TEST(ReductionOpTest, ReduceL2_bfloat16) {
 #ifdef USE_DNNL


### PR DESCRIPTION
### Description

`ReduceL2` currently computes `sqrt(sum(x * x))` on the CPU. For finite float and double inputs, the intermediate square can overflow or underflow even when the final L2 norm is finite and representable.

Examples on the current CPU implementation:

| input | expected | current |
| --- | ---: | ---: |
| float32 `[1e30, 1e30]` | `1.4142135e30` | `inf` |
| float32 `[1e-30, 1e-30]` | `1.4142136e-30` | `0` |
| float64 `[1e200, 1e200]` | `1.41421356e200` | `inf` |
| float64 `[1e-200, 1e-200]` | `1.41421356e-200` | `0` |

This change uses a scaled sum-of-squares accumulator for float and double. It covers both the contiguous all-axis path and the incremental partial-axis path, while preserving zero, infinity, and NaN behavior. Integer and other element-type paths are unchanged.

The independent public reproducer is at https://github.com/kadyrbekovhamit-cyber/gero-onnx-reducel2-range-audit. The corresponding ONNX ReferenceEvaluator fix is onnx/onnx#8455.

### Motivation and Context

The L2 norm is homogeneous, so a finite rescaling of the input should rescale the output rather than turn it into zero or infinity solely because of an avoidable intermediate square. A stable norm algorithm avoids that loss of numerical range.

### Testing

- Built `onnxruntime_provider_test` from the updated source.
- `ReductionOpTest.ReduceL2*`: 27/27 tests passed.
- New tests cover float32 and float64, full-axis and partial-axis reductions, and both overflow and underflow ranges.
- Mutation check: restoring the previous direct-square implementation made both new tests fail (`inf` for the large cases and `0` for the small cases); rebuilding the proposed implementation restored all 27 passes.

