### PR TITLE
Add BF16 routing support to CUDA MoE

### DIFF
--- a/onnxruntime/contrib_ops/cuda/moe/moe.cc
+++ b/onnxruntime/contrib_ops/cuda/moe/moe.cc
@@ -223,6 +223,7 @@ Status MoE<T>::ComputeInternal(OpKernelContext* context) const {
 
   // Perform Softmax + TopK
   bool is_fp16 = input->IsDataType<MLFloat16>();
+  bool is_bf16 = input->IsDataType<BFloat16>();
 
   if (use_sparse_mixer_) {
     ORT_ENFORCE(k_ == 2, "Sparse mixer only supports k=2");
@@ -235,6 +236,15 @@ Status MoE<T>::ComputeInternal(OpKernelContext* context) const {
           expert_scales,
           expert_indices,
           unpermuted_row_to_permuted_row,  // source_rows
+          static_cast<int>(moe_params.num_rows),
+          static_cast<int>(moe_params.num_experts),
+          stream);
+    } else if (is_bf16) {
+      LaunchSparseMixerTop2(
+          reinterpret_cast<const __nv_bfloat16*>(router_probs->DataRaw()),
+          expert_scales,
+          expert_indices,
+          unpermuted_row_to_permuted_row,
           static_cast<int>(moe_params.num_rows),
           static_cast<int>(moe_params.num_experts),
           stream);
@@ -253,6 +263,16 @@ Status MoE<T>::ComputeInternal(OpKernelContext* context) const {
     if (is_fp16) {
       LaunchSoftmaxTopK(
           reinterpret_cast<const half*>(router_probs->DataRaw()),
+          expert_scales,
+          expert_indices,
+          static_cast<int>(moe_params.num_rows),
+          static_cast<int>(moe_params.num_experts),
+          static_cast<int>(k_),
+          normalize_routing_weights_,
+          stream);
+    } else if (is_bf16) {
+      LaunchSoftmaxTopK(
+          reinterpret_cast<const __nv_bfloat16*>(router_probs->DataRaw()),
           expert_scales,
           expert_indices,
           static_cast<int>(moe_params.num_rows),


### PR DESCRIPTION
### Description

This pull request adds support for the `bfloat16` (BF16) data type in the Mixture of Experts (MoE) CUDA kernel implementation. The main changes ensure that both the sparse mixer and softmax top-k operations can now handle BF16 input tensors, improving compatibility and performance on hardware supporting BF16.

Support for BF16 data type:

* Added a check for BF16 input tensors using `IsDataType<BFloat16>()` in the MoE kernel (`moe.cc`).
* Updated the sparse mixer path to call `LaunchSparseMixerTop2` with BF16 data when appropriate.
* Updated the softmax top-k path to call `LaunchSoftmaxTopK` with BF16 data when appropriate.

### Motivation and Context

BF16 routing support was missing in the CUDA MoE kernel.

