### PR TITLE
Fix CPU ReduceMean finite-range overflow

### DIFF
--- a/onnxruntime/core/providers/cpu/reduction/reduction_ops.h
+++ b/onnxruntime/core/providers/cpu/reduction/reduction_ops.h
@@ -516,6 +516,58 @@ class ReduceAggregatorSumSquare : public ReduceAggregator<T, TVAL> {
 
 template <typename T>
 class ReduceAggregatorMean : public ReduceAggregatorSum<T> {
+  static constexpr bool kUseFiniteRangeMean = std::is_same_v<T, float> || std::is_same_v<T, double>;
+  static constexpr bool kUsePromotedMean = kUseFiniteRangeMean && std::is_same_v<T, float>;
+  static constexpr bool kUseScaledMean = kUseFiniteRangeMean && std::is_same_v<T, double>;
+
+  // float sums are promoted to double. double uses a dynamically scaled sum,
+  // because it has no wider portable accumulator type.
+  double floating_scale_ = 0.0;
+  double floating_scaled_sum_ = 0.0;
+  bool floating_has_positive_infinity_ = false;
+  bool floating_has_negative_infinity_ = false;
+  bool floating_has_nan_ = false;
+
+  inline void update_scaled_sum(const double value) {
+    if (std::isnan(value)) {
+      floating_has_nan_ = true;
+      return;
+    }
+    if (std::isinf(value)) {
+      if (value > 0) {
+        floating_has_positive_infinity_ = true;
+      } else {
+        floating_has_negative_infinity_ = true;
+      }
+      return;
+    }
+
+    const double magnitude = std::abs(value);
+    if (magnitude == 0.0) {
+      return;
+    }
+    if (floating_scale_ < magnitude) {
+      floating_scaled_sum_ = floating_scaled_sum_ * (floating_scale_ / magnitude) + value / magnitude;
+      floating_scale_ = magnitude;
+    } else {
+      floating_scaled_sum_ += value / floating_scale_;
+    }
+  }
+
+  inline T get_scaled_mean() const {
+    if (floating_has_nan_ ||
+        (floating_has_positive_infinity_ && floating_has_negative_infinity_)) {
+      return std::numeric_limits<T>::quiet_NaN();
+    }
+    if (floating_has_positive_infinity_) {
+      return std::numeric_limits<T>::infinity();
+    }
+    if (floating_has_negative_infinity_) {
+      return -std::numeric_limits<T>::infinity();
+    }
+    return static_cast<T>(floating_scale_ * (floating_scaled_sum_ / static_cast<double>(this->N_)));
+  }
+
  public:
   inline ReduceAggregatorMean(int64_t N, const T&) : ReduceAggregatorSum<T>(N, 0) {}
   static T aggall(const T* from_data, int64_t size) {
@@ -541,6 +593,18 @@ class ReduceAggregatorMean : public ReduceAggregatorSum<T> {
       if (result >= t_max) return std::numeric_limits<T>::max();
       if (result <= t_min) return std::numeric_limits<T>::min();
       return static_cast<T>(result);
+    } else if constexpr (kUsePromotedMean) {
+      double sum = 0.0;
+      for (size_t i = 0, n = onnxruntime::narrow<size_t>(size); i < n; ++i) {
+        sum += static_cast<double>(from_data[i]);
+      }
+      return static_cast<T>(sum / static_cast<double>(size));
+    } else if constexpr (kUseScaledMean) {
+      ReduceAggregatorMean<T> accumulator(size, 0);
+      for (size_t i = 0, n = onnxruntime::narrow<size_t>(size); i < n; ++i) {
+        accumulator.update(from_data[i]);
+      }
+      return accumulator.get_value();
     } else {
       return Eigen::Map<const Eigen::Matrix<T, Eigen::Dynamic, 1>>(
                  from_data, onnxruntime::narrow<size_t>(size))
@@ -550,6 +614,15 @@ class ReduceAggregatorMean : public ReduceAggregatorSum<T> {
   inline T aggall(const T* from_data) {
     return aggall(from_data, this->N_);
   }
+  inline void update(const T& v) {
+    if constexpr (kUsePromotedMean) {
+      this->double_accumulator_ += static_cast<double>(v);
+    } else if constexpr (kUseScaledMean) {
+      update_scaled_sum(v);
+    } else {
+      ReduceAggregatorSum<T>::update(v);
+    }
+  }
   inline T get_value() {
     if constexpr (std::is_integral_v<T>) {
       double result = this->double_accumulator_ / static_cast<double>(this->N_);
@@ -558,6 +631,10 @@ class ReduceAggregatorMean : public ReduceAggregatorSum<T> {
       if (result >= t_max) return std::numeric_limits<T>::max();
       if (result <= t_min) return std::numeric_limits<T>::min();
       return static_cast<T>(result);
+    } else if constexpr (kUsePromotedMean) {
+      return static_cast<T>(this->double_accumulator_ / static_cast<double>(this->N_));
+    } else if constexpr (kUseScaledMean) {
+      return get_scaled_mean();
     } else {
       return this->accumulator_ / static_cast<T>(this->N_);
     }
@@ -592,6 +669,18 @@ class ReduceAggregatorMean : public ReduceAggregatorSum<T> {
                 out[d] = std::numeric_limits<T>::lowest();
               else
                 out[d] = static_cast<T>(result);
+            }
+          });
+    } else if constexpr (kUseFiniteRangeMean) {
+      const T* data = input.Data<T>();
+      T* out = output.MutableData<T>();
+      const int64_t stride = fast_shape[1];
+      concurrency::ThreadPool::TryParallelFor(
+          tp, onnxruntime::narrow<std::ptrdiff_t>(fast_shape[0]),
+          ParallelReduceFastCost(1, stride, sizeof(T), 6),
+          [data, out, stride](ptrdiff_t first, ptrdiff_t last) {
+            for (ptrdiff_t row = first; row < last; ++row) {
+              out[row] = aggall(data + row * stride, stride);
             }
           });
     } else {
@@ -633,6 +722,23 @@ class ReduceAggregatorMean : public ReduceAggregatorSum<T> {
                 out[col] = static_cast<T>(result);
             }
           });
+    } else if constexpr (kUseFiniteRangeMean) {
+      const T* data = input.Data<T>();
+      T* out = output.MutableData<T>();
+      const int64_t columns = fast_shape[1];
+      const int64_t rows = fast_shape[0];
+      concurrency::ThreadPool::TryParallelFor(
+          tp, onnxruntime::narrow<std::ptrdiff_t>(columns),
+          ParallelReduceFastCost(1, rows, sizeof(T), 6),
+          [data, out, columns, rows](ptrdiff_t first, ptrdiff_t last) {
+            for (ptrdiff_t column = first; column < last; ++column) {
+              ReduceAggregatorMean<T> accumulator(rows, data[column]);
+              for (int64_t row = 0; row < rows; ++row) {
+                accumulator.update(data[row * columns + column]);
+              }
+              out[column] = accumulator.get_value();
+            }
+          });
     } else {
       ReduceAggregatorSum<T>::FastReduceRK(input, fast_shape, output, tp);
       T* out = output.MutableData<T>();
@@ -672,6 +778,26 @@ class ReduceAggregatorMean : public ReduceAggregatorSum<T> {
                   out[strideo * d + col] = std::numeric_limits<T>::lowest();
                 else
                   out[strideo * d + col] = static_cast<T>(result);
+              }
+            }
+          });
+    } else if constexpr (kUseFiniteRangeMean) {
+      const T* data = input.Data<T>();
+      T* out = output.MutableData<T>();
+      const int64_t columns = fast_shape[2];
+      const int64_t rows = fast_shape[1];
+      const int64_t input_stride = rows * columns;
+      concurrency::ThreadPool::TryParallelFor(
+          tp, onnxruntime::narrow<ptrdiff_t>(fast_shape[0]),
+          ParallelReduceFastCost(rows, columns, sizeof(T), 6),
+          [data, out, columns, rows, input_stride](ptrdiff_t first, ptrdiff_t last) {
+            for (ptrdiff_t block = first; block < last; ++block) {
+              for (int64_t column = 0; column < columns; ++column) {
+                ReduceAggregatorMean<T> accumulator(rows, data[block * input_stride + column]);
+                for (int64_t row = 0; row < rows; ++row) {
+                  accumulator.update(data[block * input_stride + row * columns + column]);
+                }
+                out[block * columns + column] = accumulator.get_value();
               }
             }
           });
@@ -723,6 +849,29 @@ class ReduceAggregatorMean : public ReduceAggregatorSum<T> {
                 out[d] = std::numeric_limits<T>::lowest();
               else
                 out[d] = static_cast<T>(result);
+            }
+          });
+    } else if constexpr (kUseFiniteRangeMean) {
+      const T* data = input.Data<T>();
+      T* out = output.MutableData<T>();
+      const int64_t reduced_blocks = fast_shape[0];
+      const int64_t outputs = fast_shape[1];
+      const int64_t block_width = fast_shape[2];
+      const int64_t input_stride = outputs * block_width;
+      const int64_t count = reduced_blocks * block_width;
+      concurrency::ThreadPool::TryParallelFor(
+          tp, onnxruntime::narrow<ptrdiff_t>(outputs),
+          ParallelReduceFastCost(outputs, count, sizeof(T), 6),
+          [data, out, reduced_blocks, block_width, input_stride, count](ptrdiff_t first, ptrdiff_t last) {
+            for (ptrdiff_t output_index = first; output_index < last; ++output_index) {
+              ReduceAggregatorMean<T> accumulator(count, data[output_index * block_width]);
+              const T* block = data + output_index * block_width;
+              for (int64_t outer = 0; outer < reduced_blocks; ++outer, block += input_stride) {
+                for (int64_t inner = 0; inner < block_width; ++inner) {
+                  accumulator.update(block[inner]);
+                }
+              }
+              out[output_index] = accumulator.get_value();
             }
           });
     } else {

--- a/onnxruntime/test/providers/cpu/reduction/reduction_ops_test.cc
+++ b/onnxruntime/test/providers/cpu/reduction/reduction_ops_test.cc
@@ -2000,6 +2000,41 @@ TEST(ReductionOpTest, ReduceMean_keepdims_double) {
   test.Run();
 }
 
+template <typename T>
+void RunReduceMeanFiniteRangeTests(T magnitude, float relative_error) {
+  const auto run_case = [magnitude, relative_error](
+                            const TensorShapeVector& input_shape,
+                            const std::vector<int64_t>& axes,
+                            const TensorShapeVector& output_shape) {
+    const size_t input_size = onnxruntime::narrow<size_t>(TensorShape(input_shape).Size());
+    const size_t output_size = onnxruntime::narrow<size_t>(TensorShape(output_shape).Size());
+    OpTester test("ReduceMean");
+    test.AddAttribute("axes", axes);
+    test.AddAttribute("keepdims", static_cast<int64_t>(0));
+    test.AddInput<T>("data", input_shape, std::vector<T>(input_size, magnitude));
+    test.AddOutput<T>("reduced", output_shape, std::vector<T>(output_size, magnitude));
+    test.SetOutputAbsErr("reduced", 0.0f);
+    test.SetOutputRelErr("reduced", relative_error);
+    test.ConfigEp(DefaultCpuExecutionProvider()).RunWithConfig();
+  };
+
+  // Cover the contiguous, row, column, middle-axis, and outer-plus-inner
+  // reduction layouts used by the CPU implementation.
+  run_case({2}, {0}, {});
+  run_case({2, 2}, {1}, {2});
+  run_case({5000, 2}, {0}, {2});
+  run_case({128, 2, 2}, {1}, {128, 2});
+  run_case({2, 128, 2}, {0, 2}, {128});
+}
+
+TEST(ReductionOpTest, ReduceMean_float_preserves_finite_range) {
+  RunReduceMeanFiniteRangeTests(3.0e38f, 1.0e-5f);
+}
+
+TEST(ReductionOpTest, ReduceMean_double_preserves_finite_range) {
+  RunReduceMeanFiniteRangeTests(1.0e308, 1.0e-12f);
+}
+
 TEST(ReductionOpTest, ReduceMean) {
   OpTester test("ReduceMean");
   test.AddAttribute("axes", std::vector<int64_t>{0, 2});


### PR DESCRIPTION
## Description

Fix CPU `ReduceMean` so a finite representable mean is not lost merely because
the same-type intermediate sum overflows. For example, the earlier direct-sum
implementation returns infinity for both of these finite means:

```text
float32: mean([3e38, 3e38])   = 3e38
float64: mean([1e308, 1e308]) = 1e308
```

The change retains the existing reduction layout dispatch:

- float accumulates in double before division;
- double uses a dynamically scaled signed sum, since no portable wider type is available;
- when that represented sum becomes zero, its scale resets so a later small term
  is not lost against a canceled extreme value;
- NaN and positive/negative infinity handling is explicit;
- integer and custom-type paths are unchanged.

The reset addresses the existing review example: `[DBL_MAX, -DBL_MAX, 1e-16]`
now retains the mean of approximately `3.333e-17`. This remains floating-point
summation, not an exact or compensated accumulator for every ordering.

The corresponding ReferenceEvaluator correction is tracked in onnx/onnx#8456.

## Testing

- macOS ARM64 CPU: all 40 `ReductionOpTest.ReduceMean*` tests pass, no skips.
- Existing float/double finite-range tests cover all-axis, KR, RK, KRK and RKR layouts.
- Their helper now fixes intra-op/inter-op thread-pool sizes at one, so host core
  count cannot silently select the generic fallback instead of the intended fast path.
- New cancellation coverage has 24 models across six layouts with signed small
  residuals; an additional test covers zero, NaN and infinity after cancellation.
- Reviewed head and a rebuilt mutation each fail the cancellation test with
  60 failed output-value checks. The correction has zero failures.
- A separate instrumented dispatch build confirmed KR/RK/KRK/RKR and both all-axis
  and generic fallbacks actually execute with degree of parallelism one. Its three
  selected tests pass; instrumentation is not part of the PR.
- The actual affected provider translation units and test were recompiled and
  relinked against existing dependencies; follow-up validation is not a new full clean build.
- clang-format 20.1.8, the configured formatter adapter and `git diff --check` pass.

Performance benchmarking remains outstanding. Other providers, the full ORT suite
and production-model impact were not tested.
