### PR TITLE
[Web] Fix JSEP DequantizeLinear for packed per-tensor input

### DIFF
--- a/js/web/lib/wasm/jsep/webgpu/ops/quantize-linear.ts
+++ b/js/web/lib/wasm/jsep/webgpu/ops/quantize-linear.ts
@@ -136,7 +136,10 @@ const createDequantizeLinearProgramInfo = (
           ${(() => {
             if (isPacked) {
               return `
-            let input = ${input.getByOffset('global_idx / 4')};
+            // Each packed u32 holds 4 elements. When the output is not vectorized, global_idx is a per-element
+            // index and the word offset is global_idx / 4. When it is vectorized, global_idx is already a vec4
+            // index and one word holds exactly one output vec4, so the word offset is global_idx itself.
+            let input = ${input.getByOffset(components === 1 ? 'global_idx / 4' : 'global_idx')};
             let x_vec = ${isSigned ? 'unpack4xI8(input)' : 'unpack4xU8(input)'};
             let x_value = ${components === 1 ? 'x_vec[global_idx % 4]' : 'x_vec'};`;
             } else {
@@ -203,11 +206,14 @@ const createDequantizeLinearProgramInfo = (
                 }
               }
             } else {
-              return `let zero_point_value = ${isPacked ? (isSigned ? 'i32' : 'u32') : input.type.value}(0);`;
+              return `let zero_point_value = ${scale.type.value}(0);`;
             }
           })()};
       // Compute and write output
-      ${output.setByOffset('global_idx', `${output.type.value}(x_value - zero_point_value) * scale_value`)};
+      ${output.setByOffset(
+        'global_idx',
+        `(${output.type.value}(x_value) - ${scale.type.value}(zero_point_value)) * scale_value`,
+      )};
       }`;
   };
   return {

--- a/js/web/test/data/ops/dequantizelinear.jsonc
+++ b/js/web/test/data/ops/dequantizelinear.jsonc
@@ -544,5 +544,145 @@
         ]
       }
     ]
+  },
+  {
+    "name": "dequantizelinear",
+    "operator": "DequantizeLinear",
+    "opset": { "domain": "", "version": 13 },
+    "attributes": [],
+    "cases": [
+      {
+        "name": "uint8 per-tensor no zero point, more than one vec4",
+        "inputs": [
+          {
+            "data": [10, 20, 30, 40, 50, 60, 70, 80],
+            "dims": [8],
+            "type": "uint8"
+          },
+          {
+            "data": [1.0],
+            "dims": [1],
+            "type": "float32"
+          },
+          {
+            "data": [0],
+            "dims": [1],
+            "type": "uint8"
+          }
+        ],
+        "outputs": [
+          {
+            "data": [10, 20, 30, 40, 50, 60, 70, 80],
+            "dims": [8],
+            "type": "float32"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "name": "dequantizelinear",
+    "operator": "DequantizeLinear",
+    "opset": { "domain": "", "version": 13 },
+    "attributes": [],
+    "cases": [
+      {
+        "name": "uint8 per-tensor with zero point, values below the zero point",
+        "inputs": [
+          {
+            "data": [0, 64, 128, 255],
+            "dims": [4],
+            "type": "uint8"
+          },
+          {
+            "data": [0.5],
+            "dims": [1],
+            "type": "float32"
+          },
+          {
+            "data": [128],
+            "dims": [1],
+            "type": "uint8"
+          }
+        ],
+        "outputs": [
+          {
+            "data": [-64, -32, 0, 63.5],
+            "dims": [4],
+            "type": "float32"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "name": "dequantizelinear",
+    "operator": "DequantizeLinear",
+    "opset": { "domain": "", "version": 13 },
+    "attributes": [],
+    "cases": [
+      {
+        "name": "int8 per-tensor with zero point, more than one vec4",
+        "inputs": [
+          {
+            "data": [-128, -64, -1, 0, 1, 64, 126, 127],
+            "dims": [8],
+            "type": "int8"
+          },
+          {
+            "data": [0.5],
+            "dims": [1],
+            "type": "float32"
+          },
+          {
+            "data": [-1],
+            "dims": [1],
+            "type": "int8"
+          }
+        ],
+        "outputs": [
+          {
+            "data": [-63.5, -31.5, 0, 0.5, 1, 32.5, 63.5, 64],
+            "dims": [8],
+            "type": "float32"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "name": "dequantizelinear",
+    "operator": "DequantizeLinear",
+    "opset": { "domain": "", "version": 13 },
+    "attributes": [],
+    "cases": [
+      {
+        "name": "uint8 2D per-tensor with zero point, more than one vec4",
+        "inputs": [
+          {
+            "data": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11],
+            "dims": [3, 4],
+            "type": "uint8"
+          },
+          {
+            "data": [0.25],
+            "dims": [1],
+            "type": "float32"
+          },
+          {
+            "data": [5],
+            "dims": [1],
+            "type": "uint8"
+          }
+        ],
+        "outputs": [
+          {
+            "data": [-1.25, -1, -0.75, -0.5, -0.25, 0, 0.25, 0.5, 0.75, 1, 1.25, 1.5],
+            "dims": [3, 4],
+            "type": "float32"
+          }
+        ]
+      }
+    ]
   }
 ]


### PR DESCRIPTION
Fix for issue #32578,

### Description
Two independent bugs made DequantizeLinear on the JSEP WebGPU backend return wrong results for per-tensor-quantized uint8/int8 input:

1. Wrong input read when the output is vectorized. The per-tensor fast path emits vec4 outputs, so global_idx is already a vec4 index and one packed u32 holds exactly the 4 elements of one output vec4. Dividing global_idx by 4 again re-read the same input word for every group of 4 output vec4s instead of advancing through the buffer. Only divide when the output is not vectorized, matching the branch the native WebGPU EP has in quantize_linear.cc.

2. Unsigned wraparound of the zero point. The subtraction happened while both operands were still in the packed integer type, so for uint8 with a nonzero zero point any element below the zero point wrapped in u32 instead of going negative, yielding ~2^31 after the float cast. Cast both operands to the float value type before subtracting, again mirroring the native EP.

Add op tests covering per-tensor uint8/int8 input larger than one vec4 and values below a nonzero zero point; the existing cases all used dims [4] with a zero zero point, so neither bug was caught.

### Motivation and Context
I ran into when using the DequantizeLinear on the JSEP WebGPU backend on a q8 embedding model--it was producing garbage results.

Thank you for maintaining the project!


