### PR TITLE
Fix MinMax calibration discarding buffered outputs

### DIFF
--- a/onnxruntime/python/tools/quantization/calibrate.py
+++ b/onnxruntime/python/tools/quantization/calibrate.py
@@ -521,8 +521,9 @@ class MinMaxCalibrater(CalibraterBase):
             )
             if (
                 self.max_intermediate_outputs is not None
-                and len(self.intermediate_outputs) == self.max_intermediate_outputs
+                and len(self.intermediate_outputs) >= self.max_intermediate_outputs
             ):
+                self.compute_data()
                 self.clear_collected_data()
 
         if len(self.intermediate_outputs) == 0 and self.calibrate_tensors_range is None:
@@ -555,8 +556,8 @@ class MinMaxCalibrater(CalibraterBase):
                 min_value = old_min + self.averaging_constant * (new_min - old_min)
                 max_value = old_max + self.averaging_constant * (new_max - old_max)
             else:
-                min_value = min(old_min, new_min)
-                max_value = max(old_max, new_max)
+                min_value = np.fmin(old_min, new_min)
+                max_value = np.fmax(old_max, new_max)
 
             # If structured as TensorData, wrap the result accordingly
             if isinstance(value, TensorData) or isinstance(new_range[key], TensorData):

--- a/onnxruntime/python/tools/quantization/quantize.py
+++ b/onnxruntime/python/tools/quantization/quantize.py
@@ -658,7 +658,8 @@ def quantize_static(
                 CalibMaxIntermediateOutputs = Optional[int] :
                     Default is None. If set to an integer, during calculation of the min-max range of the tensors
                     it will load at max value number of outputs before computing and merging the range. This will
-                    produce the same result as all computing with None, but is more memory efficient.
+                    produce the same result as computing with None when CalibMovingAverage is False, but is more
+                    memory efficient. When CalibMovingAverage is True, the moving average is updated per buffer.
                 SmoothQuant = True/False :
                     Default is False. If enabled, SmoothQuant algorithm will be applied before quantization to do
                     fake input channel quantization.

--- a/onnxruntime/test/python/quantization/test_calibration.py
+++ b/onnxruntime/test/python/quantization/test_calibration.py
@@ -14,6 +14,7 @@ from pathlib import Path
 import numpy as np
 import onnx
 from onnx import TensorProto, helper, numpy_helper
+from parameterized import parameterized
 
 import onnxruntime
 from onnxruntime.quantization import quantize_static
@@ -374,6 +375,92 @@ class TestCalibrateMinMaxCalibrator(unittest.TestCase):
         output_min_max_dict = dict(zip(output_names, min_max_pairs, strict=False))
         for output_name, min_max in output_min_max_dict.items():
             self.assertEqual(min_max, tensors_range[output_name].range_value)
+
+    def construct_limited_outputs_model(self, opset=13):
+        model = helper.make_model(
+            helper.make_graph(
+                [helper.make_node("Identity", ["input"], ["output"])],
+                "limited_outputs",
+                [helper.make_tensor_value_info("input", TensorProto.FLOAT, [1, 2])],
+                [helper.make_tensor_value_info("output", TensorProto.FLOAT, [1, 2])],
+            ),
+            opset_imports=[helper.make_opsetid("", opset)],
+        )
+        model_path = Path(self._tmp_model_dir.name) / "limited_outputs.onnx"
+        onnx.save(model, model_path)
+        return model_path
+
+    @parameterized.expand(
+        [
+            (sample_count, per_channel, symmetric, opset, None)
+            for sample_count in (1, 2, 3, 4, 5)
+            for per_channel in (False, True)
+            for symmetric in (False, True)
+            for opset in (13, 18)
+        ]
+        + [(3, per_channel, False, 18, nan_first) for per_channel in (False, True) for nan_first in (False, True)]
+    )
+    def test_compute_data_preserves_ranges_with_limited_outputs(
+        self, sample_count, per_channel, symmetric, opset, nan_first
+    ):
+        model_path = self.construct_limited_outputs_model(opset)
+        samples = np.array([[[-9, 1]], [[2, 12]], [[-4, 7]], [[6, -3]], [[0, 3]]], dtype=np.float32)[:sample_count]
+        if nan_first is not None:
+            if nan_first:
+                samples[:2] = np.nan
+            else:
+                samples[-2:] = np.nan
+        axes = (0, 1) if per_channel else (0, 1, 2)
+        expected_min = np.nanmin(samples, axis=axes).reshape(-1)
+        expected_max = np.nanmax(samples, axis=axes).reshape(-1)
+        if symmetric:
+            expected_max = np.maximum(np.abs(expected_min), np.abs(expected_max))
+            expected_min = -expected_max
+
+        for limit in (None, 2):
+            with self.subTest(max_intermediate_outputs=limit):
+                calibrater = create_calibrator(
+                    model_path,
+                    augmented_model_path=str(Path(self._tmp_model_dir.name) / "limited_outputs_augmented.onnx"),
+                    extra_options={
+                        "max_intermediate_outputs": limit,
+                        "per_channel": per_channel,
+                        "symmetric": symmetric,
+                    },
+                )
+                data_reader = TestDataReader()
+                data_reader.input_data_list = list(samples)
+                calibrater.collect_data(data_reader)
+                tensors_range = calibrater.compute_data()
+                for name in ("input", "output"):
+                    np.testing.assert_array_equal(tensors_range[name].range_value[0], expected_min)
+                    np.testing.assert_array_equal(tensors_range[name].range_value[1], expected_max)
+
+    @parameterized.expand((sample_count, per_channel) for sample_count in (4, 5) for per_channel in (False, True))
+    def test_compute_data_moving_average_matches_explicit_chunks(self, sample_count, per_channel):
+        model_path = self.construct_limited_outputs_model()
+        samples = np.array([[[0, 0]], [[4, 8]], [[8, 12]], [[12, 16]], [[20, 24]]], dtype=np.float32)[:sample_count]
+        ranges = []
+        for limit in (None, 2):
+            calibrater = create_calibrator(
+                model_path,
+                augmented_model_path=str(Path(self._tmp_model_dir.name) / "limited_outputs_augmented.onnx"),
+                extra_options={
+                    "max_intermediate_outputs": limit,
+                    "moving_average": True,
+                    "averaging_constant": 0.25,
+                    "per_channel": per_channel,
+                },
+            )
+            chunks = [samples[i : i + 2] for i in range(0, sample_count, 2)] if limit is None else [samples]
+            for chunk in chunks:
+                data_reader = TestDataReader()
+                data_reader.input_data_list = list(chunk)
+                calibrater.collect_data(data_reader)
+            ranges.append(calibrater.compute_data())
+
+        for name in ("input", "output"):
+            np.testing.assert_array_equal(ranges[0][name].range_value, ranges[1][name].range_value)
 
     def test_histogram_calibrators_run(self):
         """


### PR DESCRIPTION
### Description

Compute MinMax calibration ranges before clearing full buffers, fixing `CalibMaxIntermediateOutputs` exceptions and lost extrema. Use NaN-aware elementwise merging for per-channel ranges, add regression tests, and clarify moving-average behavior.

### Context

Follow up on lithium0003's unmerged #20226, and is also related to #18893.

Validation: 67 calibration tests and 10 adjacent tests pass. Tested checkout Python code with the ONNX Runtime 1.23.2 CPU wheel on macOS arm64

AI helped in the development of this